### PR TITLE
docs: add ralforion.com home link banner

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,1 +1,7 @@
 {% extends "base.html" %}
+
+{% block announce %}
+  <a href="https://ralforion.com/" style="color: inherit; text-decoration: none;">
+    Part of <strong>ralforion.com</strong> &nbsp;·&nbsp; back to home →
+  </a>
+{% endblock %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,6 +70,7 @@ theme:
     - content.code.copy
     - content.tabs.link
     - toc.follow
+    - announce.dismiss
   icon:
     repo: fontawesome/brands/github
 


### PR DESCRIPTION
## Summary
- Persistent banner at the top of every docs page: `Part of **ralforion.com** · back to home →`
- Dismissible (`announce.dismiss` feature enabled) — repeat visitors can close it
- Implemented via Material's `announce` block override in `docs/overrides/main.html`

Makes the docs feel like part of the parent ralforion.com site rather than an orphan subdirectory under a generated path.

Docs-only — no code, no version bump. Already deployed.

## Test plan
- [x] `mkdocs build --strict` passes
- [x] Banner content present in built HTML
- [x] Deployed live at https://ralforion.com/orionbelt-semantic-layer/
- [ ] Verify banner renders at top of every page in browser
- [ ] Verify dismiss button works (×) and the dismissal persists across pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)