### PR TITLE
docs: polish README for faster onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,20 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/ralfbecher/orionbelt-semantic-layer/main/docs/assets/ORIONBELT_Logo.png" alt="OrionBelt Logo" width="400">
+  <img src="https://raw.githubusercontent.com/ralfbecher/orionbelt-semantic-layer/main/docs/assets/ORIONBELT_Logo.png" alt="OrionBelt Semantic Layer logo — a stylized belt of three stars" width="400">
 </p>
 
 <h1 align="center">OrionBelt Semantic Layer</h1>
 
 <p align="center"><strong>Compile and execute YAML semantic models as analytical SQL across multiple database dialects</strong></p>
 
+<!-- TODO: confirm PyPI publication — if not yet published, remove pypi badge -->
+[![Live Demo](https://img.shields.io/badge/Live_Demo-Try_it_now-brightgreen?style=for-the-badge)](http://35.187.174.102/ui/?__theme=dark)
 [![GitHub stars](https://img.shields.io/github/stars/ralfbecher/orionbelt-semantic-layer?style=social)](https://github.com/ralfbecher/orionbelt-semantic-layer)
 [![Version 1.6.2](https://img.shields.io/badge/version-1.6.2-purple.svg)](https://github.com/ralfbecher/orionbelt-semantic-layer/releases)
+[![PyPI](https://img.shields.io/pypi/v/orionbelt-semantic-layer?logo=pypi&logoColor=white)](https://pypi.org/project/orionbelt-semantic-layer/)
+[![Docker Hub](https://img.shields.io/docker/pulls/ralforion/orionbelt-api?logo=docker&label=Docker%20Hub)](https://hub.docker.com/repositories/ralforion)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
 [![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-orange.svg)](https://github.com/ralfbecher/orionbelt-semantic-layer/blob/main/LICENSE)
-[![Docker Hub](https://img.shields.io/docker/pulls/ralforion/orionbelt-api?logo=docker&label=Docker%20Hub)](https://hub.docker.com/repositories/ralforion)
+
 [![FastAPI](https://img.shields.io/badge/FastAPI-0.128+-009688.svg?logo=fastapi&logoColor=white)](https://fastapi.tiangolo.com)
 [![Pydantic v2](https://img.shields.io/badge/Pydantic-v2-E92063.svg?logo=pydantic&logoColor=white)](https://docs.pydantic.dev)
 [![Gradio](https://img.shields.io/badge/Gradio-5.0+-F97316.svg?logo=gradio&logoColor=white)](https://www.gradio.app)
@@ -28,64 +32,208 @@ OrionBelt Semantic Layer is an **API-first** semantic engine and query planner f
 
 **Analytics as Code** — Define your analytical semantics in version-controlled YAML, compile to dialect-specific SQL, and execute against live databases, all through a single API. No BI tool in the middle: the full loop from declarative model to query results is programmable, reviewable, and reproducible.
 
+> **Companion Project:** [OrionBelt Analytics](https://github.com/ralfbecher/orionbelt-analytics) — an ontology-based MCP server that analyzes database schemas and generates RDF/OWL ontologies. Together they let AI assistants navigate your data landscape through ontologies and compile safe, dialect-aware analytical SQL.
+
+## Table of Contents
+
+- [Try it in 30 Seconds](#try-it-in-30-seconds) — Live Demo | PyPI | Docker
+- [Claude Desktop / MCP](#claude-desktop--mcp)
+- [Why OrionBelt?](#why-orionbelt)
+- [Features](#features)
+- [Example](#example)
+- [Gradio UI](#gradio-ui)
+- [Documentation](#documentation)
+- [Status & Roadmap](#status--roadmap)
+- [Companion Project](#companion-project)
+- [Development](#development)
+
+---
+
+## Try it in 30 Seconds
+
+### Option A: Live Demo (no install)
+
+**[Open the Live Demo](http://35.187.174.102/ui/?__theme=dark)** — Gradio UI with a pre-loaded example model. Paste a query, pick a dialect, see SQL instantly.
+
+API explorer: [Swagger UI](http://35.187.174.102/docs) | [ReDoc](http://35.187.174.102/redoc)
+
+### Option B: Install from PyPI
+
+```bash
+pip install orionbelt-semantic-layer
+```
+
+Then paste into a Python REPL:
+
+```python
+from orionbelt.parser import ReferenceResolver, TrackedLoader
+from orionbelt.compiler.pipeline import CompilationPipeline
+from orionbelt.models.query import QueryObject, QuerySelect
+
+model_yaml = """
+version: "1.0"
+dataObjects:
+  Orders:
+    code: ORDERS
+    columns:
+      Price: { code: PRICE, abstractType: float }
+      Country: { code: COUNTRY, abstractType: string }
+dimensions:
+  Country:
+    dataObject: Orders
+    column: Country
+    resultType: string
+measures:
+  Total Revenue:
+    resultType: float
+    aggregation: sum
+    expression: "{[Orders].[Price]}"
+"""
+
+loader = TrackedLoader()
+raw, source_map = loader.load_string(model_yaml)
+resolver = ReferenceResolver()
+model, result = resolver.resolve(raw, source_map)
+
+query = QueryObject(select=QuerySelect(dimensions=["Country"], measures=["Total Revenue"]))
+pipeline = CompilationPipeline()
+output = pipeline.compile(query, model, "postgres")
+print(output.sql)
+```
+
+Output:
+
+```sql
+SELECT
+  "Orders"."COUNTRY" AS "Country",
+  SUM("Orders"."PRICE") AS "Total Revenue"
+FROM ORDERS AS "Orders"
+GROUP BY "Orders"."COUNTRY"
+```
+
+No env file needed — the compilation pipeline is stateless.
+
+### Option C: Docker
+
+**Stage 1 — Zero-config start** (models loaded later via API or UI):
+
+```bash
+docker run -p 8080:8080 ralforion/orionbelt-api
+```
+
+Open [http://localhost:8080/docs](http://localhost:8080/docs) to explore the API.
+
+**Stage 2 — Realistic setup** with docker compose:
+
+```yaml
+# docker-compose.yml
+services:
+  api:
+    image: ralforion/orionbelt-api:1.6.2
+    ports: ["8080:8080"]
+    env_file: .env
+    volumes:
+      - ./models:/app/models:ro
+    environment:
+      MODEL_FILE: /app/models/my-model.obml.yml
+
+  ui:
+    image: ralforion/orionbelt-ui:1.6.2
+    ports: ["7860:7860"]
+    environment:
+      API_BASE_URL: http://api:8080
+```
+
+```bash
+docker compose up -d
+```
+
+See [`.env.template`](.env.template) for the full environment variable reference.
+
+> **Docker notes:**
+> - `API_SERVER_HOST` is already `0.0.0.0` inside the container — no override needed.
+> - MCP via stdio does not work in Docker. Use the [MCP HTTP client](https://github.com/ralfbecher/orionbelt-semantic-layer-mcp) for containerized deployments.
+> - Mount models to `/app/models` (or any path) and set `MODEL_FILE` to pre-load on startup.
+> - For production, pin a version tag (`:1.6.2`) rather than `:latest`.
+
+### Claude Desktop / MCP
+
+The MCP server is a separate thin client that delegates to the REST API:
+
+**[orionbelt-semantic-layer-mcp](https://github.com/ralfbecher/orionbelt-semantic-layer-mcp)**
+
+Add to your Claude Desktop `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "orionbelt": {
+      "command": "uvx",
+      "args": ["orionbelt-semantic-layer-mcp"]
+    }
+  }
+}
+```
+
+Also works with Copilot, Cursor, and Windsurf. See the [MCP repo](https://github.com/ralfbecher/orionbelt-semantic-layer-mcp) for full setup options.
+
+---
+
+## Why OrionBelt?
+
+| | OrionBelt | dbt Semantic Layer | Cube | Malloy |
+|---|---|---|---|---|
+| **Model format** | YAML-only (OBML) | Python + YAML | JavaScript | Custom DSL |
+| **SQL generation** | AST-based (injection-safe) | String templates | String templates | Compiler |
+| **Multi-dialect** | 8 dialects, no runtime lock-in | dbt Cloud required | Cube Cloud or self-host | BigQuery-focused |
+| **Multi-fact queries** | Star Schema + CFL planner (fan-trap prevention) | Limited | Pre-aggregations | Automatic joins |
+| **Integration surface** | REST API + MCP + Gradio UI | dbt Cloud API | REST + GraphQL | VS Code extension |
+| **Deployment** | Self-host anywhere, single binary | SaaS (Cloud) | SaaS or self-host | Library |
+| **License** | BSL 1.1 (converts to Apache 2.0) | Apache 2.0 | AGPL / proprietary | MIT |
+
+---
+
 ## Features
 
-- **8 SQL Dialects** — BigQuery, ClickHouse, Databricks, Dremio, DuckDB/MotherDuck, MySQL, Postgres, Snowflake
-- **OBML Model Format** — YAML-based semantic models with data objects, dimensions, measures, metrics, and joins
-- **AST-Based SQL** — Custom SQL AST ensures correct, injection-safe SQL generation
-- **Cross-Schema Queries** — Model data objects across multiple databases and schemas in a single model
-- **Static Model Filters** — Mandatory WHERE conditions baked into the model, applied to every query with auto-join extension
-- **Star Schema & CFL** — Automatic join resolution with Composite Fact Layer for multi-fact queries
-- **REST API** — FastAPI endpoints for model management, validation, compilation, and execution
-- **Gradio UI** — Interactive web interface for model editing, query testing, and ER diagrams
-- **MCP Server** — Available as a [separate thin client](https://github.com/ralfbecher/orionbelt-semantic-layer-mcp) for Claude, Copilot, Cursor, Windsurf
-- **AI Integrations** — LangChain, OpenAI Agents SDK, CrewAI, Google ADK, Vercel AI SDK, n8n, ChatGPT
-- **DB-API 2.0 + Flight SQL** — PEP 249 drivers and Arrow Flight SQL server for DBeaver, Tableau, Power BI
+### Semantic Modeling
+
+- **OBML Format** — YAML-based semantic models with data objects, dimensions, measures, metrics, and joins
+- **Cross-Schema Queries** — model data objects across multiple databases and schemas in a single model
+- **Static Model Filters** — mandatory WHERE conditions baked into the model, auto-applied with join extension
 - **OBSL Graph & SPARQL** — RDF graph export and read-only SPARQL querying for every loaded model
-- **OSI Interoperability** — Bidirectional conversion between OBML and Open Semantic Interchange format
+- **OSI Interoperability** — bidirectional conversion between OBML and Open Semantic Interchange format
 
-## Quick Start
+### SQL Compilation
 
-### Docker (fastest)
+- **8 SQL Dialects** — BigQuery, ClickHouse, Databricks, Dremio, DuckDB/MotherDuck, MySQL, Postgres, Snowflake
+- **AST-Based Generation** — custom SQL AST ensures correct, injection-safe SQL (not string templates)
+- **Star Schema & CFL** — automatic join resolution with Composite Fact Layer for multi-fact queries
+- **sqlglot Validation** — post-generation syntax check across all supported dialects
 
-```bash
-# API only
-docker run -p 8080:8080 ralforion/orionbelt-api
+### Integration Surface
 
-# API + Gradio UI (two containers)
-docker run -p 8080:8080 ralforion/orionbelt-api
-docker run -p 7860:7860 -e API_BASE_URL=http://host.docker.internal:8080 ralforion/orionbelt-ui
+- **REST API** — FastAPI endpoints for model management, validation, compilation, and execution
+- **MCP Server** — [separate thin client](https://github.com/ralfbecher/orionbelt-semantic-layer-mcp) for Claude, Copilot, Cursor, Windsurf
+- **AI Integrations** — LangChain, OpenAI Agents SDK, CrewAI, Google ADK, Vercel AI SDK, n8n, ChatGPT
+- **Gradio UI** — interactive web interface for model editing, query testing, and ER diagrams
+- **DB-API 2.0 + Flight SQL** — PEP 249 drivers and Arrow Flight SQL server for DBeaver, Tableau, Power BI
 
-# API + Flight SQL + Gradio UI (all-in-one image)
-docker run -p 8080:8080 -p 8815:8815 ralforion/orionbelt-flight
-docker run -p 7860:7860 -e API_BASE_URL=http://host.docker.internal:8080 ralforion/orionbelt-ui
-```
+### Developer Experience
 
-API at `http://localhost:8080` — Swagger docs at [`/docs`](http://localhost:8080/docs) — UI at `http://localhost:7860`
+- **Source-Position Errors** — validation errors report exact YAML line and column
+- **ER Diagrams** — interactive Mermaid diagrams with zoom and download (MD/PNG/Turtle)
+- **Session Management** — TTL-scoped sessions with thread-safe model isolation
+- **JSON Schema** — full OBML and query schema for IDE autocompletion (`yaml-language-server`)
 
-### From Source
-
-```bash
-git clone https://github.com/ralfbecher/orionbelt-semantic-layer.git
-cd orionbelt-semantic-layer
-uv sync
-uv run orionbelt-api
-```
-
-API at `http://localhost:8000` — Swagger docs at [`/docs`](http://localhost:8000/docs)
-
-### Live Demo
-
-> **[http://35.187.174.102/ui](http://35.187.174.102/ui/?__theme=dark)** — Gradio UI with pre-loaded example model
-
-API: `http://35.187.174.102` — [Swagger UI](http://35.187.174.102/docs) | [ReDoc](http://35.187.174.102/redoc)
+---
 
 ## Example
 
 ### Define a Semantic Model (OBML)
 
 ```yaml
-version: 1.0
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ralfbecher/orionbelt-semantic-layer/main/schema/obml-schema.json
+version: "1.0"
 dataObjects:
   Customers:
     code: CUSTOMERS
@@ -126,23 +274,24 @@ measures:
 
 ```bash
 # Create a session
-curl -s -X POST http://localhost:8000/v1/sessions | jq .session_id
+curl -s -X POST http://localhost:8080/v1/sessions | jq .session_id
 # -> "a1b2c3d4"
 
 # Load the model
-curl -s -X POST http://localhost:8000/v1/sessions/a1b2c3d4/models \
+curl -s -X POST http://localhost:8080/v1/sessions/a1b2c3d4/models \
   -H "Content-Type: application/json" \
   -d '{"model_yaml": "..."}' | jq .model_id
 # -> "abcd1234"
 
 # Compile a query
-curl -s -X POST http://localhost:8000/v1/sessions/a1b2c3d4/query/sql \
+curl -s -X POST http://localhost:8080/v1/sessions/a1b2c3d4/query/sql \
   -H "Content-Type: application/json" \
   -d '{"model_id":"abcd1234","query":{"select":{"dimensions":["Country"],"measures":["Revenue"]}},"dialect":"postgres"}' \
   | jq -r .sql
 ```
 
-**Generated SQL (Postgres):**
+<details>
+<summary><strong>Generated SQL (Postgres)</strong></summary>
 
 ```sql
 SELECT
@@ -154,12 +303,16 @@ LEFT JOIN WAREHOUSE.PUBLIC.CUSTOMERS AS "Customers"
 GROUP BY "Customers"."COUNTRY"
 ```
 
+</details>
+
 Change `dialect` to `bigquery`, `clickhouse`, `databricks`, `dremio`, `duckdb`, `mysql`, or `snowflake` for dialect-specific SQL.
+
+---
 
 ## Gradio UI
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/ralfbecher/orionbelt-semantic-layer/main/docs/assets/ui-sqlcompiler-dark.png" alt="SQL Compiler in Gradio UI" width="900">
+  <img src="https://raw.githubusercontent.com/ralfbecher/orionbelt-semantic-layer/main/docs/assets/ui-sqlcompiler-dark.png" alt="OrionBelt Gradio UI showing side-by-side OBML model editor and compiled SQL output" width="900">
 </p>
 
 - **SQL Compiler** — side-by-side OBML model and query editors with syntax highlighting, 8 dialect selector, one-click compilation with formatted SQL output and query explain
@@ -172,18 +325,19 @@ Change `dialect` to `bigquery`, `clickhouse`, `databricks`, `dremio`, `duckdb`, 
 **Embedded mode** — the UI is mounted at `/ui` on the API server:
 
 ```bash
-uv sync && uv run orionbelt-api
+pip install orionbelt-semantic-layer && orionbelt-api
 # -> UI at http://localhost:8000/ui
 ```
 
 **Standalone mode** — run API and UI as separate processes:
 
 ```bash
-uv sync
-uv run orionbelt-api                                          # API on :8000
-uv run orionbelt-ui                                           # UI on :7860 (connects to API on :8000)
-API_BASE_URL=http://remote-api:8080 uv run orionbelt-ui       # point UI to a remote API
+orionbelt-api                                              # API on :8000
+orionbelt-ui                                               # UI on :7860 (connects to API on :8000)
+API_BASE_URL=http://remote-api:8080 orionbelt-ui           # point UI to a remote API
 ```
+
+---
 
 ## Documentation
 
@@ -213,6 +367,18 @@ API_BASE_URL=http://remote-api:8080 uv run orionbelt-ui       # point UI to a re
 | TPC-DS Benchmark | [examples/tpcds](https://ralforion.com/orionbelt-semantic-layer/examples/tpcds/) |
 | Quickstart Notebook | [examples/quickstart.ipynb](examples/quickstart.ipynb) |
 
+---
+
+## Status & Roadmap
+
+| Status | Area |
+|--------|------|
+| Shipped | 8 SQL dialects, REST API, MCP server, Gradio UI, DB-API drivers, Flight SQL, OBSL/SPARQL, OSI interop, AI integrations (LangChain, CrewAI, ADK, etc.), model inheritance & extends |
+| In progress | Additional dialects, CLI tool |
+| Planned | Metric data types & numerical precision (CAST-based decimal formatting), authentication & API tokens, CLI for automation & CI/CD, DDL view generation (CREATE VIEW from queries), additional BI tool integrations |
+
+---
+
 ## Companion Project
 
 ### [OrionBelt Analytics](https://github.com/ralfbecher/orionbelt-analytics)
@@ -220,8 +386,34 @@ API_BASE_URL=http://remote-api:8080 uv run orionbelt-ui       # point UI to a re
 An ontology-based MCP server that analyzes relational database schemas and generates RDF/OWL ontologies. Together with OrionBelt Semantic Layer, it enables AI assistants to navigate your data landscape through ontologies and compile safe, dialect-aware analytical SQL.
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/ralfbecher/orionbelt-semantic-layer/main/docs/assets/architecture.png" alt="OrionBelt Analytics Architecture" width="800">
+  <img src="https://raw.githubusercontent.com/ralfbecher/orionbelt-semantic-layer/main/docs/assets/architecture.png" alt="Architecture diagram showing OrionBelt Analytics generating ontologies from database schemas, feeding into OrionBelt Semantic Layer for SQL compilation" width="800">
 </p>
+
+---
+
+## Development
+
+Contributing to OrionBelt or running from source:
+
+```bash
+git clone https://github.com/ralfbecher/orionbelt-semantic-layer.git
+cd orionbelt-semantic-layer
+uv sync                           # install all deps (dev, docs, ui, flight, drivers)
+uv run orionbelt-api              # start API on :8000
+```
+
+```bash
+# Quality
+uv run pytest                     # run tests
+uv run ruff check src/            # lint
+uv run ruff format src/ tests/    # format
+uv run mypy src/                  # type check
+
+# Docs
+uv sync --extra docs && uv run mkdocs serve  # docs on :8080
+```
+
+---
 
 ## License
 


### PR DESCRIPTION
## Summary
- Reorder README so fastest paths come first: Live Demo → pip install → Docker → from-source (moved to Development section at bottom)
- Add "Why OrionBelt?" comparison table (vs dbt, Cube, Malloy)
- Add Table of Contents, MCP/Claude Desktop quick-start, Status & Roadmap section
- Restructure Features into 4 categories (Semantic Modeling, SQL Compilation, Integration Surface, Developer Experience)
- Add Companion Project callout near the top
- Improve alt text on images, collapse generated SQL under `<details>`, add `yaml-language-server` schema comment

## Test plan
- [ ] Verify README renders correctly on GitHub (badges, TOC links, details/summary, code fences)
- [ ] Confirm all links resolve (Live Demo, docs site, MCP repo, Docker Hub)

🤖 Generated with [Claude Code](https://claude.com/claude-code)