### PR TITLE
docs(comparison): correct OBSL cardinality vocabulary

### DIFF
--- a/docs/comparison/atscale.md
+++ b/docs/comparison/atscale.md
@@ -112,7 +112,7 @@ For complex OLAP-style metrics (MDX is genuinely more expressive than any YAML f
 | | OBSL | AtScale |
 |---|---|---|
 | Definition site | `joins:` array on `DataObject` | Relationships in Design Center between dimensions and facts |
-| Cardinality | `joinType` (inner/left/right) | Relationship cardinality + role-playing dimensions |
+| Cardinality | `joinType`: `many-to-one`, `one-to-one`, `many-to-many` | Relationship cardinality + role-playing dimensions |
 | Multiple paths | First-class via `secondary: true` + `pathName` + per-query `usePathNames` | **Role-playing dimensions** (a dimension joined multiple ways with different roles) — the OLAP-native way |
 | Cycle / multi-path validation | Built into resolver | Engine-level checks |
 

--- a/docs/comparison/cube.md
+++ b/docs/comparison/cube.md
@@ -149,7 +149,8 @@ Beyond pre-aggregations, Cube has a tiered caching architecture: in-memory query
 | | OBSL | Cube |
 |---|---|---|
 | Definition site | `joins:` array on `DataObject` | `joins:` block inside each `cube` |
-| Cardinality | `joinType` (inner/left/right) | `relationship: one_to_one`/`one_to_many`/`many_to_one` — drives symmetric aggregates |
+| Cardinality | `joinType`: `many-to-one`, `one-to-one`, `many-to-many` | `relationship`: `one_to_one`, `one_to_many`, `many_to_one` |
+| What cardinality drives | Static fanout detection + CFL multi-fact planning | Symmetric aggregates |
 | Join condition | `columnsFrom`/`columnsTo` arrays | `sql: "{CUBE}.id = {other.foo_id}"` (free-form SQL with `{CUBE}` reference) |
 | Multiple paths | First-class via `secondary: true` + named `pathName`, query-time selection via `usePathNames` | No path-name primitive; workaround via `view`s exposing one path or aliased cubes |
 | Join direction | Directed, declared per data object | Bidirectional inference based on `relationship:` |

--- a/docs/comparison/lookml.md
+++ b/docs/comparison/lookml.md
@@ -134,7 +134,8 @@ Bottom line: LookML's **breadth of aggregate types** is wider; OBSL's **time-awa
 | | OBSL | LookML |
 |---|---|---|
 | Definition site | `joins:` array on `DataObject` (model-level) | `join:` blocks inside an `explore` (explore-level) |
-| Cardinality | `joinType` (inner/left/right) | `relationship:` (`one_to_one`/`many_to_one`/etc.) drives symmetric aggregates |
+| Cardinality | `joinType`: `many-to-one`, `one-to-one`, `many-to-many` | `relationship`: `one_to_one`, `many_to_one`, `one_to_many`, `many_to_many` |
+| What cardinality drives | Static fanout detection + CFL multi-fact planning | Symmetric aggregates |
 | Join condition | `columnsFrom`/`columnsTo` arrays | `sql_on: ${a.id} = ${b.a_id} ;;` (free-form SQL) |
 | Multiple paths | First-class via `secondary: true` + named `pathName`, query-time selection via `usePathNames` | Multiple aliased joins via `from:` keyword + different names — no path naming primitive |
 | Multiple "starting points" | Each query picks a base data object | Each `explore` is a separate starting point with its own join tree |

--- a/docs/comparison/malloy.md
+++ b/docs/comparison/malloy.md
@@ -133,7 +133,8 @@ OBSL has no named-view-with-refinements concept. Queries are constructed fresh e
 | | OBSL | Malloy |
 |---|---|---|
 | Definition site | YAML `joins:` array on each `DataObject` | `join_one:`, `join_many:`, `join_cross:` inside `source extend { ... }` |
-| Cardinality | `joinType` (inner/left/right) | Cardinality is part of the join keyword (`join_one` vs `join_many`) — drives symmetric aggregate logic |
+| Cardinality | `joinType`: `many-to-one`, `one-to-one`, `many-to-many` | Cardinality is part of the join keyword: `join_one`, `join_many`, `join_cross` |
+| What cardinality drives | Static fanout detection + CFL multi-fact planning | Symmetric aggregate logic |
 | Multiple paths between same tables | First-class via `secondary: true` + named `pathName`, selected per-query via `usePathNames: [{source, target, pathName}]` | Multiple `join_one`/`join_many` declarations with different aliases — no path-name primitive |
 | Cycle / multi-path validation | Built into resolver | Compiler-level checks |
 


### PR DESCRIPTION
## Problem
The Cardinality row in the joins comparison tables (in malloy, lookml, cube, atscale) showed OBSL as `joinType (inner/left/right)`. That was wrong — `DataObjectJoin.join_type` is typed as `Cardinality`, not the SQL `JoinType` enum.

```python
class Cardinality(StrEnum):
    MANY_TO_ONE = "many-to-one"
    ONE_TO_ONE = "one-to-one"
    MANY_TO_MANY = "many-to-many"

class DataObjectJoin(BaseModel):
    join_type: Cardinality = Field(alias="joinType")
```

So OBSL is in the same cardinality family as Cube / LookML / Malloy / AtScale — not different.

## Fix
- Cardinality cell now reads `joinType: many-to-one, one-to-one, many-to-many`
- Added a new row "What cardinality drives" to malloy/lookml/cube to make the real difference explicit: OBSL uses cardinality for static fanout detection + CFL multi-fact planning, where Cube/LookML/Malloy use it for symmetric-aggregate SQL emission. Same input, different mechanism.
- Existing "Symmetric aggregates" matrix rows are unchanged (still accurate: OBSL ❌ uses CFL, others ✅).

Docs-only — already deployed.

## Test plan
- [x] `mkdocs build --strict` passes
- [x] Deployed live at https://ralforion.com/orionbelt-semantic-layer/comparison/

🤖 Generated with [Claude Code](https://claude.com/claude-code)