### PR TITLE
fix: v2.1.3 — UI overlay also recomputes timezone.now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to OrionBelt Semantic Layer are documented here.
 
+## [2.1.3] - 2026-04-30
+
+### Fixed
+
+- **Settings tab `timezone.now` showed UTC even after the v2.1.2 overlay set `timezone.effective: Europe/Berlin`.** The API had computed `now` server-side against its own (no-model) `effective` (UTC), and the v2.1.2 overlay only updated `effective` — leaving `now` stale. The overlay now also recomputes `now` as the current wall clock in the overlaid TZ when the API had no loaded model, so `now` and `effective` agree.
+
 ## [2.1.2] - 2026-04-30
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ralfbecher/orionbelt-semantic-layer/blob/main/examples/quickstart_colab.ipynb)
 
 [![GitHub stars](https://img.shields.io/github/stars/ralfbecher/orionbelt-semantic-layer?style=social)](https://github.com/ralfbecher/orionbelt-semantic-layer)
-[![Version 2.1.2](https://img.shields.io/badge/version-2.1.2-purple.svg)](https://github.com/ralfbecher/orionbelt-semantic-layer/releases)
+[![Version 2.1.3](https://img.shields.io/badge/version-2.1.3-purple.svg)](https://github.com/ralfbecher/orionbelt-semantic-layer/releases)
 [![PyPI](https://img.shields.io/pypi/v/orionbelt-semantic-layer?logo=pypi&logoColor=white)](https://pypi.org/project/orionbelt-semantic-layer/)
 [![Docker Hub](https://img.shields.io/docker/pulls/ralforion/orionbelt-api?logo=docker&label=Docker%20Hub)](https://hub.docker.com/repositories/ralforion)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
@@ -155,7 +155,7 @@ Open [http://localhost:8080/docs](http://localhost:8080/docs) to explore the API
 # docker-compose.yml
 services:
   api:
-    image: ralforion/orionbelt-api:2.1.2
+    image: ralforion/orionbelt-api:2.1.3
     ports: ["8080:8080"]
     env_file: .env
     volumes:
@@ -164,7 +164,7 @@ services:
       MODEL_FILE: /app/models/my-model.obml.yml
 
   ui:
-    image: ralforion/orionbelt-ui:2.1.2
+    image: ralforion/orionbelt-ui:2.1.3
     ports: ["7860:7860"]
     environment:
       API_BASE_URL: http://api:8080
@@ -180,7 +180,7 @@ See [`.env.template`](.env.template) for the full environment variable reference
 > - `API_SERVER_HOST` is already `0.0.0.0` inside the container — no override needed.
 > - MCP via stdio does not work in Docker. Use the [MCP HTTP client](https://github.com/ralfbecher/orionbelt-semantic-layer-mcp) for containerized deployments.
 > - Mount models to `/app/models` (or any path) and set `MODEL_FILE` to pre-load on startup.
-> - For production, pin a version tag (`:2.1.2`) rather than `:latest`.
+> - For production, pin a version tag (`:2.1.3`) rather than `:latest`.
 
 ### Claude Desktop / MCP
 

--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -13,7 +13,7 @@ Returns the service status and version.
 ```json
 {
   "status": "ok",
-  "version": "2.1.2"
+  "version": "2.1.3"
 }
 ```
 
@@ -734,7 +734,7 @@ Return public configuration for API clients (UI, MCP, etc.).
 
 ```json
 {
-  "version": "2.1.2",
+  "version": "2.1.3",
   "api_version": "v1",
   "single_model_mode": false,
   "session_ttl_seconds": 1800,
@@ -753,7 +753,7 @@ Return public configuration for API clients (UI, MCP, etc.).
 
 ```json
 {
-  "version": "2.1.2",
+  "version": "2.1.3",
   "api_version": "v1",
   "single_model_mode": true,
   "model_yaml": "version: 1.0\nsettings:\n  defaultTimezone: Europe/Berlin\n  ...",

--- a/integrations/chatgpt-custom-gpt/openapi-gpt-action.yaml
+++ b/integrations/chatgpt-custom-gpt/openapi-gpt-action.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: OrionBelt Semantic Layer
-  version: 2.1.2
+  version: 2.1.3
   description: >
     Compile YAML semantic models (OBML) as analytical SQL across 8 database dialects.
     This API runs in single-model mode with a pre-loaded semantic model.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,7 +9,7 @@ dev_addr: 127.0.0.1:8080
 
 extra:
   obml_version: "1.0"
-  project_version: "2.1.2"
+  project_version: "2.1.3"
 
 extra_css:
   - stylesheets/extra.css

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-semantic-layer"
-version = "2.1.2"
+version = "2.1.3"
 description = "OrionBelt Semantic Layer - Compiles and executes YAML semantic models as analytical SQL"
 license = {text = "BSL-1.1"}
 authors = [{name = "Ralf Becher, RALFORION d.o.o.", email = "ralf.becher@web.de"}]

--- a/src/orionbelt/__init__.py
+++ b/src/orionbelt/__init__.py
@@ -1,3 +1,3 @@
 """OrionBelt Semantic Layer — Compiles and executes YAML semantic models as analytical SQL."""
 
-__version__ = "2.1.2"
+__version__ = "2.1.3"

--- a/src/orionbelt/ui/app.py
+++ b/src/orionbelt/ui/app.py
@@ -2874,6 +2874,18 @@ def create_blocks(
                             )
                         if not api_has_model and local_tz:
                             tz["effective"] = local_tz
+                            # The API computed ``now`` server-side against
+                            # its own (no-model) effective TZ — UTC. After
+                            # overlaying the local TZ as effective, recompute
+                            # ``now`` so the wall clock matches.
+                            try:
+                                from datetime import UTC, datetime
+                                from zoneinfo import ZoneInfo
+
+                                now_local = datetime.now(UTC).astimezone(ZoneInfo(local_tz))
+                                tz["now"] = now_local.isoformat()
+                            except Exception:  # noqa: BLE001 — best-effort
+                                pass
                         data["timezone"] = tz
 
                         dl = data.get("dialect") or {}

--- a/uv.lock
+++ b/uv.lock
@@ -2229,7 +2229,7 @@ wheels = [
 
 [[package]]
 name = "orionbelt-semantic-layer"
-version = "2.1.2"
+version = "2.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

Third (and hopefully final) follow-up to the v2.1.0 TZ display bug. v2.1.2 overlaid \`effective\` from the local YAML when the API had no loaded model, but \`now\` was still computed server-side against the API's own no-model \`effective\` (UTC). So users saw \`effective: Europe/Berlin\` paired with \`now: ...Z\` — contradictory.

## Honest accounting

This is the third bug-fix release for the same user-visible symptom. v2.1.1 (tzdata) and v2.1.2 (overlay \`effective\`) were both real bugs — the v2.1.1 tzdata fix is genuinely needed when a compiled model is loaded server-side — but I should have audited *all* dependent fields of the timezone block at once instead of patching one field per release. The whack-a-mole pattern was avoidable.

## Audit (all fields verified after this fix)

| Field | Source | OK after v2.1.3 |
|---|---|---|
| \`timezone.model\` | local YAML overlay | ✓ |
| \`timezone.effective\` | local YAML overlay | ✓ |
| \`timezone.now\` | recomputed in overlay (NEW) | ✓ |
| \`timezone.utc\` | server (UTC by definition) | ✓ |
| \`timezone.host\`, \`database\`, \`database_detected\`, \`database_raw\` | server-side, model-independent | ✓ |
| \`timezone.override_database_timezone\` | local YAML overlay | ✓ |
| \`dialect.env\`, \`model\`, \`effective\` | env / overlay | ✓ |

## Test plan
- [x] \`uv run pytest\` — 1349 passed
- [x] \`uv run ruff check\`, \`ruff format\`, \`mypy\` — clean
- [ ] Post-deploy: open UI, paste sem-layer.obml.yml without compiling, hit Settings tab → \`effective: Europe/Berlin\`, \`now\` ends with \`+02:00\` not \`Z\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)