### PR TITLE
perf(query): raw CFL — UNION ALL BY NAME on DuckDB/Snowflake

### DIFF
--- a/docs/guide/query-language.md
+++ b/docs/guide/query-language.md
@@ -213,6 +213,24 @@ A "leg root" is a fact data object referenced by some field that is not reachabl
 
 WHERE filters are applied to legs whose joined objects contain all the filter's referenced data objects; ORDER BY is remapped to the field aliases at the outer level.
 
+#### `UNION ALL BY NAME` optimization (DuckDB, Snowflake)
+
+DuckDB and Snowflake both support `UNION ALL BY NAME`, which aligns columns by name across legs and auto-fills any missing columns with `NULL`. On these dialects the planner skips the per-leg `CAST(NULL AS …)` padding entirely and emits only the columns each leg actually has — the database does the rest:
+
+```sql
+-- DuckDB / Snowflake
+WITH composite_raw_01 AS (
+  SELECT c.NAME AS "Customers.Name", o.ORDER_ID AS "Orders.Order ID", o.AMOUNT AS "Orders.Amount"
+  FROM ORDERS o LEFT JOIN CUSTOMERS c ON o.CUSTOMER_ID = c.CUSTOMER_ID
+  UNION ALL BY NAME
+  SELECT c.NAME, r.RETURN_ID AS "Returns.Return ID", r.REFUND AS "Returns.Refund"
+  FROM RETURNS r LEFT JOIN CUSTOMERS c ON r.CUSTOMER_ID = c.CUSTOMER_ID
+)
+SELECT DISTINCT * FROM composite_raw_01
+```
+
+The other six dialects (BigQuery, ClickHouse, Databricks, Dremio, MySQL, Postgres) keep the explicit typed-NULL padding shown above. Output rows are identical either way; the optimization is purely about leg readability and slightly less SQL the database has to parse.
+
 ## Secondary Join Paths
 
 When a model defines secondary joins (e.g., `Flights` → `Airports` via departure and arrival), use `usePathNames` to select which join path to use:

--- a/src/orionbelt/compiler/pipeline.py
+++ b/src/orionbelt/compiler/pipeline.py
@@ -114,7 +114,11 @@ class CompilationPipeline:
         use_cfl = resolved.requires_cfl or resolved.dimensions_exclude
         if resolved.is_raw:
             plan = self._raw_planner.plan(
-                resolved, model, qualify_table=qualify_table, dialect=dialect
+                resolved,
+                model,
+                qualify_table=qualify_table,
+                dialect=dialect,
+                union_by_name=dialect.capabilities.supports_union_all_by_name,
             )
         elif use_cfl:
             plan = self._cfl_planner.plan(

--- a/src/orionbelt/compiler/raw.py
+++ b/src/orionbelt/compiler/raw.py
@@ -46,9 +46,10 @@ class RawPlanner:
         model: SemanticModel,
         qualify_table: Callable[[DataObject], str] | None = None,
         dialect: Dialect | None = None,  # noqa: ARG002 — kept for parity with other planners
+        union_by_name: bool = False,
     ) -> QueryPlan:
         if resolved.requires_cfl:
-            return self._plan_cfl(resolved, model, qualify_table)
+            return self._plan_cfl(resolved, model, qualify_table, union_by_name=union_by_name)
         return self._plan_single_fact(resolved, model, qualify_table)
 
     # ------------------------------------------------------------------
@@ -128,6 +129,8 @@ class RawPlanner:
         resolved: ResolvedQuery,
         model: SemanticModel,
         qualify_table: Callable[[DataObject], str] | None,
+        *,
+        union_by_name: bool = False,
     ) -> QueryPlan:
         graph = JoinGraph(model, use_path_names=resolved.use_path_names or None)
 
@@ -162,17 +165,23 @@ class RawPlanner:
                 model,
                 graph,
                 qualify,
+                union_by_name=union_by_name,
             )
             union_legs.append(leg)
 
             steps = graph.find_join_path({root}, leg_required) if len(leg_required) > 1 else []
