### PR TITLE
feat(query): raw CFL — multi-fact UNION ALL with NULL padding

### DIFF
--- a/docs/guide/query-language.md
+++ b/docs/guide/query-language.md
@@ -174,9 +174,44 @@ Raw mode is mutually exclusive with aggregate features. The following are reject
 
 Raw mode reuses the model's directed join graph: when fields span multiple data objects connected by many-to-one joins, the planner walks the graph and emits the necessary `LEFT JOIN`s. Fanout protection still applies — reversed many-to-one joins (which would multiply rows on the "one" side) are rejected.
 
-### Multi-fact raw queries (not yet supported)
+### Multi-fact raw queries (raw CFL)
 
-If `select.fields` references columns from independent fact tables (i.e. fact tables that share a common dimension but are not connected to each other via directed joins), the request is rejected with `RAW_MODE_MULTI_FACT_NOT_SUPPORTED`. Until raw-mode CFL lands, split such queries so each fact is queried separately.
+When `select.fields` references columns from **independent fact tables** — facts that share a common dimension via reverse many-to-one joins but are not connected to each other directly — the planner emits a Composite Fact Layer: one `UNION ALL` leg per leg-root fact, with NULL-padding for fields not reachable from that leg. The outer query selects from the composite CTE.
+
+```yaml
+# Customers ← Orders (m:1)
+# Customers ← Returns (m:1)
+select:
+  fields:
+    - Customers.Name
+    - Orders.Order ID
+    - Orders.Amount
+    - Returns.Return ID
+    - Returns.Refund
+  distinct: true
+```
+
+Compiles roughly to:
+
+```sql
+WITH composite_raw_01 AS (
+  SELECT c.NAME AS "Customers.Name",
+         o.ORDER_ID AS "Orders.Order ID",
+         o.AMOUNT AS "Orders.Amount",
+         CAST(NULL AS VARCHAR) AS "Returns.Return ID",
+         CAST(NULL AS FLOAT)   AS "Returns.Refund"
+  FROM ORDERS o LEFT JOIN CUSTOMERS c ON o.CUSTOMER_ID = c.CUSTOMER_ID
+  UNION ALL
+  SELECT c.NAME, CAST(NULL AS VARCHAR), CAST(NULL AS FLOAT),
+         r.RETURN_ID, r.REFUND
+  FROM RETURNS r LEFT JOIN CUSTOMERS c ON r.CUSTOMER_ID = c.CUSTOMER_ID
+)
+SELECT DISTINCT * FROM composite_raw_01
+```
+
+A "leg root" is a fact data object referenced by some field that is not reachable from another field's source via directed joins — i.e. it is maximal under reachability. Each leg root yields one `UNION ALL` leg. Conformed dim columns (those reachable from every leg) project the same value across legs and line up; fact-specific columns are typed `CAST(NULL AS …)` in legs that don't cover them. `distinct: true` is applied once at the outer query — the most portable place.
+
+WHERE filters are applied to legs whose joined objects contain all the filter's referenced data objects; ORDER BY is remapped to the field aliases at the outer level.
 
 ## Secondary Join Paths
 

--- a/src/orionbelt/api/routers/sessions.py
+++ b/src/orionbelt/api/routers/sessions.py
@@ -38,7 +38,6 @@ from orionbelt.api.schemas import (
     ValidateResponse,
 )
 from orionbelt.compiler.fanout import FanoutError
-from orionbelt.compiler.pipeline import RawModeUnsupportedError
 from orionbelt.compiler.resolution import ResolutionError
 from orionbelt.compiler.validator import format_sql
 from orionbelt.dialect.base import UnsupportedAggregationError
@@ -333,16 +332,6 @@ async def compile_query(
             status_code=422,
             detail={"error": "Query fanout detected", "message": exc.message},
         ) from None
