### PR TITLE
fix: verbose validation error messages for MCP consumers

### DIFF
--- a/src/orionbelt/api/routers/sessions.py
+++ b/src/orionbelt/api/routers/sessions.py
@@ -168,10 +168,14 @@ async def load_model(
     except ModelCapacityError as exc:
         raise HTTPException(status_code=429, detail=str(exc)) from None
     except ModelValidationError as exc:
+        error_lines = "; ".join(
+            f"[{e.code}] {e.message}" + (f" (at {e.path})" if e.path else "")
+            for e in exc.errors
+        )
         raise HTTPException(
             status_code=422,
             detail={
-                "message": "Invalid OBML model: parsing or validation failed",
+                "message": f"Invalid OBML model: {error_lines}",
                 "errors": [
                     {"code": e.code, "message": e.message, "path": e.path} for e in exc.errors
                 ],


### PR DESCRIPTION
## Summary
- The 422 `message` field now includes all error codes and messages inline (e.g., `"Invalid OBML model: [YAML_PARSE_ERROR] expected block...; [UNKNOWN_COLUMN] dimension references..."`)
- Previously it was just `"Invalid OBML model: parsing or validation failed"` — MCP consumers only read the `message` field and got no actionable detail

## Test plan
- [x] 947 tests passing
- [ ] Test via MCP client with an invalid model — error details should now appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)