### PR TITLE
chore(drivers): align all 10 driver packages to 2.1.0

### DIFF
--- a/drivers/ob-bigquery/pyproject.toml
+++ b/drivers/ob-bigquery/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ob-bigquery"
-version = "0.1.0"
+version = "2.1.0"
 description = "OrionBelt Semantic Layer driver for BigQuery (DB-API 2.0)"
 license = { text = "BSL-1.1" }
 readme = "README.md"

--- a/drivers/ob-clickhouse/pyproject.toml
+++ b/drivers/ob-clickhouse/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ob-clickhouse"
-version = "0.1.0"
+version = "2.1.0"
 description = "OrionBelt Semantic Layer driver for ClickHouse (DB-API 2.0)"
 license = { text = "BSL-1.1" }
 readme = "README.md"

--- a/drivers/ob-databricks/pyproject.toml
+++ b/drivers/ob-databricks/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ob-databricks"
-version = "0.1.0"
+version = "2.1.0"
 description = "OrionBelt Semantic Layer driver for Databricks (DB-API 2.0)"
 license = { text = "BSL-1.1" }
 readme = "README.md"

--- a/drivers/ob-dremio/pyproject.toml
+++ b/drivers/ob-dremio/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ob-dremio"
-version = "0.1.0"
+version = "2.1.0"
 description = "OrionBelt Semantic Layer driver for Dremio (DB-API 2.0)"
 license = { text = "BSL-1.1" }
 readme = "README.md"

--- a/drivers/ob-driver-core/pyproject.toml
+++ b/drivers/ob-driver-core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ob-driver-core"
-version = "0.1.0"
+version = "2.1.0"
 description = "Shared foundation for OrionBelt DB-API 2.0 drivers (PEP 249 types, OBML detection, compilation bridge)"
 license = { text = "BSL-1.1" }
 readme = "README.md"

--- a/drivers/ob-duckdb/pyproject.toml
+++ b/drivers/ob-duckdb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ob-duckdb"
-version = "0.1.0"
+version = "2.1.0"
 description = "OrionBelt Semantic Layer driver for DuckDB (DB-API 2.0)"
 license = { text = "BSL-1.1" }
 readme = "README.md"

--- a/drivers/ob-flight-extension/pyproject.toml
+++ b/drivers/ob-flight-extension/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ob-flight-extension"
-version = "0.1.0"
+version = "2.1.0"
 description = "Arrow Flight SQL server extension for orionbelt-api (DBeaver, Tableau, Power BI)"
 license = { text = "BSL-1.1" }
 readme = "README.md"

--- a/drivers/ob-mysql/pyproject.toml
+++ b/drivers/ob-mysql/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ob-mysql"
-version = "0.1.0"
+version = "2.1.0"
 description = "OrionBelt Semantic Layer driver for MySQL 8.0+ (DB-API 2.0)"
 license = { text = "BSL-1.1" }
 readme = "README.md"

--- a/drivers/ob-postgres/pyproject.toml
+++ b/drivers/ob-postgres/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ob-postgres"
-version = "0.1.0"
+version = "2.1.0"
 description = "OrionBelt Semantic Layer driver for PostgreSQL (DB-API 2.0)"
 license = { text = "BSL-1.1" }
 readme = "README.md"

--- a/drivers/ob-snowflake/pyproject.toml
+++ b/drivers/ob-snowflake/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ob-snowflake"
-version = "0.1.0"
+version = "2.1.0"
 description = "OrionBelt Semantic Layer driver for Snowflake (DB-API 2.0)"
 license = { text = "BSL-1.1" }
 readme = "README.md"


### PR DESCRIPTION
## Summary
Bookkeeping commit: bumps all 10 driver packages from \`0.1.0\` to \`2.1.0\` to align with the umbrella orionbelt-semantic-layer release. PyPI wheels for the 2.1.0 driver versions are already published as part of the v2.1.0 release pipeline — this PR is the source-of-truth side.

Affected packages: \`ob-driver-core\`, \`ob-bigquery\`, \`ob-clickhouse\`, \`ob-databricks\`, \`ob-dremio\`, \`ob-duckdb\`, \`ob-mysql\`, \`ob-postgres\`, \`ob-snowflake\`, \`ob-flight-extension\`.

## Why now
PyPI 0.1.0 wheels had drifted (months of internal-only changes — most recently the lint cleanups in \`ef04fe1\`). PyPI rejected re-publishing 0.1.0 with new content. Aligning to 2.1.0 lets the umbrella's \`>=0.1\` constraints pull the freshest driver wheels.

## Why not bump constraints
Inter-driver dependency constraints stay at \`>=0.1\` for forward-compatibility (drivers don't break ABI; pinning higher would force lockstep upgrades unnecessarily).

## Test plan
- [x] \`uv build\` succeeded for all 10 drivers
- [x] PyPI shows 2.1.0 for all 10 driver packages
- [x] Inter-driver constraints (\`>=0.1\`) still satisfied by 2.1.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)