### PR TITLE
docs: comparison section vs. dbt SL, Malloy, LookML, Cube, AtScale

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,12 @@ API_BASE_URL=http://remote-api:8080 orionbelt-ui           # point UI to a remot
 | Multi-Fact: Sales & Returns | [examples/multi-fact](https://ralforion.com/orionbelt-semantic-layer/examples/multi-fact/) |
 | TPC-DS Benchmark | [examples/tpcds](https://ralforion.com/orionbelt-semantic-layer/examples/tpcds/) |
 | Quickstart Notebook | [examples/quickstart.ipynb](examples/quickstart.ipynb) |
+| **Comparison: Overview** | [comparison/](https://ralforion.com/orionbelt-semantic-layer/comparison/) |
+| Comparison: vs. dbt Semantic Layer | [comparison/dbt](https://ralforion.com/orionbelt-semantic-layer/comparison/dbt/) |
+| Comparison: vs. Malloy | [comparison/malloy](https://ralforion.com/orionbelt-semantic-layer/comparison/malloy/) |
+| Comparison: vs. LookML / Looker | [comparison/lookml](https://ralforion.com/orionbelt-semantic-layer/comparison/lookml/) |
+| Comparison: vs. Cube | [comparison/cube](https://ralforion.com/orionbelt-semantic-layer/comparison/cube/) |
+| Comparison: vs. AtScale | [comparison/atscale](https://ralforion.com/orionbelt-semantic-layer/comparison/atscale/) |
 
 ---
 

--- a/docs/comparison/atscale.md
+++ b/docs/comparison/atscale.md
@@ -1,0 +1,292 @@
+# OBSL vs AtScale
+
+A feature comparison between **OrionBelt Semantic Layer (OBSL)** and **AtScale** — the enterprise "universal semantic layer" with deep OLAP heritage and native MDX/DAX support. Captured 2026-05-01.
+
+---
+
+## TL;DR
+
+- **AtScale wins on**: enterprise OLAP capabilities (true hierarchies, parent-child, ragged, time-intelligence), **native MDX support** for Excel pivot tables and SSAS-protocol clients (no other peer in this comparison set has this), **DAX support** for Power BI live connections, **autonomous aggregates** (machine-learned auto-rollups similar to Cube pre-aggregations but more automated), enterprise governance (RLS, perspectives, lineage), and broad legacy/cloud warehouse coverage.
+- **OBSL wins on**: being **open-source and self-hostable for production with no licensing tier** (AtScale offers a free Developer Community Edition for evaluation, but production multi-user deployments require an enterprise license), a **simple JSON Query API** consumable by any client, **first-class declarative cumulative and period-over-period metric types**, an **RDF/SPARQL graph view** of the model, **named secondary join paths**, **multi-rooted DAG topology with the CFL planner**, an **interactive ontology-graph playground**, OSI ↔ OBML format conversion, and a much smaller operational footprint.
+- **Different niches**: AtScale is "the enterprise OLAP semantic layer for Excel/PowerBI/Tableau shops that need MDX." OBSL is "the open-source, embeddable semantic compiler for apps, agents, and modern BI tools that speak Arrow Flight SQL or REST."
+
+AtScale is the only peer in this comparison set that natively speaks **MDX**, the OLAP wire protocol that Excel and SSAS clients use. That's a real moat for organizations standardized on Microsoft BI tooling. OBSL doesn't compete on that axis.
+
+---
+
+## 1. Modeling philosophy
+
+| Aspect | OBSL (OBML) | AtScale |
+|---|---|---|
+| Format | Declarative YAML (`OBML`) | Visual model designer (Design Center) backed by JSON / XML model definitions; CLI/API for programmatic deployment |
+| Source of truth | YAML model files | Models authored in AtScale Design Center; deployed to AtScale Engine |
+| Top-level constructs | `dataObjects`, `dimensions`, `measures`, `metrics`, `filters` | `data models` (cubes), `dimensions` (with hierarchies, levels, attributes), `measures`, `calculated members`, `perspectives`, `aggregates`, `security` |
+| OLAP primitives | Time grain on dimensions, no first-class hierarchies | First-class **hierarchies** (multiple per dimension), **levels**, **parent-child** dimensions, **ragged** hierarchies |
+| Templating | None | Limited; some calculated-member expressions |
+| Runtime | OSS, self-hosted (single Python service) | Proprietary AtScale Engine — on-prem, cloud-hosted, or AtScale-managed |
+
+**Key cultural difference**: AtScale carries OLAP heritage from the SSAS/MDX world — it thinks in cubes, hierarchies, and calculated members. OBSL thinks in data objects, joins, and metrics. The model overlap is real but the conceptual frames differ.
+
+---
+
+## 2. Concept mapping
+
+| OBSL | AtScale | Notes |
+|---|---|---|
+| `DataObject` | Dataset (mapped to a warehouse table or query) | |
+| `Dimension` (model-scoped) | Dimension with one or more hierarchies + levels | AtScale has richer dimension structure |
+| `Measure` | Measure on a fact dataset | |
+| `Metric` `type: derived` | Calculated member (MDX expression) or calculated measure | AtScale uses MDX syntax for calculations |
+| `Metric` `type: cumulative` | Time-intelligence functions in MDX (`PeriodsToDate`, `YTD`, etc.) — declarative via dimension hierarchies | AtScale's time intelligence is OLAP-native |
+| `Metric` `type: period_over_period` | Calculated members using time-shift MDX expressions (`ParallelPeriod`, `Lag`) | Idiomatic in AtScale |
+| `DataObjectJoin` | Relationships between dimensions and facts | |
+| `secondary: true` + `pathName` | Multiple relationships / role-playing dimensions | |
+| `QueryObject` JSON | Queries arrive via MDX, DAX, SQL, or REST | |
+| `Filter` (named, reusable) | Perspectives (curated subsets of a model) + named sets | Conceptually similar |
+| OBSL session-scoped REST | AtScale Engine + JDBC/ODBC/MDX/DAX endpoints | |
+
+---
+
+## 3. The headline AtScale features
+
+### 3.1 Native MDX (the unique moat)
+
+AtScale speaks **MDX** (Multidimensional Expressions) natively over the **XMLA** protocol — the same protocol Excel pivot tables, SSAS, and tools like Tableau (when using the MDX driver) use. Excel users connect to AtScale as if it were a SQL Server Analysis Services cube and get full pivot-table experience including drill-down, hierarchies, and time intelligence.
+
+**This is unique in this comparison set.** No other tool here (OBSL, dbt SL, Malloy, LookML, Cube) speaks MDX. For organizations whose business users live in Excel and demand pivot-table workflows on warehouse data, AtScale is the only practical choice.
+
+**OBSL** does not speak MDX. Excel connectivity would require an ODBC bridge to the Arrow Flight SQL endpoint or REST.
+
+### 3.2 DAX support (Power BI live connections)
+
+AtScale also speaks **DAX**, enabling Power BI live (non-import) connections that hit AtScale instead of Power BI's own Tabular engine. This means a Power BI dashboard can use the centrally-governed AtScale model rather than a per-user imported dataset.
+
+**OBSL** does not speak DAX. Power BI integration is via Arrow Flight SQL ODBC.
+
+### 3.3 Autonomous aggregates
+
+AtScale's "Autonomous Data Engineering" automatically creates and maintains aggregate tables in the warehouse based on observed query patterns. Similar in spirit to Cube pre-aggregations but more automated — AtScale picks what to aggregate, builds it, and routes queries transparently.
+
+**OBSL** has no aggregate / materialization story.
+
+### 3.4 OLAP hierarchies and time intelligence
+
+AtScale natively models multi-level hierarchies (e.g. `Year > Quarter > Month > Day`) within a single dimension, including:
+- **Multiple hierarchies** per dimension (calendar vs. fiscal year)
+- **Parent-child** hierarchies (org charts, account trees)
+- **Ragged** hierarchies (geography with optional state/region levels)
+- **Time intelligence** functions: YTD, MTD, parallel period, period-to-date
+
+**OBSL** has time grain on dimensions but no first-class multi-level hierarchies or parent-child structures.
+
+### 3.5 Enterprise governance
+
+AtScale ships first-class enterprise primitives:
+- **Row-level security** based on user attributes / Active Directory groups
+- **Dimension-level / measure-level security** (hide measures from certain roles)
+- **Perspectives** — curated subsets of a model exposed to specific user groups
+- **Lineage and impact analysis** baked into the platform
+- **SAML, OAuth, AD integration**
+
+**OBSL** has session-scoped models (TTL, max-age, rate limits) but no first-class user/auth model.
+
+---
+
+## 4. Metric types
+
+| OBSL | AtScale | Notes |
+|---|---|---|
+| `Measure` (sum/avg/count/min/max, `total: bool`) | Measures with rich aggregation types (sum, count, distinct count, min, max, average, semi-additive measures) | Both first-class; AtScale has more built-in semi-additive types |
+| `Metric` `type: derived` | Calculated members (MDX expressions) | Both first-class |
+| `Metric` `type: cumulative` (running, rolling, grain-to-date) | Time-intelligence MDX (`Aggregate(YTD([Date].CurrentMember), [Sales])`) — idiomatic OLAP | Both expressive; OBSL is YAML-declarative, AtScale is MDX-declarative |
+| `Metric` `type: period_over_period` (4 comparison modes) | Calculated members using `ParallelPeriod` / `Lag` MDX functions | Both expressive; AtScale is more flexible (full MDX), OBSL is more turnkey |
+| Reusable filter context / filtered measures | Named sets, perspectives | Comparable |
+| Hierarchical aggregation | Limited (use grains) | First-class via hierarchies and `Aggregate()` |
+
+For complex OLAP-style metrics (MDX is genuinely more expressive than any YAML format), AtScale wins on flexibility. For straightforward cumulative/PoP that you want declared once and reused everywhere, OBSL is more turnkey.
+
+---
+
+## 5. Joins / relationships
+
+| | OBSL | AtScale |
+|---|---|---|
+| Definition site | `joins:` array on `DataObject` | Relationships in Design Center between dimensions and facts |
+| Cardinality | `joinType` (inner/left/right) | Relationship cardinality + role-playing dimensions |
+| Multiple paths | First-class via `secondary: true` + `pathName` + per-query `usePathNames` | **Role-playing dimensions** (a dimension joined multiple ways with different roles) — the OLAP-native way |
+| Cycle / multi-path validation | Built into resolver | Engine-level checks |
+
+AtScale's role-playing dimensions are conceptually similar to OBSL's named secondary paths — both are first-class ways to handle "same dim joined two different ways." Different terminology, similar capability.
+
+---
+
+## 6. Data modeling topology (a major differentiator)
+
+AtScale models are typically **single-cube-rooted**: each data model has a single fact base (or a small number of fact tables joined via shared dimensions). Multi-fact reporting is achieved either by (a) having multiple data models, (b) carefully designing one model that joins facts via conformed dimensions, or (c) using AtScale's cube-of-cubes patterns. Multi-path joins are handled via role-playing dimensions, which is elegant but distinct from OBSL's `pathName` primitive.
+
+OBSL is built on a **directed join graph (DAG)** with explicit support for richer topologies:
+
+| Topology | Star (single fact + dims) | Snowflake (chained dims) | Multi-rooted (multiple facts) | Multi-path (alt. joins between same pair) | Cycles |
+|---|---|---|---|---|---|
+| **OBSL** | ✅ | ✅ | ✅ via CFL `UNION ALL` legs with per-leg common root | ✅ first-class via `secondary: true` + `pathName` + per-query `usePathNames` | Detected and rejected |
+| **AtScale** | ✅ | ✅ | Conformed-dimension patterns or multiple data models | ✅ via role-playing dimensions (different mechanism, similar capability) | Implicit |
+
+**Why this matters**: AtScale's OLAP heritage assumes you've designed a clean cube up front. OBSL's CFL planner lets you query across multiple unrelated facts in one go without pre-designing the cube boundary. For ad-hoc embedded analytics or AI/agent queries that don't know in advance which facts they'll touch, OBSL's flexibility is a real advantage.
+
+---
+
+## 7. Dialects / data sources
+
+AtScale connects to a broad list of warehouses via its query engine.
+
+| Dialect | OBSL | AtScale |
+|---|---|---|
+| BigQuery | ✅ | ✅ |
+| Snowflake | ✅ | ✅ |
+| Postgres | ✅ | ✅ |
+| MySQL | ✅ | Partial (less common) |
+| DuckDB | ✅ | ❌ |
+| Databricks | ✅ | ✅ |
+| ClickHouse | ✅ | Partial |
+| Dremio | ✅ | ❌ |
+| Redshift | ❌ | ✅ |
+| Synapse / SQL Server | ❌ | ✅ |
+| Hive / Hadoop | ❌ | ✅ (legacy strength) |
+| Iceberg / Open table formats | ❌ | ✅ |
+
+AtScale wins on legacy and enterprise (Synapse, Hive, Iceberg lakehouse). OBSL is competitive on modern cloud warehouses and uniquely supports DuckDB and Dremio.
+
+---
+
+## 8. APIs / interfaces
+
+| | OBSL | AtScale |
+|---|---|---|
+| REST API | Yes — first-party FastAPI service | Yes — REST API for model management and queries |
+| MCP | Yes — first-party server | Limited (via AI-Link integrations) |
+| GraphQL | No | No |
+| Native SQL endpoint | Apache Arrow Flight SQL (gRPC, columnar) | JDBC / ODBC SQL endpoint |
+| MDX (XMLA) | ❌ | ✅ — primary protocol for Excel/SSAS clients |
+| DAX | ❌ | ✅ — for Power BI live connections |
+| JDBC | ✅ via Arrow Flight SQL JDBC driver | ✅ native |
+| ODBC | ✅ via Arrow Flight SQL ODBC driver | ✅ native |
+| DB-API 2.0 drivers | ✅ 8 drivers shipped | ❌ |
+| Python SDK | Via FastAPI client | AI-Link Python SDK |
+| UI / IDE | Interactive Gradio playground (SQL Compiler, Mermaid ER, RDF ontology graph, OSI import/export) | AtScale Design Center (visual model designer, polished, proprietary) |
+| RDF graph + SPARQL | Yes (`/graph`, `/sparql`) | No |
+| Format conversion | OSI ↔ OBML (`/convert/*`) | OSI support (founding contributor — direction of travel) |
+
+AtScale's MDX/DAX support is unique and a genuine advantage for Microsoft-stack BI environments. OBSL's RDF/SPARQL surface and DB-API drivers are unique in the other direction.
+
+---
+
+## 9. Open-source vs. proprietary
+
+| | OBSL | AtScale |
+|---|---|---|
+| License | Source-available (BSL) | Proprietary; **free Developer Community Edition** for non-production / individual use |
+| Self-hostable | ✅ (one Python service) | ✅ — Developer Edition is free to install; production deployment requires enterprise license |
+| Pricing | Free (OSS) | **Developer Edition: free** (with feature/scale limits). Enterprise: typical six-figure annual licensing for production |
+| Vendor lock-in | None (plain YAML, OSI-portable) | High — model lives in AtScale's proprietary format (mitigated for OSI-aware exports) |
+| Air-gapped deploy | ✅ supported | ✅ supported (enterprise) |
+| Self-host parity | Full feature parity in OSS | Full features in licensed enterprise tier; Developer Edition has feature/scale restrictions |
+
+The free **Developer Community Edition** lowers the barrier for evaluation, prototyping, and individual learning — you can model, run MDX queries from Excel, and explore AtScale without a contract. For production multi-user deployments, autonomous aggregates at scale, or enterprise governance/support, the licensed tier is required. For OBSL the free OSS tier *is* the production tier — no upgrade path needed.
+
+---
+
+## 10. Other distinctives
+
+| Feature | OBSL | AtScale |
+|---|---|---|
+| Native MDX (XMLA / SSAS protocol) | ❌ | ✅ unique strength |
+| Native DAX (Power BI live) | ❌ | ✅ |
+| Autonomous aggregates | ❌ | ✅ flagship enterprise feature |
+| Multi-level hierarchies, parent-child, ragged | ❌ (grain only) | ✅ first-class OLAP |
+| Time intelligence (YTD, MTD, parallel period) | Via `cumulative` and `period_over_period` metric types | First-class MDX functions |
+| Role-playing dimensions | Via `secondary: true` + `pathName` (different mechanism) | First-class OLAP idiom |
+| Enterprise RLS / governance | ❌ | ✅ |
+| Perspectives (model subsets) | Via separate models | ✅ |
+| Lineage / impact analysis | ❌ | ✅ |
+| Multi-rooted DAG modeling | ✅ via CFL | ❌ (cube-rooted) |
+| Named secondary join paths (per-query) | ✅ | Role-playing dimensions are model-time, not query-time |
+| First-class declarative PoP metric type | ✅ | Via MDX (more flexible but less turnkey) |
+| First-class declarative cumulative metric type | ✅ | Via MDX time intelligence |
+| Apache Arrow Flight SQL | ✅ | ❌ |
+| DB-API 2.0 drivers | ✅ 8 drivers | ❌ |
+| RDF/SPARQL graph view | ✅ | ❌ |
+| Interactive ontology-graph playground | ✅ Gradio | ❌ |
+| OSI interoperability | ✅ converter shipped | ✅ founding contributor |
+| MCP server (LLM/agent) | ✅ first-party | Limited |
+| Built-in caching | ❌ | ✅ result cache + autonomous aggregates |
+| Visual model designer | ❌ | ✅ Design Center (polished) |
+| Open source / self-host without license | ✅ | ❌ |
+
+---
+
+## 11. When to pick which
+
+### Pick **AtScale** when:
+
+- Your business users live in **Excel pivot tables** and you need a real OLAP/MDX experience (this is the killer feature — no peer here matches it).
+- You're running **Power BI** with live (DirectQuery / non-import) connections to a centrally-governed model via DAX.
+- You need **autonomous aggregates** maintained by the platform without DIY rollup engineering.
+- You need first-class **OLAP hierarchies**, parent-child structures, ragged hierarchies, and time intelligence as model primitives.
+- You need **enterprise governance**: RLS, perspectives, lineage, AD integration, SAML/OAuth, audit trails.
+- You're already buying enterprise BI tools (Tableau, Power BI, Excel, MicroStrategy) and the per-seat math works.
+- Your warehouse is **Synapse, Hive, or Iceberg** (AtScale's lakehouse story is mature).
+- You're **evaluating** an OLAP/MDX semantic layer — the free Developer Community Edition lets you prototype before committing.
+
+### Pick **OBSL** when:
+
+- You need an **open-source, self-hostable, embeddable** semantic layer with **no production licensing tier** — OBML is plain YAML, the runtime is one Python service, and the same OSS bits run in production as in development. AtScale's free Community Edition is great for evaluation, but production multi-user deployments still need an enterprise contract.
+- Your consumers are **applications, agents, or LLMs** — a stable JSON/Arrow Flight SQL API beats requiring callers to know MDX/DAX.
+- You need **multi-rooted DAG modeling** for messy real-world warehouses with multiple fact tables and ambiguous join paths.
+- You want **first-class declarative cumulative and period-over-period metric types** rather than expressing them as MDX calculated members.
+- You target **DuckDB, Dremio, or ClickHouse** with full driver coverage.
+- You want **OSI interoperability** for portability between semantic layers.
+- You want a **graph view of the model** (RDF/SPARQL) for governance/lineage tooling without buying enterprise software.
+- Your operational appetite is small — **one Python service**, no separate model designer or aggregate engine to operate.
+
+### They could coexist
+
+In a Microsoft-stack enterprise: AtScale serves the human BI audience (Excel, Power BI, Tableau via MDX) and OBSL serves the embedded / API / agent audience (REST, Arrow Flight SQL, MCP). With OSI as a common interchange format the two models could in principle stay in sync — though in practice you'll author one as the source of truth and synchronize toward the other.
+
+---
+
+## 12. Gap analysis
+
+### To match AtScale, OBSL would need:
+
+1. **MDX / XMLA support** — speak the OLAP wire protocol that Excel and SSAS clients use. This is the biggest single gap and a major engineering investment (MDX is a sizable language to implement).
+2. **DAX support** for Power BI live connections — separate but related effort.
+3. **Multi-level hierarchies, parent-child, ragged** — first-class OLAP dimension structures beyond simple grains.
+4. **Autonomous aggregates / pre-aggregations** — automated rollup creation and query routing (also a Cube gap).
+5. **Enterprise governance primitives** — RLS, perspectives, dimension/measure-level security, AD integration.
+6. **Lineage and impact analysis** — first-class governance surface.
+7. **Time intelligence library** richer than the current `cumulative` + `period_over_period` types — full MDX-equivalent functions like `ParallelPeriod`, `OpeningPeriod`, `ClosingPeriod`.
+8. **Visual model designer** for non-developer authors.
+9. **More dialects** — Synapse, Redshift, Iceberg lakehouse format.
+
+### To match OBSL, AtScale would need:
+
+1. **Open-source / self-hostable runtime in production** — the free Developer Community Edition is welcome for evaluation, but production deployments still require an enterprise license. A truly OSS production tier would be the structural unlock.
+2. **Multi-rooted DAG modeling with explicit CFL multi-fact planning** — the ability to query across genuinely independent fact tables in one go without pre-designing a cube.
+3. **First-class declarative cumulative & period-over-period metric types** — turnkey alternatives to writing MDX calculated members.
+4. **RDF/SPARQL graph surface** for governance/lineage tooling outside the proprietary platform.
+5. **Apache Arrow Flight SQL** as a modern columnar wire protocol option.
+6. **First-class DB-API 2.0 drivers** for direct programmatic access from Python.
+7. **MCP server (first-party)** for LLM/agent integration.
+8. **Plain-text portable model format** — OBML is a static YAML file that diffs in Git; AtScale models are richer but harder to version-control as plain text.
+
+---
+
+## References
+
+- OBSL `MetricType` enum: `src/orionbelt/models/semantic.py`
+- OBSL CFL planner: `src/orionbelt/compiler/cfl.py`
+- OBSL fanout detection: `src/orionbelt/compiler/fanout.py`
+- OBSL docs: [Model Format](../guide/model-format.md), [Period-over-Period Metrics](../guide/period-over-period.md), [Compilation Pipeline](../guide/compilation.md)
+- AtScale: https://www.atscale.com/
+- AtScale docs: https://documentation.atscale.com/
+- AtScale and OSI: https://open-semantic-interchange.org/

--- a/docs/comparison/cube.md
+++ b/docs/comparison/cube.md
@@ -1,0 +1,324 @@
+# OBSL vs Cube
+
+A feature comparison between **OrionBelt Semantic Layer (OBSL)** and **Cube** (formerly Cube.js — the open-source semantic layer from Cube Dev). Captured 2026-05-01.
+
+---
+
+## TL;DR
+
+- **Cube wins on**: **pre-aggregations** (its flagship feature — materialized rollups with refresh, partitioning, and lambda strategies), a **Postgres-wire SQL API** with the broadest BI-tool compatibility today, GraphQL alongside REST, first-class multi-tenancy and row-level security via `query_rewrite` + JWT security contexts, Twig templating for dynamic models, and the broadest data-source portfolio of the OSS semantic layers.
+- **OBSL wins on**: **richer modeling topologies** (multi-rooted DAG with named secondary join paths) where Cube assumes single-rooted cubes plus combining `views`; **first-class declarative metric types** for cumulative and period-over-period (Cube has `rolling_window` and `time_shift` but they're query/measure patterns, not metric *types*); an **RDF/SPARQL graph view** of the model and a matching **interactive ontology-graph playground**; **Apache Arrow Flight SQL** as a modern columnar wire protocol (vs. Cube's Postgres wire); 8 first-class **DB-API 2.0 drivers**; an explicit **CFL multi-fact planner**; OSI ↔ OBML format conversion; and a simpler operational footprint (no Redis, no scheduler, no separate query orchestrator).
+- **Different niches**: Cube is "the production semantic-layer + caching + API gateway" — built to serve high-volume embedded analytics with millisecond response times. OBSL is "an embeddable semantic compiler with a clean REST surface and rich modeling primitives" — best when you don't need pre-aggregation infrastructure and want a smaller dependency footprint.
+
+Cube is the closest peer to OBSL in the OSS space — both are self-hostable, both target embedded analytics, both expose REST/MCP. The interesting differences are in modeling topology, metric expressivity, and the caching/pre-aggregation layer.
+
+---
+
+## 1. Modeling philosophy
+
+| Aspect | OBSL (OBML) | Cube |
+|---|---|---|
+| Format | Declarative YAML (`OBML`) | YAML or JavaScript (`.yml` or `.js` cube definitions); supports Twig/Jinja templating |
+| Source of truth | YAML model files | `model/cubes/*.{yml,js}` and `model/views/*.{yml,js}` files |
+| Top-level constructs | `dataObjects`, `dimensions`, `measures`, `metrics`, `filters` | `cubes` (with `measures`, `dimensions`, `segments`, `joins`, `pre_aggregations`), `views` (combining cubes), `pre_aggregations` |
+| Object scoping | Each `DataObject` has `columns:`; dimensions/measures/metrics live at model scope | Measures and dimensions live *inside* each `cube`; `view`s expose a curated subset for end users |
+| Templating | None (static YAML) | Twig (Jinja2-like) — `COMPILE_CONTEXT` for compile-time multi-tenancy, dynamic SQL, masking |
+| Runtime | OSS, self-hosted (single Python service) | OSS Cube Core (Node.js + Cube Store + optional Redis) **or** Cube Cloud (managed, paid) |
+
+---
+
+## 2. Concept mapping
+
+| OBSL | Cube | Notes |
+|---|---|---|
+| `DataObject` | `cube` | Both wrap a physical table or SQL block |
+| `DataObject.columns` | `dimensions` on a cube | |
+| `Dimension` (model-scoped) | n/a — dimensions live inside cubes | OBSL has model-scoped dimensions; Cube does not |
+| `Measure` | `measures` on a cube | |
+| `Metric` `type: derived` | `measure: { type: number; sql: ... }` referencing other measures | Both first-class |
+| `Metric` `type: cumulative` | `measure: { type: sum; rolling_window: { trailing: '7 day' } }` | Cube has rolling windows but they live on individual measures, not as a separate metric type |
+| `Metric` `type: period_over_period` | `time_shift` in queries (`compareDateRange`, `time_shift: { interval: '1 year', type: 'prior' }`) | Cube does PoP at *query time*, not in the model |
+| `DataObjectJoin` | `joins:` inside a cube with `relationship: many_to_one`/`one_to_many`/`one_to_one` | Cube uses relationship-driven symmetric aggregates |
+| Combining multiple data objects in one query | Native via join graph + CFL | `view` entity required to combine cubes; views are first-class but distinct from cubes |
+| `secondary: true` + `pathName` | n/a — multiple joins between the same pair require workarounds | No path-name primitive |
+| `QueryObject` JSON | Cube REST query shape (`measures`, `dimensions`, `filters`, `timeDimensions`, `segments`, `order`, `limit`) | Different shape but same idea |
+| `Filter` (named, reusable) | `segments` (named WHERE-style filters reusable in queries) | |
+
+---
+
+## 3. The headline Cube features
+
+### 3.1 Pre-aggregations (Cube's flagship)
+
+Pre-aggregations are materialized rollups that Cube builds, refreshes, and routes queries through automatically. This is the single biggest Cube feature OBSL has no answer for.
+
+```yaml
+cubes:
+  - name: orders
+    pre_aggregations:
+      - name: monthly_revenue
+        measures: [total_revenue, order_count]
+        dimensions: [status]
+        time_dimension: created_at
+        granularity: month
+        partition_granularity: month
+        refresh_key:
+          every: 1 hour
+        build_range_start:
+          sql: SELECT DATE('2020-01-01')
+        build_range_end:
+          sql: SELECT NOW()
+```
+
+Capabilities:
+- **Rollup** (most common), **original_sql**, **rollup_join**, **rollup_lambda** strategies
+- **Partitioning** for incremental refresh
+- **Cube Store** — Cube's columnar materialization engine (SQLite/Parquet-backed)
+- **Query routing** — Cube transparently rewrites incoming queries to hit the matching pre-aggregation
+- Sub-second query response times even on billion-row source tables
+
+**OBSL** has no materialization story. "Make this faster" is the warehouse's job (materialized views, dbt models, scheduled jobs).
+
+### 3.2 SQL wire protocol for BI tools (both have one)
+
+Both projects expose a SQL wire protocol so BI tools can connect to the semantic layer like a database — just over **different wires**:
+
+| | OBSL | Cube |
+|---|---|---|
+| Protocol | **Apache Arrow Flight SQL** (gRPC, port 8815) | **Postgres wire** (port 15432) |
+| Underlying format | Columnar (Arrow) — modern, efficient for analytics | Row-based (Postgres) |
+| BI tool support | DBeaver, Tableau (Flight SQL JDBC), Power BI (Flight SQL ODBC), `pyarrow.flight` | Tableau, Superset, Metabase, PowerBI, `psql`, anything with a Postgres driver |
+| Maturity in BI ecosystem | Newer (Arrow Flight SQL is the modern standard but tool support is still rolling out) | Very wide — anything that speaks Postgres wire works |
+| Self-hostable | Via `ob-flight-extension` package, daemon thread inside the API process | Built into Cube core |
+| OBSL also ships | 8 PEP 249 DB-API drivers (`ob-bigquery`, `ob-snowflake`, `ob-postgres`, `ob-mysql`, `ob-duckdb`, `ob-clickhouse`, `ob-databricks`, `ob-dremio`) for direct programmatic access | n/a |
+
+So this is a wash on capability, with Cube currently winning on **breadth of compatible tooling today** (Postgres wire is everywhere) and OBSL winning on **modern columnar transport** (Arrow Flight SQL is faster for analytical payloads, especially over the wire).
+
+### 3.3 Multi-API parity
+
+Cube exposes the same semantic model through:
+- **REST API** (`/cubejs-api/v1/load`)
+- **GraphQL API** (`/graphql`)
+- **SQL API** (Postgres wire on port 15432)
+- **MCP** (Model Context Protocol)
+
+OBSL exposes:
+- **REST API** (FastAPI)
+- **Arrow Flight SQL** (gRPC port 8815, JDBC/ODBC via Arrow Flight SQL drivers)
+- **DB-API 2.0 drivers** (8 PEP 249 packages)
+- **MCP**
+
+Cube uniquely has GraphQL; OBSL uniquely has DB-API drivers and the RDF/SPARQL surface. Both have REST + a SQL wire protocol + MCP.
+
+### 3.4 Multi-tenancy and row-level security
+
+Cube has first-class multi-tenancy:
+
+- **Compile-time multi-tenancy** via `COMPILE_CONTEXT` in Twig templates — generate different schemas per tenant.
+- **Runtime RLS** via `query_rewrite(query, { securityContext })` — inject filters based on JWT claims.
+- **Member-level access control** via `public: false` on dimensions/measures, conditional masking in Twig.
+- **JWT-based authentication** built into the API gateway.
+
+**OBSL** has session-scoped models (TTL, max-age, rate limits) but no first-class user/auth model. Authn/authz is the host application's job.
+
+### 3.5 Pre-aggregations + caching = production-grade serving
+
+Beyond pre-aggregations, Cube has a tiered caching architecture: in-memory query cache, Redis (optional), and Cube Store. This is built for the embedded-analytics use case where you serve thousands of dashboard requests per second.
+
+**OBSL** has no built-in caching. It's a stateless query compiler.
+
+---
+
+## 4. Metric types
+
+| OBSL | Cube | Notes |
+|---|---|---|
+| `Measure` (sum/avg/count/min/max, `total: bool`) | `measures` (`type: sum/count/count_distinct/avg/min/max/number/string/time/boolean`) | Cube has more types out of the box |
+| `Metric` `type: derived` | `measure: { type: number; sql: ... }` referencing other measures | Both first-class |
+| `Metric` `type: cumulative` (running, rolling, grain-to-date) | `measure: { rolling_window: { trailing: '7 day', offset: 'end' } }` — rolling only | Cube has rolling windows but no grain-to-date or unbounded cumulative as a declarative type |
+| `Metric` `type: period_over_period` (4 comparison modes) | Query-side: `compareDateRange` parameter or `time_shift: { interval: '1 year', type: 'prior' }` | Cube does PoP at query time, not as a model-defined metric |
+| Reusable filter context / filtered measures | `segments` (named, reusable filter sets) + `filters` on individual measure definitions | Comparable |
+| Grand totals (`total: true`) | n/a — done at query/visualization time | OBSL has it as a measure attribute |
+
+**Different philosophies**: OBSL bakes time-aware metrics into the model (write once, every query gets the comparison). Cube treats time comparisons as query-time concerns (more flexible, but the consumer has to know how to ask). Either fits depending on whether you're publishing a metrics catalog or empowering query authors.
+
+---
+
+## 5. Joins
+
+| | OBSL | Cube |
+|---|---|---|
+| Definition site | `joins:` array on `DataObject` | `joins:` block inside each `cube` |
+| Cardinality | `joinType` (inner/left/right) | `relationship: one_to_one`/`one_to_many`/`many_to_one` — drives symmetric aggregates |
+| Join condition | `columnsFrom`/`columnsTo` arrays | `sql: "{CUBE}.id = {other.foo_id}"` (free-form SQL with `{CUBE}` reference) |
+| Multiple paths | First-class via `secondary: true` + named `pathName`, query-time selection via `usePathNames` | No path-name primitive; workaround via `view`s exposing one path or aliased cubes |
+| Join direction | Directed, declared per data object | Bidirectional inference based on `relationship:` |
+| Symmetric aggregates | ❌ (uses CFL) | ✅ |
+
+Cube's `relationship:` keyword drives symmetric aggregate logic (similar to LookML and Malloy). OBSL takes the static-fanout-detection + CFL approach instead.
+
+---
+
+## 6. Data modeling topology (a major differentiator)
+
+Cube is fundamentally **single-rooted per cube**: each cube has its own measures and dimensions, joins fan out from there. To combine multiple cubes into a unified end-user surface, Cube uses **views** — a separate entity that selectively re-exposes measures/dimensions from joined cubes. Views are good, but they don't escape the underlying single-rooted-per-cube topology, and multi-path scenarios (two valid joins between the same pair of cubes) aren't a first-class primitive.
+
+OBSL is built on a **directed join graph (DAG)** with explicit support for richer topologies:
+
+| Topology | Star (single fact + dims) | Snowflake (chained dims) | Multi-rooted (multiple facts) | Multi-path (alt. joins between same pair) | Cycles |
+|---|---|---|---|---|---|
+| **OBSL** | ✅ | ✅ | ✅ via CFL `UNION ALL` legs with per-leg common root | ✅ first-class via `secondary: true` + `pathName` + per-query `usePathNames` | Detected and rejected |
+| **Cube** | ✅ | ✅ | Via `view`s combining cubes (workable but indirect) | Workaround via duplicate cubes or views | Implicit |
+
+**Why this matters**: When you need a single semantic surface that exposes revenue + support tickets by customer, or to choose between `ship_address_id` and `billing_address_id` joins to the same address dimension per query, Cube wants you to design `view`s upstream and pick the right one. OBSL lets you model the messy graph as-is and resolve at query time.
+
+---
+
+## 7. Dialects / data sources
+
+Cube supports a very broad list including all OBSL dialects plus more.
+
+| Source | OBSL | Cube |
+|---|---|---|
+| BigQuery | ✅ | ✅ |
+| Snowflake | ✅ | ✅ |
+| Postgres | ✅ | ✅ |
+| MySQL | ✅ | ✅ |
+| DuckDB | ✅ | ✅ |
+| Databricks | ✅ | ✅ |
+| ClickHouse | ✅ | ✅ |
+| Dremio | ✅ | ❌ |
+| Redshift | ❌ | ✅ |
+| Trino / Presto | ❌ | ✅ |
+| MS SQL / Oracle | ❌ | ✅ |
+| Druid | ❌ | ✅ |
+| Athena, Hive, Vertica, etc. | ❌ | ✅ |
+
+Cube wins on breadth (especially legacy enterprise sources); OBSL covers modern cloud warehouses well and is competitive on Databricks/ClickHouse, with Dremio unique to OBSL.
+
+---
+
+## 8. APIs / interfaces
+
+| | OBSL | Cube |
+|---|---|---|
+| REST API | Yes — first-party FastAPI service | Yes — `/cubejs-api/v1/load`, mature |
+| GraphQL | No | Yes |
+| SQL wire protocol | **Apache Arrow Flight SQL** (gRPC, columnar) — JDBC/ODBC via Flight SQL drivers | **Postgres wire** (port 15432) — works with anything that speaks Postgres |
+| DB-API 2.0 drivers | Yes — 8 PEP 249 drivers shipped (`ob-{bigquery,snowflake,postgres,mysql,duckdb,clickhouse,databricks,dremio}`) | No (SQL API supplants this) |
+| MCP | Yes — first-party server | Yes — first-party server |
+| Native SDKs | Python (FastAPI client) + DB-API drivers | JS/TS (`@cubejs-client/*`), React, Vue, Angular bindings |
+| UI / Playground | Interactive Gradio playground: SQL Compiler, Query Results, auto-generated Mermaid ER diagrams, **interactive RDF/OBSL ontology graph** (vis-network), OSI import/export, settings panel | Cube Playground (OSS): query builder, schema browser, generated SQL preview. Cube Cloud Studio (paid) adds advanced workspace features |
+| RDF graph + SPARQL | Yes (`/graph`, `/sparql`) | No |
+| Format conversion | OSI ↔ OBML (`/convert/*`) | No equivalent |
+
+Cube's SQL API is a structural advantage for BI-tool connectivity. OBSL's RDF/SPARQL surface is unique for governance/lineage tooling.
+
+---
+
+## 9. Open-source vs. commercial story
+
+Both projects ship a free OSS core and offer commercial extensions, but the split is different:
+
+| | OBSL | Cube |
+|---|---|---|
+| Core license | Source-available (BSL 1.1) | Apache 2.0 |
+| Self-hostable | ✅ (one Python service) | ✅ (Cube Core: Node.js + optional Cube Store + optional Redis) |
+| Commercial offering | Hosted instance (the public demo on Cloud Run) | Cube Cloud — managed runtime, multi-cluster, advanced security, Studio IDE, paid |
+| Operational footprint | Light: one process, in-memory sessions | Heavier: API server + Cube Store + Redis (optional) + scheduler + refresh workers in production |
+| Self-host parity | Full feature parity in OSS | Many advanced features (Studio, advanced workspaces, AI features) are Cube Cloud-only |
+
+For a small embedded-analytics use case OBSL is operationally simpler. For high-throughput multi-tenant production with heavy caching, Cube's architecture is purpose-built and Cube Cloud provides the managed experience.
+
+---
+
+## 10. Other distinctives
+
+| Feature | OBSL | Cube |
+|---|---|---|
+| Pre-aggregations / materialized rollups | ❌ | ✅ flagship |
+| SQL wire protocol for BI tools | ✅ Arrow Flight SQL (gRPC, columnar) | ✅ Postgres wire (row-based, broader BI tool support today) |
+| DB-API 2.0 drivers (PEP 249) | ✅ 8 drivers shipped | ❌ |
+| Interactive RDF/ontology graph in playground | ✅ vis-network ontology view | ❌ (schema browser only) |
+| GraphQL API | ❌ | ✅ |
+| Twig/Jinja templating | ❌ | ✅ |
+| Multi-tenancy primitives | Session-scoped only | ✅ first-class (compile-time + runtime) |
+| Row-level security in model | ❌ | ✅ via `query_rewrite` |
+| Field-level masking | ❌ | ✅ via Twig conditionals |
+| First-class PoP metric type | ✅ (4 comparison modes) | ❌ (`time_shift` at query time) |
+| First-class cumulative metric type | ✅ (running, rolling, grain-to-date) | Partial (`rolling_window` only) |
+| Multi-rooted DAG modeling | ✅ via CFL | ❌ (single-rooted cubes + views) |
+| Named secondary join paths | ✅ | ❌ |
+| Symmetric aggregates | ❌ (uses CFL) | ✅ |
+| RDF/SPARQL graph view | ✅ | ❌ |
+| OSI ↔ OBML conversion | ✅ | ❌ |
+| Built-in caching layer | ❌ | ✅ multi-tier |
+| Cube Store / materialization engine | n/a | ✅ |
+| Operational simplicity | Single Python process | Multiple services in production |
+
+---
+
+## 11. When to pick which
+
+### Pick **Cube** when:
+
+- You need **pre-aggregations** for sub-second analytics on large datasets — this is Cube's defining feature and OBSL has no equivalent.
+- Your BI tools speak **Postgres wire protocol** and you want the broadest tool compatibility today (vs. OBSL's Arrow Flight SQL, which is the modern columnar standard but has narrower current tool coverage).
+- You need **GraphQL** alongside REST (e.g. for a frontend that already uses Apollo).
+- You need first-class **multi-tenancy + RLS** without writing it yourself.
+- Your model needs **dynamic SQL via templating** (Twig/Jinja) — per-tenant table names, masking, conditional logic.
+- You're building **high-throughput embedded analytics** with thousands of concurrent dashboard requests.
+- You're willing to operate Node.js + Cube Store + Redis, or pay for Cube Cloud.
+
+### Pick **OBSL** when:
+
+- You need **richer modeling topologies** — multi-rooted facts, named alternative join paths — and don't want to design around them via views.
+- You want **first-class declarative cumulative and period-over-period metric types** instead of expressing them via query-time `time_shift` or per-measure `rolling_window`.
+- You want a **graph view of the model** (RDF/SPARQL) for governance/lineage tooling.
+- You need **OSI interoperability** for moving models between semantic layer formats.
+- Your operational appetite is small — **one Python service**, no Redis, no scheduler, no separate query orchestrator.
+- You're targeting **Dremio** or otherwise want full feature parity in self-hosted OSS without a Cloud upgrade path.
+- Your consumers are **agents/LLMs** primarily — both projects expose MCP, but OBSL's smaller surface is easier to point an agent at without query-shape ambiguity.
+
+### They could coexist
+
+A workable hybrid: use Cube as the production query gateway with pre-aggregations and a SQL API for BI tools, and OBSL as a complementary modeling/governance surface (RDF graph, OSI export, richer topology modeling) that you can keep authoritative and mirror into Cube definitions. Two semantic surfaces is operationally heavier, but it's defensible if you need both Cube's caching and OBSL's modeling primitives.
+
+---
+
+## 12. Gap analysis
+
+### To match Cube, OBSL would need:
+
+1. **Pre-aggregations / materialization** — declarative rollup definitions, refresh strategies, query routing. This is a major piece of infrastructure (a Cube-Store-equivalent or an integration with an external materialization engine like dbt/MaterializedView).
+2. **Postgres-wire SQL API** — Arrow Flight SQL covers the BI-tool-connectivity use case via JDBC/ODBC drivers, but Postgres wire still has broader native tool support today (Tableau, Superset, Metabase, plain `psql`, etc.).
+3. **GraphQL API** — modest effort given the existing FastAPI surface.
+4. **Templating in the model** — Jinja2 or similar for compile-time dynamism.
+5. **Multi-tenancy primitives** — compile-time per-tenant model generation, runtime RLS hooks, JWT integration.
+6. **Field-level masking and access grants** — analogous to LookML's `required_access_grants`.
+7. **More dialects** — Trino/Presto, Redshift, MSSQL, Oracle if those markets matter.
+8. **Built-in caching** — at minimum, an in-memory query result cache.
+
+### To match OBSL, Cube would need:
+
+1. **First-class cumulative & period-over-period metric types** — declarative versions of what's currently `rolling_window` and query-side `time_shift`.
+2. **Multi-rooted DAG modeling** — the ability to query across genuinely independent fact tables in one go without the consumer needing to pre-design a `view`.
+3. **Named secondary join paths** with per-query selection.
+4. **RDF/SPARQL graph surface** for governance/lineage.
+5. **Apache Arrow Flight SQL** as a columnar wire protocol option alongside Postgres wire — modern analytical payloads transfer more efficiently in Arrow.
+6. **First-class DB-API 2.0 drivers** for direct programmatic access from Python (PEP 249).
+7. **Interactive RDF/ontology graph visualization** in the playground (vis-network-style) — Cube Playground's schema browser is functional but not graph-shaped.
+8. **OSI ↔ Cube model round-trip** for portability between semantic layers.
+
+---
+
+## References
+
+- OBSL `MetricType` enum: `src/orionbelt/models/semantic.py`
+- OBSL CFL planner: `src/orionbelt/compiler/cfl.py`
+- OBSL fanout detection: `src/orionbelt/compiler/fanout.py`
+- OBSL docs: [Model Format](../guide/model-format.md), [Period-over-Period Metrics](../guide/period-over-period.md), [Compilation Pipeline](../guide/compilation.md)
+- Cube docs: https://cube.dev/docs
+- Cube data modeling reference: https://cube.dev/docs/product/data-modeling/reference
+- Cube pre-aggregations: https://cube.dev/docs/product/caching/using-pre-aggregations
+- Cube SQL API: https://cube.dev/docs/product/apis-integrations/sql-api

--- a/docs/comparison/dbt.md
+++ b/docs/comparison/dbt.md
@@ -1,0 +1,226 @@
+# OBSL vs dbt Semantic Layer (MetricFlow)
+
+A feature comparison between **OrionBelt Semantic Layer (OBSL)** and the **dbt Semantic Layer** (powered by MetricFlow). Captured 2026-05-01.
+
+---
+
+## TL;DR
+
+- **dbt SL wins on**: conversion metrics, the `metric_time` virtual dimension, ecosystem maturity, and governance/lineage tied to the dbt transformation pipeline.
+- **OBSL wins on**: being a self-hostable, warehouse-agnostic, transformation-tool-agnostic engine; **richer modeling topologies** (multi-rooted DAG, named alternative join paths) where dbt assumes single-rooted star/snowflake; explicit multi-fact CFL planning; an RDF/SPARQL view of the model; a clean REST surface; and a more ergonomic period-over-period metric type.
+- **Different niches**: dbt SL is "metrics on top of your dbt project, served by dbt Cloud." OBSL is "drop-in semantic compiler you can embed anywhere, modeling-tool independent."
+
+---
+
+## 1. Modeling philosophy
+
+| Aspect | OBSL (OBML) | dbt Semantic Layer |
+|---|---|---|
+| Source of truth | Standalone YAML (`OBML`) — independent of any transformation tool | YAML coupled to dbt models; semantic models reference dbt `ref()`s |
+| Top-level objects | `dataObjects`, `dimensions`, `measures`, `metrics`, `filters` | `semantic_models` (entities, measures, dimensions) + `metrics` |
+| Object scoping | Each `DataObject` has its own `columns:`; dimensions/measures/metrics live at model scope and reference `{[DataObject].[Column]}` | Dimensions/measures/entities are scoped *inside* each `semantic_model`; metrics reference measures |
+| Identity for joins | Explicit `joins` between data objects with `columnsFrom`/`columnsTo`, `joinType`, `secondary`, `pathName` | Implicit: `entities` of type `primary`/`foreign`/`unique`/`natural`; MetricFlow auto-resolves joins by matching entity names |
+| Deployment | Self-hosted FastAPI service, MCP server, Gradio UI; OSS | Definitions in dbt Core OSS; **query API gated behind dbt Cloud** |
+
+---
+
+## 2. Metric types
+
+OBSL `MetricType` enum (`src/orionbelt/models/semantic.py`):
+
+| OBSL | dbt SL | Notes |
+|---|---|---|
+| `Measure` (sum/avg/count/min/max, `total: bool` for grand totals) | `simple` metric over a `measure` | Both first-class |
+| `Metric` `type: derived` with `{[Measure A]}/{[Measure B]}` expression | `ratio`, `derived` | Both first-class |
+| `Metric` `type: cumulative` (running total, rolling window, grain-to-date) | `cumulative` (running, period-to-date, rolling) | Both first-class — see §3 |
+| `Metric` `type: period_over_period` with 4 comparison modes | Approximated via `offset_window` and `metric_time` | OBSL has a dedicated metric type — see §4 |
+| — | `conversion` | **Gap in OBSL** |
+
+OBSL coverage: ~95% of dbt's metric expressivity, missing only `conversion`.
+
+---
+
+## 3. Cumulative metrics (parity)
+
+Implementation: `src/orionbelt/compiler/cumulative_wrap.py` (~230 lines), pipeline phase placed after PoP wrap so it operates on already-compared data when needed.
+
+Three patterns supported, all dbt-equivalent:
+
+```yaml
+metrics:
+  # 1. Running total (unbounded cumulative sum)
+  - name: revenue_running_total
+    type: cumulative
+    measure: revenue
+    timeDimension: order_date
+    cumulativeType: sum
+
+  # 2. Rolling window (e.g. last 7 days)
+  - name: revenue_7d_avg
+    type: cumulative
+    measure: revenue
+    timeDimension: order_date
+    cumulativeType: avg
+    cumulativeWindow: 7
+
+  # 3. Grain-to-date (e.g. month-to-date, resets each month)
+  - name: revenue_mtd
+    type: cumulative
+    measure: revenue
+    timeDimension: order_date
+    cumulativeType: sum
+    grainToDate: month
+```
+
+Window functions used:
+
+| Pattern | SQL produced |
+|---|---|
+| Running total | `SUM(x) OVER (ORDER BY time)` |
+| Rolling window | `SUM(x) OVER (ORDER BY time ROWS BETWEEN N-1 PRECEDING AND CURRENT ROW)` |
+| Grain-to-date | `SUM(x) OVER (PARTITION BY DATE_TRUNC(grain, time) ORDER BY time)` |
+
+Aggregations: `sum`, `avg`, `min`, `max`, `count` (`CumulativeAggType`).
+Grains for grain-to-date: `year`, `quarter`, `month`, `week` (`GrainToDate`).
+
+---
+
+## 4. Period-over-Period (OBSL advantage)
+
+Implementation: `src/orionbelt/compiler/pop_wrap.py` (~510 lines).
+
+OBSL exposes PoP as a **first-class metric type** with a comparison-mode enum, where dbt requires composing `offset_window` + `metric_time` + a derived metric.
+
+```yaml
+metrics:
+  - name: revenue_yoy
+    type: period_over_period
+    measure: revenue
+    periodOverPeriod:
+      grain: month            # bucket grain
+      offset: -1              # compare vs. previous period
+      offsetGrain: year       # one year earlier
+      comparison: percentChange   # ratio | difference | previousValue | percentChange
+```
+
+Comparison modes (`PeriodOverPeriodComparison`):
+
+- `ratio` — current / prior
+- `difference` — current − prior
+- `previousValue` — just the prior period's value
+- `percentChange` — (current − prior) / prior
+
+Internally builds a synthetic date range and joins current vs. comparison period.
+
+**vs. dbt**: dbt typically requires:
+1. Define a `simple` metric.
+2. Reference it in a `derived` metric using `metric_time` and `offset_window` parameters.
+3. Compose ratio/percent-change manually in `expr`.
+
+OBSL's single-declaration approach is more ergonomic for the common case.
+
+---
+
+## 5. Multi-fact / fanout
+
+| | OBSL | dbt SL |
+|---|---|---|
+| Fanout detection | Explicit `compiler/fanout.py` raises `FanoutError` | Avoided implicitly via entity types |
+| Multi-fact strategy | Dedicated **CFL (Composite Fact Layer)** planner — `compiler/cfl.py` — emits `UNION ALL` legs with per-leg common-root resolution via `JoinGraph.find_common_root()` | MetricFlow join planner traverses entity graph; strategy is internal/opaque |
+| User control | Explicit star-vs-CFL switch surfaces in compilation | Not exposed |
+| Snowflake optimization | Uses `UNION ALL BY NAME` | n/a |
+
+OBSL's CFL is more transparent and inspectable; dbt's approach is more declarative but harder to reason about for complex join graphs.
+
+## 6. Data modeling topology (a major differentiator)
+
+dbt SL is fundamentally **single-rooted, tree-shaped** in practice: each query resolves a base measure to a primary entity and traverses outward via matching entity names. Multi-fact queries work, but the topology is implicit and ambiguous multi-paths are a smell rather than a feature.
+
+OBSL is built on a **directed join graph (DAG)** with explicit support for richer topologies:
+
+| Topology | Star (single fact + dims) | Snowflake (chained dims) | Multi-rooted (multiple facts) | Multi-path (alt. joins between same pair) | Cycles |
+|---|---|---|---|---|---|
+| **OBSL** | ✅ | ✅ | ✅ via CFL `UNION ALL` legs with per-leg common root | ✅ first-class via `secondary: true` + `pathName` + per-query `usePathNames` | Detected and rejected |
+| **dbt SL** | ✅ | ✅ | Partial — works if entities line up, but no explicit multi-fact planner | Workaround: define alternate entities and pick by relationship | Implicit |
+
+**Why this matters**: Real-world warehouses are messy. You routinely need a customer→order→order_item path *and* a customer→returns path queryable in one model, or to choose between "ship_address_id" and "billing_address_id" joins to the same address dimension on a per-query basis. dbt expects you to flatten these into well-shaped entities upstream; OBSL lets you model them as-is and resolve at query time.
+
+---
+
+## 7. Joins
+
+| | OBSL | dbt SL |
+|---|---|---|
+| Definition | Directed `join` declarations with `columnsFrom`/`columnsTo`, `joinType`, `secondary`, `pathName` | Inferred by matching `entity` names across semantic models |
+| Multiple paths between same objects | First-class via `secondary: true` + named `pathName`, selected per-query via `usePathNames: [{source, target, pathName}]` | Express via additional entities — no path naming primitive |
+| Cycle / multi-path validation | Built into resolver; `pathName` required for secondary | n/a (graph traversal handles) |
+
+---
+
+## 8. Dialects / execution
+
+| | OBSL | dbt SL |
+|---|---|---|
+| Dialect coverage | 8: BigQuery, ClickHouse, Databricks, Dremio, DuckDB, MySQL, Postgres, Snowflake | All warehouses dbt supports (broader) |
+| SQL generation | Full custom AST → SQL with per-dialect codegen (`dialect/*.py`) | MetricFlow → SQL |
+| Execution surface | Self-hosted, runs anywhere | Query API (JDBC/GraphQL/Python SDK/MCP) **dbt Cloud only** |
+| dbt Core query API | n/a | Definitions only — no built-in runtime serving |
+
+---
+
+## 9. APIs / interfaces
+
+| | OBSL | dbt SL |
+|---|---|---|
+| REST API | Yes — full session lifecycle, validate/compile/execute, ER diagram, `find`, lineage `explain`, OSI conversion | No (REST not offered) |
+| Arrow Flight SQL | Yes — gRPC server on port 8815; BI tools (DBeaver, Tableau JDBC, Power BI ODBC) connect natively | No |
+| DB-API 2.0 drivers | Yes — 8 drivers (`ob-bigquery`, `ob-snowflake`, `ob-postgres`, `ob-mysql`, `ob-duckdb`, `ob-clickhouse`, `ob-databricks`, `ob-dremio`) | No |
+| GraphQL | No | Yes (dbt Cloud) |
+| JDBC | Via Arrow Flight SQL JDBC driver | Yes (dbt Cloud) |
+| MCP | Yes (in-tree thin client + standalone repo `orionbelt-semantic-layer-mcp`) | Yes (`dbt-mcp`) |
+| Python SDK | Via FastAPI client | Yes |
+| UI / Playground | Yes — interactive Gradio playground: SQL Compiler, Query Results table, auto-generated Mermaid ER diagrams, interactive RDF/OBSL ontology graph (vis-network), OSI import/export, settings panel | dbt Cloud Studio (paid) |
+| RDF graph + SPARQL | Yes (`/graph`, `/sparql`) | No |
+| Format conversion | OSI ↔ OBML round-trip (`/convert/*`) | n/a |
+
+---
+
+## 10. Other distinctives
+
+| Feature | OBSL | dbt SL |
+|---|---|---|
+| Sessions / multi-tenant runtime | TTL, max-age, rate limits, 410/429 | Cloud-managed |
+| Caching | None built-in | dbt Cloud query cache |
+| Versioned governance, lineage to upstream models | No (model is standalone) | Strong — inherits dbt's lineage, tests, docs, exposures |
+| Filter ergonomics | `MeasureFilter`, `FilterContext`, `GrainOverride`, query-level `where`/`having` | Per-metric `filter:`, `metric_time` |
+| Vendor-agnostic | Yes — pure OSS | Practical lock-in: production query APIs require dbt Cloud |
+
+---
+
+## 11. Gap analysis (OBSL → dbt parity)
+
+To match dbt SL feature-for-feature, OBSL would need:
+
+1. **`conversion` metric type** — funnel-style metric: count of base events that converted to a target event within a window.
+2. **`metric_time` virtual dimension** — a unified time axis across heterogeneous fact tables, abstracting per-table date columns. (Partially achievable today via dimensions on each data object, but not as a single canonical handle.)
+3. **(Nice to have) Caching layer** — query result cache keyed on (model version, query, filters).
+4. **(Nice to have) GraphQL or JDBC surface** — for BI tool integration parity.
+
+Conversely, dbt SL would need to add to match OBSL's strengths:
+
+1. **Self-hostable query runtime** (currently dbt Cloud only).
+2. **RDF/SPARQL graph view** of the model.
+3. **Named secondary join paths** for non-trivial multi-path scenarios.
+4. **Explicit fanout detection / CFL planner exposure**.
+
+---
+
+## References
+
+- OBSL `MetricType` enum: `src/orionbelt/models/semantic.py`
+- OBSL cumulative wrap: `src/orionbelt/compiler/cumulative_wrap.py`
+- OBSL PoP wrap: `src/orionbelt/compiler/pop_wrap.py`
+- OBSL CFL planner: `src/orionbelt/compiler/cfl.py`
+- OBSL docs: [Model Format](../guide/model-format.md), [Period-over-Period Metrics](../guide/period-over-period.md), [Compilation Pipeline](../guide/compilation.md)
+- dbt SL: https://docs.getdbt.com/docs/build/about-metricflow
+- dbt SL GraphQL API: https://docs.getdbt.com/docs/dbt-cloud-apis/sl-graphql

--- a/docs/comparison/index.md
+++ b/docs/comparison/index.md
@@ -1,0 +1,75 @@
+# Comparison with Other Semantic Layers
+
+How OrionBelt Semantic Layer (OBSL) stacks up against the leading semantic layer / metrics tools. These pages are honest, two-sided comparisons including gap analyses in both directions — useful when evaluating which tool fits your stack.
+
+## At a glance
+
+| | OBSL | dbt SL | Malloy | LookML | Cube | AtScale |
+|---|---|---|---|---|---|---|
+| License | Source-available (BSL) | Definitions OSS; runtime in dbt Cloud | Open source | Proprietary | Apache 2.0 (core) + Cube Cloud | Proprietary; **free Developer Community Edition** for non-prod |
+| Self-hostable | ✅ | Definitions yes, runtime no | ✅ | ❌ | ✅ | ✅ (licensed) |
+| Standalone (no transformation tool dep.) | ✅ | ❌ requires dbt | ✅ | ✅ | ✅ | ✅ |
+| Format | YAML (`OBML`) | YAML on dbt models | DSL (`.malloy`) | DSL (`.lkml`) | YAML / JS + Twig | Visual designer |
+| Query interface | REST + **Arrow Flight SQL** + DB-API | GraphQL/JDBC (Cloud) | Malloy language | Looker UI / API | REST + GraphQL + **Postgres-wire SQL** | **MDX + DAX** + JDBC/ODBC + REST |
+| First-class cumulative metric | ✅ | ✅ | Per-query | Partial | Partial (`rolling_window`) | Via MDX |
+| First-class period-over-period metric | ✅ | Via `offset_window` | Per-query | Via table calc | Query-time `time_shift` | Via MDX |
+| Conversion / funnel metrics | ❌ | ✅ | Patterns | Patterns | Patterns | Patterns |
+| Symmetric aggregates | ❌ (uses CFL) | ❌ | ✅ | ✅ | ✅ | ✅ (OLAP) |
+| Multi-rooted DAG | ✅ via CFL | Implicit | Workaround | One-explore-per-fact | Workaround via `view`s | Cube-rooted |
+| Named secondary join paths | ✅ first-class | ❌ | ❌ | ❌ | ❌ | ✅ (role-playing dims) |
+| Nested / hierarchical results | ❌ | ❌ | ✅ (`nest:`) | ❌ | ❌ | ❌ |
+| OLAP hierarchies (multi-level, parent-child) | ❌ | ❌ | ❌ | Partial | ❌ | ✅ first-class |
+| MDX / Excel pivot tables | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ unique |
+| RDF/SPARQL graph view | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| MCP server | ✅ | ✅ (dbt-mcp) | ✅ (Publisher) | ❌ | ✅ | Limited |
+| Interactive playground / UI | ✅ Gradio (incl. RDF ontology graph) | dbt Cloud Studio (paid) | VS Code + Publisher | ✅ Looker IDE | Cube Playground / Studio | ✅ Design Center |
+| Built-in BI dashboards | ❌ | ❌ | VS Code | ✅ Looker | ❌ | Via MDX in Tableau/Excel |
+| Pre-aggregations / materialization | ❌ | Via dbt models | ❌ | ✅ (PDTs) | ✅ flagship | ✅ autonomous |
+| Row-level security in model | ❌ | Via dbt | ❌ | ✅ | ✅ (`query_rewrite`) | ✅ enterprise |
+| Multi-tenancy primitives | Sessions only | Cloud-managed | ❌ | ❌ | ✅ first-class | ✅ enterprise |
+| OSI interoperability | ✅ converter | ❌ | ❌ | ❌ | ❌ | ✅ founding contributor |
+
+## Detailed comparisons
+
+- [vs. dbt Semantic Layer (MetricFlow)](dbt.md) — coupled to dbt projects, served via dbt Cloud
+- [vs. Malloy](malloy.md) — a query language with semantic modeling, plus the Publisher REST/MCP server
+- [vs. LookML / Looker](lookml.md) — the proprietary modeling language behind Google Cloud Looker
+- [vs. Cube](cube.md) — the OSS production semantic layer with pre-aggregations, multi-API parity, and a Postgres-wire SQL surface
+- [vs. AtScale](atscale.md) — the enterprise universal semantic layer with native MDX/DAX for Excel and Power BI live connections
+
+## Topology: a recurring theme
+
+Most semantic layers assume a **single-rooted, tree-shaped** model (one fact at the center, dimensions fanning out). OBSL is built on a **directed join graph (DAG)** that supports:
+
+- **Star** and **snowflake** schemas (the common cases)
+- **Multi-rooted** models — query across multiple unrelated facts in a single semantic surface, resolved via the **CFL (Composite Fact Layer)** planner that emits `UNION ALL` legs
+- **Multi-path** joins — multiple valid join paths between the same pair of objects, named via `pathName` and selected per query via `usePathNames`
+- **Cycle detection** — explicit, not silent
+
+This matters when your warehouse doesn't fit a clean star: you need ship-address vs. billing-address joins to the same dimension, or a single API surface that exposes revenue *and* support tickets together. See the [Compilation Pipeline](../guide/compilation.md) guide for how this flows through the planner.
+
+## Where OBSL fits best
+
+- **Embedded analytics** in a SaaS product where consumers (apps, agents, BI tools) need a stable JSON Query API and you don't want to ship a DSL interpreter.
+- **Multi-tenant** semantic models with TTL-scoped sessions.
+- **LLM/agent integration** via MCP — a clean, schema-driven query surface beats teaching the agent a new language.
+- **Modern cloud warehouses** including ClickHouse, Databricks, Dremio, and DuckDB.
+- **Open-source / self-hostable / air-gapped** deployments.
+
+## Where another tool may be a better fit
+
+- **dbt SL** if you've standardized on dbt and want metrics tightly coupled to your transformation pipeline, with dbt Cloud governance.
+- **Malloy** for analyst-driven exploration and BI authoring, especially if you need hierarchical (`nest:`) result shapes.
+- **Looker** if you're buying an end-to-end BI platform with dashboards, alerts, RLS, and PDTs — and the per-user licensing fits your org.
+- **Cube** if you need pre-aggregations for sub-second analytics on large datasets, a Postgres-wire SQL API for BI-tool connectivity, or first-class multi-tenancy/RLS — and you're willing to operate (or pay for Cube Cloud to operate) the heavier runtime.
+- **AtScale** if your business users live in Excel pivot tables and need native MDX, or you need DAX for Power BI live connections — no other tool in this comparison set speaks those protocols.
+
+These tools are not mutually exclusive — it's plausible to ship a BI platform (Looker / AtScale) for the human audience and OBSL alongside it for the embedded / API / agent audience.
+
+---
+
+## About OSI
+
+Several comparisons reference **OSI (Open Semantic Interchange)** — an open standard for portable semantic models, founded to let metric and dimension definitions move between BI tools, semantic layers, and data platforms without rewriting. See [open-semantic-interchange.org](https://open-semantic-interchange.org/) for the specification.
+
+OBSL ships bidirectional converters (`POST /v1/convert/osi-to-obml`, `POST /v1/convert/obml-to-osi`) and Import/Export buttons in the Gradio playground. AtScale is a founding contributor to the OSI initiative; the other tools in this comparison do not currently support OSI directly. See the [OSI Interoperability](../guide/osi.md) guide for usage details.

--- a/docs/comparison/lookml.md
+++ b/docs/comparison/lookml.md
@@ -1,0 +1,296 @@
+# OBSL vs LookML / Looker
+
+A feature comparison between **OrionBelt Semantic Layer (OBSL)** and **LookML**, the modeling language behind Google Cloud's **Looker** BI platform. Captured 2026-05-01.
+
+---
+
+## TL;DR
+
+- **LookML wins on**: deep BI integration (drill fields, parameters, Liquid templating, PDTs, access filters/grants), `dimension_group` auto-timeframe expansion, symmetric aggregates (Looker invented the term), the broadest warehouse connector portfolio, and a polished proprietary IDE/UI.
+- **OBSL wins on**: being **open-source and self-hostable** (LookML is Looker-only — proprietary, paid, vendor-locked), a **language-agnostic JSON Query API** consumable by any client, **richer modeling topologies** (multi-rooted DAG with first-class named secondary join paths) where LookML's explore is a single-rooted tree, **first-class cumulative and period-over-period metric types** (LookML expresses these via table calculations or filtered measures, not declarative metric types), an **RDF/SPARQL graph view** of the model, an explicit **CFL multi-fact planner**, and an MCP server for LLM/agent integration.
+- **Different niches**: LookML is "the modeling language for Looker, your BI platform." OBSL is "an embeddable semantic compiler that exposes metrics over a stable API to apps, agents, and BI tools you didn't have to buy."
+
+LookML and Looker are inseparable in practice — you cannot run LookML without Looker. So this is also a comparison of build-vs-buy on the runtime.
+
+---
+
+## 1. Modeling philosophy
+
+| Aspect | OBSL (OBML) | LookML |
+|---|---|---|
+| Format | Declarative YAML (`OBML`) | Domain-specific declarative language (`.lkml` files) |
+| Source of truth | YAML model files | LookML files, hosted in a Looker project (Git-backed) |
+| Top-level constructs | `dataObjects`, `dimensions`, `measures`, `metrics`, `filters` | `connection`, `model`, `view`, `explore`, `dimension`, `dimension_group`, `measure`, `parameter`, `filter`, `derived_table`, `access_filter`, `access_grant` |
+| Object scoping | Each `DataObject` has `columns:`; dimensions/measures/metrics live at model scope | Dimensions and measures are *inside* `view`s; joins live in `explore`s in `model` files |
+| Runtime | OSS, self-hosted | **Looker proprietary platform only** (Google Cloud) |
+
+---
+
+## 2. Concept mapping
+
+| OBSL | LookML | Notes |
+|---|---|---|
+| `DataObject` | `view` | Both wrap a physical table/SQL block |
+| `DataObject.columns` | `dimension` declarations on a view | |
+| `Dimension` (model-scoped) | n/a — dimensions live on views | LookML has no model-scoped dimensions; views are the unit of definition |
+| `Measure` | `measure` (with `type: sum`, `count`, `count_distinct`, `avg`, `running_total`, etc.) | |
+| `Metric` `type: derived` | `measure: { type: number; sql: ... ;; }` referencing other measures | |
+| `Metric` `type: cumulative` | `measure: { type: running_total }` or table calculations in UI | LookML has narrow built-in support; richer cumulative is UI-side |
+| `Metric` `type: period_over_period` | Liquid + filtered measures + table calculations | No first-class metric type |
+| `DataObjectJoin` | `explore` `join:` blocks with `relationship: many_to_one` etc. | LookML's `relationship:` drives symmetric aggregates |
+| `secondary: true` + `pathName` | Multiple aliased joins (`from:` clause + alternate names) | No first-class path naming |
+| `QueryObject` JSON | Looker query (built via UI or sent via API; LookML files are not query targets directly) | |
+| OBSL session-scoped REST | Looker API + SDK | |
+
+---
+
+## 3. The headline LookML features
+
+### 3.1 Symmetric aggregates (the original)
+
+Looker pioneered symmetric aggregates as a productionized concept. The `relationship:` keyword on each join (`one_to_one`, `many_to_one`, `one_to_many`, `many_to_many`) tells Looker how to wrap aggregates so joins can fan out without double-counting. OBSL uses a different approach: static fanout detection + the **CFL** planner emitting `UNION ALL` legs.
+
+| | LookML | OBSL |
+|---|---|---|
+| Strategy | Symmetric aggregates driven by `relationship:` | Static fanout detection + CFL `UNION ALL` planner |
+| User experience | Implicit, "it just works" if you set `relationship` correctly | Explicit error/plan; CFL output is inspectable |
+| Failure mode | Wrong `relationship` → silently wrong numbers | Wrong join model → `FanoutError` raised at compile |
+
+### 3.2 `dimension_group` (time auto-expansion)
+
+A single LookML declaration generates many time-grain dimensions:
+
+```lookml
+dimension_group: created {
+  type: time
+  timeframes: [raw, date, week, month, quarter, year, day_of_week]
+  sql: ${TABLE}.created_at ;;
+}
+```
+
+That produces `created_raw`, `created_date`, `created_week`, etc. as separate dimensions, each ready to group by.
+
+**OBSL**: a single `Dimension` carries a `timeGrain` enum, and queries pass the grain at query time. More compact in the model, less ergonomic from a "list everything available" UI perspective.
+
+### 3.3 Liquid templating + parameters
+
+LookML embeds Liquid (Shopify's template language) for dynamic SQL and UI logic. Combined with `parameter:`, this drives dynamic dimensions, swappable measures, and personalization on user attributes.
+
+```lookml
+parameter: metric_selector {
+  type: unquoted
+  allowed_value: { value: "revenue" }
+  allowed_value: { value: "profit" }
+}
+
+measure: selected_metric {
+  type: sum
+  sql: {% if metric_selector._parameter_value == 'revenue' %}
+         ${TABLE}.revenue
+       {% else %}
+         ${TABLE}.profit
+       {% endif %} ;;
+}
+```
+
+**OBSL** has no equivalent. The model is static YAML — runtime swapping is handled by the consumer composing different queries, or by maintaining multiple measure definitions.
+
+### 3.4 PDTs / NDTs (materialization)
+
+Looker can materialize derived tables into the warehouse on a schedule — **PDTs** (Persistent Derived Tables) for SQL-defined datasets, **NDTs** (Native Derived Tables) for derived-from-explore datasets. Looker manages the build, dependency graph, and refresh cadence.
+
+**OBSL** has no materialization story. It's a query-time compiler; "make this faster" is the warehouse's or upstream tool's job (e.g., dbt models, scheduled jobs, materialized views).
+
+### 3.5 Access filters and access grants
+
+LookML has fine-grained row-level security baked into the model: `access_filter: { field: ...; user_attribute: ... }` injects a WHERE based on the logged-in user, and `required_access_grants:` gates fields/measures by role.
+
+**OBSL** has no first-class user/auth model. Authn/authz is the host application's job. (For the public demo, no auth by design.)
+
+### 3.6 Drill fields and visualization metadata
+
+LookML carries UI metadata: `drill_fields: [order_id, customer_name, ...]`, `value_format`, `html`, `link`, label/group_label, etc. — Looker uses these to render a coherent BI experience.
+
+**OBSL** carries minimal UI metadata. Rendering is the consumer's job.
+
+---
+
+## 4. Metric types
+
+| OBSL | LookML | Notes |
+|---|---|---|
+| `Measure` (sum/avg/count/min/max, `total: bool`) | `measure: { type: sum/avg/count/count_distinct/... }` | LookML has more aggregate types out of the box (`sum_distinct`, `percentile`, `median`, etc.) |
+| `Metric` `type: derived` | `measure: { type: number; sql: ...references other measures... }` | Both first-class |
+| `Metric` `type: cumulative` (running, rolling, grain-to-date) | `type: running_total` (basic), or table calculations in UI for richer cases | OBSL has richer **declarative** cumulative |
+| `Metric` `type: period_over_period` (4 comparison modes) | Patterns: filtered measures (`{% if date.is_in_period %} ... {% endif %}`) or table calculations | OBSL has a dedicated metric type |
+| `Measure.filterContext` / `filteredMeasures` | Filtered measure pattern: `measure: { type: sum; filters: [is_paid: "yes"] }` | Comparable |
+
+Bottom line: LookML's **breadth of aggregate types** is wider; OBSL's **time-aware metric types** (cumulative/PoP) are more declarative and reusable. Looker-style PoP usually ends up as a *table calculation* in the UI — not portable to other consumers.
+
+---
+
+## 5. Joins
+
+| | OBSL | LookML |
+|---|---|---|
+| Definition site | `joins:` array on `DataObject` (model-level) | `join:` blocks inside an `explore` (explore-level) |
+| Cardinality | `joinType` (inner/left/right) | `relationship:` (`one_to_one`/`many_to_one`/etc.) drives symmetric aggregates |
+| Join condition | `columnsFrom`/`columnsTo` arrays | `sql_on: ${a.id} = ${b.a_id} ;;` (free-form SQL) |
+| Multiple paths | First-class via `secondary: true` + named `pathName`, query-time selection via `usePathNames` | Multiple aliased joins via `from:` keyword + different names — no path naming primitive |
+| Multiple "starting points" | Each query picks a base data object | Each `explore` is a separate starting point with its own join tree |
+
+LookML's `sql_on:` is more flexible (any SQL); OBSL's column lists are more constrained but easier to validate and reason about programmatically.
+
+## 6. Data modeling topology (a major differentiator)
+
+LookML `explore`s are **single-rooted trees**: each explore has one base view and joins fan out from it. To query against two different fact tables you typically build two explores, or design carefully around a shared dimension. Multi-path scenarios (two valid joins between the same view pair) require duplicating the join with a `from:` alias, and there is no first-class "name this path and pick it per query" primitive — the consumer has to know which alias to use.
+
+OBSL is built on a **directed join graph (DAG)** with explicit support for richer topologies:
+
+| Topology | Star (single fact + dims) | Snowflake (chained dims) | Multi-rooted (multiple facts) | Multi-path (alt. joins between same pair) | Cycles |
+|---|---|---|---|---|---|
+| **OBSL** | ✅ | ✅ | ✅ via CFL `UNION ALL` legs with per-leg common root | ✅ first-class via `secondary: true` + `pathName` + per-query `usePathNames` | Detected and rejected |
+| **LookML** | ✅ | ✅ | One explore per fact; no in-explore multi-fact union | Workaround: `from:` aliasing; no path-name primitive | Implicit |
+
+**Why this matters**: Looker's "explore-per-fact" pattern works well when the org's analytics are organized around a few well-curated explores. It works less well when you want a single semantic surface that an embedded app or agent can hit and ask "give me revenue *and* support tickets by customer this month," or when the same dimension table is joined by different keys in different contexts. OBSL's named secondary paths and CFL planner make those messy real-world topologies first-class rather than something to design around.
+
+---
+
+## 7. Dialect / warehouse support
+
+LookML connects via Looker's connector library. Looker supports a very broad list including all the OBSL dialects plus many more (Redshift, Athena, Vertica, Teradata, Oracle, SQL Server, Spark SQL, etc.).
+
+| Dialect | OBSL | Looker |
+|---|---|---|
+| BigQuery | ✅ | ✅ |
+| Snowflake | ✅ | ✅ |
+| Postgres | ✅ | ✅ |
+| MySQL | ✅ | ✅ |
+| DuckDB | ✅ | ❌ (not a typical Looker target) |
+| Databricks | ✅ | ✅ |
+| ClickHouse | ✅ | ✅ |
+| Dremio | ✅ | ✅ |
+| Redshift | ❌ | ✅ |
+| Athena / Trino / Presto | ❌ | ✅ |
+| SQL Server / Oracle / Teradata | ❌ | ✅ |
+
+Looker is broader on enterprise legacy databases; OBSL is competitive on modern cloud warehouses and uniquely supports DuckDB out of the box.
+
+---
+
+## 8. APIs / interfaces
+
+| | OBSL | LookML / Looker |
+|---|---|---|
+| REST API | Yes — first-party FastAPI service | Yes — Looker API (rich, mature, but proprietary) |
+| Arrow Flight SQL | Yes — gRPC server on port 8815 for BI tool connectivity (DBeaver, Tableau, Power BI via Arrow Flight SQL JDBC/ODBC) | No (Looker is the BI front-end itself) |
+| JDBC | Yes — via Arrow Flight SQL JDBC driver | n/a (Looker is the BI tool) |
+| DB-API 2.0 drivers | Yes — 8 drivers shipped | No |
+| MCP | Yes — first-party server | Not native; community efforts exist |
+| GraphQL | No | No |
+| Native SDK | Python (FastAPI client) | Python, Ruby, TypeScript, Java, etc. (`looker-sdk`) |
+| UI / Playground | Interactive Gradio playground: SQL Compiler, Query Results table, auto-generated Mermaid ER diagrams, interactive RDF/OBSL ontology graph (vis-network), OSI import/export, settings panel | Looker IDE (very polished) + Looker Explore + dashboards |
+| RDF graph + SPARQL | Yes (`/graph`, `/sparql`) | No |
+| Format conversion | OSI ↔ OBML (`/convert/*`) | n/a |
+| Visualization | Not built-in | First-class: tables, charts, dashboards, alerts |
+
+---
+
+## 9. Open source vs. proprietary
+
+This is the most consequential difference and worth calling out separately.
+
+| | OBSL | LookML |
+|---|---|---|
+| License | Open source | Proprietary (Google Cloud / Looker) |
+| Self-hostable | Yes — runs anywhere Python runs | Limited: Looker is a hosted SaaS; "Looker (original)" had a self-hosted option but is being deprecated |
+| Cost | Free | Per-user licensing on the Looker platform |
+| Vendor lock-in | None | LookML files only run inside Looker |
+| Air-gapped deploy | Possible | Not supported |
+| Format portability | OBML is plain YAML, can be read by any tool | LookML is a Looker-specific DSL with no widely-adopted external parser other than `pylookml` |
+
+For embedded SaaS, multi-tenant analytics, or air-gapped/on-prem use cases, OBSL is the only option of the two.
+
+---
+
+## 10. Other distinctives
+
+| Feature | OBSL | LookML |
+|---|---|---|
+| `dimension_group` time auto-expansion | ❌ (single dim + grain at query time) | ✅ |
+| Liquid templating | ❌ | ✅ |
+| `parameter:` runtime knobs | ❌ | ✅ |
+| Persistent Derived Tables (PDTs) | ❌ (no materialization) | ✅ |
+| Access filters / access grants | ❌ | ✅ |
+| Drill fields / UI metadata | Minimal | ✅ |
+| Symmetric aggregates | ❌ (uses CFL instead) | ✅ |
+| First-class PoP metric type | ✅ | ❌ (table calc / filtered measures) |
+| First-class cumulative metric type | ✅ | Partial (`running_total` only) |
+| RDF/SPARQL graph view | ✅ | ❌ |
+| Named secondary join paths | ✅ | ❌ |
+| Explicit CFL multi-fact planner | ✅ | n/a |
+| MCP server (LLM/agent) | ✅ | ❌ (not native) |
+| OSS / self-hostable | ✅ | ❌ |
+| Built-in BI front-end | ❌ | ✅ |
+
+---
+
+## 11. When to pick which
+
+### Pick **Looker / LookML** when:
+
+- You're already buying Looker, or your org needs an end-to-end BI platform (modeling + dashboards + alerts + governance).
+- You need **fine-grained row/field-level security** baked into the model (`access_filter`, `access_grant`).
+- You need **PDT/NDT materialization** managed by the modeling layer.
+- You need **drill paths** and visualization metadata to drive a coherent BI UI.
+- You're running on enterprise legacy warehouses (Redshift, Oracle, Teradata, Vertica).
+- Your team is happy living inside the Looker IDE.
+
+### Pick **OBSL** when:
+
+- You need an **open-source, self-hostable, embeddable** semantic layer — no vendor lock-in.
+- Your consumers are **applications, agents, or LLMs** — a stable JSON Query API beats requiring callers to know LookML.
+- You need first-class, *reusable* **cumulative** and **period-over-period** metric types instead of expressing them as table calculations.
+- You target ClickHouse, Databricks, Dremio, or DuckDB.
+- You want a **graph view of the model** (RDF/SPARQL) for governance/lineage tooling.
+- You need **multi-tenant** semantic models (sessions, TTL) without provisioning a Looker instance per tenant.
+- Cost matters and per-user Looker licensing isn't justifiable for your use case.
+
+### They could coexist
+
+A common hybrid: ship Looker for the human BI audience and run OBSL alongside it for the embedded / API / agent audience. The models are expressed twice (different formats), but neither is a strict superset of the other. OSI conversion may help if you're going from another semantic format into OBSL.
+
+---
+
+## 12. Gap analysis
+
+### To match LookML, OBSL would need:
+
+1. **`dimension_group`-style time auto-expansion** — a single dimension declaration that surfaces multiple grain variants in introspection / autocomplete.
+2. **Templating / parameters** — a way to inject runtime values into measure SQL or pick between expressions (Liquid-equivalent or simpler conditionals).
+3. **Materialization** — first-class PDT-style derived table support, or at least integration hooks to a materialization tool.
+4. **Row-level security primitives** — access filters / grants tied to a session-level user attribute.
+5. **Symmetric aggregates** as an alternative to (or alongside) CFL — let users pick the strategy.
+6. **Drill paths and UI metadata** — `drill_fields:`, `value_format:`, etc., to enable consumer UIs to render coherently.
+7. **More dialect coverage** for legacy enterprise databases (Redshift, Trino/Presto, SQL Server) if those markets matter.
+
+### To match OBSL, LookML/Looker would need:
+
+1. **Open-source / self-hostable runtime** (the structural blocker).
+2. **First-class cumulative & period-over-period metric types** — declarative versions of what's currently table calculations.
+3. **Named secondary join paths** with per-query selection.
+4. **RDF/SPARQL graph surface** for governance/lineage.
+5. **Native MCP server** for LLM/agent consumers.
+6. **OSI ↔ model round-trip** for portability.
+
+---
+
+## References
+
+- OBSL `MetricType` enum: `src/orionbelt/models/semantic.py`
+- OBSL CFL planner: `src/orionbelt/compiler/cfl.py`
+- OBSL fanout detection: `src/orionbelt/compiler/fanout.py`
+- OBSL docs: [Model Format](../guide/model-format.md), [Period-over-Period Metrics](../guide/period-over-period.md), [Compilation Pipeline](../guide/compilation.md)
+- LookML docs: https://cloud.google.com/looker/docs/what-is-lookml
+- Looker API: https://cloud.google.com/looker/docs/api-and-integration
+- pylookml (programmatic LookML generation): https://github.com/looker-open-source/pylookml

--- a/docs/comparison/malloy.md
+++ b/docs/comparison/malloy.md
@@ -1,0 +1,280 @@
+# OBSL vs Malloy
+
+A feature comparison between **OrionBelt Semantic Layer (OBSL)** and **Malloy** (the open-source data language and semantic modeling tool from the Malloy Data project). Captured 2026-05-01.
+
+---
+
+## TL;DR
+
+- **Malloy wins on**: expressive query language (pipeline operator `->`, refinements, nesting), **symmetric aggregates** that handle fanout automatically, hierarchical query results via `nest:`, and a polished VS Code-native developer experience.
+- **OBSL wins on**: more dialects (8 vs. ~6, with ClickHouse/Databricks/Dremio unique to OBSL), **richer modeling topologies** (multi-rooted DAG with first-class named secondary join paths) where Malloy assumes a single-rooted source tree, **first-class metric types** for cumulative and period-over-period (Malloy expresses these ad-hoc per query), an RDF/SPARQL graph view of the model, an explicit CFL planner, and a stable JSON Query API that's trivial for non-Malloy clients to call.
+- **Different niches**: Malloy is "a new query language with semantic modeling baked in" — best for analyst-driven exploration and BI development. OBSL is "an API-first semantic compiler" — best for embedding into SaaS products and exposing metrics to LLMs/agents/external apps without teaching them a DSL.
+
+---
+
+## 1. Modeling philosophy
+
+| Aspect | OBSL (OBML) | Malloy |
+|---|---|---|
+| Format | Declarative YAML (`OBML`) | A purpose-built **language** (`.malloy` files) — both modeling *and* querying |
+| Source of truth | YAML model file | `.malloy` source files; `source: foo is duckdb.table('...') extend { ... }` |
+| Top-level objects | `dataObjects`, `dimensions`, `measures`, `metrics`, `filters` | `source` (with extensions: `dimension:`, `measure:`, `view:`, `join_one:`, `join_many:`) |
+| Queries | JSON `QueryObject` (`select`, `where`, `having`, `order_by`, ...) | Malloy query syntax: `run: source -> { group_by: ...; aggregate: ...; nest: ... }` |
+| Embedding | Drop-in compiler, no client language needed | Requires a Malloy-aware client/parser |
+
+**Key cultural difference**: Malloy is a *language*; OBSL is a *contract*. Malloy gives expressiveness in a `.malloy` file. OBSL gives a stable JSON over HTTP that any tool, agent, or LLM can call without learning a DSL.
+
+---
+
+## 2. Query model
+
+### Malloy
+
+```malloy
+source: flights is duckdb.table('flights.parquet') extend {
+  measure: flight_count is count()
+  view: by_carrier is {
+    group_by: carrier
+    aggregate: flight_count
+    limit: 10
+  }
+}
+
+run: flights -> by_carrier + {
+  where: distance > 1000
+  nest: top_origins is {
+    group_by: origin
+    aggregate: flight_count
+    limit: 3
+  }
+}
+```
+
+### OBSL
+
+```yaml
+# Model
+metrics:
+  - name: flight_count
+    type: derived
+    expr: "{[Flights].[Count]}"
+```
+
+```json
+// Query
+{
+  "select": { "dimensions": ["Carrier"], "measures": ["flight_count"] },
+  "where": [{ "field": "Distance", "op": ">", "value": 1000 }],
+  "limit": 10
+}
+```
+
+**Trade-off**: Malloy's pipeline-and-refinement syntax is more expressive and composable; OBSL's JSON is dumber but trivial for any client (curl, Python, an LLM tool call) to produce.
+
+---
+
+## 3. The headline Malloy features
+
+These are genuinely distinctive and OBSL has no direct equivalent:
+
+### 3.1 Symmetric aggregates (fanout safety, automatic)
+
+Malloy uses *symmetric aggregates* — the engine emits SQL that prevents double-counting when joining one-to-many. You write `line_items.amount.sum()` and it Just Works regardless of how the join graph fans out.
+
+OBSL takes a different route: it **detects** fanout statically (`compiler/fanout.py` raises `FanoutError`) and uses the **CFL planner** to emit `UNION ALL` legs across independent fact paths. Different mechanism, same goal: correctness on multi-fact queries.
+
+| | Malloy | OBSL |
+|---|---|---|
+| Strategy | Symmetric aggregates (per-aggregate path qualification) | Static fanout detection + CFL `UNION ALL` planner |
+| Visibility | Implicit, automatic | Explicit error/plan; CFL is inspectable |
+| User experience | "It just works" | "Compiler tells you what it did" |
+
+### 3.2 Nested queries (`nest:`)
+
+Malloy returns hierarchical (tree-shaped) results in a single query — a parent group_by row contains a child query result inline. This is uniquely powerful for dashboard-style "row + drill-down" data.
+
+```malloy
+run: flights -> {
+  group_by: origin
+  aggregate: flight_count
+  nest: top_carriers is { group_by: carrier; aggregate: flight_count; limit: 3 }
+}
+```
+
+OBSL has **no equivalent**. OBSL queries return flat tabular result sets. To produce a parent/child shape you'd run multiple queries.
+
+### 3.3 Refinements (`+ { ... }`)
+
+Malloy lets you take a named view and add filters/limits/aggregates inline:
+
+```malloy
+run: flights -> by_carrier + { where: carrier = 'WN'; limit: 5 }
+```
+
+OBSL has no named-view-with-refinements concept. Queries are constructed fresh each call (though the Query API is small enough that programmatic composition is straightforward).
+
+---
+
+## 4. Metric types
+
+| OBSL | Malloy | Notes |
+|---|---|---|
+| `Measure` (sum/avg/count/min/max, `total: bool` for grand totals) | `measure:` declarations inside `source` | Both first-class |
+| `Metric` `type: derived` (`{[Measure A]}/{[Measure B]}`) | Composed by referencing other measures inside aggregate expressions | Both first-class |
+| `Metric` `type: cumulative` (running, rolling, grain-to-date) | Express via **calculations** (window functions) inside queries | OBSL is declarative; Malloy is per-query |
+| `Metric` `type: period_over_period` with 4 comparison modes | Pattern via `prior_period` style queries; renderer has a `big_value { comparison_field=... }` for visual deltas | OBSL has a dedicated metric type; Malloy treats it as "just write the query" |
+
+**Different philosophies**: OBSL prefers reusable metric definitions (write once, every query gets PoP). Malloy prefers expressive ad-hoc queries (write the comparison in the query itself). Either fits depending on whether you're publishing a metrics catalog or empowering analysts.
+
+---
+
+## 5. Joins
+
+| | OBSL | Malloy |
+|---|---|---|
+| Definition site | YAML `joins:` array on each `DataObject` | `join_one:`, `join_many:`, `join_cross:` inside `source extend { ... }` |
+| Cardinality | `joinType` (inner/left/right) | Cardinality is part of the join keyword (`join_one` vs `join_many`) — drives symmetric aggregate logic |
+| Multiple paths between same tables | First-class via `secondary: true` + named `pathName`, selected per-query via `usePathNames: [{source, target, pathName}]` | Multiple `join_one`/`join_many` declarations with different aliases — no path-name primitive |
+| Cycle / multi-path validation | Built into resolver | Compiler-level checks |
+
+OBSL's named secondary paths are more explicit for ambiguous join graphs; Malloy's cardinality keywords are more elegant for the symmetric-aggregate runtime.
+
+## 6. Data modeling topology (a major differentiator)
+
+Malloy `source`s are **rooted at a single source** and extended outward via `join_one`/`join_many`. Conceptually that's a tree from the perspective of any one query — and Malloy's symmetric aggregates make that tree query-safe — but multi-rooted scenarios (querying across two unrelated facts in one go) and multi-path scenarios (two valid joins between the same pair of tables) are not first-class.
+
+OBSL is built on a **directed join graph (DAG)** with explicit support for richer topologies:
+
+| Topology | Star (single fact + dims) | Snowflake (chained dims) | Multi-rooted (multiple facts) | Multi-path (alt. joins between same pair) | Cycles |
+|---|---|---|---|---|---|
+| **OBSL** | ✅ | ✅ | ✅ via CFL `UNION ALL` legs with per-leg common root | ✅ first-class via `secondary: true` + `pathName` + per-query `usePathNames` | Detected and rejected |
+| **Malloy** | ✅ | ✅ | Workaround: separate sources, join-as-source patterns; no explicit multi-fact union planner | Workaround: aliased sources; no path-name primitive | Implicit |
+
+**Why this matters**: Real-world warehouses are messy. You routinely need a customer→order→order_item path *and* a customer→returns path queryable together, or to choose between "ship_address_id" and "billing_address_id" joins to the same address dimension per-query. Malloy expects you to denormalize or flatten upstream; OBSL lets you model the graph as-is and resolve at query time.
+
+---
+
+## 7. Dialects
+
+| Dialect | OBSL | Malloy |
+|---|---|---|
+| BigQuery | ✅ | ✅ |
+| Postgres | ✅ | ✅ |
+| MySQL | ✅ | ✅ |
+| DuckDB | ✅ | ✅ (native — Malloy's reference dialect) |
+| Snowflake | ✅ | ✅ |
+| Databricks | ✅ | ❌ |
+| ClickHouse | ✅ | ❌ |
+| Dremio | ✅ | ❌ |
+| Trino / Presto | ❌ | ✅ |
+
+**OBSL: 8 dialects, Malloy: ~6.** OBSL covers a wider modern-warehouse footprint (ClickHouse, Databricks, Dremio); Malloy adds Trino/Presto. Both projects have strong DuckDB stories.
+
+---
+
+## 8. APIs / interfaces
+
+| | OBSL | Malloy |
+|---|---|---|
+| REST API | Yes — first-party FastAPI service in this repo | Yes — via the **Publisher** companion project (`malloydata/publisher`) |
+| Arrow Flight SQL | Yes — gRPC server on port 8815; BI tools (DBeaver, Tableau, Power BI) connect via Arrow Flight SQL JDBC | No |
+| JDBC | Yes — via Arrow Flight SQL JDBC driver | No |
+| DB-API 2.0 drivers | Yes — 8 drivers shipped | No |
+| MCP | Yes — first-party server | Yes — via Publisher |
+| GraphQL | No | No |
+| Native SDK | Python (FastAPI client) | TypeScript (`@malloydata/malloy`, `@malloydata/malloy-query-builder`) |
+| UI / Playground | Interactive Gradio playground: SQL Compiler, Query Results table, auto-generated Mermaid ER diagrams, interactive RDF/OBSL ontology graph (vis-network), OSI import/export, settings panel | VS Code extension (very polished) + Publisher web UI |
+| RDF graph + SPARQL | Yes (`/graph`, `/sparql`) | No |
+| Format conversion | OSI ↔ OBML (`/convert/*`) | n/a |
+
+Both projects converge on REST + MCP for serving models. OBSL additionally exposes Arrow Flight SQL (JDBC-compatible) for BI tool integration; Malloy doesn't have a comparable BI-tool wire protocol. The experiential difference: **Malloy's VS Code extension** is stronger for analyst authoring (it's a full editor with autocomplete and inline visualizations); **OBSL's Gradio playground** is stronger for ad-hoc model exploration (interactive ER + ontology graphs, OSI conversion in-browser).
+
+---
+
+## 9. Time handling
+
+| | OBSL | Malloy |
+|---|---|---|
+| Time grain | `TimeGrain` enum on dimensions/queries (year/quarter/month/week/day/hour/minute/second) | First-class field operators: `field.month`, `field.year_quarter`, `field.day_of_week`, etc. |
+| Period comparison | Dedicated `period_over_period` metric type (4 comparison modes) | Ad-hoc query patterns + `prior_period` techniques |
+| Cumulative / windowed | Dedicated `cumulative` metric type (running, rolling, grain-to-date) | `calculation:` declarations using window functions |
+
+Malloy's time syntax is more ergonomic in a query; OBSL's metric types are more reusable across queries.
+
+---
+
+## 10. Other distinctives
+
+| Feature | OBSL | Malloy |
+|---|---|---|
+| Hierarchical / nested results | ❌ flat tables only | ✅ `nest:` is a headline feature |
+| Symmetric aggregates | ❌ uses static fanout detection + CFL | ✅ |
+| Pipeline operator / refinements | ❌ JSON queries are atomic | ✅ `->` and `+ { ... }` |
+| RDF/SPARQL graph view | ✅ | ❌ |
+| Named secondary join paths | ✅ | ❌ |
+| Explicit CFL multi-fact planner | ✅ | n/a (symmetric aggregates) |
+| OSI ↔ OBML conversion | ✅ | ❌ |
+| First-class PoP metric type | ✅ | ❌ (ad-hoc) |
+| First-class cumulative metric type | ✅ | ❌ (calculations) |
+| Dialect breadth (ClickHouse/Databricks/Dremio) | ✅ | ❌ |
+| Trino/Presto | ❌ | ✅ |
+| VS Code-native authoring | ❌ | ✅ |
+| Visualization renderer | ❌ (Gradio is ad-hoc) | ✅ first-class chart/dashboard renderer |
+| LLM/agent-friendly query API | ✅ JSON, no DSL to learn | Possible via Publisher MCP, but Malloy's expressiveness asks more of the agent |
+
+---
+
+## 11. When to pick which
+
+### Pick **Malloy** when:
+
+- Your audience is analysts/engineers who'll write queries by hand and care about expressiveness.
+- You need **hierarchical / nested** result shapes for dashboards (this is the killer feature).
+- You want **symmetric aggregates** to remove fanout as a class of bug without thinking about it.
+- You're heavy on Trino/Presto.
+- VS Code-native authoring + visualization matters to you.
+
+### Pick **OBSL** when:
+
+- Your consumers are **applications, agents, or LLMs**, not humans writing a DSL — a stable JSON Query API is a feature, not a limitation.
+- You need first-class, *reusable* **cumulative** and **period-over-period** metric definitions (vs. embedding window logic in each query).
+- You target **ClickHouse, Databricks, or Dremio**.
+- You need **named alternative join paths** for ambiguous graphs.
+- You want a **graph view of the model** (RDF/SPARQL) for governance/lineage tooling.
+- You want a **fully self-hostable, embeddable** semantic engine with no DSL dependency on the consumer side.
+
+### They could coexist
+
+It's plausible to use both: Malloy as the analyst-facing modeling/exploration layer and OBSL as the API-facing metrics service for embedded/agent use cases. The models would be expressed twice, but neither is a strict superset of the other.
+
+---
+
+## 12. Gap analysis
+
+### To match Malloy, OBSL would need:
+
+1. **Nested query results** — return tree-shaped data structures from a single query. This is the biggest functional gap and would require new AST nodes (`NestedQuery`) and result shape changes.
+2. **Symmetric aggregates** — as an alternative to (or in addition to) the current static fanout + CFL approach. Would let users join across fanout without thinking.
+3. **Trino/Presto dialect** — straightforward to add given the existing dialect plugin system.
+4. **Named views with refinements** — a way to register a parameterized query template and apply per-call overrides.
+5. **A polished authoring experience** — VS Code extension or rich web IDE (Gradio is functional but not in the same league).
+
+### To match OBSL, Malloy would need:
+
+1. **First-class cumulative & period-over-period metric types** — declarative versions of what's currently expressed per-query.
+2. **Named secondary join paths** with per-query selection.
+3. **More warehouse dialects** — ClickHouse, Databricks, Dremio.
+4. **RDF/SPARQL graph surface** for governance/lineage.
+5. **A consumer-friendly JSON Query API** — Publisher gets close, but the schema is Malloy-shaped, so consumers still benefit from understanding Malloy.
+
+---
+
+## References
+
+- OBSL `MetricType` enum: `src/orionbelt/models/semantic.py`
+- OBSL CFL planner: `src/orionbelt/compiler/cfl.py`
+- OBSL fanout detection: `src/orionbelt/compiler/fanout.py`
+- OBSL docs: [Model Format](../guide/model-format.md), [Period-over-Period Metrics](../guide/period-over-period.md), [Compilation Pipeline](../guide/compilation.md)
+- Malloy: https://github.com/malloydata/malloy
+- Malloy Publisher (REST + MCP server for Malloy models): https://github.com/malloydata/publisher
+- Malloy docs: https://docs.malloydata.dev/

--- a/docs/guide/osi.md
+++ b/docs/guide/osi.md
@@ -1,6 +1,8 @@
 # OSI Interoperability
 
-OrionBelt includes a bidirectional converter between OBML and the [Open Semantic Interchange (OSI)](https://github.com/open-semantic-interchange/OSI) format. The converter handles structural differences between the two formats — including metric decomposition, relationship restructuring, and lossless `ai_context` preservation via `customExtensions` — with built-in validation for both directions.
+**OSI (Open Semantic Interchange)** is an open standard for portable semantic models, founded with the goal of letting metric and dimension definitions move between BI tools, semantic layers, and data platforms without rewriting. See [open-semantic-interchange.org](https://open-semantic-interchange.org/) for the specification and contributor list.
+
+OrionBelt includes a bidirectional converter between OBML and the [OSI specification](https://github.com/open-semantic-interchange/OSI) format. The converter handles structural differences between the two formats — including metric decomposition, relationship restructuring, and lossless `ai_context` preservation via `customExtensions` — with built-in validation for both directions.
 
 ## REST API
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -110,6 +110,13 @@ nav:
       - Multi-Dialect Output: examples/multi-dialect.md
       - "Multi-Fact: Sales & Returns": examples/multi-fact.md
       - TPC-DS Benchmark: examples/tpcds.md
+  - Comparison:
+      - Overview: comparison/index.md
+      - vs. dbt Semantic Layer: comparison/dbt.md
+      - vs. Malloy: comparison/malloy.md
+      - vs. LookML / Looker: comparison/lookml.md
+      - vs. Cube: comparison/cube.md
+      - vs. AtScale: comparison/atscale.md
   - Reference:
       - Python API: reference/python-api.md
       - Architecture: reference/architecture.md


### PR DESCRIPTION
## Summary
- Adds `docs/comparison/` with an index hub + five honest two-sided comparisons (dbt Semantic Layer, Malloy, LookML / Looker, Cube, AtScale)
- Each page follows the same structure: TL;DR, modeling philosophy, concept mapping, headline features, metric types, joins, **data modeling topology**, dialects, APIs, gap analysis in both directions
- Surfaces OBSL's multi-rooted DAG + named secondary join paths as a recurring differentiator across all comparisons
- Updates `docs/guide/osi.md` to lead with the [open-semantic-interchange.org](https://open-semantic-interchange.org/) definition and link
- Wires the new section into `mkdocs.yml` nav and the README documentation table

Docs-only — no code, no API change, no version bump needed. Already deployed to https://ralforion.com/orionbelt-semantic-layer/comparison/.

## Test plan
- [x] `mkdocs build --strict` passes
- [x] All internal links resolve (verified by strict build)
- [x] Deployed live at https://ralforion.com/orionbelt-semantic-layer/comparison/
- [ ] Reviewer skim of each comparison page for accuracy / tone

🤖 Generated with [Claude Code](https://claude.com/claude-code)