### PR TITLE
fix: v2.1.2 — UI Settings tab overlay shows wrong effective TZ/dialect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to OrionBelt Semantic Layer are documented here.
 
+## [2.1.2] - 2026-04-30
+
+### Fixed
+
+- **Settings tab in the Gradio UI showed stale `effective` values** for `timezone` and `dialect` when the user had a model YAML pasted/loaded but had not yet compiled. The UI's `_fetch_settings_yaml` overlay only populated `tz["effective"]` and `dl["effective"]` when the API response was *missing* those keys — but the API always returns them (with no-model fallbacks: `UTC` / `DB_VENDOR`). The result: the overlay correctly added `model_settings` and `timezone.model` from the local YAML, but `effective` stayed at the API's no-model fallback. Now the overlay detects "API has no loaded model" by checking whether `model_settings` was returned by the API, and when absent, fully overlays the local YAML's TZ and dialect — including `effective` — so the Settings tab mirrors what compiling will produce.
+
 ## [2.1.1] - 2026-04-30
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ralfbecher/orionbelt-semantic-layer/blob/main/examples/quickstart_colab.ipynb)
 
 [![GitHub stars](https://img.shields.io/github/stars/ralfbecher/orionbelt-semantic-layer?style=social)](https://github.com/ralfbecher/orionbelt-semantic-layer)
-[![Version 2.1.1](https://img.shields.io/badge/version-2.1.1-purple.svg)](https://github.com/ralfbecher/orionbelt-semantic-layer/releases)
+[![Version 2.1.2](https://img.shields.io/badge/version-2.1.2-purple.svg)](https://github.com/ralfbecher/orionbelt-semantic-layer/releases)
 [![PyPI](https://img.shields.io/pypi/v/orionbelt-semantic-layer?logo=pypi&logoColor=white)](https://pypi.org/project/orionbelt-semantic-layer/)
 [![Docker Hub](https://img.shields.io/docker/pulls/ralforion/orionbelt-api?logo=docker&label=Docker%20Hub)](https://hub.docker.com/repositories/ralforion)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
@@ -155,7 +155,7 @@ Open [http://localhost:8080/docs](http://localhost:8080/docs) to explore the API
 # docker-compose.yml
 services:
   api:
-    image: ralforion/orionbelt-api:2.1.1
+    image: ralforion/orionbelt-api:2.1.2
     ports: ["8080:8080"]
     env_file: .env
     volumes:
@@ -164,7 +164,7 @@ services:
       MODEL_FILE: /app/models/my-model.obml.yml
 
   ui:
-    image: ralforion/orionbelt-ui:2.1.1
+    image: ralforion/orionbelt-ui:2.1.2
     ports: ["7860:7860"]
     environment:
       API_BASE_URL: http://api:8080
@@ -180,7 +180,7 @@ See [`.env.template`](.env.template) for the full environment variable reference
 > - `API_SERVER_HOST` is already `0.0.0.0` inside the container — no override needed.
 > - MCP via stdio does not work in Docker. Use the [MCP HTTP client](https://github.com/ralfbecher/orionbelt-semantic-layer-mcp) for containerized deployments.
 > - Mount models to `/app/models` (or any path) and set `MODEL_FILE` to pre-load on startup.
-> - For production, pin a version tag (`:2.1.1`) rather than `:latest`.
+> - For production, pin a version tag (`:2.1.2`) rather than `:latest`.
 
 ### Claude Desktop / MCP
 

--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -13,7 +13,7 @@ Returns the service status and version.
 ```json
 {
   "status": "ok",
-  "version": "2.1.1"
+  "version": "2.1.2"
 }
 ```
 
@@ -734,7 +734,7 @@ Return public configuration for API clients (UI, MCP, etc.).
 
 ```json
 {
-  "version": "2.1.1",
+  "version": "2.1.2",
   "api_version": "v1",
   "single_model_mode": false,
   "session_ttl_seconds": 1800,
@@ -753,7 +753,7 @@ Return public configuration for API clients (UI, MCP, etc.).
 
 ```json
 {
-  "version": "2.1.1",
+  "version": "2.1.2",
   "api_version": "v1",
   "single_model_mode": true,
   "model_yaml": "version: 1.0\nsettings:\n  defaultTimezone: Europe/Berlin\n  ...",

--- a/integrations/chatgpt-custom-gpt/openapi-gpt-action.yaml
+++ b/integrations/chatgpt-custom-gpt/openapi-gpt-action.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: OrionBelt Semantic Layer
-  version: 2.1.1
+  version: 2.1.2
   description: >
     Compile YAML semantic models (OBML) as analytical SQL across 8 database dialects.
     This API runs in single-model mode with a pre-loaded semantic model.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,7 +9,7 @@ dev_addr: 127.0.0.1:8080
 
 extra:
   obml_version: "1.0"
-  project_version: "2.1.1"
+  project_version: "2.1.2"
 
 extra_css:
   - stylesheets/extra.css

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-semantic-layer"
-version = "2.1.1"
+version = "2.1.2"
 description = "OrionBelt Semantic Layer - Compiles and executes YAML semantic models as analytical SQL"
 license = {text = "BSL-1.1"}
 authors = [{name = "Ralf Becher, RALFORION d.o.o.", email = "ralf.becher@web.de"}]

--- a/src/orionbelt/__init__.py
+++ b/src/orionbelt/__init__.py
@@ -1,3 +1,3 @@
 """OrionBelt Semantic Layer — Compiles and executes YAML semantic models as analytical SQL."""
 
-__version__ = "2.1.1"
+__version__ = "2.1.2"

--- a/src/orionbelt/ui/app.py
+++ b/src/orionbelt/ui/app.py
@@ -2844,30 +2844,44 @@ def create_blocks(
                         local_settings = {}
 
                     if local_settings:
-                        # Only overwrite fields the API didn't supply, so a
-                        # truly compiled session keeps the server's view.
+                        # If the API didn't return ``model_settings`` the
+                        # server has no loaded model — the user has typed
+                        # the YAML but not compiled yet, and the API's
+                        # ``timezone.effective`` / ``dialect.effective``
+                        # are no-model fallbacks (UTC / DB_VENDOR). In
+                        # that case the local YAML is the source of
+                        # truth: overlay its values onto the response,
+                        # including ``effective``, so the Settings tab
+                        # mirrors what compiling will produce.
+                        #
+                        # When the API DOES return ``model_settings``
+                        # (compiled session), only fill in the ``model``
+                        # fields if the API didn't supply them — the
+                        # server is authoritative for everything else.
+                        api_has_model = bool(data.get("model_settings"))
+
                         existing_ms = data.get("model_settings") or {}
                         merged_ms = {**local_settings, **existing_ms}
                         data["model_settings"] = merged_ms
 
                         tz = data.get("timezone") or {}
-                        if "model" not in tz and local_settings.get("defaultTimezone"):
-                            tz["model"] = local_settings["defaultTimezone"]
+                        local_tz = local_settings.get("defaultTimezone")
+                        if local_tz and (not api_has_model or "model" not in tz):
+                            tz["model"] = local_tz
                         if "override_database_timezone" not in tz:
                             tz["override_database_timezone"] = bool(
                                 local_settings.get("overrideDatabaseTimezone", False)
                             )
-                        if "effective" not in tz:
-                            tz["effective"] = (
-                                local_settings.get("defaultTimezone") or tz.get("host") or "UTC"
-                            )
+                        if not api_has_model and local_tz:
+                            tz["effective"] = local_tz
                         data["timezone"] = tz
 
                         dl = data.get("dialect") or {}
-                        if "model" not in dl and local_settings.get("defaultDialect"):
-                            dl["model"] = local_settings["defaultDialect"]
-                        if dl.get("model") and "effective" not in dl:
-                            dl["effective"] = dl["model"]
+                        local_dl = local_settings.get("defaultDialect")
+                        if local_dl and (not api_has_model or "model" not in dl):
+                            dl["model"] = local_dl
+                        if not api_has_model and local_dl:
+                            dl["effective"] = local_dl
                         data["dialect"] = dl
 
                     return yaml.dump(data, default_flow_style=False, sort_keys=False)

--- a/uv.lock
+++ b/uv.lock
@@ -2229,7 +2229,7 @@ wheels = [
 
 [[package]]
 name = "orionbelt-semantic-layer"
-version = "2.1.1"
+version = "2.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

The Gradio UI's Settings tab showed stale \`effective\` values when the user had a model YAML loaded but not yet compiled.

## What was happening

User reports \`/v1/settings\` (as rendered by the UI) showing:
\`\`\`yaml
timezone:
  effective: UTC                    # ← wrong
  model: Europe/Berlin              # ← from overlay
dialect:
  effective: duckdb                 # ← wrong (DB_VENDOR fallback)
  model: postgres                   # ← from overlay
model_settings:
  defaultDialect: postgres
  defaultTimezone: Europe/Berlin
\`\`\`

The API was correct: with no compiled model, it returns no-model fallbacks (\`UTC\` for timezone, \`DB_VENDOR\` for dialect). The bug was in the UI overlay (\`_fetch_settings_yaml\`) which only set \`tz[\"effective\"]\` / \`dl[\"effective\"]\` when those keys were *missing* from the API response — but the API always returns them. Net effect: \`model_settings\` and \`model\` got correctly overlaid from the local YAML, but \`effective\` stayed at the API's no-model fallback.

## Fix

Detect "API has no loaded model" by checking whether \`model_settings\` was in the API response. When absent, the local YAML is the source of truth — fully overlay its TZ/dialect including \`effective\`. When present (compiled session), the server's view remains authoritative.

## Test plan
- [x] \`uv run pytest\` — 1349 passed
- [x] \`uv run ruff check\`, \`ruff format --check\`, \`mypy\` — clean
- [ ] Post-deploy: open UI, paste sem-layer.obml.yml, hit Settings tab → \`effective: Europe/Berlin\`, \`effective: postgres\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)