### PR TITLE
feat(query): add raw mode (select.fields, select.distinct)

### DIFF
--- a/docs/guide/query-language.md
+++ b/docs/guide/query-language.md
@@ -123,6 +123,61 @@ select:
     - Revenue per Order    # metric
 ```
 
+## Raw Mode (`select.fields`)
+
+**Raw mode** returns un-aggregated rows from one or more data objects, projecting physical columns directly. It is the right choice when you need detail rows rather than aggregated metrics — e.g., exporting a transaction list, building a row-level export, or feeding a downstream tool that does its own aggregation.
+
+```yaml
+select:
+  fields:
+    - Customers.Country
+    - Orders.Order ID
+    - Orders.Amount
+  distinct: false
+where:
+  - field: Orders.Amount
+    op: gt
+    value: 100
+order_by:
+  - field: Orders.Amount
+    direction: desc
+limit: 100
+```
+
+Compiles to a flat `SELECT field1, field2, ... FROM base [LEFT JOIN ...] [WHERE ...] [ORDER BY ...] [LIMIT n]` — no `GROUP BY`, no aggregates.
+
+### Field references
+
+Each entry in `fields` is a qualified `DataObject.Column` reference to a physical column in the model. Logical dimension/measure names are **not** accepted in raw mode — use `dimensions` / `measures` for those.
+
+The output column is aliased to the original `"DataObject.Column"` reference so result rows are self-describing.
+
+### `distinct`
+
+Set `select.distinct: true` to emit `SELECT DISTINCT`, deduplicating rows after projection. Outside raw mode this flag is rejected.
+
+### What's excluded in raw mode
+
+Raw mode is mutually exclusive with aggregate features. The following are rejected at validation time:
+
+- `select.dimensions`
+- `select.measures`
+- `having` (HAVING references measures, which raw mode doesn't have)
+- `dimensionsExclude`
+
+### Filters and ordering in raw mode
+
+- **WHERE**: same operators as aggregate mode. Filter fields can reference a dimension name (resolved to its physical column) or a qualified `DataObject.Column`.
+- **ORDER BY**: must reference a `DataObject.Column` alias from `select.fields`, or a 1-based numeric position.
+
+### Joins and fanout
+
+Raw mode reuses the model's directed join graph: when fields span multiple data objects connected by many-to-one joins, the planner walks the graph and emits the necessary `LEFT JOIN`s. Fanout protection still applies — reversed many-to-one joins (which would multiply rows on the "one" side) are rejected.
+
+### Multi-fact raw queries (not yet supported)
+
+If `select.fields` references columns from independent fact tables (i.e. fact tables that share a common dimension but are not connected to each other via directed joins), the request is rejected with `RAW_MODE_MULTI_FACT_NOT_SUPPORTED`. Until raw-mode CFL lands, split such queries so each fact is queried separately.
+
 ## Secondary Join Paths
 
 When a model defines secondary joins (e.g., `Flights` → `Airports` via departure and arrival), use `usePathNames` to select which join path to use:

--- a/schema/query-schema.json
+++ b/schema/query-schema.json
@@ -91,11 +91,11 @@
     },
     "queryOrderBy": {
       "type": "object",
-      "description": "Order-by clause. Field must reference a dimension or measure in the query's SELECT, or a numeric position (1-based).",
+      "description": "Order-by clause. In aggregate mode the field must reference a dimension or measure in the query's SELECT; in raw mode it must reference a 'DataObject.Column' alias from select.fields. Numeric positions (1-based) are accepted in both modes.",
       "properties": {
         "field": {
           "type": "string",
-          "description": "Dimension or measure name from the query's SELECT, or a numeric position (e.g. \"1\")"
+          "description": "Aggregate mode: dimension/measure name. Raw mode: 'DataObject.Column' alias from select.fields. Either: numeric position (e.g. \"1\")."
         },
         "direction": {
           "$ref": "#/definitions/sortDirection",
@@ -107,11 +107,11 @@
     },
     "querySelect": {
       "type": "object",
-      "description": "The SELECT part: dimensions and measures to retrieve",
+      "description": "The SELECT part. Two mutually exclusive modes: aggregate mode uses 'dimensions' + 'measures' (GROUP BY + aggregates); raw mode uses 'fields' for un-aggregated row-level projection of physical columns. 'distinct' is only valid in raw mode and 'having' is rejected in raw mode.",
       "properties": {
         "dimensions": {
           "type": "array",
-          "description": "List of dimension names (string) or coalesce groups. Use 'name:grain' notation for time grain (e.g. 'Order Date:month').",
+          "description": "Aggregate mode. List of dimension names (string) or coalesce groups. Use 'name:grain' notation for time grain (e.g. 'Order Date:month'). Mutually exclusive with 'fields'.",
           "items": {
             "oneOf": [
               { "type": "string" },
@@ -121,10 +121,23 @@
         },
         "measures": {
           "type": "array",
-          "description": "List of measure or metric names",
+          "description": "Aggregate mode. List of measure or metric names. Mutually exclusive with 'fields'.",
           "items": {
             "type": "string"
           }
+        },
+        "fields": {
+          "type": "array",
+          "description": "Raw mode. List of qualified physical-column references in 'DataObject.Column' form. Returns un-aggregated rows; no GROUP BY is emitted. Mutually exclusive with 'dimensions', 'measures', and 'having'.",
+          "items": {
+            "type": "string",
+            "pattern": "^[^.]+\\.[^.]+$"
+          }
+        },
+        "distinct": {
+          "type": "boolean",
+          "description": "Raw mode only. Emit SELECT DISTINCT to deduplicate rows. Ignored (and rejected) in aggregate mode.",
+          "default": false
         }
       },
       "additionalProperties": false

--- a/src/orionbelt/api/routers/sessions.py
+++ b/src/orionbelt/api/routers/sessions.py
@@ -38,6 +38,7 @@ from orionbelt.api.schemas import (
     ValidateResponse,
 )
 from orionbelt.compiler.fanout import FanoutError
+from orionbelt.compiler.pipeline import RawModeUnsupportedError
 from orionbelt.compiler.resolution import ResolutionError
 from orionbelt.compiler.validator import format_sql
 from orionbelt.dialect.base import UnsupportedAggregationError
@@ -332,6 +333,16 @@ async def compile_query(
             status_code=422,
             detail={"error": "Query fanout detected", "message": exc.message},
         ) from None
+    except RawModeUnsupportedError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "error": "Raw-mode query not supported",
+                "errors": [
+                    {"code": e.code, "message": e.message, "path": e.path} for e in exc.errors
+                ],
+            },
+        ) from None
     except UnsupportedAggregationError as exc:
         raise HTTPException(
             status_code=422,
@@ -525,6 +536,16 @@ async def execute_query(
         raise HTTPException(
             status_code=422,
             detail={"error": "Query fanout detected", "message": exc.message},
+        ) from None
+    except RawModeUnsupportedError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "error": "Raw-mode query not supported",
+                "errors": [
+                    {"code": e.code, "message": e.message, "path": e.path} for e in exc.errors
+                ],
+            },
         ) from None
     except UnsupportedAggregationError as exc:
         raise HTTPException(

--- a/src/orionbelt/api/routers/shortcuts.py
+++ b/src/orionbelt/api/routers/shortcuts.py
@@ -48,6 +48,7 @@ from orionbelt.api.schemas import (
     ValidateResponse,
 )
 from orionbelt.compiler.fanout import FanoutError
+from orionbelt.compiler.pipeline import RawModeUnsupportedError
 from orionbelt.compiler.resolution import ResolutionError
 from orionbelt.compiler.validator import format_sql
 from orionbelt.dialect.base import UnsupportedAggregationError
@@ -402,6 +403,16 @@ async def shortcut_compile_query(
             status_code=422,
             detail={"error": "Query fanout detected", "message": exc.message},
         ) from None
+    except RawModeUnsupportedError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "error": "Raw-mode query not supported",
+                "errors": [
+                    {"code": e.code, "message": e.message, "path": e.path} for e in exc.errors
+                ],
+            },
+        ) from None
     except UnsupportedAggregationError as exc:
         raise HTTPException(
             status_code=422,
@@ -515,6 +526,16 @@ async def shortcut_execute_query(
         raise HTTPException(
             status_code=422,
             detail={"error": "Query fanout detected", "message": exc.message},
+        ) from None
+    except RawModeUnsupportedError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "error": "Raw-mode query not supported",
+                "errors": [
+                    {"code": e.code, "message": e.message, "path": e.path} for e in exc.errors
+                ],
+            },
         ) from None
     except UnsupportedAggregationError as exc:
         raise HTTPException(

--- a/src/orionbelt/ast/builder.py
+++ b/src/orionbelt/ast/builder.py
@@ -34,6 +34,7 @@ class QueryBuilder:
         self._limit: int | None = None
         self._offset: int | None = None
         self._ctes: list[CTE] = []
+        self._distinct: bool = False
 
     def select(self, *columns: Expr) -> Self:
         self._columns.extend(columns)
@@ -95,6 +96,10 @@ class QueryBuilder:
         self._ctes.append(CTE(name=name, query=query))
         return self
 
+    def distinct(self, value: bool = True) -> Self:
+        self._distinct = value
+        return self
+
     def build(self) -> Select:
         return Select(
             columns=self._columns,
@@ -107,6 +112,7 @@ class QueryBuilder:
             limit=self._limit,
             offset=self._offset,
             ctes=self._ctes,
+            distinct=self._distinct,
         )
 
 

--- a/src/orionbelt/ast/nodes.py
+++ b/src/orionbelt/ast/nodes.py
@@ -254,6 +254,7 @@ class Select:
     limit: int | None = None
     offset: int | None = None
     ctes: list[CTE] = field(default_factory=list)
+    distinct: bool = False
 
 
 @dataclass(frozen=True)

--- a/src/orionbelt/compiler/pipeline.py
+++ b/src/orionbelt/compiler/pipeline.py
@@ -10,13 +10,23 @@ from orionbelt.compiler.cumulative_wrap import wrap_with_cumulative
 from orionbelt.compiler.fanout import detect_fanout
 from orionbelt.compiler.filter_wrap import wrap_with_filter_context
 from orionbelt.compiler.pop_wrap import wrap_with_pop
+from orionbelt.compiler.raw import RawPlanner
 from orionbelt.compiler.resolution import QueryResolver, ResolvedQuery
 from orionbelt.compiler.star import QueryPlan, StarSchemaPlanner
 from orionbelt.compiler.total_wrap import wrap_with_totals
 from orionbelt.compiler.validator import validate_sql
 from orionbelt.dialect.registry import DialectRegistry
+from orionbelt.models.errors import SemanticError
 from orionbelt.models.query import QueryObject
 from orionbelt.models.semantic import SemanticModel
+
+
+class RawModeUnsupportedError(Exception):
+    """Raised when a raw-mode query needs CFL (multi-fact union); not yet supported."""
+
+    def __init__(self, errors: list[SemanticError]) -> None:
+        self.errors = errors
+        super().__init__("; ".join(e.message for e in errors))
 
 
 @dataclass
@@ -87,6 +97,7 @@ class CompilationPipeline:
         self._resolver = QueryResolver()
         self._star_planner = StarSchemaPlanner()
         self._cfl_planner = CFLPlanner()
+        self._raw_planner = RawPlanner()
 
     def compile(
         self,
@@ -98,6 +109,22 @@ class CompilationPipeline:
         # Phase 1: Resolution
         resolved = self._resolver.resolve(query, model)
 
+        # Raw mode: reject multi-fact queries — raw CFL is a planned follow-up.
+        if resolved.is_raw and resolved.requires_cfl:
+            raise RawModeUnsupportedError(
+                [
+                    SemanticError(
+                        code="RAW_MODE_MULTI_FACT_NOT_SUPPORTED",
+                        message=(
+                            "Raw mode does not yet support fields spanning independent "
+                            "fact tables (would require UNION ALL with NULL padding). "
+                            "Split the query so each fact is queried separately."
+                        ),
+                        path="select.fields",
+                    )
+                ]
+            )
+
         # Phase 1.5: Fanout detection (skip for CFL — each fact queried independently)
         if not resolved.requires_cfl:
             detect_fanout(resolved, model)
@@ -108,9 +135,13 @@ class CompilationPipeline:
             obj.database, obj.schema_name, obj.code
         )
 
-        # Phase 2: Planning (star schema or CFL)
+        # Phase 2: Planning (raw / star schema / CFL)
         use_cfl = resolved.requires_cfl or resolved.dimensions_exclude
-        if use_cfl:
+        if resolved.is_raw:
+            plan = self._raw_planner.plan(
+                resolved, model, qualify_table=qualify_table, dialect=dialect
+            )
+        elif use_cfl:
             plan = self._cfl_planner.plan(
                 resolved,
                 model,
@@ -123,26 +154,34 @@ class CompilationPipeline:
                 resolved, model, qualify_table=qualify_table, dialect=dialect
             )
 
-        # Phase 2.3: Wrap with filter context CTEs if needed
-        wrapped_ast = wrap_with_filter_context(plan.ast, resolved, model, dialect, qualify_table)
-
-        # Phase 2.4: Wrap with PoP CTEs if needed
-        wrapped_ast = wrap_with_pop(wrapped_ast, resolved, model, dialect, qualify_table)
-
-        # Phase 2.5: Wrap with totals CTE if needed
-        # Skip totals wrap when PoP or cumulative is active — the combination
-        # produces invalid SQL because totals rewrites the AST structure that
-        # PoP/cumulative wrappers depend on.
-        if resolved.has_totals and (resolved.has_pop or resolved.has_cumulative):
-            resolved.warnings.append(
-                "total=True measures are ignored when combined with "
-                "period-over-period or cumulative metrics in the same query"
-            )
+        # Phase 2.3 – 2.6: Aggregate-mode wrappers (filter context, PoP,
+        # totals, cumulative). Raw mode has no measures, so these are no-ops
+        # and skipped entirely for clarity.
+        if resolved.is_raw:
+            wrapped_ast = plan.ast
         else:
-            wrapped_ast = wrap_with_totals(wrapped_ast, resolved)
+            # Wrap with filter context CTEs if needed
+            wrapped_ast = wrap_with_filter_context(
+                plan.ast, resolved, model, dialect, qualify_table
+            )
 
-        # Phase 2.6: Wrap with cumulative CTE if needed
-        wrapped_ast = wrap_with_cumulative(wrapped_ast, resolved)
+            # Wrap with PoP CTEs if needed
+            wrapped_ast = wrap_with_pop(wrapped_ast, resolved, model, dialect, qualify_table)
+
+            # Wrap with totals CTE if needed
+            # Skip totals wrap when PoP or cumulative is active — the combination
+            # produces invalid SQL because totals rewrites the AST structure that
+            # PoP/cumulative wrappers depend on.
+            if resolved.has_totals and (resolved.has_pop or resolved.has_cumulative):
+                resolved.warnings.append(
+                    "total=True measures are ignored when combined with "
+                    "period-over-period or cumulative metrics in the same query"
+                )
+            else:
+                wrapped_ast = wrap_with_totals(wrapped_ast, resolved)
+
+            # Wrap with cumulative CTE if needed
+            wrapped_ast = wrap_with_cumulative(wrapped_ast, resolved)
 
         # Phase 3: Dialect-specific SQL rendering
         codegen = CodeGenerator(dialect)
@@ -187,7 +226,14 @@ class CompilationPipeline:
         q = self._q
 
         # Planner choice
-        if use_cfl:
+        if resolved.is_raw:
+            planner = "Raw"
+            distinct_note = " with DISTINCT" if resolved.distinct else ""
+            planner_reason = (
+                f"Raw-mode projection of physical columns{distinct_note} — "
+                f"no aggregation, no GROUP BY"
+            )
+        elif use_cfl:
             if resolved.dimensions_exclude:
                 planner = "CFL"
                 planner_reason = (

--- a/src/orionbelt/compiler/raw.py
+++ b/src/orionbelt/compiler/raw.py
@@ -1,0 +1,97 @@
+"""Raw-mode planner: project physical columns without aggregation."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+from orionbelt.ast.builder import QueryBuilder
+from orionbelt.ast.nodes import AliasedExpr, ColumnRef
+from orionbelt.compiler.graph import JoinGraph
+from orionbelt.compiler.resolution import ResolvedQuery
+from orionbelt.compiler.star import QueryPlan
+from orionbelt.models.semantic import DataObject, SemanticModel
+
+if TYPE_CHECKING:
+    from orionbelt.dialect.base import Dialect
+
+
+class RawPlanner:
+    """Plans raw-mode queries: flat projection of physical columns.
+
+    Emits ``SELECT [DISTINCT] field1, field2, ... FROM base [LEFT JOIN ...]
+    [WHERE ...] [ORDER BY ...] [LIMIT n]`` with no GROUP BY and no aggregates.
+    Multi-fact queries (fields spanning independent fact tables) are rejected
+    by the pipeline; raw CFL is a planned follow-up.
+    """
+
+    def plan(
+        self,
+        resolved: ResolvedQuery,
+        model: SemanticModel,
+        qualify_table: Callable[[DataObject], str] | None = None,
+        dialect: Dialect | None = None,  # noqa: ARG002 — kept for parity with other planners
+    ) -> QueryPlan:
+        builder = QueryBuilder()
+        graph = JoinGraph(model, use_path_names=resolved.use_path_names or None)
+
+        def qualify(obj: DataObject) -> str:
+            return qualify_table(obj) if qualify_table else obj.qualified_code
+
+        base_object = model.data_objects.get(resolved.base_object)
+        if not base_object:
+            return QueryPlan(ast=builder.build())
+
+        base_alias = resolved.base_object
+
+        # SELECT — one aliased ColumnRef per field, in declaration order.
+        for f in resolved.fields:
+            builder.select(
+                AliasedExpr(
+                    expr=ColumnRef(name=f.source_column, table=f.object_name),
+                    alias=f.alias,
+                )
+            )
+
+        if resolved.distinct:
+            builder.distinct(True)
+
+        # FROM
+        builder.from_(qualify(base_object), alias=base_alias)
+
+        # JOINs (same logic as star schema; raw mode reuses join_steps).
+        joined = {base_alias}
+        for step in resolved.join_steps:
+            if step.to_object not in joined:
+                new_object = step.to_object
+            elif step.from_object not in joined:
+                new_object = step.from_object
+            else:
+                continue
+            obj = model.data_objects.get(new_object)
+            if not obj:
+                continue
+            on_expr = graph.build_join_condition(step)
+            builder.join(
+                table=qualify(obj),
+                on=on_expr,
+                join_type=step.join_type,
+                alias=new_object,
+            )
+            joined.add(new_object)
+
+        # WHERE
+        for wf in resolved.where_filters:
+            builder.where(wf.expression)
+
+        # ORDER BY
+        for expr, desc in resolved.order_by_exprs:
+            builder.order_by(expr, desc=desc)
+
+        # LIMIT / OFFSET
+        if resolved.limit is not None:
+            builder.limit(resolved.limit)
+        if resolved.offset is not None:
+            builder.offset(resolved.offset)
+
+        return QueryPlan(ast=builder.build())

--- a/src/orionbelt/compiler/resolution.py
+++ b/src/orionbelt/compiler/resolution.py
@@ -53,6 +53,22 @@ from orionbelt.models.semantic import (
 
 
 @dataclass
+class ResolvedField:
+    """A resolved raw-mode field reference: ``DataObject.Column`` → physical column.
+
+    Raw mode (``select.fields``) bypasses the semantic dimension/measure layer
+    and projects physical columns directly. The ``alias`` defaults to the
+    original ``"DataObject.Column"`` reference so result columns are
+    self-describing.
+    """
+
+    object_name: str  # logical data object name (table alias)
+    column_name: str  # logical column name
+    source_column: str  # physical column name in the source table
+    alias: str  # output column name (defaults to "object_name.column_name")
+
+
+@dataclass
 class ResolvedDimension:
     """A resolved dimension with its physical column reference."""
 
@@ -112,6 +128,9 @@ class ResolvedQuery:
 
     dimensions: list[ResolvedDimension] = field(default_factory=list)
     measures: list[ResolvedMeasure] = field(default_factory=list)
+    fields: list[ResolvedField] = field(default_factory=list)
+    is_raw: bool = False
+    distinct: bool = False
     base_object: str = ""
     required_objects: set[str] = field(default_factory=set)
     join_steps: list[JoinStep] = field(default_factory=list)
@@ -209,6 +228,8 @@ class QueryResolver:
                 limit=query.limit,
                 offset=query.offset,
                 use_path_names=list(query.use_path_names),
+                is_raw=query.select.is_raw,
+                distinct=query.select.distinct,
             ),
         )
 
@@ -217,24 +238,30 @@ class QueryResolver:
             for col_name, col_obj in obj.columns.items():
                 ctx.global_columns[col_name] = (obj_name, col_obj.code)
 
-        # 1. Resolve dimensions (string or coalesce group).
-        # Coalesce groups expand into their constituent dimensions, each
-        # tagged with the same coalesce_alias so the CFL outer wrapper can
-        # emit COALESCE(d1, d2, ...) AS <alias>.
-        for dim_entry in query.select.dimensions:
-            if isinstance(dim_entry, CoalesceDimension):
-                self._resolve_coalesce_dimension(ctx, dim_entry, ctx.result.coalesce_aliases)
-            else:
-                self._append_resolved_dimension(ctx, dim_entry)
+        if query.select.is_raw:
+            # Raw mode: project physical columns, no aggregation.
+            for ref in query.select.fields:
+                self._resolve_raw_field(ctx, ref)
+        else:
+            # Aggregate mode (default).
+            # 1. Resolve dimensions (string or coalesce group).
+            # Coalesce groups expand into their constituent dimensions, each
+            # tagged with the same coalesce_alias so the CFL outer wrapper can
+            # emit COALESCE(d1, d2, ...) AS <alias>.
+            for dim_entry in query.select.dimensions:
+                if isinstance(dim_entry, CoalesceDimension):
+                    self._resolve_coalesce_dimension(ctx, dim_entry, ctx.result.coalesce_aliases)
+                else:
+                    self._append_resolved_dimension(ctx, dim_entry)
 
-        # 2. Resolve measures and track their source objects
-        for measure_name in query.select.measures:
-            resolved_meas = self._resolve_measure(ctx, measure_name)
-            if resolved_meas:
-                ctx.result.measures.append(resolved_meas)
-                source_objs = self._get_measure_source_objects(ctx, measure_name)
-                ctx.result.measure_source_objects.update(source_objs)
-                ctx.result.required_objects.update(source_objs)
+            # 2. Resolve measures and track their source objects
+            for measure_name in query.select.measures:
+                resolved_meas = self._resolve_measure(ctx, measure_name)
+                if resolved_meas:
+                    ctx.result.measures.append(resolved_meas)
+                    source_objs = self._get_measure_source_objects(ctx, measure_name)
+                    ctx.result.measure_source_objects.update(source_objs)
+                    ctx.result.required_objects.update(source_objs)
 
         # 3. Determine base object (the one with most joins / most measures)
         ctx.result.base_object = self._select_base_object(ctx)
@@ -266,6 +293,18 @@ class QueryResolver:
                 for step in steps:
                     ctx.result.required_objects.add(step.from_object)
                     ctx.result.required_objects.add(step.to_object)
+
+        # Raw mode: detect multi-fact (fields span objects unreachable from
+        # the base via directed joins). The pipeline rejects this case for
+        # now — raw CFL is a planned follow-up.
+        if ctx.result.is_raw and ctx.result.base_object:
+            field_objects = {f.object_name for f in ctx.result.fields}
+            if len(field_objects) > 1:
+                graph = JoinGraph(model, use_path_names=query.use_path_names or None)
+                reachable = graph.descendants(ctx.result.base_object)
+                unreachable = field_objects - reachable - {ctx.result.base_object}
+                if unreachable:
+                    ctx.result.requires_cfl = True
 
         # Validate dimensionsExclude constraints
         if query.dimensions_exclude:
@@ -360,6 +399,62 @@ class QueryResolver:
             raise ResolutionError(ctx.errors)
 
         return ctx.result
+
+    # -- raw mode fields -----------------------------------------------------
+
+    def _resolve_raw_field(self, ctx: _ResolutionContext, ref: str) -> None:
+        """Resolve a ``DataObject.Column`` reference for raw-mode projection.
+
+        Errors are accumulated in the resolution context (raised at the end).
+        """
+        if "." not in ref:
+            ctx.errors.append(
+                SemanticError(
+                    code="RAW_FIELD_INVALID_REF",
+                    message=(
+                        f"Raw-mode field '{ref}' must be a qualified 'DataObject.Column' reference"
+                    ),
+                    path="select.fields",
+                )
+            )
+            return
+
+        obj_name, col_name = ref.split(".", 1)
+        obj_name = obj_name.strip()
+        col_name = col_name.strip()
+        obj = ctx.model.data_objects.get(obj_name)
+        if obj is None:
+            ctx.errors.append(
+                SemanticError(
+                    code="RAW_FIELD_UNKNOWN_OBJECT",
+                    message=f"Raw-mode field '{ref}' references unknown data object '{obj_name}'",
+                    path="select.fields",
+                )
+            )
+            return
+        column = obj.columns.get(col_name)
+        if column is None:
+            ctx.errors.append(
+                SemanticError(
+                    code="RAW_FIELD_UNKNOWN_COLUMN",
+                    message=(
+                        f"Raw-mode field '{ref}' references unknown column "
+                        f"'{col_name}' on data object '{obj_name}'"
+                    ),
+                    path="select.fields",
+                )
+            )
+            return
+
+        ctx.result.fields.append(
+            ResolvedField(
+                object_name=obj_name,
+                column_name=col_name,
+                source_column=column.code,
+                alias=ref,
+            )
+        )
+        ctx.result.required_objects.add(obj_name)
 
     # -- dimensions ----------------------------------------------------------
 
@@ -1206,6 +1301,11 @@ class QueryResolver:
         for meas in ctx.result.measures:
             if meas.name == field_name:
                 return meas.expression
+
+        # Raw mode: order by the field's "DataObject.Column" alias.
+        for f in ctx.result.fields:
+            if f.alias == field_name:
+                return ColumnRef(name=f.source_column, table=f.object_name)
 
         if field_name.isdigit():
             pos = int(field_name)

--- a/src/orionbelt/dialect/base.py
+++ b/src/orionbelt/dialect/base.py
@@ -278,11 +278,12 @@ class Dialect(ABC):
             parts.append("WITH " + ",\n".join(cte_parts))
 
         # SELECT
+        keyword = "SELECT DISTINCT" if node.distinct else "SELECT"
         if node.columns:
             cols = ", ".join(self.compile_expr(c) for c in node.columns)
-            parts.append(f"SELECT {cols}")
+            parts.append(f"{keyword} {cols}")
         else:
-            parts.append("SELECT *")
+            parts.append(f"{keyword} *")
 
         # FROM
         if node.from_:

--- a/src/orionbelt/models/query.py
+++ b/src/orionbelt/models/query.py
@@ -6,7 +6,7 @@ from datetime import date, datetime
 from enum import StrEnum
 from typing import Any
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from orionbelt.models.semantic import FilterLogic, TimeGrain
 
@@ -147,10 +147,27 @@ class CoalesceDimension(BaseModel):
 
 
 class QuerySelect(BaseModel):
-    """The SELECT part of a query: dimensions + measures."""
+    """The SELECT part of a query.
+
+    Two mutually exclusive modes:
+
+    * **Aggregate mode** (default): ``dimensions`` + ``measures`` produce a
+      grouped, aggregated result (GROUP BY dimensions, aggregate measures).
+    * **Raw mode**: ``fields`` returns un-aggregated rows from one or more
+      data objects joined per the model. Set ``distinct: true`` for
+      ``SELECT DISTINCT``. Raw mode rejects ``dimensions``, ``measures``,
+      ``metrics``, and ``HAVING``.
+    """
 
     dimensions: list[str | CoalesceDimension] = []
     measures: list[str] = []
+    fields: list[str] = []
+    distinct: bool = False
+
+    @property
+    def is_raw(self) -> bool:
+        """True when this select is in raw mode (fields-based projection)."""
+        return bool(self.fields)
 
 
 class UsePathName(BaseModel):
@@ -176,3 +193,25 @@ class QueryObject(BaseModel):
     dimensions_exclude: bool = Field(False, alias="dimensionsExclude")
 
     model_config = {"populate_by_name": True}
+
+    @model_validator(mode="after")
+    def _validate_raw_mode_exclusivity(self) -> QueryObject:
+        """Raw mode (``select.fields``) is mutually exclusive with aggregate
+        features. Catch misuse early so the resolver can assume a clean shape.
+        """
+        if self.select.is_raw:
+            if self.select.dimensions:
+                raise ValueError(
+                    "select.fields (raw mode) cannot be combined with select.dimensions"
+                )
+            if self.select.measures:
+                raise ValueError("select.fields (raw mode) cannot be combined with select.measures")
+            if self.having:
+                raise ValueError("select.fields (raw mode) cannot be combined with having")
+            if self.dimensions_exclude:
+                raise ValueError(
+                    "select.fields (raw mode) cannot be combined with dimensionsExclude"
+                )
+        elif self.select.distinct:
+            raise ValueError("select.distinct is only valid in raw mode (with select.fields)")
+        return self

--- a/tests/unit/test_raw_mode.py
+++ b/tests/unit/test_raw_mode.py
@@ -1,0 +1,350 @@
+"""Tests for raw query mode (`select.fields`)."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+# Make sure all dialects are registered
+import orionbelt.dialect  # noqa: F401
+from orionbelt.compiler.pipeline import CompilationPipeline, RawModeUnsupportedError
+from orionbelt.compiler.resolution import QueryResolver, ResolutionError
+from orionbelt.dialect.registry import DialectRegistry
+from orionbelt.models.query import (
+    FilterOperator,
+    QueryFilter,
+    QueryObject,
+    QueryOrderBy,
+    QuerySelect,
+    SortDirection,
+)
+from orionbelt.models.semantic import SemanticModel
+from orionbelt.parser.loader import TrackedLoader
+from orionbelt.parser.resolver import ReferenceResolver
+from tests.conftest import SAMPLE_MODEL_YAML
+
+
+def _load_model(yaml_content: str = SAMPLE_MODEL_YAML) -> SemanticModel:
+    loader = TrackedLoader()
+    resolver = ReferenceResolver()
+    raw, source_map = loader.load_string(yaml_content)
+    model, result = resolver.resolve(raw, source_map)
+    assert result.valid, f"Model errors: {[e.message for e in result.errors]}"
+    return model
+
+
+# ---------------------------------------------------------------------------
+# QueryObject validation
+# ---------------------------------------------------------------------------
+
+
+class TestQueryObjectValidation:
+    def test_raw_mode_with_dimensions_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="cannot be combined with select.dimensions"):
+            QueryObject(
+                select=QuerySelect(
+                    fields=["Customers.Country"],
+                    dimensions=["Customer Country"],
+                ),
+            )
+
+    def test_raw_mode_with_measures_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="cannot be combined with select.measures"):
+            QueryObject(
+                select=QuerySelect(
+                    fields=["Orders.Amount"],
+                    measures=["Total Revenue"],
+                ),
+            )
+
+    def test_raw_mode_with_having_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="cannot be combined with having"):
+            QueryObject(
+                select=QuerySelect(fields=["Orders.Amount"]),
+                having=[QueryFilter(field="Total Revenue", op=FilterOperator.GT, value=0)],
+            )
+
+    def test_raw_mode_with_dimensions_exclude_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="cannot be combined with dimensionsExclude"):
+            QueryObject(
+                select=QuerySelect(fields=["Customers.Country"]),
+                dimensions_exclude=True,
+            )
+
+    def test_distinct_without_fields_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="select.distinct is only valid in raw mode"):
+            QueryObject(
+                select=QuerySelect(
+                    dimensions=["Customer Country"],
+                    measures=["Total Revenue"],
+                    distinct=True,
+                ),
+            )
+
+    def test_is_raw_property(self) -> None:
+        agg = QuerySelect(dimensions=["Customer Country"], measures=["Total Revenue"])
+        raw = QuerySelect(fields=["Customers.Country"])
+        assert agg.is_raw is False
+        assert raw.is_raw is True
+
+
+# ---------------------------------------------------------------------------
+# Resolver
+# ---------------------------------------------------------------------------
+
+
+class TestRawModeResolver:
+    def test_resolves_qualified_field(self) -> None:
+        model = _load_model()
+        query = QueryObject(select=QuerySelect(fields=["Customers.Country"]))
+        resolved = QueryResolver().resolve(query, model)
+        assert resolved.is_raw is True
+        assert len(resolved.fields) == 1
+        f = resolved.fields[0]
+        assert f.object_name == "Customers"
+        assert f.column_name == "Country"
+        assert f.source_column == "COUNTRY"
+        assert f.alias == "Customers.Country"
+
+    def test_resolves_multiple_fields_across_joined_objects(self) -> None:
+        model = _load_model()
+        query = QueryObject(
+            select=QuerySelect(
+                fields=[
+                    "Customers.Country",
+                    "Orders.Order ID",
+                    "Orders.Amount",
+                ]
+            ),
+        )
+        resolved = QueryResolver().resolve(query, model)
+        assert resolved.is_raw is True
+        # Orders → Customers is m:1, so Orders is the base (most joins)
+        assert resolved.base_object == "Orders"
+        assert {"Customers", "Orders"} <= resolved.required_objects
+        assert len(resolved.join_steps) == 1
+
+    def test_distinct_propagates(self) -> None:
+        model = _load_model()
+        query = QueryObject(
+            select=QuerySelect(fields=["Customers.Country"], distinct=True),
+        )
+        resolved = QueryResolver().resolve(query, model)
+        assert resolved.distinct is True
+
+    def test_unknown_object_errors(self) -> None:
+        model = _load_model()
+        query = QueryObject(select=QuerySelect(fields=["Bogus.Country"]))
+        with pytest.raises(ResolutionError) as exc_info:
+            QueryResolver().resolve(query, model)
+        codes = [e.code for e in exc_info.value.errors]
+        assert "RAW_FIELD_UNKNOWN_OBJECT" in codes
+
+    def test_unknown_column_errors(self) -> None:
+        model = _load_model()
+        query = QueryObject(select=QuerySelect(fields=["Customers.Bogus"]))
+        with pytest.raises(ResolutionError) as exc_info:
+            QueryResolver().resolve(query, model)
+        codes = [e.code for e in exc_info.value.errors]
+        assert "RAW_FIELD_UNKNOWN_COLUMN" in codes
+
+    def test_invalid_ref_format_errors(self) -> None:
+        model = _load_model()
+        query = QueryObject(select=QuerySelect(fields=["Country"]))
+        with pytest.raises(ResolutionError) as exc_info:
+            QueryResolver().resolve(query, model)
+        codes = [e.code for e in exc_info.value.errors]
+        assert "RAW_FIELD_INVALID_REF" in codes
+
+
+# ---------------------------------------------------------------------------
+# End-to-end SQL generation
+# ---------------------------------------------------------------------------
+
+
+class TestRawModeCompilation:
+    def test_single_object_single_field(self) -> None:
+        model = _load_model()
+        query = QueryObject(select=QuerySelect(fields=["Customers.Country"]))
+        result = CompilationPipeline().compile(query, model, dialect_name="postgres")
+        sql = result.sql
+        assert "GROUP BY" not in sql
+        assert "DISTINCT" not in sql
+        assert '"Customers"."COUNTRY"' in sql
+        assert 'AS "Customers.Country"' in sql
+
+    def test_distinct_emits_select_distinct(self) -> None:
+        model = _load_model()
+        query = QueryObject(
+            select=QuerySelect(fields=["Customers.Country"], distinct=True),
+        )
+        sql = CompilationPipeline().compile(query, model, dialect_name="postgres").sql
+        assert "SELECT DISTINCT" in sql
+
+    def test_join_across_objects(self) -> None:
+        model = _load_model()
+        query = QueryObject(
+            select=QuerySelect(
+                fields=["Customers.Country", "Orders.Order ID", "Orders.Amount"],
+            ),
+        )
+        sql = CompilationPipeline().compile(query, model, dialect_name="postgres").sql
+        assert "GROUP BY" not in sql
+        assert "LEFT JOIN" in sql
+        assert '"Customers"."COUNTRY"' in sql
+        assert '"Orders"."ORDER_ID"' in sql
+        assert '"Orders"."AMOUNT"' in sql
+
+    def test_where_filter_qualified(self) -> None:
+        model = _load_model()
+        query = QueryObject(
+            select=QuerySelect(fields=["Orders.Order ID", "Orders.Amount"]),
+            where=[
+                QueryFilter(field="Orders.Amount", op=FilterOperator.GT, value=100),
+            ],
+        )
+        sql = CompilationPipeline().compile(query, model, dialect_name="postgres").sql
+        assert "WHERE" in sql
+        assert "> 100" in sql
+
+    def test_where_filter_via_dimension(self) -> None:
+        # Dimension-name filters still work in raw mode (resolved to columns).
+        model = _load_model()
+        query = QueryObject(
+            select=QuerySelect(fields=["Orders.Order ID", "Customers.Country"]),
+            where=[
+                QueryFilter(field="Customer Country", op=FilterOperator.EQ, value="DE"),
+            ],
+        )
+        sql = CompilationPipeline().compile(query, model, dialect_name="postgres").sql
+        assert "WHERE" in sql
+        assert "'DE'" in sql
+
+    def test_order_by_field_alias(self) -> None:
+        model = _load_model()
+        query = QueryObject(
+            select=QuerySelect(fields=["Orders.Order ID", "Orders.Amount"]),
+            order_by=[
+                QueryOrderBy(field="Orders.Amount", direction=SortDirection.DESC),
+            ],
+        )
+        sql = CompilationPipeline().compile(query, model, dialect_name="postgres").sql
+        assert "ORDER BY" in sql
+        assert "DESC" in sql
+
+    def test_limit_propagates(self) -> None:
+        model = _load_model()
+        query = QueryObject(
+            select=QuerySelect(fields=["Customers.Country"]),
+            limit=42,
+        )
+        sql = CompilationPipeline().compile(query, model, dialect_name="postgres").sql
+        assert "LIMIT 42" in sql
+
+    @pytest.mark.parametrize(
+        "dialect_name",
+        [
+            "bigquery",
+            "clickhouse",
+            "databricks",
+            "dremio",
+            "duckdb",
+            "mysql",
+            "postgres",
+            "snowflake",
+        ],
+    )
+    def test_compiles_on_all_dialects(self, dialect_name: str) -> None:
+        model = _load_model()
+        query = QueryObject(
+            select=QuerySelect(fields=["Customers.Country", "Orders.Amount"], distinct=True),
+            limit=5,
+        )
+        result = CompilationPipeline().compile(query, model, dialect_name=dialect_name)
+        sql = result.sql
+        assert "SELECT DISTINCT" in sql
+        assert "GROUP BY" not in sql
+        # Sanity: dialect resolved
+        assert DialectRegistry.get(dialect_name) is not None
+
+    def test_explain_reports_raw_planner(self) -> None:
+        model = _load_model()
+        query = QueryObject(select=QuerySelect(fields=["Customers.Country"], distinct=True))
+        result = CompilationPipeline().compile(query, model, dialect_name="postgres")
+        assert result.explain is not None
+        assert result.explain.planner == "Raw"
+        assert "DISTINCT" in result.explain.planner_reason
+
+
+class TestRawModeMultiFact:
+    """Multi-fact raw queries are rejected for now (raw CFL is a follow-up)."""
+
+    MULTI_FACT_YAML = """\
+version: 1.0
+
+dataObjects:
+  Customers:
+    code: CUSTOMERS
+    columns:
+      Customer ID:
+        code: CUSTOMER_ID
+        abstractType: string
+      Name:
+        code: NAME
+        abstractType: string
+
+  Orders:
+    code: ORDERS
+    columns:
+      Order ID:
+        code: ORDER_ID
+        abstractType: string
+      Order Customer ID:
+        code: CUSTOMER_ID
+        abstractType: string
+      Amount:
+        code: AMOUNT
+        abstractType: float
+    joins:
+      - joinType: many-to-one
+        joinTo: Customers
+        columnsFrom: [Order Customer ID]
+        columnsTo: [Customer ID]
+
+  Returns:
+    code: RETURNS
+    columns:
+      Return ID:
+        code: RETURN_ID
+        abstractType: string
+      Return Customer ID:
+        code: CUSTOMER_ID
+        abstractType: string
+      Refund:
+        code: REFUND
+        abstractType: float
+    joins:
+      - joinType: many-to-one
+        joinTo: Customers
+        columnsFrom: [Return Customer ID]
+        columnsTo: [Customer ID]
+
+dimensions:
+  Customer Name:
+    dataObject: Customers
+    column: Name
+    resultType: string
+"""
+
+    def test_multi_fact_raw_query_rejected(self) -> None:
+        model = _load_model(self.MULTI_FACT_YAML)
+        # Orders and Returns are independent facts — both reverse-reach Customers.
+        query = QueryObject(
+            select=QuerySelect(
+                fields=["Customers.Name", "Orders.Order ID", "Returns.Return ID"],
+            ),
+        )
+        with pytest.raises(RawModeUnsupportedError) as exc_info:
+            CompilationPipeline().compile(query, model, dialect_name="postgres")
+        codes = [e.code for e in exc_info.value.errors]
+        assert "RAW_MODE_MULTI_FACT_NOT_SUPPORTED" in codes


### PR DESCRIPTION
## Summary

Adds **raw mode** to the query language — un-aggregated row-level projection of physical columns. Useful for detail-row exports or any flow where the caller does its own aggregation.

\`\`\`yaml
select:
  fields:
    - Customers.Country
    - Orders.Order ID
    - Orders.Amount
  distinct: false
where:
  - field: Orders.Amount
    op: gt
    value: 100
order_by:
  - field: Orders.Amount
    direction: desc
limit: 100
\`\`\`

Compiles to a flat \`SELECT [DISTINCT] field1, ... FROM base [LEFT JOIN ...] [WHERE ...] [ORDER BY ...] [LIMIT n]\` — no GROUP BY, no aggregates.

## Surface

- \`select.fields\` — qualified \`DataObject.Column\` references only (no dimension/measure names; use aggregate mode for those)
- \`select.distinct\` — emits \`SELECT DISTINCT\`; valid in raw mode only
- WHERE filters: same operator set; accepts \`DataObject.Column\` refs *and* dimension names (resolved to columns)
- ORDER BY: must reference a \`DataObject.Column\` alias from \`select.fields\`, or a 1-based numeric position
- HAVING: rejected
- \`dimensionsExclude\`: rejected

## Pipeline

- \`models/query.py\`: \`Select.fields\`, \`Select.distinct\`, \`model_validator\` enforces mutual exclusivity
- \`ast/nodes.py\` + \`ast/builder.py\` + \`dialect/base.py\`: \`Select.distinct\` → \`SELECT DISTINCT\`
- \`compiler/resolution.py\`: \`ResolvedField\`, raw-mode branch in \`resolve()\`
- \`compiler/raw.py\` *(new)*: \`RawPlanner\` — single-fact flat projection
- \`compiler/pipeline.py\`: routes to \`RawPlanner\`, skips PoP/cumulative/totals/filter-context wraps in raw mode
- \`api/routers/{sessions,shortcuts}.py\`: 422 mapping for \`RawModeUnsupportedError\`
- \`schema/query-schema.json\`: new \`fields\` / \`distinct\` props with mutual-exclusion notes
- \`docs/guide/query-language.md\`: \"Raw Mode\" section

## Fanout / CFL

- Fanout protection still applies — reversed many-to-one joins (which would multiply rows on the \"one\" side) raise \`FanoutError\`
- **Multi-fact raw queries are rejected** for now with \`RAW_MODE_MULTI_FACT_NOT_SUPPORTED\` (would require UNION ALL with NULL padding — implementing this is a non-trivial follow-up). Single-fact raw queries with conformed dimension joins compile fine.

## Tests

- 29 new unit tests in \`tests/unit/test_raw_mode.py\` covering:
  - QueryObject validation (5 mutual-exclusivity cases + \`is_raw\` property)
  - Resolver (qualified field resolution, multi-object joins, distinct propagation, 3 error paths)
  - End-to-end compilation: single-field, distinct, joined fields, qualified WHERE filter, dimension-name WHERE filter, ORDER BY, LIMIT
  - **All 8 dialects** parametrized (bigquery, clickhouse, databricks, dremio, duckdb, mysql, postgres, snowflake)
  - Explain plan reports \`Raw\` planner with DISTINCT note
  - Multi-fact rejection path
- Full suite: **1204 passed**, 51 skipped (was 1175 before)
- \`ruff check\`, \`ruff format\`, \`mypy\` all clean

## Test plan

- [ ] Hit \`POST /v1/sessions/{id}/query/sql\` with a raw-mode query against the live demo, confirm SQL has no \`GROUP BY\`
- [ ] Confirm 422 with \`RAW_MODE_MULTI_FACT_NOT_SUPPORTED\` when fields span unrelated facts
- [ ] Confirm \`select.distinct: true\` emits \`SELECT DISTINCT\`

## Follow-up

- Raw CFL (UNION ALL with NULL padding for fields spanning independent facts) — separate PR
- WHERE EXISTS / NOT EXISTS subquery filters (postponed; will need outer-column correlation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)