### PR TITLE
docs: switch live-demo URLs to https://orionbelt.ralforion.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center"><strong>Compile and execute YAML semantic models as analytical SQL across multiple database dialects</strong></p>
 
 <!-- TODO: confirm PyPI publication — if not yet published, remove pypi badge -->
-[![Live Demo](https://img.shields.io/badge/Live_Demo-Try_it_now-brightgreen?style=for-the-badge)](http://35.187.174.102/ui/?__theme=dark)
+[![Live Demo](https://img.shields.io/badge/Live_Demo-Try_it_now-brightgreen?style=for-the-badge)](https://orionbelt.ralforion.com/ui/?__theme=dark)
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ralfbecher/orionbelt-semantic-layer/blob/main/examples/quickstart_colab.ipynb)
 
 [![GitHub stars](https://img.shields.io/github/stars/ralfbecher/orionbelt-semantic-layer?style=social)](https://github.com/ralfbecher/orionbelt-semantic-layer)
@@ -55,9 +55,9 @@ OrionBelt Semantic Layer is an **API-first** semantic engine and query planner f
 
 ### Option A: Live Demo (no install)
 
-**[Open the Live Demo](http://35.187.174.102/ui/?__theme=dark)** — Gradio UI with a pre-loaded example model. Paste a query, pick a dialect, see SQL instantly.
+**[Open the Live Demo](https://orionbelt.ralforion.com/ui/?__theme=dark)** — Gradio UI with a pre-loaded example model. Paste a query, pick a dialect, see SQL instantly.
 
-API explorer: [Swagger UI](http://35.187.174.102/docs) | [ReDoc](http://35.187.174.102/redoc)
+API explorer: [Swagger UI](https://orionbelt.ralforion.com/docs) | [ReDoc](https://orionbelt.ralforion.com/redoc)
 
 ### Option B: Google Colab (no install)
 

--- a/docs/guide/ui.md
+++ b/docs/guide/ui.md
@@ -48,6 +48,6 @@ API_BASE_URL=http://remote-api:8080 uv run orionbelt-ui # point to remote API
 
 The hosted demo is available at:
 
-> **[http://35.187.174.102/ui](http://35.187.174.102/ui/?__theme=dark)**
+> **[https://orionbelt.ralforion.com/ui](https://orionbelt.ralforion.com/ui/?__theme=dark)**
 
-API endpoint: `http://35.187.174.102` — Interactive docs: [Swagger UI](http://35.187.174.102/docs) | [ReDoc](http://35.187.174.102/redoc)
+API endpoint: `https://orionbelt.ralforion.com` — Interactive docs: [Swagger UI](https://orionbelt.ralforion.com/docs) | [ReDoc](https://orionbelt.ralforion.com/redoc)


### PR DESCRIPTION
## Summary

The public load balancer now has a Google-managed wildcard cert
(`*.ralforion.com`) and a port-443 forwarding rule. Replace the
`http://35.187.174.102` URLs in user-facing docs with the HTTPS hostname.

- `README.md` — Live Demo badge, "Option A" hero CTA, Swagger / ReDoc links
- `docs/guide/ui.md` — hosted demo block

The raw IP still works on plain HTTP (port-80 forwarding rule unchanged),
so existing bookmarks aren't broken — the docs just no longer surface a
plaintext URL.

## Test plan

- [x] All `35.187.174.102` references in `README.md`, `CLAUDE.md`, and `docs/` now resolve to `https://orionbelt.ralforion.com`
- [x] `https://orionbelt.ralforion.com/ui/`, `/docs`, `/redoc` all return HTTP 200 with a valid `*.ralforion.com` cert from Google Trust Services
- [x] MkDocs build is unaffected — links are simple substitutions

🤖 Generated with [Claude Code](https://claude.com/claude-code)