-    except RawModeUnsupportedError as exc:
-        raise HTTPException(
-            status_code=422,
-            detail={
-                "error": "Raw-mode query not supported",
-                "errors": [
-                    {"code": e.code, "message": e.message, "path": e.path} for e in exc.errors
-                ],
-            },
-        ) from None
     except UnsupportedAggregationError as exc:
         raise HTTPException(
             status_code=422,
@@ -536,16 +525,6 @@ async def execute_query(
         raise HTTPException(
             status_code=422,
             detail={"error": "Query fanout detected", "message": exc.message},
-        ) from None
-    except RawModeUnsupportedError as exc:
-        raise HTTPException(
-            status_code=422,
-            detail={
-                "error": "Raw-mode query not supported",
-                "errors": [
-                    {"code": e.code, "message": e.message, "path": e.path} for e in exc.errors
-                ],
-            },
         ) from None
     except UnsupportedAggregationError as exc:
         raise HTTPException(

--- a/src/orionbelt/api/routers/shortcuts.py
+++ b/src/orionbelt/api/routers/shortcuts.py
@@ -48,7 +48,6 @@ from orionbelt.api.schemas import (
     ValidateResponse,
 )
 from orionbelt.compiler.fanout import FanoutError
-from orionbelt.compiler.pipeline import RawModeUnsupportedError
 from orionbelt.compiler.resolution import ResolutionError
 from orionbelt.compiler.validator import format_sql
 from orionbelt.dialect.base import UnsupportedAggregationError
@@ -403,16 +402,6 @@ async def shortcut_compile_query(
             status_code=422,
             detail={"error": "Query fanout detected", "message": exc.message},
         ) from None
-    except RawModeUnsupportedError as exc:
-        raise HTTPException(
-            status_code=422,
-            detail={
-                "error": "Raw-mode query not supported",
-                "errors": [
-                    {"code": e.code, "message": e.message, "path": e.path} for e in exc.errors
-                ],
-            },
-        ) from None
     except UnsupportedAggregationError as exc:
         raise HTTPException(
             status_code=422,
@@ -526,16 +515,6 @@ async def shortcut_execute_query(
         raise HTTPException(
             status_code=422,
             detail={"error": "Query fanout detected", "message": exc.message},
-        ) from None
-    except RawModeUnsupportedError as exc:
-        raise HTTPException(
-            status_code=422,
-            detail={
-                "error": "Raw-mode query not supported",
-                "errors": [
-                    {"code": e.code, "message": e.message, "path": e.path} for e in exc.errors
-                ],
-            },
         ) from None
     except UnsupportedAggregationError as exc:
         raise HTTPException(

--- a/src/orionbelt/ast/builder.py
+++ b/src/orionbelt/ast/builder.py
@@ -9,6 +9,7 @@ from orionbelt.ast.nodes import (
     AliasedExpr,
     BinaryOp,
     ColumnRef,
+    Except,
     Expr,
     From,
     FunctionCall,
@@ -16,7 +17,9 @@ from orionbelt.ast.nodes import (
     JoinType,
     Literal,
     OrderByItem,
+    RawSQL,
     Select,
+    UnionAll,
 )
 
 
@@ -92,7 +95,7 @@ class QueryBuilder:
         self._offset = n
         return self
 
-    def with_cte(self, name: str, query: Select) -> Self:
+    def with_cte(self, name: str, query: Select | UnionAll | Except | RawSQL) -> Self:
         self._ctes.append(CTE(name=name, query=query))
         return self
 

--- a/src/orionbelt/compiler/pipeline.py
+++ b/src/orionbelt/compiler/pipeline.py
@@ -16,17 +16,8 @@ from orionbelt.compiler.star import QueryPlan, StarSchemaPlanner
 from orionbelt.compiler.total_wrap import wrap_with_totals
 from orionbelt.compiler.validator import validate_sql
 from orionbelt.dialect.registry import DialectRegistry
-from orionbelt.models.errors import SemanticError
 from orionbelt.models.query import QueryObject
 from orionbelt.models.semantic import SemanticModel
-
-
-class RawModeUnsupportedError(Exception):
-    """Raised when a raw-mode query needs CFL (multi-fact union); not yet supported."""
-
-    def __init__(self, errors: list[SemanticError]) -> None:
-        self.errors = errors
-        super().__init__("; ".join(e.message for e in errors))
 
 
 @dataclass
@@ -108,22 +99,6 @@ class CompilationPipeline:
         """Compile a query to SQL for the specified dialect."""
         # Phase 1: Resolution
         resolved = self._resolver.resolve(query, model)
-
-        # Raw mode: reject multi-fact queries — raw CFL is a planned follow-up.
-        if resolved.is_raw and resolved.requires_cfl:
-            raise RawModeUnsupportedError(
-                [
-                    SemanticError(
-                        code="RAW_MODE_MULTI_FACT_NOT_SUPPORTED",
-                        message=(
-                            "Raw mode does not yet support fields spanning independent "
-                            "fact tables (would require UNION ALL with NULL padding). "
-                            "Split the query so each fact is queried separately."
-                        ),
-                        path="select.fields",
-                    )
-                ]
-            )
 
         # Phase 1.5: Fanout detection (skip for CFL — each fact queried independently)
         if not resolved.requires_cfl:

--- a/src/orionbelt/compiler/raw.py
+++ b/src/orionbelt/compiler/raw.py
@@ -1,4 +1,13 @@
-"""Raw-mode planner: project physical columns without aggregation."""
+"""Raw-mode planner: project physical columns without aggregation.
+
+Two strategies:
+
+* Single-fact: all field source objects reachable from one base via directed
+  joins → flat ``SELECT [DISTINCT] ... FROM base LEFT JOIN ... WHERE ...``.
+* Multi-fact (raw CFL): fields span independent facts → one UNION ALL leg
+  per leg-root with NULL-padding for fields not reachable from that leg.
+  Outer wrapper: ``SELECT [DISTINCT] * FROM (composite) ORDER BY ... LIMIT ...``.
+"""
 
 from __future__ import annotations
 
@@ -6,10 +15,19 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from orionbelt.ast.builder import QueryBuilder
-from orionbelt.ast.nodes import AliasedExpr, ColumnRef
+from orionbelt.ast.nodes import (
+    CTE,
+    AliasedExpr,
+    Cast,
+    ColumnRef,
+    Expr,
+    Literal,
+    Select,
+    UnionAll,
+)
 from orionbelt.compiler.graph import JoinGraph
-from orionbelt.compiler.resolution import ResolvedQuery
-from orionbelt.compiler.star import QueryPlan
+from orionbelt.compiler.resolution import ResolvedField, ResolvedQuery
+from orionbelt.compiler.star import CflLegInfo, QueryPlan
 from orionbelt.models.semantic import DataObject, SemanticModel
 
 if TYPE_CHECKING:
@@ -19,10 +37,7 @@ if TYPE_CHECKING:
 class RawPlanner:
     """Plans raw-mode queries: flat projection of physical columns.
 
-    Emits ``SELECT [DISTINCT] field1, field2, ... FROM base [LEFT JOIN ...]
-    [WHERE ...] [ORDER BY ...] [LIMIT n]`` with no GROUP BY and no aggregates.
-    Multi-fact queries (fields spanning independent fact tables) are rejected
-    by the pipeline; raw CFL is a planned follow-up.
+    Routes to single-fact or CFL strategy based on ``resolved.requires_cfl``.
     """
 
     def plan(
@@ -31,6 +46,20 @@ class RawPlanner:
         model: SemanticModel,
         qualify_table: Callable[[DataObject], str] | None = None,
         dialect: Dialect | None = None,  # noqa: ARG002 — kept for parity with other planners
+    ) -> QueryPlan:
+        if resolved.requires_cfl:
+            return self._plan_cfl(resolved, model, qualify_table)
+        return self._plan_single_fact(resolved, model, qualify_table)
+
+    # ------------------------------------------------------------------
+    # Single-fact path
+    # ------------------------------------------------------------------
+
+    def _plan_single_fact(
+        self,
+        resolved: ResolvedQuery,
+        model: SemanticModel,
+        qualify_table: Callable[[DataObject], str] | None,
     ) -> QueryPlan:
         builder = QueryBuilder()
         graph = JoinGraph(model, use_path_names=resolved.use_path_names or None)
@@ -44,7 +73,6 @@ class RawPlanner:
 
         base_alias = resolved.base_object
 
-        # SELECT — one aliased ColumnRef per field, in declaration order.
         for f in resolved.fields:
             builder.select(
                 AliasedExpr(
@@ -56,10 +84,8 @@ class RawPlanner:
         if resolved.distinct:
             builder.distinct(True)
 
-        # FROM
         builder.from_(qualify(base_object), alias=base_alias)
 
-        # JOINs (same logic as star schema; raw mode reuses join_steps).
         joined = {base_alias}
         for step in resolved.join_steps:
             if step.to_object not in joined:
@@ -80,18 +106,280 @@ class RawPlanner:
             )
             joined.add(new_object)
 
-        # WHERE
         for wf in resolved.where_filters:
             builder.where(wf.expression)
 
-        # ORDER BY
         for expr, desc in resolved.order_by_exprs:
             builder.order_by(expr, desc=desc)
 
-        # LIMIT / OFFSET
         if resolved.limit is not None:
             builder.limit(resolved.limit)
         if resolved.offset is not None:
             builder.offset(resolved.offset)
 
         return QueryPlan(ast=builder.build())
+
+    # ------------------------------------------------------------------
+    # Multi-fact (raw CFL) path
+    # ------------------------------------------------------------------
+
+    def _plan_cfl(
+        self,
+        resolved: ResolvedQuery,
+        model: SemanticModel,
+        qualify_table: Callable[[DataObject], str] | None,
+    ) -> QueryPlan:
+        graph = JoinGraph(model, use_path_names=resolved.use_path_names or None)
+
+        def qualify(obj: DataObject) -> str:
+            return qualify_table(obj) if qualify_table else obj.qualified_code
+
+        # Field source objects are the candidate set. A "leg root" is one
+        # that is not a directed descendant of any other source — i.e. it
+        # cannot be reached from another field's source via m:1 joins.
+        field_objects = {f.object_name for f in resolved.fields}
+        leg_roots = self._identify_leg_roots(field_objects, graph)
+
+        # Filter-referenced objects: each leg must include them so WHERE
+        # predicates compile. Use the same collector as aggregate CFL.
+        filter_objects: set[str] = set()
+        for wf in resolved.where_filters:
+            self._collect_table_refs(wf.expression, filter_objects)
+
+        union_legs: list[Select] = []
+        leg_infos: list[CflLegInfo] = []
+
+        for root in sorted(leg_roots):
+            reachable = graph.descendants(root) | {root}
+            leg_required = {f.object_name for f in resolved.fields if f.object_name in reachable}
+            leg_required.add(root)
+            leg_required.update(filter_objects & reachable)
+
+            leg = self._build_cfl_leg(
+                root,
+                leg_required,
+                resolved,
+                model,
+                graph,
+                qualify,
+            )
+            union_legs.append(leg)
+
+            steps = graph.find_join_path({root}, leg_required) if len(leg_required) > 1 else []
+            leg_infos.append(
+                CflLegInfo(
+                    measure_source=root,
+                    common_root=root,
+                    reason=(
+                        f'"{root}" is a leg root — fields from this fact + '
+                        f"reachable dim objects projected; non-reachable fields NULL-padded"
+                    ),
+                    measures=[],
+                    joins=[f"{s.from_object} → {s.to_object}" for s in steps],
+                )
+            )
+
+        # Build the composite CTE and the outer wrapper.
+        cte_name = "composite_raw_01"
+        union_cte = CTE(name=cte_name, query=UnionAll(queries=union_legs))
+
+        outer = QueryBuilder()
+        # Re-emit fields by alias from the CTE
+        for f in resolved.fields:
+            outer.select(AliasedExpr(expr=ColumnRef(name=f.alias), alias=f.alias))
+        if resolved.distinct:
+            outer.distinct(True)
+        outer.from_(cte_name, alias=cte_name)
+
+        # ORDER BY remapped to alias-only refs (CTE has no table qualifier).
+        for expr, desc in resolved.order_by_exprs:
+            outer.order_by(self._remap_order_by(expr, resolved), desc=desc)
+
+        if resolved.limit is not None:
+            outer.limit(resolved.limit)
+        if resolved.offset is not None:
+            outer.offset(resolved.offset)
+
+        outer_select = outer.build()
+        final = Select(
+            columns=outer_select.columns,
+            from_=outer_select.from_,
+            joins=outer_select.joins,
+            where=outer_select.where,
+            group_by=outer_select.group_by,
+            having=outer_select.having,
+            order_by=outer_select.order_by,
+            limit=outer_select.limit,
+            offset=outer_select.offset,
+            ctes=[union_cte],
+            distinct=outer_select.distinct,
+        )
+        return QueryPlan(ast=final, cfl_legs=leg_infos)
+
+    # ------------------------------------------------------------------
+    # CFL helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _identify_leg_roots(field_objects: set[str], graph: JoinGraph) -> set[str]:
+        """Maximal elements under directed reachability.
+
+        A source is a leg root iff no other source can reach it via directed
+        m:1 joins. With strict m:1 joins, leg roots are the "deepest fact"
+        nodes — they have descendants but no field-set ancestors.
+        """
+        roots = set(field_objects)
+        for src in field_objects:
+            for other in field_objects:
+                if other != src and src in graph.descendants(other):
+                    roots.discard(src)
+                    break
+        return roots
+
+    def _build_cfl_leg(
+        self,
+        root: str,
+        leg_required: set[str],
+        resolved: ResolvedQuery,
+        model: SemanticModel,
+        graph: JoinGraph,
+        qualify: Callable[[DataObject], str],
+    ) -> Select:
+        """Construct a single UNION ALL leg rooted at *root*."""
+        builder = QueryBuilder()
+
+        # SELECT: one entry per declared field, in original order.
+        # Fields whose source is reachable → real ColumnRef.
+        # Otherwise → typed NULL cast so UNION ALL line-up is unambiguous.
+        for f in resolved.fields:
+            if f.object_name in leg_required:
+                builder.select(
+                    AliasedExpr(
+                        expr=ColumnRef(name=f.source_column, table=f.object_name),
+                        alias=f.alias,
+                    )
+                )
+            else:
+                builder.select(
+                    AliasedExpr(
+                        expr=self._null_cast_for_field(f, model),
+                        alias=f.alias,
+                    )
+                )
+
+        # FROM the leg root
+        root_obj = model.data_objects.get(root)
+        if root_obj is not None:
+            builder.from_(qualify(root_obj), alias=root)
+
+        # JOINs to all other required objects in this leg
+        if len(leg_required) > 1:
+            steps = graph.find_join_path({root}, leg_required)
+            for step in steps:
+                target = model.data_objects.get(step.to_object)
+                if target is None:
+                    continue
+                on_expr = graph.build_join_condition(step)
+                builder.join(
+                    table=qualify(target),
+                    on=on_expr,
+                    join_type=step.join_type,
+                    alias=step.to_object,
+                )
+
+        # WHERE — apply filters whose referenced objects are in this leg.
+        # Filters that touch objects unreachable from this leg are skipped
+        # because the columns they reference don't exist here.
+        leg_objects = self._compute_leg_objects(root, resolved, model, graph)
+        for wf in resolved.where_filters:
+            ref_objects: set[str] = set()
+            self._collect_table_refs(wf.expression, ref_objects)
+            if ref_objects.issubset(leg_objects):
+                builder.where(wf.expression)
+
+        return builder.build()
+
+    @staticmethod
+    def _compute_leg_objects(
+        root: str,
+        resolved: ResolvedQuery,
+        model: SemanticModel,
+        graph: JoinGraph,
+    ) -> set[str]:
+        """Return the set of data objects this leg actually JOINs."""
+        reachable = graph.descendants(root) | {root}
+        required = {f.object_name for f in resolved.fields if f.object_name in reachable}
+        required.add(root)
+        if len(required) > 1:
+            steps = graph.find_join_path({root}, required)
+            for s in steps:
+                required.add(s.to_object)
+                required.add(s.from_object)
+        # Drop objects not in the model (defensive; resolution should have caught these)
+        return {o for o in required if o in model.data_objects}
+
+    @staticmethod
+    def _null_cast_for_field(field: ResolvedField, model: SemanticModel) -> Expr:
+        """Return a typed ``CAST(NULL AS <type>)`` for the column's abstract type.
+
+        Falls back to a bare NULL when the column or its type cannot be
+        resolved — keeps codegen working without a hard error.
+        """
+        obj = model.data_objects.get(field.object_name)
+        if obj is None:
+            return Literal.null()
+        column = obj.columns.get(field.column_name)
+        if column is None:
+            return Literal.null()
+        type_name = column.abstract_type.value
+        return Cast(Literal.null(), type_name=type_name)
+
+    @staticmethod
+    def _remap_order_by(expr: Expr, resolved: ResolvedQuery) -> Expr:
+        """Convert table-qualified column refs to alias-only refs.
+
+        The CFL outer query selects from the composite CTE — original
+        ``"DataObject"."COLUMN"`` references are out of scope. Map them
+        back to the field alias instead.
+        """
+        if isinstance(expr, ColumnRef) and expr.table is not None:
+            for f in resolved.fields:
+                if f.object_name == expr.table and f.source_column == expr.name:
+                    return ColumnRef(name=f.alias)
+        return expr
+
+    @staticmethod
+    def _collect_table_refs(expr: Expr, tables: set[str]) -> None:
+        """Walk an expression tree collecting referenced table names.
+
+        Mirrors ``CFLPlanner._collect_table_refs`` for the subset of node
+        types raw-mode WHERE filters can produce. Imported lazily to avoid
+        a circular import with ``compiler/cfl.py``.
+        """
+        from orionbelt.ast.nodes import (
+            Between,
+            BinaryOp,
+            FunctionCall,
+            InList,
+            IsNull,
+            RelativeDateRange,
+            UnaryOp,
+        )
+
+        if isinstance(expr, ColumnRef) and expr.table:
+            tables.add(expr.table)
+        elif isinstance(expr, BinaryOp):
+            RawPlanner._collect_table_refs(expr.left, tables)
+            RawPlanner._collect_table_refs(expr.right, tables)
+        elif isinstance(expr, UnaryOp):
+            RawPlanner._collect_table_refs(expr.operand, tables)
+        elif isinstance(expr, (InList, IsNull, Between)):
+            RawPlanner._collect_table_refs(expr.expr, tables)
+        elif isinstance(expr, RelativeDateRange):
+            RawPlanner._collect_table_refs(expr.column, tables)
+        elif isinstance(expr, FunctionCall):
+            for arg in expr.args:
+                RawPlanner._collect_table_refs(arg, tables)
+
+
+__all__ = ["RawPlanner"]

--- a/tests/unit/test_raw_mode.py
+++ b/tests/unit/test_raw_mode.py
@@ -7,7 +7,7 @@ from pydantic import ValidationError
 
 # Make sure all dialects are registered
 import orionbelt.dialect  # noqa: F401
-from orionbelt.compiler.pipeline import CompilationPipeline, RawModeUnsupportedError
+from orionbelt.compiler.pipeline import CompilationPipeline
 from orionbelt.compiler.resolution import QueryResolver, ResolutionError
 from orionbelt.dialect.registry import DialectRegistry
 from orionbelt.models.query import (
@@ -277,7 +277,7 @@ class TestRawModeCompilation:
 
 
 class TestRawModeMultiFact:
-    """Multi-fact raw queries are rejected for now (raw CFL is a follow-up)."""
+    """Multi-fact raw queries (raw CFL) — UNION ALL with NULL padding."""
 
     MULTI_FACT_YAML = """\
 version: 1.0
@@ -336,15 +336,119 @@ dimensions:
     resultType: string
 """
 
-    def test_multi_fact_raw_query_rejected(self) -> None:
+    def test_multi_fact_resolution_marks_cfl(self) -> None:
         model = _load_model(self.MULTI_FACT_YAML)
-        # Orders and Returns are independent facts — both reverse-reach Customers.
         query = QueryObject(
             select=QuerySelect(
                 fields=["Customers.Name", "Orders.Order ID", "Returns.Return ID"],
             ),
         )
-        with pytest.raises(RawModeUnsupportedError) as exc_info:
-            CompilationPipeline().compile(query, model, dialect_name="postgres")
-        codes = [e.code for e in exc_info.value.errors]
-        assert "RAW_MODE_MULTI_FACT_NOT_SUPPORTED" in codes
+        resolved = QueryResolver().resolve(query, model)
+        assert resolved.is_raw is True
+        assert resolved.requires_cfl is True
+
+    def test_multi_fact_compiles_as_union_all(self) -> None:
+        model = _load_model(self.MULTI_FACT_YAML)
+        query = QueryObject(
+            select=QuerySelect(
+                fields=[
+                    "Customers.Name",
+                    "Orders.Order ID",
+                    "Orders.Amount",
+                    "Returns.Return ID",
+                    "Returns.Refund",
+                ],
+            ),
+        )
+        result = CompilationPipeline().compile(query, model, dialect_name="postgres")
+        sql = result.sql
+        assert "WITH" in sql
+        assert "composite_raw_01" in sql
+        assert "UNION ALL" in sql
+        # Each leg projects every field — non-applicable ones as typed NULL casts.
+        # The Orders leg can't project Returns columns; the Returns leg can't
+        # project Orders columns.
+        assert sql.count("NULL") >= 4
+        # GROUP BY must be absent — raw mode never aggregates.
+        assert "GROUP BY" not in sql
+
+    def test_multi_fact_distinct_emits_outer_select_distinct(self) -> None:
+        model = _load_model(self.MULTI_FACT_YAML)
+        query = QueryObject(
+            select=QuerySelect(
+                fields=["Customers.Name", "Orders.Order ID", "Returns.Return ID"],
+                distinct=True,
+            ),
+        )
+        sql = CompilationPipeline().compile(query, model, dialect_name="postgres").sql
+        # Outer query carries the DISTINCT, not each leg.
+        assert "SELECT DISTINCT" in sql
+        assert "UNION ALL" in sql
+
+    def test_multi_fact_explain_reports_legs(self) -> None:
+        model = _load_model(self.MULTI_FACT_YAML)
+        query = QueryObject(
+            select=QuerySelect(
+                fields=["Customers.Name", "Orders.Order ID", "Returns.Return ID"],
+            ),
+        )
+        result = CompilationPipeline().compile(query, model, dialect_name="postgres")
+        assert result.explain is not None
+        assert result.explain.planner == "Raw"
+        leg_sources = {leg.measure_source for leg in result.explain.cfl_legs}
+        assert leg_sources == {"Orders", "Returns"}
+
+    @pytest.mark.parametrize(
+        "dialect_name",
+        [
+            "bigquery",
+            "clickhouse",
+            "databricks",
+            "dremio",
+            "duckdb",
+            "mysql",
+            "postgres",
+            "snowflake",
+        ],
+    )
+    def test_multi_fact_compiles_on_all_dialects(self, dialect_name: str) -> None:
+        model = _load_model(self.MULTI_FACT_YAML)
+        query = QueryObject(
+            select=QuerySelect(
+                fields=["Customers.Name", "Orders.Amount", "Returns.Refund"],
+                distinct=True,
+            ),
+            limit=10,
+        )
+        result = CompilationPipeline().compile(query, model, dialect_name=dialect_name)
+        sql = result.sql
+        assert "UNION ALL" in sql
+        assert "GROUP BY" not in sql
+        assert "LIMIT 10" in sql
+
+    def test_multi_fact_with_where_and_order_by(self) -> None:
+        model = _load_model(self.MULTI_FACT_YAML)
+        query = QueryObject(
+            select=QuerySelect(
+                fields=[
+                    "Customers.Name",
+                    "Orders.Amount",
+                    "Returns.Refund",
+                ],
+            ),
+            where=[
+                QueryFilter(field="Customer Name", op=FilterOperator.EQ, value="Alice"),
+            ],
+            order_by=[
+                QueryOrderBy(field="Customers.Name", direction=SortDirection.ASC),
+            ],
+            limit=50,
+        )
+        sql = CompilationPipeline().compile(query, model, dialect_name="postgres").sql
+        # Filter on Customers.Name applies to both legs (Customers is reachable from each).
+        assert "WHERE" in sql
+        assert "'Alice'" in sql
+        # ORDER BY must reference the CTE alias, not the underlying table.
+        assert "ORDER BY" in sql
+        assert '"Customers.Name"' in sql
+        assert "LIMIT 50" in sql


### PR DESCRIPTION
**Stacked on #30** (\`feat/raw-query-mode\`). Completes raw mode by replacing the multi-fact rejection with a working Composite Fact Layer.

## What changed

When \`select.fields\` references columns from independent fact tables — facts that share a common dimension via reverse m:1 joins but aren't connected to each other — the planner now emits a UNION ALL composite instead of rejecting with \`RAW_MODE_MULTI_FACT_NOT_SUPPORTED\`.

Example: Customers ← Orders (m:1) **and** Customers ← Returns (m:1)

\`\`\`yaml
select:
  fields:
    - Customers.Name
    - Orders.Order ID
    - Orders.Amount
    - Returns.Return ID
    - Returns.Refund
  distinct: true
\`\`\`

Compiles to:

\`\`\`sql
WITH composite_raw_01 AS (
  SELECT c.NAME AS \"Customers.Name\",
         o.ORDER_ID AS \"Orders.Order ID\",
         o.AMOUNT   AS \"Orders.Amount\",
         CAST(NULL AS VARCHAR) AS \"Returns.Return ID\",
         CAST(NULL AS FLOAT)   AS \"Returns.Refund\"
  FROM ORDERS o LEFT JOIN CUSTOMERS c ON o.CUSTOMER_ID = c.CUSTOMER_ID
  UNION ALL
  SELECT c.NAME, CAST(NULL AS VARCHAR), CAST(NULL AS FLOAT),
         r.RETURN_ID, r.REFUND
  FROM RETURNS r LEFT JOIN CUSTOMERS c ON r.CUSTOMER_ID = c.CUSTOMER_ID
)
SELECT DISTINCT * FROM composite_raw_01
\`\`\`

## Strategy

- **Leg roots**: maximal elements of the field source set under directed reachability. Each leg root → one UNION ALL leg.
- **Per-leg projection**: every declared field is emitted in the same order; fields whose source is reachable from this leg project a real \`ColumnRef\`, others project a typed \`CAST(NULL AS <abstract_type>)\`.
- **WHERE filters**: applied to legs whose joined objects cover all the filter's referenced data objects; skipped where they would dangle.
- **DISTINCT** placed at the outer query (portable across all 8 dialects; per-leg DISTINCT would not eliminate cross-leg duplicates).
- **ORDER BY** remapped to the field aliases since the CTE has no table qualifiers.
- **LIMIT** applied at the outer level.

## Tests

12 new unit tests in \`tests/unit/test_raw_mode.py\` cover:

- Resolver: \`requires_cfl=True\` for multi-fact fields
- SQL contains \`WITH composite_raw_01\` / \`UNION ALL\` / typed NULL casts
- \`distinct: true\` → outer \`SELECT DISTINCT\`
- Explain plan reports per-leg info (\`{Orders, Returns}\` leg sources)
- **All 8 dialects** parametrized
- WHERE filter on shared dim applies to both legs
- ORDER BY remapped to CTE alias

Full suite: **1216 passed**, 51 skipped (was 1204). \`ruff check\`, \`ruff format\`, \`mypy\` all clean.

## Cleanup

Removes \`RawModeUnsupportedError\` and matching API exception handlers — they were stop-gap scaffolding from #30 and are now dead code.

## Test plan

- [ ] Hit \`POST /v1/sessions/{id}/query/sql\` with a multi-fact raw query, confirm UNION ALL SQL
- [ ] Confirm DISTINCT placed once at outer level
- [ ] Confirm typed NULL casts (e.g. \`CAST(NULL AS VARCHAR)\`) match column abstract types

## Followups

- WHERE EXISTS / NOT EXISTS subquery filters (still postponed; needs outer-column correlation design)
- \`UNION ALL BY NAME\` optimization for DuckDB/Snowflake (skip per-leg NULL padding when supported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)