### PR TITLE
fix: v2.1.4 — reject timeGrain on non-temporal columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to OrionBelt Semantic Layer are documented here.
 
+## [2.1.4] - 2026-05-03
+
+### Fixed
+
+- **`timeGrain` on a non-temporal column is now rejected at validation time** instead of producing a runtime SQL error. Previously a dimension like `{ column: YearMonth, resultType: string, timeGrain: month }` passed validation but compiled to `date_trunc('month', "Calendar"."ym")`, which Postgres (and other strict dialects) reject with `function date_trunc(unknown, text) does not exist`. The new check inspects the underlying `DataObject.columns[col].abstractType` and emits `TIME_GRAIN_ON_NON_TEMPORAL` unless the type is `date`, `timestamp`, or `timestamp_tz`. Error message includes a remediation hint (drop `timeGrain`, fix the column's `abstractType`, or define a computed column with `to_date()`). Particularly relevant for LLM-generated models, which were the most common source of this mistake.
+
+### Documentation
+
+- `docs/guide/model-format.md` and the `OBML_REFERENCE` resource now document the `timeGrain` constraint inline so LLMs generating OBML have the rule in their prompt context.
+
 ## [2.1.3] - 2026-04-30
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ralfbecher/orionbelt-semantic-layer/blob/main/examples/quickstart_colab.ipynb)
 
 [![GitHub stars](https://img.shields.io/github/stars/ralfbecher/orionbelt-semantic-layer?style=social)](https://github.com/ralfbecher/orionbelt-semantic-layer)
-[![Version 2.1.3](https://img.shields.io/badge/version-2.1.3-purple.svg)](https://github.com/ralfbecher/orionbelt-semantic-layer/releases)
+[![Version 2.1.4](https://img.shields.io/badge/version-2.1.4-purple.svg)](https://github.com/ralfbecher/orionbelt-semantic-layer/releases)
 [![PyPI](https://img.shields.io/pypi/v/orionbelt-semantic-layer?logo=pypi&logoColor=white)](https://pypi.org/project/orionbelt-semantic-layer/)
 [![Docker Hub](https://img.shields.io/docker/pulls/ralforion/orionbelt-api?logo=docker&label=Docker%20Hub)](https://hub.docker.com/repositories/ralforion)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
@@ -155,7 +155,7 @@ Open [http://localhost:8080/docs](http://localhost:8080/docs) to explore the API
 # docker-compose.yml
 services:
   api:
-    image: ralforion/orionbelt-api:2.1.3
+    image: ralforion/orionbelt-api:2.1.4
     ports: ["8080:8080"]
     env_file: .env
     volumes:
@@ -164,7 +164,7 @@ services:
       MODEL_FILE: /app/models/my-model.obml.yml
 
   ui:
-    image: ralforion/orionbelt-ui:2.1.3
+    image: ralforion/orionbelt-ui:2.1.4
     ports: ["7860:7860"]
     environment:
       API_BASE_URL: http://api:8080
@@ -180,7 +180,7 @@ See [`.env.template`](.env.template) for the full environment variable reference
 > - `API_SERVER_HOST` is already `0.0.0.0` inside the container — no override needed.
 > - MCP via stdio does not work in Docker. Use the [MCP HTTP client](https://github.com/ralfbecher/orionbelt-semantic-layer-mcp) for containerized deployments.
 > - Mount models to `/app/models` (or any path) and set `MODEL_FILE` to pre-load on startup.
-> - For production, pin a version tag (`:2.1.3`) rather than `:latest`.
+> - For production, pin a version tag (`:2.1.4`) rather than `:latest`.
 
 ### Claude Desktop / MCP
 

--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -13,7 +13,7 @@ Returns the service status and version.
 ```json
 {
   "status": "ok",
-  "version": "2.1.3"
+  "version": "2.1.4"
 }
 ```
 
@@ -734,7 +734,7 @@ Return public configuration for API clients (UI, MCP, etc.).
 
 ```json
 {
-  "version": "2.1.3",
+  "version": "2.1.4",
   "api_version": "v1",
   "single_model_mode": false,
   "session_ttl_seconds": 1800,
@@ -753,7 +753,7 @@ Return public configuration for API clients (UI, MCP, etc.).
 
 ```json
 {
-  "version": "2.1.3",
+  "version": "2.1.4",
   "api_version": "v1",
   "single_model_mode": true,
   "model_yaml": "version: 1.0\nsettings:\n  defaultTimezone: Europe/Berlin\n  ...",

--- a/docs/guide/model-format.md
+++ b/docs/guide/model-format.md
@@ -273,7 +273,7 @@ dimensions:
 | `column` | string | Yes | Column name in the data object |
 | `resultType` | enum | Yes | Data type of the result (informative only, not used for SQL generation) |
 | `label` | string | No | Display label |
-| `timeGrain` | enum | No | Time grain: `year`, `quarter`, `month`, `week`, `day`, `hour`, `minute`, `second` |
+| `timeGrain` | enum | No | Time grain: `year`, `quarter`, `month`, `week`, `day`, `hour`, `minute`, `second`. The underlying column's `abstractType` must be `date`, `timestamp`, or `timestamp_tz` — validation rejects `timeGrain` on string/numeric columns (error code `TIME_GRAIN_ON_NON_TEMPORAL`). For text columns that encode dates (e.g. `'2024-03'`), define a computed column with `to_date()` first and point the dimension at that. |
 | `via` | string | No | Force join path through this intermediate data object (role-playing dimensions) |
 | `format` | string | No | Display format pattern (e.g. `#,##0.00`, `0.00%`) |
 | `synonyms` | list | No | Alternative names or terms (LLM hints) |

--- a/integrations/chatgpt-custom-gpt/openapi-gpt-action.yaml
+++ b/integrations/chatgpt-custom-gpt/openapi-gpt-action.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: OrionBelt Semantic Layer
-  version: 2.1.3
+  version: 2.1.4
   description: >
     Compile YAML semantic models (OBML) as analytical SQL across 8 database dialects.
     This API runs in single-model mode with a pre-loaded semantic model.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,7 +9,7 @@ dev_addr: 127.0.0.1:8080
 
 extra:
   obml_version: "1.0"
-  project_version: "2.1.3"
+  project_version: "2.1.4"
   analytics:
     provider: google
     property: G-X19K4GX3EX

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-semantic-layer"
-version = "2.1.3"
+version = "2.1.4"
 description = "OrionBelt Semantic Layer - Compiles and executes YAML semantic models as analytical SQL"
 license = {text = "BSL-1.1"}
 authors = [{name = "Ralf Becher, RALFORION d.o.o.", email = "ralf.becher@web.de"}]

--- a/src/orionbelt/__init__.py
+++ b/src/orionbelt/__init__.py
@@ -1,3 +1,3 @@
 """OrionBelt Semantic Layer — Compiles and executes YAML semantic models as analytical SQL."""
 
-__version__ = "2.1.3"
+__version__ = "2.1.4"

--- a/src/orionbelt/obml_reference.py
+++ b/src/orionbelt/obml_reference.py
@@ -41,6 +41,12 @@ dimensions:
     column: Country               # column within that data object
     resultType: string            # data type of the result (informative only)
     timeGrain: month              # optional: year | quarter | month | week | day | hour
+                                  # REQUIRES the underlying column's abstractType to be
+                                  # date, timestamp, or timestamp_tz. Setting timeGrain on
+                                  # a string/int column is rejected at validation time
+                                  # (error code TIME_GRAIN_ON_NON_TEMPORAL). For text columns
+                                  # encoding dates (e.g. '2024-03'), define a computed column
+                                  # with to_date() and point the dimension at that.
     via: Orders                   # optional: force join path through this data object
 
   # Role-playing dimensions — same target, different join paths

--- a/src/orionbelt/parser/validator.py
+++ b/src/orionbelt/parser/validator.py
@@ -30,6 +30,7 @@ class SemanticValidator:
         errors.extend(self._check_join_targets_exist(model))
         errors.extend(self._check_references_resolve(model))
         errors.extend(self._check_num_class_on_numeric_columns(model))
+        errors.extend(self._check_time_grain_on_temporal_columns(model))
         errors.extend(self._check_measure_filter_refs(model))
         errors.extend(self._check_via_reachability(model))
         errors.extend(self._check_missing_via(model))
@@ -376,6 +377,46 @@ class SemanticValidator:
         return errors
 
     _NUMERIC_TYPES = {DataType.INT, DataType.FLOAT}
+    _TIME_GRAIN_TYPES = {DataType.DATE, DataType.TIMESTAMP, DataType.TIMESTAMP_TZ}
+
+    def _check_time_grain_on_temporal_columns(self, model: SemanticModel) -> list[SemanticError]:
+        """Ensure timeGrain is only set when the underlying column is temporal.
+
+        ``timeGrain`` compiles to ``date_trunc(grain, column)``, which fails at
+        runtime if the column's abstractType is not date/timestamp/timestamp_tz.
+        Reject at model-load time so the error surfaces during validation rather
+        than during the first query.
+        """
+        errors: list[SemanticError] = []
+        for name, dim in model.dimensions.items():
+            if dim.time_grain is None:
+                continue
+            obj_name = dim.view
+            col_name = dim.column
+            if not obj_name or not col_name:
+                continue
+            obj = model.data_objects.get(obj_name)
+            if obj is None or col_name not in obj.columns:
+                # Caught by _check_references_resolve.
+                continue
+            col = obj.columns[col_name]
+            if col.abstract_type not in self._TIME_GRAIN_TYPES:
+                errors.append(
+                    SemanticError(
+                        code="TIME_GRAIN_ON_NON_TEMPORAL",
+                        message=(
+                            f"Dimension '{name}' has timeGrain "
+                            f"'{dim.time_grain.value}' but underlying column "
+                            f"'{obj_name}.{col_name}' has abstractType "
+                            f"'{col.abstract_type.value}'. timeGrain requires "
+                            f"the column to be date, timestamp, or timestamp_tz. "
+                            f"Drop timeGrain, fix the column's abstractType, or "
+                            f"define a computed column with to_date()."
+                        ),
+                        path=f"dimensions.{name}",
+                    )
+                )
+        return errors
 
     def _check_num_class_on_numeric_columns(self, model: SemanticModel) -> list[SemanticError]:
         """Ensure numClass is only set on numeric columns (int or float)."""

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -1183,6 +1183,81 @@ dataObjects:
         errors = validator.validate(model)
         assert not any(e.code == "NUM_CLASS_ON_NON_NUMERIC" for e in errors)
 
+    def test_time_grain_on_string_column_rejected(self, resolver: ReferenceResolver) -> None:
+        """timeGrain on a string-typed column should produce TIME_GRAIN_ON_NON_TEMPORAL."""
+        yaml_content = """\
+version: 1.0
+dataObjects:
+  Calendar:
+    code: calendar
+    database: DB
+    schema: SCH
+    columns:
+      YearMonth:
+        code: ym
+        abstractType: string
+dimensions:
+  Date (Month):
+    dataObject: Calendar
+    column: YearMonth
+    resultType: string
+    timeGrain: month
+"""
+        loader = TrackedLoader()
+        raw, source_map = loader.load_string(yaml_content)
+        model, _result = resolver.resolve(raw, source_map)
+        validator = SemanticValidator()
+        errors = validator.validate(model)
+        assert any(e.code == "TIME_GRAIN_ON_NON_TEMPORAL" for e in errors), (
+            f"Expected TIME_GRAIN_ON_NON_TEMPORAL, got: {[e.code for e in errors]}"
+        )
+
+    def test_time_grain_on_date_column_ok(self, resolver: ReferenceResolver) -> None:
+        """timeGrain on a date/timestamp/timestamp_tz column should not produce errors."""
+        yaml_content = """\
+version: 1.0
+dataObjects:
+  Calendar:
+    code: calendar
+    database: DB
+    schema: SCH
+    columns:
+      OrderDate:
+        code: order_date
+        abstractType: date
+      OrderedAt:
+        code: ordered_at
+        abstractType: timestamp
+      OrderedAtTz:
+        code: ordered_at_tz
+        abstractType: timestamp_tz
+dimensions:
+  Order Date (Month):
+    dataObject: Calendar
+    column: OrderDate
+    resultType: date
+    timeGrain: month
+  Ordered At (Day):
+    dataObject: Calendar
+    column: OrderedAt
+    resultType: timestamp
+    timeGrain: day
+  Ordered At TZ (Hour):
+    dataObject: Calendar
+    column: OrderedAtTz
+    resultType: timestamp_tz
+    timeGrain: hour
+"""
+        loader = TrackedLoader()
+        raw, source_map = loader.load_string(yaml_content)
+        model, _result = resolver.resolve(raw, source_map)
+        validator = SemanticValidator()
+        errors = validator.validate(model)
+        assert not any(e.code == "TIME_GRAIN_ON_NON_TEMPORAL" for e in errors), (
+            f"Did not expect TIME_GRAIN_ON_NON_TEMPORAL, got: "
+            f"{[(e.code, e.message) for e in errors]}"
+        )
+
     def test_malformed_metric_ref_missing_close_bracket(self, resolver: ReferenceResolver) -> None:
         yaml_content = """\
 version: 1.0

--- a/uv.lock
+++ b/uv.lock
@@ -2229,7 +2229,7 @@ wheels = [
 
 [[package]]
 name = "orionbelt-semantic-layer"
-version = "2.1.3"
+version = "2.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Problem
A model can declare a dimension with `timeGrain: month` referencing a column whose `abstractType` is `string` (or any non-temporal type). The compiler then emits `date_trunc('month', "Calendar"."ym")`, which Postgres rejects at runtime:

```
ERROR: function date_trunc(unknown, text) does not exist
HINT: No function matches the given name and argument types.
```

This was hit in production after an LLM-generated model passed validation but failed on the first query. The validator should catch this at model-load time, not at query execution time.

## Fix
- New validator method `_check_time_grain_on_temporal_columns` in `parser/validator.py`. For every dimension with `timeGrain` set, looks up the underlying `DataObject.columns[col].abstractType` and rejects if it's not `date`, `timestamp`, or `timestamp_tz`.
- New error code: `TIME_GRAIN_ON_NON_TEMPORAL`
- Error message includes a remediation hint (drop timeGrain, fix abstractType, or use a computed column with `to_date()`).

## Why column.abstractType, not dimension.resultType
The compiler emits `date_trunc` against the **column**, so the column's actual type is what matters. Checking `resultType` would miss cases where the dimension's resultType is set correctly to `date` but the underlying column is still text (the most common LLM mistake).

## LLM-prevention angle
Updates the `OBML_REFERENCE` resource (`obml_reference.py`) and the model-format docs to document the constraint inline near the `timeGrain` field. LLMs generating OBML now have the rule in their prompt context, which should prevent the bad model from being produced in the first place.

## Test plan
- [x] New unit tests: `test_time_grain_on_string_column_rejected`, `test_time_grain_on_date_column_ok` (covers date/timestamp/timestamp_tz)
- [x] Full test suite: 1351 passed
- [x] `ruff check src/` clean
- [x] `mypy src/orionbelt/parser/validator.py` clean
- [x] `mkdocs build --strict` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)