+            null_strategy = (
+                "non-reachable fields omitted (UNION ALL BY NAME fills them)"
+                if union_by_name
+                else "non-reachable fields NULL-padded"
+            )
             leg_infos.append(
                 CflLegInfo(
                     measure_source=root,
                     common_root=root,
                     reason=(
                         f'"{root}" is a leg root — fields from this fact + '
-                        f"reachable dim objects projected; non-reachable fields NULL-padded"
+                        f"reachable dim objects projected; {null_strategy}"
                     ),
                     measures=[],
                     joins=[f"{s.from_object} → {s.to_object}" for s in steps],
@@ -244,13 +253,19 @@ class RawPlanner:
         model: SemanticModel,
         graph: JoinGraph,
         qualify: Callable[[DataObject], str],
+        *,
+        union_by_name: bool = False,
     ) -> Select:
-        """Construct a single UNION ALL leg rooted at *root*."""
+        """Construct a single UNION ALL leg rooted at *root*.
+
+        When *union_by_name* is True (DuckDB, Snowflake) the leg only emits
+        the fields it actually has — the database fills missing columns with
+        NULL automatically via ``UNION ALL BY NAME``. Otherwise each leg
+        emits a typed ``CAST(NULL AS <type>)`` for non-reachable fields so
+        positional UNION ALL line-up is unambiguous.
+        """
         builder = QueryBuilder()
 
-        # SELECT: one entry per declared field, in original order.
-        # Fields whose source is reachable → real ColumnRef.
-        # Otherwise → typed NULL cast so UNION ALL line-up is unambiguous.
         for f in resolved.fields:
             if f.object_name in leg_required:
                 builder.select(
@@ -259,7 +274,7 @@ class RawPlanner:
                         alias=f.alias,
                     )
                 )
