### PR TITLE
docs(comparison): fix at-a-glance matrix layout (AtScale was cut off)

### DIFF
--- a/docs/comparison/index.md
+++ b/docs/comparison/index.md
@@ -4,6 +4,8 @@ How OrionBelt Semantic Layer (OBSL) stacks up against the leading semantic layer
 
 ## At a glance
 
+<div class="compact-table" markdown>
+
 | | OBSL | dbt SL | Malloy | LookML | Cube | AtScale |
 |---|---|---|---|---|---|---|
 | License | Source-available (BSL) | Definitions OSS; runtime in dbt Cloud | Open source | Proprietary | Apache 2.0 (core) + Cube Cloud | Proprietary; **free Developer Community Edition** for non-prod |
@@ -29,6 +31,8 @@ How OrionBelt Semantic Layer (OBSL) stacks up against the leading semantic layer
 | Row-level security in model | ❌ | Via dbt | ❌ | ✅ | ✅ (`query_rewrite`) | ✅ enterprise |
 | Multi-tenancy primitives | Sessions only | Cloud-managed | ❌ | ❌ | ✅ first-class | ✅ enterprise |
 | OSI interoperability | ✅ converter | ❌ | ❌ | ❌ | ❌ | ✅ founding contributor |
+
+</div>
 
 ## Detailed comparisons
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -3,6 +3,30 @@ td code {
   white-space: nowrap;
 }
 
+/* Widen the docs content area so wide comparison matrices have room.
+   Default Material is 61rem; 80rem (~1280px) gives the 7-column at-a-glance table room without horizontal scroll on standard screens. */
+.md-grid {
+  max-width: 80rem;
+}
+
+/* Compact comparison matrix tables — opt in by wrapping the table in
+   <div class="compact-table" markdown>. Smaller font + tight padding +
+   horizontal scroll fallback keeps very wide matrices readable. */
+.compact-table {
+  overflow-x: auto;
+  max-width: 100%;
+}
+.compact-table table {
+  font-size: 0.7rem !important;
+  margin: 0 !important;
+}
+.compact-table th,
+.compact-table td {
+  padding: 0.45em 0.55em !important;
+  vertical-align: top;
+  line-height: 1.4;
+}
+
 /* Version badge — only visible in the right (TOC) sidebar */
 .obml-version-badge {
   display: none;


### PR DESCRIPTION
## Problem
The 7-column at-a-glance matrix on `/comparison/` was wider than Material's default 61rem content area, so AtScale was cut off the right edge with no obvious horizontal-scroll affordance.

## Fix
Three combined changes in `docs/stylesheets/extra.css`:
- `.md-grid { max-width: 80rem; }` — widen the docs content area so wide tables fit naturally on standard screens
- New `.compact-table` wrapper class with smaller font, tighter padding, vertical-align top, and `overflow-x: auto` as a fallback
- Wrap the matrix in `<div class="compact-table" markdown>` in `docs/comparison/index.md`

The matrix now fits without scrolling on standard screens and scrolls gracefully on narrow viewports. The rest of the docs is unchanged at standard sizing.

Docs-only — already deployed.

## Test plan
- [x] `mkdocs build --strict` passes
- [x] Built HTML wraps the matrix in `<div class="compact-table">`
- [x] Deployed live at https://ralforion.com/orionbelt-semantic-layer/comparison/
- [ ] Visual: AtScale column visible without horizontal scroll on a 1280px+ screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)