### PR TITLE
fix: v2.1.1 — tzdata runtime dep, sem-layer defaultDialect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to OrionBelt Semantic Layer are documented here.
 
+## [2.1.1] - 2026-04-30
+
+### Fixed
+
+- **`/v1/settings.timezone.effective` falls back to UTC instead of the model's `defaultTimezone` on slim Linux Docker images.** Root cause: `python:3.12-slim` has no `/usr/share/zoneinfo`, so `ZoneInfo("Europe/Berlin")` (or any IANA name) raises `ZoneInfoNotFoundError`. The resolver caught the exception, walked the fallback chain (host TZ on Cloud Run is UTC and skipped), and ended at `UTC`. Now `tzdata>=2025.1` is a runtime dependency of `orionbelt-semantic-layer`, and both `Dockerfile` / `Dockerfile.ui` also `apt-get install tzdata` for defense in depth.
+
+### Changed
+
+- `examples/sem-layer.obml.yml` (the UI's default preloaded model) now declares `settings.defaultDialect: postgres`. Aligns the UI dialect dropdown and `/v1/settings.dialect.effective` for users loading the bundled demo — previously they could diverge when `DB_VENDOR` differed from the UI's hardcoded `postgres` fallback.
+
 ## [2.1.0] - 2026-04-30
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,15 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 
+# Install IANA tzdata so Python's zoneinfo can resolve names like
+# Europe/Berlin. python:3.12-slim has no /usr/share/zoneinfo, and without
+# it ZoneInfo("Europe/Berlin") raises ZoneInfoNotFoundError — the timezone
+# resolver then silently falls back to UTC. Belt-and-suspenders alongside
+# the tzdata Python dep.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends tzdata \
+    && rm -rf /var/lib/apt/lists/*
+
 # Create non-root user
 RUN groupadd -r app && useradd -r -g app -d /app -s /sbin/nologin app
 

--- a/Dockerfile.ui
+++ b/Dockerfile.ui
@@ -25,6 +25,11 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 
+# Install IANA tzdata (see Dockerfile for rationale).
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends tzdata \
+    && rm -rf /var/lib/apt/lists/*
+
 # Create non-root user
 RUN groupadd -r app && useradd -r -g app -d /app -s /sbin/nologin app
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ralfbecher/orionbelt-semantic-layer/blob/main/examples/quickstart_colab.ipynb)
 
 [![GitHub stars](https://img.shields.io/github/stars/ralfbecher/orionbelt-semantic-layer?style=social)](https://github.com/ralfbecher/orionbelt-semantic-layer)
-[![Version 2.1.0](https://img.shields.io/badge/version-2.1.0-purple.svg)](https://github.com/ralfbecher/orionbelt-semantic-layer/releases)
+[![Version 2.1.1](https://img.shields.io/badge/version-2.1.1-purple.svg)](https://github.com/ralfbecher/orionbelt-semantic-layer/releases)
 [![PyPI](https://img.shields.io/pypi/v/orionbelt-semantic-layer?logo=pypi&logoColor=white)](https://pypi.org/project/orionbelt-semantic-layer/)
 [![Docker Hub](https://img.shields.io/docker/pulls/ralforion/orionbelt-api?logo=docker&label=Docker%20Hub)](https://hub.docker.com/repositories/ralforion)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
@@ -155,7 +155,7 @@ Open [http://localhost:8080/docs](http://localhost:8080/docs) to explore the API
 # docker-compose.yml
 services:
   api:
-    image: ralforion/orionbelt-api:2.1.0
+    image: ralforion/orionbelt-api:2.1.1
     ports: ["8080:8080"]
     env_file: .env
     volumes:
@@ -164,7 +164,7 @@ services:
       MODEL_FILE: /app/models/my-model.obml.yml
 
   ui:
-    image: ralforion/orionbelt-ui:2.1.0
+    image: ralforion/orionbelt-ui:2.1.1
     ports: ["7860:7860"]
     environment:
       API_BASE_URL: http://api:8080
@@ -180,7 +180,7 @@ See [`.env.template`](.env.template) for the full environment variable reference
 > - `API_SERVER_HOST` is already `0.0.0.0` inside the container — no override needed.
 > - MCP via stdio does not work in Docker. Use the [MCP HTTP client](https://github.com/ralfbecher/orionbelt-semantic-layer-mcp) for containerized deployments.
 > - Mount models to `/app/models` (or any path) and set `MODEL_FILE` to pre-load on startup.
-> - For production, pin a version tag (`:2.1.0`) rather than `:latest`.
+> - For production, pin a version tag (`:2.1.1`) rather than `:latest`.
 
 ### Claude Desktop / MCP
 

--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -13,7 +13,7 @@ Returns the service status and version.
 ```json
 {
   "status": "ok",
-  "version": "2.1.0"
+  "version": "2.1.1"
 }
 ```
 
@@ -734,7 +734,7 @@ Return public configuration for API clients (UI, MCP, etc.).
 
 ```json
 {
-  "version": "2.1.0",
+  "version": "2.1.1",
   "api_version": "v1",
   "single_model_mode": false,
   "session_ttl_seconds": 1800,
@@ -753,7 +753,7 @@ Return public configuration for API clients (UI, MCP, etc.).
 
 ```json
 {
-  "version": "2.1.0",
+  "version": "2.1.1",
   "api_version": "v1",
   "single_model_mode": true,
   "model_yaml": "version: 1.0\nsettings:\n  defaultTimezone: Europe/Berlin\n  ...",

--- a/examples/sem-layer.obml.yml
+++ b/examples/sem-layer.obml.yml
@@ -2,6 +2,7 @@
 version: 1.0
 
 settings:
+  defaultDialect: postgres
   defaultNumericDataType: "decimal(18, 2)"
   defaultTimezone: "Europe/Berlin"
 

--- a/integrations/chatgpt-custom-gpt/openapi-gpt-action.yaml
+++ b/integrations/chatgpt-custom-gpt/openapi-gpt-action.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: OrionBelt Semantic Layer
-  version: 2.1.0
+  version: 2.1.1
   description: >
     Compile YAML semantic models (OBML) as analytical SQL across 8 database dialects.
     This API runs in single-model mode with a pre-loaded semantic model.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,7 +9,7 @@ dev_addr: 127.0.0.1:8080
 
 extra:
   obml_version: "1.0"
-  project_version: "2.1.0"
+  project_version: "2.1.1"
 
 extra_css:
   - stylesheets/extra.css

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-semantic-layer"
-version = "2.1.0"
+version = "2.1.1"
 description = "OrionBelt Semantic Layer - Compiles and executes YAML semantic models as analytical SQL"
 license = {text = "BSL-1.1"}
 authors = [{name = "Ralf Becher, RALFORION d.o.o.", email = "ralf.becher@web.de"}]
@@ -52,6 +52,11 @@ dependencies = [
     "sqlglot>=26.0,<27.0",
     "jsonschema>=4.23,<5.0",
     "rdflib>=7.0,<8.0",
+    # IANA timezone database for Python's zoneinfo on systems without
+    # /usr/share/zoneinfo (e.g. python:3.12-slim Docker images). Without it,
+    # ZoneInfo("Europe/Berlin") raises ZoneInfoNotFoundError and the
+    # timezone resolver silently falls back to UTC.
+    "tzdata>=2025.1",
 ]
 
 [project.scripts]

--- a/src/orionbelt/__init__.py
+++ b/src/orionbelt/__init__.py
@@ -1,3 +1,3 @@
 """OrionBelt Semantic Layer — Compiles and executes YAML semantic models as analytical SQL."""
 
-__version__ = "2.1.0"
+__version__ = "2.1.1"

--- a/uv.lock
+++ b/uv.lock
@@ -1834,7 +1834,7 @@ wheels = [
 
 [[package]]
 name = "ob-bigquery"
-version = "0.1.0"
+version = "2.1.0"
 source = { editable = "drivers/ob-bigquery" }
 dependencies = [
     { name = "google-cloud-bigquery", extra = ["pandas"] },
@@ -1866,7 +1866,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "ob-clickhouse"
-version = "0.1.0"
+version = "2.1.0"
 source = { editable = "drivers/ob-clickhouse" }
 dependencies = [
     { name = "clickhouse-connect" },
@@ -1902,7 +1902,7 @@ provides-extras = ["sqlalchemy", "dev"]
 
 [[package]]
 name = "ob-databricks"
-version = "0.1.0"
+version = "2.1.0"
 source = { editable = "drivers/ob-databricks" }
 dependencies = [
     { name = "databricks-sql-connector" },
@@ -1936,7 +1936,7 @@ provides-extras = ["sqlalchemy", "dev"]
 
 [[package]]
 name = "ob-dremio"
-version = "0.1.0"
+version = "2.1.0"
 source = { editable = "drivers/ob-dremio" }
 dependencies = [
     { name = "ob-driver-core" },
@@ -1970,7 +1970,7 @@ provides-extras = ["sqlalchemy", "dev"]
 
 [[package]]
 name = "ob-driver-core"
-version = "0.1.0"
+version = "2.1.0"
 source = { editable = "drivers/ob-driver-core" }
 dependencies = [
     { name = "httpx" },
@@ -1998,7 +1998,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "ob-duckdb"
-version = "0.1.0"
+version = "2.1.0"
 source = { editable = "drivers/ob-duckdb" }
 dependencies = [
     { name = "duckdb" },
@@ -2030,7 +2030,7 @@ provides-extras = ["sqlalchemy", "dev"]
 
 [[package]]
 name = "ob-flight-extension"
-version = "0.1.0"
+version = "2.1.0"
 source = { editable = "drivers/ob-flight-extension" }
 dependencies = [
     { name = "ob-driver-core" },
@@ -2098,7 +2098,7 @@ provides-extras = ["duckdb", "snowflake", "postgres", "clickhouse", "dremio", "d
 
 [[package]]
 name = "ob-mysql"
-version = "0.1.0"
+version = "2.1.0"
 source = { editable = "drivers/ob-mysql" }
 dependencies = [
     { name = "mysql-connector-python" },
@@ -2134,7 +2134,7 @@ provides-extras = ["sqlalchemy", "dev"]
 
 [[package]]
 name = "ob-postgres"
-version = "0.1.0"
+version = "2.1.0"
 source = { editable = "drivers/ob-postgres" }
 dependencies = [
     { name = "adbc-driver-postgresql" },
@@ -2170,7 +2170,7 @@ provides-extras = ["sqlalchemy", "dev"]
 
 [[package]]
 name = "ob-snowflake"
-version = "0.1.0"
+version = "2.1.0"
 source = { editable = "drivers/ob-snowflake" }
 dependencies = [
     { name = "ob-driver-core" },
@@ -2229,7 +2229,7 @@ wheels = [
 
 [[package]]
 name = "orionbelt-semantic-layer"
-version = "2.1.0"
+version = "2.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
@@ -2244,6 +2244,7 @@ dependencies = [
     { name = "ruamel-yaml" },
     { name = "sqlglot" },
     { name = "structlog" },
+    { name = "tzdata" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -2359,6 +2360,7 @@ requires-dist = [
     { name = "sqlglot", specifier = ">=26.0,<27.0" },
     { name = "structlog", specifier = ">=25.1,<26.0" },
     { name = "testcontainers", marker = "extra == 'dev'", specifier = ">=4.0" },
+    { name = "tzdata", specifier = ">=2025.1" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.40,<1.0" },
 ]
 provides-extras = ["dev", "docs", "ui", "flight"]


### PR DESCRIPTION
## Summary
Hotfix for v2.1.0 — the live Cloud Run demo was returning \`/v1/settings.timezone.effective: UTC\` even when the loaded model declared \`defaultTimezone: Europe/Berlin\`, and the UI dialect dropdown could disagree with \`/v1/settings.dialect.effective\` on the bundled demo.

## Root cause: missing tzdata
\`python:3.12-slim\` has no \`/usr/share/zoneinfo\`. The umbrella package didn't pull \`tzdata\` transitively (no pandas/numpy in runtime deps), so \`ZoneInfo("Europe/Berlin")\` raised \`ZoneInfoNotFoundError\`. The resolver caught the exception, walked the fallback chain (host TZ on Cloud Run is UTC and skipped), and ended at \`UTC\`. The chain was correct — only the IANA data was missing.

**Two-layer fix:**
1. \`tzdata>=2025.1\` is now a runtime dependency of \`orionbelt-semantic-layer\`. PyPI installs on slim systems pick up the data automatically.
2. \`Dockerfile\` and \`Dockerfile.ui\` also \`apt-get install -y --no-install-recommends tzdata\` as defense in depth.

## sem-layer.obml.yml: defaultDialect: postgres
The UI dialect dropdown defaults to a hardcoded \`postgres\` while \`/v1/settings.dialect.effective\` falls back to \`DB_VENDOR\` env. On the public demo (\`DB_VENDOR=duckdb\`) the two disagreed when the loaded model didn't declare \`defaultDialect\`. Adding \`defaultDialect: postgres\` to the bundled \`sem-layer.obml.yml\` aligns both surfaces — model wins on both.

## Version bump
\`__version__\`, \`pyproject.toml\`, \`mkdocs.yml\`, README badge + Docker tags, \`docs/api/endpoints.md\`, \`openapi-gpt-action.yaml\`, \`uv.lock\` → **2.1.1**.

## Test plan
- [x] \`uv run pytest\` — 1349 passed
- [x] \`uv run ruff check\`, \`ruff format --check\`, \`mypy\`, \`mkdocs build --strict\` — clean
- [x] Local \`python -c 'from zoneinfo import ZoneInfo; print(ZoneInfo("Europe/Berlin"))'\` — works (already had system tzdata, but the new runtime dep is what slim Docker needs)
- [ ] Post-deploy: \`/v1/settings.timezone.effective\` returns \`Europe/Berlin\` (or the model's TZ) when a model is loaded
- [ ] Post-deploy: \`/v1/settings.dialect.effective\` returns \`postgres\` when sem-layer.obml.yml is loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)