### PR TITLE
docs: add Google Analytics, cookie consent, and feedback widget

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,34 @@ dev_addr: 127.0.0.1:8080
 extra:
   obml_version: "1.0"
   project_version: "2.1.3"
+  analytics:
+    provider: google
+    property: G-X19K4GX3EX
+    feedback:
+      title: Was this page helpful?
+      ratings:
+        - icon: material/emoticon-happy-outline
+          name: This page was helpful
+          data: 1
+          note: >-
+            Thanks for your feedback!
+        - icon: material/emoticon-sad-outline
+          name: This page could be improved
+          data: 0
+          note: >-
+            Thanks for your feedback! Help us improve by
+            <a href="https://github.com/ralfbecher/orionbelt-semantic-layer/issues/new?labels=docs&template=docs-feedback.md" target="_blank" rel="noopener">opening a docs issue</a>.
+  consent:
+    title: Cookie consent
+    description: >-
+      We use cookies to recognize your repeated visits and preferences, as well
+      as to measure the effectiveness of our documentation and whether users
+      find what they're searching for. With your consent, you're helping us
+      to make our documentation better.
+    actions:
+      - accept
+      - reject
+      - manage
 
 extra_css:
   - stylesheets/extra.css


### PR DESCRIPTION
## Summary
- Wires GA4 property `G-X19K4GX3EX` (same as the main ralforion.com site) into the docs build
- Adds Material theme cookie consent banner with accept / reject / manage actions (GDPR)
- Adds "Was this page helpful?" feedback widget with thumbs-up/down ratings linking to a docs issue template

GA only fires after the user grants consent — Material integrates the analytics snippet with the consent state automatically.

Docs-only — no code, no version bump. Already deployed to https://ralforion.com/orionbelt-semantic-layer/.

## Test plan
- [x] `mkdocs build --strict` passes
- [x] Built site contains the GA snippet (`gtag`, `G-X19K4GX3EX`)
- [x] Built site contains consent banner markup (`md-consent`)
- [x] Deployed live
- [ ] Verify in GA4 Realtime that pageviews appear from `/orionbelt-semantic-layer/*` after accepting consent
- [ ] Confirm consent banner renders on first visit (clear cookies / incognito)

🤖 Generated with [Claude Code](https://claude.com/claude-code)