-            else:
+            elif not union_by_name:
                 builder.select(
                     AliasedExpr(
                         expr=self._null_cast_for_field(f, model),

--- a/tests/unit/test_raw_mode.py
+++ b/tests/unit/test_raw_mode.py
@@ -452,3 +452,67 @@ dimensions:
         assert "ORDER BY" in sql
         assert '"Customers.Name"' in sql
         assert "LIMIT 50" in sql
+
+
+class TestRawModeUnionByName:
+    """DuckDB / Snowflake skip per-leg NULL padding via UNION ALL BY NAME."""
+
+    MULTI_FACT_YAML = TestRawModeMultiFact.MULTI_FACT_YAML
+
+    @pytest.mark.parametrize("dialect_name", ["duckdb", "snowflake"])
+    def test_legs_omit_null_padding(self, dialect_name: str) -> None:
+        model = _load_model(self.MULTI_FACT_YAML)
+        query = QueryObject(
+            select=QuerySelect(
+                fields=[
+                    "Customers.Name",
+                    "Orders.Order ID",
+                    "Orders.Amount",
+                    "Returns.Return ID",
+                    "Returns.Refund",
+                ],
+            ),
+        )
+        sql = CompilationPipeline().compile(query, model, dialect_name=dialect_name).sql
+        assert "UNION ALL BY NAME" in sql
+        # Optimized legs do not emit CAST(NULL AS ...) — the database fills
+        # missing columns with NULL automatically.
+        assert "CAST(NULL" not in sql
+        # And there's no bare NULL projection either (we just omit those columns).
+        assert "AS NULL" not in sql
+
+    @pytest.mark.parametrize(
+        "dialect_name",
+        ["bigquery", "clickhouse", "databricks", "dremio", "mysql", "postgres"],
+    )
+    def test_legs_keep_null_padding_when_unsupported(self, dialect_name: str) -> None:
+        model = _load_model(self.MULTI_FACT_YAML)
+        query = QueryObject(
+            select=QuerySelect(
+                fields=[
+                    "Customers.Name",
+                    "Orders.Order ID",
+                    "Orders.Amount",
+                    "Returns.Return ID",
+                    "Returns.Refund",
+                ],
+            ),
+        )
+        sql = CompilationPipeline().compile(query, model, dialect_name=dialect_name).sql
+        assert "UNION ALL BY NAME" not in sql
+        # Two fact legs × two missing fields each = at least 4 typed NULL casts.
+        assert sql.count("CAST(NULL") >= 4
+
+    def test_explain_reason_reflects_strategy(self) -> None:
+        model = _load_model(self.MULTI_FACT_YAML)
+        query = QueryObject(
+            select=QuerySelect(
+                fields=["Customers.Name", "Orders.Order ID", "Returns.Return ID"],
+            ),
+        )
+        # DuckDB → "fills them" wording
+        result = CompilationPipeline().compile(query, model, dialect_name="duckdb")
+        assert any("UNION ALL BY NAME fills" in leg.reason for leg in result.explain.cfl_legs)
+        # Postgres → "NULL-padded" wording
+        result = CompilationPipeline().compile(query, model, dialect_name="postgres")
+        assert any("NULL-padded" in leg.reason for leg in result.explain.cfl_legs)


### PR DESCRIPTION
**Stacked on #31** (\`feat/raw-cfl\`). Optimization for the two dialects that natively align UNION ALL legs by column name.

## What changed

DuckDB and Snowflake support \`UNION ALL BY NAME\`, which aligns columns across legs by name and fills any missing columns with \`NULL\` automatically. On these dialects the raw-CFL planner now skips the per-leg \`CAST(NULL AS <type>)\` padding entirely — each leg only emits the columns it actually has.

The other six dialects (BigQuery, ClickHouse, Databricks, Dremio, MySQL, Postgres) keep the existing positional NULL-padded \`UNION ALL\`. Output rows are identical either way; this is purely about leg readability and slightly less SQL for the database to parse.

## Before / after

**Postgres** (unchanged):
\`\`\`sql
SELECT c.NAME, o.ORDER_ID, o.AMOUNT,
       CAST(NULL AS VARCHAR) AS \"Returns.Return ID\",
       CAST(NULL AS FLOAT)   AS \"Returns.Refund\"
FROM ORDERS o LEFT JOIN CUSTOMERS c ON ...
UNION ALL
SELECT c.NAME, CAST(NULL AS VARCHAR), CAST(NULL AS FLOAT),
       r.RETURN_ID, r.REFUND
FROM RETURNS r LEFT JOIN CUSTOMERS c ON ...
\`\`\`

**DuckDB / Snowflake** (new):
\`\`\`sql
SELECT c.NAME, o.ORDER_ID AS \"Orders.Order ID\", o.AMOUNT AS \"Orders.Amount\"
FROM ORDERS o LEFT JOIN CUSTOMERS c ON ...
UNION ALL BY NAME
SELECT c.NAME, r.RETURN_ID AS \"Returns.Return ID\", r.REFUND AS \"Returns.Refund\"
FROM RETURNS r LEFT JOIN CUSTOMERS c ON ...
\`\`\`

## Tests

9 new in \`tests/unit/test_raw_mode.py\`:
- DuckDB & Snowflake parametrized: SQL contains \`UNION ALL BY NAME\` and no \`CAST(NULL\`
- BigQuery, ClickHouse, Databricks, Dremio, MySQL, Postgres parametrized: still emit ≥4 typed NULL casts (regression check)
- \`explain.cfl_legs[*].reason\` wording reflects strategy (\"UNION ALL BY NAME fills them\" vs \"NULL-padded\")

Full suite: **1225 passed** (was 1216). \`ruff check\`, \`ruff format\`, \`mypy\` clean.

## Plumbing

- \`RawPlanner.plan\` / \`_plan_cfl\` take a \`union_by_name: bool = False\` flag
- \`CompilationPipeline\` forwards \`dialect.capabilities.supports_union_all_by_name\`
- \`_build_cfl_leg\` skips the typed-NULL branch when \`union_by_name=True\`
- \`CflLegInfo.reason\` reflects the strategy

🤖 Generated with [Claude Code](https://claude.com/claude-code)