### PR TITLE
feat: agent-facing API improvements (5-phase bundle)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to OrionBelt Semantic Layer are documented here.
 
+## [2.2.0] - 2026-05-05
+
+### Added
+
+- **`POST /v1/oneshot/batch` — one-shot batch endpoint.** Loads (or references) an OBML model and runs N independent queries against it in a single round trip. Designed for agent workflows where one model + multiple sub-questions is the dominant pattern. Supports `model_yaml` (transient or persisted via `persist_model: true`) or `model_id` (reference an already-loaded model). Queries run concurrently under an `asyncio.Semaphore` capped by `ONESHOT_BATCH_MAX_PARALLELISM` (default 8). Per-query overrides for `dialect` and `execute`. Stable result ordering keyed by caller-provided `id`. Partial failure is the default — each result carries its own `status` (`ok` / `error` / `cancelled`) and `error` envelope. `fail_fast: true` cancels remaining queries on first failure. Whole-batch and per-query timeouts are honored. Server limits surface via `GET /v1/settings.oneshot_batch`. See `design/PLAN_oneshot_batch.md`.
+- **Model load deduplication.** `POST /v1/sessions/{sid}/models` and `POST /v1/oneshot/batch` now reuse an existing `model_id` when the same OBML bytes (whitespace-normalized) are already loaded in the session. The response includes a new `model_load` field (`"fresh"` | `"reused"` | `"referenced"` for batch). Skips parsing, validation, and OBSL graph generation on the dedup path. Disable with `dedup: false`. Index is per-session (session isolation preserved) and is cleared automatically on model removal. See `design/PLAN_model_load_dedup.md`.
+
+### Settings
+
+- New env vars: `ONESHOT_BATCH_MAX_QUERIES` (50), `ONESHOT_BATCH_MAX_PARALLELISM` (8), `ONESHOT_BATCH_DEFAULT_TIMEOUT_MS` (30000), `ONESHOT_BATCH_BATCH_TIMEOUT_MS` (120000). All exposed in `GET /v1/settings.oneshot_batch`.
+
+### Behavior change
+
+- Identical OBML loads in the same session now return the same `model_id` instead of minting a new one each time. Disable per-call with `dedup: false`.
+
 ## [2.1.4] - 2026-05-03
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,6 +191,7 @@ All API routes are prefixed with `/v1/` except `/health` and `/robots.txt`.
 | POST | `/v1/sessions/{id}/models/{mid}/sparql` | SPARQL query (SELECT/ASK) |
 | POST | `/v1/convert/osi-to-obml` | Convert OSI YAML → OBML YAML |
 | POST | `/v1/convert/obml-to-osi` | Convert OBML YAML → OSI YAML |
+| POST | `/v1/oneshot/batch` | Load (or reference) a model and run N independent queries in one round trip |
 | GET | `/v1/reference/obml` | OBML reference documentation |
 
 Top-level shortcuts (auto-resolve when single session/model): `/v1/schema`, `/v1/dimensions`, `/v1/measures`, `/v1/metrics`, `/v1/explain/{name}`, `/v1/find`, `/v1/join-graph`, `/v1/graph`, `/v1/sparql`, `/v1/query/sql`, `/v1/query/execute`.

--- a/README.md
+++ b/README.md
@@ -247,6 +247,14 @@ Also works with Copilot, Cursor, and Windsurf. See the [MCP repo](https://github
 - **Gradio UI** — interactive web interface for model editing, query testing, and ER diagrams
 - **DB-API 2.0 + Flight SQL** — PEP 249 drivers and Arrow Flight SQL server for DBeaver, Tableau, Power BI
 
+### Agent-Facing API
+
+- **Model Health on Load** — every model load returns a `health` block with orphan dataObjects, fan-trap risks, and unreachable dimensions — agents skip the defensive second round trip
+- **Query Plan Endpoint** — `POST /query/plan` returns the planner's understanding (planner choice, physical tables, join path, `would_compile`) without compiling SQL or executing; opt-in `include_database_explain` adds the warehouse's raw EXPLAIN
+- **Structured Warnings** — every `warnings` list across the API uses a stable `{code, severity, message, path, hint, context}` shape with a documented code taxonomy; agents branch on codes instead of parsing messages
+- **Fuzzy `/find` Recovery** — when a search produces no exact or synonym hits, deterministic Levenshtein + trigram fallback returns near-miss candidates with scores and reasons
+- **Model Examples** — optional OBML `examples:` block of canonical queries; `GET /examples` (with `?intent=` filtering) gives agents one-round-trip discovery of what a model is designed to answer
+
 ### Developer Experience
 
 - **Source-Position Errors** — validation errors report exact YAML line and column

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ralfbecher/orionbelt-semantic-layer/blob/main/examples/quickstart_colab.ipynb)
 
 [![GitHub stars](https://img.shields.io/github/stars/ralfbecher/orionbelt-semantic-layer?style=social)](https://github.com/ralfbecher/orionbelt-semantic-layer)
-[![Version 2.1.4](https://img.shields.io/badge/version-2.1.4-purple.svg)](https://github.com/ralfbecher/orionbelt-semantic-layer/releases)
+[![Version 2.2.0](https://img.shields.io/badge/version-2.2.0-purple.svg)](https://github.com/ralfbecher/orionbelt-semantic-layer/releases)
 [![PyPI](https://img.shields.io/pypi/v/orionbelt-semantic-layer?logo=pypi&logoColor=white)](https://pypi.org/project/orionbelt-semantic-layer/)
 [![Docker Hub](https://img.shields.io/docker/pulls/ralforion/orionbelt-api?logo=docker&label=Docker%20Hub)](https://hub.docker.com/repositories/ralforion)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
@@ -155,7 +155,7 @@ Open [http://localhost:8080/docs](http://localhost:8080/docs) to explore the API
 # docker-compose.yml
 services:
   api:
-    image: ralforion/orionbelt-api:2.1.4
+    image: ralforion/orionbelt-api:2.2.0
     ports: ["8080:8080"]
     env_file: .env
     volumes:
@@ -164,7 +164,7 @@ services:
       MODEL_FILE: /app/models/my-model.obml.yml
 
   ui:
-    image: ralforion/orionbelt-ui:2.1.4
+    image: ralforion/orionbelt-ui:2.2.0
     ports: ["7860:7860"]
     environment:
       API_BASE_URL: http://api:8080
@@ -180,7 +180,7 @@ See [`.env.template`](.env.template) for the full environment variable reference
 > - `API_SERVER_HOST` is already `0.0.0.0` inside the container — no override needed.
 > - MCP via stdio does not work in Docker. Use the [MCP HTTP client](https://github.com/ralfbecher/orionbelt-semantic-layer-mcp) for containerized deployments.
 > - Mount models to `/app/models` (or any path) and set `MODEL_FILE` to pre-load on startup.
-> - For production, pin a version tag (`:2.1.4`) rather than `:latest`.
+> - For production, pin a version tag (`:2.2.0`) rather than `:latest`.
 
 ### Claude Desktop / MCP
 

--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -125,11 +125,51 @@ Load an OBML semantic model into a session. The model is parsed, validated, and 
   "measures": 2,
   "metrics": 1,
   "warnings": [],
-  "model_load": "fresh"
+  "model_load": "fresh",
+  "health": {
+    "status": "ok",
+    "data_objects": 2,
+    "joins": 1,
+    "orphan_data_objects": [],
+    "fan_trap_risks": [],
+    "unreachable_dimensions": [],
+    "warnings_count": 0
+  }
 }
 ```
 
 `model_load` is `"fresh"` when the OBML was parsed and loaded normally, `"reused"` when an identical model was already present in the session (no parsing/validation work was done; the existing `model_id` is returned). Dedup applies only to plain `model_yaml` loads — supplying `extends` or `inherits` always loads fresh.
+
+#### `health` block
+
+Structural health of the model's join graph, computed during load (no extra round trip required). Always present on `fresh` loads and on `reused` dedup hits. Fields:
+
+| Field | Type | Description |
+|---|---|---|
+| `status` | string | `ok` when nothing surfaced, `warnings` when one or more risks were detected. |
+| `data_objects` | int | Count of dataObjects in the model. |
+| `joins` | int | Count of (non-secondary) joins detected. |
+| `orphan_data_objects` | array of strings | DataObjects with no incoming or outgoing joins. May be intentional in single-table models. |
+| `fan_trap_risks` | array of objects | Pairs of facts that share a dimension via the same FK columns. Each entry has `tables` (qualified physical names), `reason`, and `suggested_pattern` (typically `"composite_fact_layer"`). |
+| `unreachable_dimensions` | array of strings | Dimensions whose dataObject is not reachable from any fact via directed joins. |
+| `warnings_count` | int | Total warnings across orphans, fan-traps, and unreachable dims. |
+
+#### Structured `warnings`
+
+Every `warnings` list in this API uses the same shape so agents can branch on stable codes without parsing message text:
+
+```json
+{
+  "code": "FAN_TRAP_RISK",
+  "severity": "warning",
+  "message": "Measure 'Revenue' (SUM): cross-join through 'Movie Directors' …",
+  "path": "select.measures[0]",
+  "hint": "Add the junction-table dimension to the GROUP BY, …",
+  "context": { "measure": "Revenue", "junction": "Movie Directors" }
+}
+```
+
+Initial warning code taxonomy: `GRAIN_OVERRIDE_INCOMPATIBLE`, `FILTER_CONTEXT_OVERRIDE_INCOMPATIBLE`, `POP_CONSTRAINT_VIOLATED`, `CUMULATIVE_CONSTRAINT_VIOLATED`, `FAN_TRAP_RISK`, `ORPHAN_DATA_OBJECT`, `SHARED_TABLE_CONTRACT_DISAGREEMENT`, `LARGE_RESULT_SET`, `CACHE_TTL_FLOOR_HIT`, `INCOMPATIBLE_COMBINATION`, `SQL_VALIDATION`, `MERGE_WARNING`. Codes are extended over time, never repurposed.
 
 **Error (403):** Single-model mode: model upload is disabled.
 
@@ -313,6 +353,80 @@ Compile a semantic query against a model loaded in the session.
 | 400 | Unsupported dialect |
 | 404 | Model or session not found |
 | 422 | Resolution error |
+
+### `POST /v1/sessions/{session_id}/query/plan`
+
+Return the planner's understanding of a query without compiling SQL or executing. Cheap by default (no warehouse round trip) — agents use it as a "would this work?" probe in their planning loop.
+
+**Request:**
+
+```json
+{
+  "model_id": "abcd1234",
+  "query": {
+    "select": {
+      "dimensions": ["Customer Country"],
+      "measures": ["Revenue"]
+    }
+  },
+  "dialect": "postgres",
+  "include_database_explain": false
+}
+```
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `model_id` | string | — | Loaded model id. |
+| `query` | object | — | QueryObject (same shape as `/query/sql`). |
+| `dialect` | string | model/env default | SQL dialect. |
+| `include_database_explain` | bool | `false` | When `true`, also runs `EXPLAIN <sql>` against the configured warehouse and includes the raw output. Costs one round trip; some warehouses bill compute for `EXPLAIN`. |
+
+**Response (200, OBSL-only plan):**
+
+```json
+{
+  "status": "ok",
+  "planner": "Star Schema",
+  "planner_reason": "All requested objects are reachable from a single base via directed joins",
+  "physical_tables": ["WAREHOUSE.PUBLIC.ORDERS", "WAREHOUSE.PUBLIC.CUSTOMERS"],
+  "join_path": [
+    {
+      "from_object": "Orders",
+      "to_object": "Customers",
+      "cardinality": "many-to-one",
+      "fk": "CUSTOMER_ID = CUSTOMER_ID"
+    }
+  ],
+  "filters_applied": 0,
+  "warnings": [],
+  "would_compile": true,
+  "compiled_sql_length_estimate": 312,
+  "database_explain": null
+}
+```
+
+**Response (200, with `include_database_explain: true`):**
+
+Adds a `database_explain` block. The `explain_output` is opaque text in the dialect's native EXPLAIN format — OBSL does not normalize across dialects.
+
+```json
+{
+  "...": "...",
+  "database_explain": {
+    "dialect": "postgres",
+    "compiled_sql": "SELECT ...",
+    "explain_output": "Hash Join (cost=128.50..1247.30 rows=1042 width=48) ...",
+    "explain_format": "text"
+  }
+}
+```
+
+**Failure modes:**
+
+- Resolution / fanout / unsupported-aggregation errors → `status: "error"`, `would_compile: false`, structured `warnings` with the failure cause.
+- `include_database_explain: true` but the warehouse rejects `EXPLAIN` → OBSL plan still returned with a `DATABASE_EXPLAIN_FAILED` warning describing why; `database_explain` is `null`.
+
+The plan endpoint never executes the actual query, even with `include_database_explain: true`.
 
 ### `POST /v1/sessions/{session_id}/query/execute`
 
@@ -699,7 +813,7 @@ Explain the lineage of a dimension, measure, or metric — traces back through t
 
 ### `POST /v1/sessions/{session_id}/models/{model_id}/find`
 
-Search across model artefacts by name or synonym.
+Search across model artefacts by name or synonym. When the query produces zero exact and zero synonym matches, deterministic fuzzy fallback (Levenshtein + trigram-Jaccard) returns the closest near-miss candidates. Threshold is 0.5; up to 10 results are returned.
 
 **Request:**
 
@@ -712,16 +826,41 @@ Search across model artefacts by name or synonym.
 
 The `types` filter is optional. Valid types: `dimension`, `measure`, `metric`, `data_object`.
 
-**Response (200):**
+**Response (200, exact / synonym hits):**
 
 ```json
 {
+  "query": "Revenue",
   "results": [
-    { "name": "Revenue", "type": "measure", "match": "name" },
-    { "name": "Revenue per Order", "type": "metric", "match": "name" }
+    { "name": "Revenue", "type": "measure", "match_field": "name", "score": 1.0 },
+    { "name": "Revenue per Order", "type": "metric", "match_field": "name", "score": 1.0 }
+  ],
+  "exact_matches": [...],
+  "synonym_matches": [],
+  "fuzzy_matches": []
+}
+```
+
+**Response (200, no exact/synonym hit — fuzzy fallback fires):**
+
+```json
+{
+  "query": "Custmr Cuntry",
+  "results": [],
+  "exact_matches": [],
+  "synonym_matches": [],
+  "fuzzy_matches": [
+    {
+      "name": "Customer Country",
+      "kind": "dimension",
+      "score": 0.78,
+      "reason": "trigram overlap"
+    }
   ]
 }
 ```
+
+`fuzzy_matches` is empty when the query produced exact or synonym hits, and also when nothing scored above the 0.5 threshold (truly no match).
 
 ### `GET /v1/sessions/{session_id}/models/{model_id}/join-graph`
 
@@ -742,6 +881,73 @@ Return the join graph as nodes and edges.
   ]
 }
 ```
+
+---
+
+## Model Examples
+
+Canonical example queries authored alongside the model in OBML's optional `examples:` block. Surfaced through these endpoints so agents can discover what kinds of questions a model is designed to answer in one round trip.
+
+See `docs/guide/model-format.md` for the OBML `examples:` syntax.
+
+### `GET /v1/sessions/{session_id}/models/{model_id}/examples`
+
+List every example summary in the loaded model.
+
+**Query parameters (optional):**
+
+| Param | Description |
+|---|---|
+| `intent` | Filter by intent tag (case-insensitive). Resolution: exact tag match → substring match → fuzzy match against the tag corpus. |
+
+**Response (200):**
+
+```json
+{
+  "examples": [
+    {
+      "name": "revenue_by_country",
+      "description": "Total completed-order revenue, broken down by customer country.",
+      "intent_tags": ["revenue", "geography"]
+    }
+  ],
+  "suggestion": null
+}
+```
+
+**Response (200, `?intent=` did not match anything):**
+
+```json
+{
+  "examples": [],
+  "suggestion": "no examples for 'foo'; available tags: revenue, orders, geography"
+}
+```
+
+### `GET /v1/sessions/{session_id}/models/{model_id}/examples/{example_name}`
+
+Return a single example by name, with the full query payload and a best-effort compiled SQL preview.
+
+**Response (200):**
+
+```json
+{
+  "name": "revenue_by_country",
+  "description": "Total completed-order revenue, broken down by customer country.",
+  "intent_tags": ["revenue", "geography"],
+  "query": {
+    "select": {
+      "dimensions": ["Customer Country"],
+      "measures": ["Total Revenue"]
+    }
+  },
+  "compiled_sql_preview": "SELECT ..."
+}
+```
+
+`compiled_sql_preview` is `null` when the example fails to compile against the current model (e.g. the model has drifted since the example was authored).
+
+**Error (404):** Example name not found in model.
 
 ---
 

--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -13,7 +13,7 @@ Returns the service status and version.
 ```json
 {
   "status": "ok",
-  "version": "2.1.4"
+  "version": "2.2.0"
 }
 ```
 
@@ -102,9 +102,18 @@ Load an OBML semantic model into a session. The model is parsed, validated, and 
 
 ```json
 {
-  "model_yaml": "version: 1.0\ndataObjects:\n  Orders:\n    code: ORDERS\n    ..."
+  "model_yaml": "version: 1.0\ndataObjects:\n  Orders:\n    code: ORDERS\n    ...",
+  "dedup": true
 }
 ```
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `model_yaml` | string | — | OBML YAML (or use `model_json`). |
+| `model_json` | object/string | — | OBML as JSON (or use `model_yaml`). |
+| `extends` | array | — | Inline YAML fragments to merge. |
+| `inherits` | string | — | Parent model_id to inherit from. |
+| `dedup` | bool | `true` | When true, identical OBML content already loaded in this session reuses the existing `model_id`. Set `false` to force a fresh parse. |
 
 **Response (201):**
 
@@ -115,9 +124,12 @@ Load an OBML semantic model into a session. The model is parsed, validated, and 
   "dimensions": 3,
   "measures": 2,
   "metrics": 1,
-  "warnings": []
+  "warnings": [],
+  "model_load": "fresh"
 }
 ```
+
+`model_load` is `"fresh"` when the OBML was parsed and loaded normally, `"reused"` when an identical model was already present in the session (no parsing/validation work was done; the existing `model_id` is returned). Dedup applies only to plain `model_yaml` loads — supplying `extends` or `inherits` always loads fresh.
 
 **Error (403):** Single-model mode: model upload is disabled.
 
@@ -385,6 +397,114 @@ UK	9.870,00
 | 503 | Query execution not available (`FLIGHT_ENABLED` not set) |
 
 **Top-level shortcut:** `POST /v1/query/execute` — auto-resolves session/model, auto-detects dialect from `DB_VENDOR`.
+
+---
+
+## One-shot Batch
+
+### `POST /v1/oneshot/batch`
+
+Load (or reference) a model and run multiple independent queries against it in a single round trip. Designed for agent workflows: one model, N sub-questions, parallel execution under a server-capped semaphore. See `design/PLAN_oneshot_batch.md` for the full design.
+
+**Request:**
+
+```json
+{
+  "session_id": null,
+  "model_yaml": "version: 1.0\ndataObjects: ...",
+  "model_id": null,
+  "queries": [
+    {
+      "id": "revenue_by_country",
+      "query": {
+        "select": {"dimensions": ["Customer Country"], "measures": ["Total Revenue"]},
+        "limit": 100
+      }
+    },
+    {
+      "id": "revenue_by_product",
+      "query": {"select": {"dimensions": ["Product"], "measures": ["Total Revenue"]}},
+      "execute": false
+    }
+  ],
+  "dialect": "postgres",
+  "execute": true,
+  "max_parallelism": 4,
+  "fail_fast": false,
+  "persist_model": false,
+  "dedup": true
+}
+```
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `session_id` | string | auto-create | Existing session, otherwise OBSL creates one. |
+| `model_yaml` | string | — | OBML YAML. Mutually exclusive with `model_id`. |
+| `model_id` | string | — | ID of an already-loaded model in the session. Mutually exclusive with `model_yaml`. |
+| `queries` | array | required | List of queries (1..max_queries). Each needs a unique `id`. |
+| `queries[].execute` | bool | inherits batch | Per-query override for compile-only vs. execute. |
+| `queries[].dialect` | string | inherits batch | Per-query dialect override. |
+| `dialect` | string | model/env | Default dialect for the batch. |
+| `execute` | bool | `false` | Default execute flag for the batch. |
+| `max_parallelism` | int | server cap | Concurrency cap (silently lowered to the server max). |
+| `fail_fast` | bool | `false` | Cancel remaining queries on first failure. |
+| `persist_model` | bool | `false` | Keep the model loaded after the batch (only for `model_yaml` loads). |
+| `dedup` | bool | `true` | Reuse an existing identical model loaded in this session. |
+
+**Response (200):**
+
+```json
+{
+  "session_id": "a1b2c3d4...",
+  "model_id": "abcd1234",
+  "model_persisted": false,
+  "model_load": "fresh",
+  "results": [
+    {
+      "id": "revenue_by_country",
+      "status": "ok",
+      "sql": "SELECT ...",
+      "dialect": "postgres",
+      "sql_valid": true,
+      "executed": true,
+      "columns": [{"name": "Customer Country", "type": "string"}],
+      "rows": [["US", 15230.5]],
+      "row_count": 42,
+      "execution_time_ms": 38.2,
+      "warnings": []
+    },
+    {
+      "id": "revenue_by_product",
+      "status": "ok",
+      "sql": "SELECT ...",
+      "dialect": "postgres",
+      "sql_valid": true,
+      "executed": false,
+      "warnings": []
+    }
+  ],
+  "batch_warnings": []
+}
+```
+
+`model_load` is `"fresh"` (parsed and loaded), `"reused"` (matched dedup index), or `"referenced"` (caller supplied `model_id`).
+
+Per-query `status` is `"ok"`, `"error"` (with an `error` envelope: `{code, message, path, hint}`), or `"cancelled"` (only when `fail_fast: true` triggers and remaining queries are short-circuited).
+
+**Error (422):** Validation failure (duplicate query IDs, both/neither of `model_yaml`/`model_id`, batch over `ONESHOT_BATCH_MAX_QUERIES`, or model load failure).
+
+**Error (404):** Session or `model_id` not found.
+
+**Error (410):** Session expired.
+
+**Limits** (configurable, see `GET /v1/settings.oneshot_batch`):
+
+| Setting | Default |
+|---|---|
+| `ONESHOT_BATCH_MAX_QUERIES` | 50 |
+| `ONESHOT_BATCH_MAX_PARALLELISM` | 8 |
+| `ONESHOT_BATCH_DEFAULT_TIMEOUT_MS` | 30000 (per-query) |
+| `ONESHOT_BATCH_BATCH_TIMEOUT_MS` | 120000 (whole batch) |
 
 ---
 
@@ -734,7 +854,7 @@ Return public configuration for API clients (UI, MCP, etc.).
 
 ```json
 {
-  "version": "2.1.4",
+  "version": "2.2.0",
   "api_version": "v1",
   "single_model_mode": false,
   "session_ttl_seconds": 1800,
@@ -753,7 +873,7 @@ Return public configuration for API clients (UI, MCP, etc.).
 
 ```json
 {
-  "version": "2.1.4",
+  "version": "2.2.0",
   "api_version": "v1",
   "single_model_mode": true,
   "model_yaml": "version: 1.0\nsettings:\n  defaultTimezone: Europe/Berlin\n  ...",

--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -441,7 +441,8 @@ Load (or reference) a model and run multiple independent queries against it in a
 | `session_id` | string | auto-create | Existing session, otherwise OBSL creates one. |
 | `model_yaml` | string | — | OBML YAML. Mutually exclusive with `model_id`. |
 | `model_id` | string | — | ID of an already-loaded model in the session. Mutually exclusive with `model_yaml`. |
-| `queries` | array | required | List of queries (1..max_queries). Each needs a unique `id`. |
+| `queries` | array | required | List of queries (1..max_queries). |
+| `queries[].id` | string | auto (`q0`,`q1`,...) | Optional caller ID. Must be unique within the batch when supplied. Omit to let the server assign positional IDs. |
 | `queries[].execute` | bool | inherits batch | Per-query override for compile-only vs. execute. |
 | `queries[].dialect` | string | inherits batch | Per-query dialect override. |
 | `dialect` | string | model/env | Default dialect for the batch. |

--- a/docs/guide/model-format.md
+++ b/docs/guide/model-format.md
@@ -1076,6 +1076,45 @@ filters:
 
 Produces: `WHERE "STATUS" = 'completed' AND "COUNTRY" = 'Germany'`
 
+## Examples
+
+The optional top-level `examples:` block lists canonical queries authored alongside the model — the kinds of questions the model is designed to answer. Surfaced through `GET /v1/sessions/{sid}/models/{mid}/examples` so agents can ground on the model in one round trip without guessing from dimension and measure names alone.
+
+```yaml
+examples:
+  - name: revenue_by_country
+    description: "Total completed-order revenue, broken down by customer country, last 90 days."
+    intent_tags: [revenue, geography, "trailing window"]
+    query:
+      select:
+        dimensions: ["Customer Country"]
+        measures: ["Total Revenue"]
+      where:
+        - field: "Order Date"
+          op: ">="
+          value: "2026-01-01"
+      order_by:
+        - { field: "Total Revenue", direction: "desc" }
+      limit: 100
+
+  - name: refund_rate_by_product
+    description: "Returns as percentage of sales, by product."
+    intent_tags: [returns, rate, product]
+    query:
+      select:
+        dimensions: ["Product Name"]
+        measures: ["Refund Rate"]
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | yes | Snake_case identifier, unique within the examples block. |
+| `description` | string | yes | One- or two-sentence explanation of what this example shows. |
+| `intent_tags` | list of strings | no | Free-form tags. The `?intent=` query parameter on the examples list endpoint matches against these (exact → contains → fuzzy fallback). camelCase alias `intentTags` is accepted. |
+| `query` | object | yes | Full QueryObject payload — same shape accepted by `/query/sql`. |
+
+The single-example endpoint (`GET .../examples/{name}`) returns the full query plus a best-effort `compiled_sql_preview` so agents can inspect what the example would produce without executing it.
+
 ## Validation Rules
 
 OrionBelt validates models against these rules:

--- a/integrations/chatgpt-custom-gpt/openapi-gpt-action.yaml
+++ b/integrations/chatgpt-custom-gpt/openapi-gpt-action.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: OrionBelt Semantic Layer
-  version: 2.1.4
+  version: 2.2.0
   description: >
     Compile YAML semantic models (OBML) as analytical SQL across 8 database dialects.
     This API runs in single-model mode with a pre-loaded semantic model.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,7 +9,7 @@ dev_addr: 127.0.0.1:8080
 
 extra:
   obml_version: "1.0"
-  project_version: "2.1.4"
+  project_version: "2.2.0"
   analytics:
     provider: google
     property: G-X19K4GX3EX

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-semantic-layer"
-version = "2.1.4"
+version = "2.2.0"
 description = "OrionBelt Semantic Layer - Compiles and executes YAML semantic models as analytical SQL"
 license = {text = "BSL-1.1"}
 authors = [{name = "Ralf Becher, RALFORION d.o.o.", email = "ralf.becher@web.de"}]

--- a/schema/obml-schema.json
+++ b/schema/obml-schema.json
@@ -1056,6 +1056,39 @@
         "additionalProperties": false
       }
     },
+    "examples": {
+      "type": "array",
+      "description": "Canonical example queries authored alongside the model. Surfaced via the /examples endpoints so agents can discover what kinds of questions the model is designed to answer. See PLAN_agent_api_improvements.md §5.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Snake_case identifier, unique within the examples block"
+          },
+          "description": {
+            "type": "string",
+            "description": "One- or two-sentence explanation of what this example shows"
+          },
+          "intent_tags": {
+            "type": "array",
+            "description": "Free-form tags used by the /examples?intent= filter",
+            "items": { "type": "string" }
+          },
+          "intentTags": {
+            "type": "array",
+            "description": "camelCase alias for intent_tags",
+            "items": { "type": "string" }
+          },
+          "query": {
+            "type": "object",
+            "description": "Full QueryObject payload (the same shape accepted by /query/sql)"
+          }
+        },
+        "required": ["name", "description", "query"],
+        "additionalProperties": false
+      }
+    },
     "extends": {
       "type": "array",
       "description": "List of OBML files to merge as analytical layers (dimensions, measures, metrics). Extend files must not contain dataObjects.",

--- a/src/orionbelt/__init__.py
+++ b/src/orionbelt/__init__.py
@@ -1,3 +1,3 @@
 """OrionBelt Semantic Layer — Compiles and executes YAML semantic models as analytical SQL."""
 
-__version__ = "2.1.4"
+__version__ = "2.2.0"

--- a/src/orionbelt/api/app.py
+++ b/src/orionbelt/api/app.py
@@ -13,7 +13,7 @@ from fastapi import APIRouter, FastAPI, Request
 from fastapi.responses import JSONResponse, Response
 
 from orionbelt import __version__
-from orionbelt.api.deps import init_session_manager, reset_session_manager
+from orionbelt.api.deps import OneshotBatchConfig, init_session_manager, reset_session_manager
 from orionbelt.api.logging_config import configure_logging
 from orionbelt.api.middleware import (
     RequestBodyLimitMiddleware,
@@ -27,6 +27,7 @@ from orionbelt.api.routers import (
     dialects,
     graph,
     model_api,
+    oneshot,
     reference,
     sessions,
     shortcuts,
@@ -125,6 +126,12 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
         db_vendor=settings.db_vendor,
         query_default_limit=settings.query_default_limit,
         default_locale=settings.default_locale,
+        oneshot_batch_config=OneshotBatchConfig(
+            max_queries=settings.oneshot_batch_max_queries,
+            max_parallelism=settings.oneshot_batch_max_parallelism,
+            default_timeout_ms=settings.oneshot_batch_default_timeout_ms,
+            batch_timeout_ms=settings.oneshot_batch_batch_timeout_ms,
+        ),
     )
 
     # Start Arrow Flight SQL server if ob-flight-extension is installed
@@ -230,6 +237,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     v1.include_router(shortcuts.router, tags=["model-discovery"])
     v1.include_router(convert.router, prefix="/convert", tags=["convert"])
     v1.include_router(dialects.router, prefix="/dialects", tags=["dialects"])
+    v1.include_router(oneshot.router, prefix="/oneshot", tags=["oneshot"])
     v1.include_router(reference.router, prefix="/reference", tags=["reference"])
     v1.include_router(settings_router.router, prefix="/settings", tags=["settings"])
     app.include_router(v1)

--- a/src/orionbelt/api/deps.py
+++ b/src/orionbelt/api/deps.py
@@ -2,7 +2,20 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 from orionbelt.service.session_manager import SessionManager
+
+
+@dataclass(frozen=True)
+class OneshotBatchConfig:
+    """Server-side config for POST /v1/oneshot/batch."""
+
+    max_queries: int = 50
+    max_parallelism: int = 8
+    default_timeout_ms: int = 30000
+    batch_timeout_ms: int = 120000
+
 
 _session_manager: SessionManager | None = None
 _disable_session_list: bool = False
@@ -13,6 +26,7 @@ _query_execute_enabled: bool = False
 _db_vendor: str = "duckdb"
 _query_default_limit: int = 1000
 _default_locale: str = ""
+_oneshot_batch_config: OneshotBatchConfig = OneshotBatchConfig()
 
 
 def init_session_manager(
@@ -25,12 +39,13 @@ def init_session_manager(
     db_vendor: str = "duckdb",
     query_default_limit: int = 1000,
     default_locale: str = "",
+    oneshot_batch_config: OneshotBatchConfig | None = None,
 ) -> None:
     """Set the global SessionManager (called at app startup)."""
     global _session_manager, _disable_session_list  # noqa: PLW0603
     global _single_model_mode, _preload_model_yaml, _flight_info  # noqa: PLW0603
     global _query_execute_enabled, _db_vendor, _query_default_limit  # noqa: PLW0603
-    global _default_locale  # noqa: PLW0603
+    global _default_locale, _oneshot_batch_config  # noqa: PLW0603
     _session_manager = manager
     _disable_session_list = disable_session_list
     _single_model_mode = preload_model_yaml is not None
@@ -40,6 +55,8 @@ def init_session_manager(
     _db_vendor = db_vendor
     _query_default_limit = query_default_limit
     _default_locale = default_locale
+    if oneshot_batch_config is not None:
+        _oneshot_batch_config = oneshot_batch_config
 
 
 def get_session_manager() -> SessionManager:
@@ -100,12 +117,17 @@ def get_default_locale() -> str:
     return _default_locale
 
 
+def get_oneshot_batch_config() -> OneshotBatchConfig:
+    """Return the configured one-shot batch limits."""
+    return _oneshot_batch_config
+
+
 def reset_session_manager() -> None:
     """Clear the global SessionManager (for tests)."""
     global _session_manager, _disable_session_list  # noqa: PLW0603
     global _single_model_mode, _preload_model_yaml, _flight_info  # noqa: PLW0603
     global _query_execute_enabled, _db_vendor, _query_default_limit  # noqa: PLW0603
-    global _default_locale  # noqa: PLW0603
+    global _default_locale, _oneshot_batch_config  # noqa: PLW0603
     _session_manager = None
     _disable_session_list = False
     _single_model_mode = False
@@ -115,3 +137,4 @@ def reset_session_manager() -> None:
     _db_vendor = "duckdb"
     _query_default_limit = 1000
     _default_locale = ""
+    _oneshot_batch_config = OneshotBatchConfig()

--- a/src/orionbelt/api/routers/model_api.py
+++ b/src/orionbelt/api/routers/model_api.py
@@ -14,6 +14,9 @@ from orionbelt.api.schemas import (
     ColumnDetail,
     DataObjectDetail,
     DimensionDetail,
+    ExampleDetail,
+    ExampleListResponse,
+    ExampleSummary,
     ExplainLineageItem,
     ExplainResponse,
     JoinEdge,
@@ -258,41 +261,70 @@ def _build_explain(name: str, model: SemanticModel) -> ExplainResponse:
 
 
 def _search_model(model: SemanticModel, query: str, types: list[str]) -> list[SearchResultItem]:
-    """Search across model artefacts by name/synonym."""
-    results: list[SearchResultItem] = []
+    """Search across model artefacts by name/synonym (legacy flat results)."""
+    exact, synonym, _ = _search_model_split(model, query, types)
+    return exact + synonym
+
+
+def _search_model_split(
+    model: SemanticModel,
+    query: str,
+    types: list[str],
+) -> tuple[list[SearchResultItem], list[SearchResultItem], list[tuple[str, str, list[str]]]]:
+    """Search and return (exact, synonym, fuzzy_candidates).
+
+    ``fuzzy_candidates`` is the full ``(name, kind, synonyms)`` corpus across
+    the requested ``types`` so callers can fall back to fuzzy matching when
+    both exact and synonym lists are empty.
+    """
+    exact: list[SearchResultItem] = []
+    synonym: list[SearchResultItem] = []
+    fuzzy_candidates: list[tuple[str, str, list[str]]] = []
     q = query.lower()
+
+    def _consider(name: str, kind: str, synonyms: list[str]) -> None:
+        if q in name.lower():
+            exact.append(SearchResultItem(type=kind, name=name, match_field="name"))
+        elif any(q in s.lower() for s in synonyms):
+            synonym.append(SearchResultItem(type=kind, name=name, match_field="synonym"))
+        fuzzy_candidates.append((name, kind, list(synonyms)))
 
     if "dimension" in types:
         for name, dim in model.dimensions.items():
-            if q in name.lower():
-                results.append(SearchResultItem(type="dimension", name=name, match_field="name"))
-            elif any(q in s.lower() for s in dim.synonyms):
-                results.append(SearchResultItem(type="dimension", name=name, match_field="synonym"))
+            _consider(name, "dimension", list(dim.synonyms))
 
     if "measure" in types:
         for name, m in model.measures.items():
-            if q in name.lower():
-                results.append(SearchResultItem(type="measure", name=name, match_field="name"))
-            elif any(q in s.lower() for s in m.synonyms):
-                results.append(SearchResultItem(type="measure", name=name, match_field="synonym"))
+            _consider(name, "measure", list(m.synonyms))
 
     if "metric" in types:
         for name, met in model.metrics.items():
-            if q in name.lower():
-                results.append(SearchResultItem(type="metric", name=name, match_field="name"))
-            elif any(q in s.lower() for s in met.synonyms):
-                results.append(SearchResultItem(type="metric", name=name, match_field="synonym"))
+            _consider(name, "metric", list(met.synonyms))
 
     if "data_object" in types:
         for name, obj in model.data_objects.items():
-            if q in name.lower():
-                results.append(SearchResultItem(type="data_object", name=name, match_field="name"))
-            elif any(q in s.lower() for s in obj.synonyms):
-                results.append(
-                    SearchResultItem(type="data_object", name=name, match_field="synonym")
-                )
+            _consider(name, "data_object", list(obj.synonyms))
 
-    return results
+    return exact, synonym, fuzzy_candidates
+
+
+def _build_search_response(model: SemanticModel, query: str, types: list[str]) -> SearchResponse:
+    """Run /find with split exact/synonym buckets and fuzzy fallback."""
+    from orionbelt.api.schemas import FuzzyMatch as ApiFuzzyMatch
+    from orionbelt.service.fuzzy import fuzzy_search
+
+    exact, synonym, candidates = _search_model_split(model, query, types)
+    fuzzy: list[ApiFuzzyMatch] = []
+    if not exact and not synonym and query.strip():
+        for m in fuzzy_search(query, candidates):
+            fuzzy.append(ApiFuzzyMatch(name=m.name, kind=m.kind, score=m.score, reason=m.reason))
+    return SearchResponse(
+        query=query,
+        results=exact + synonym,
+        exact_matches=exact,
+        synonym_matches=synonym,
+        fuzzy_matches=fuzzy,
+    )
 
 
 def _build_join_graph(model: SemanticModel) -> JoinGraphResponse:
@@ -499,10 +531,14 @@ async def find_artefacts(
     body: SearchRequest,
     mgr: SessionManager = Depends(get_session_manager),  # noqa: B008
 ) -> SearchResponse:
-    """Search across model artefacts by name or synonym."""
+    """Search across model artefacts by name or synonym.
+
+    When the search produces zero exact or synonym matches, fuzzy fallback
+    (Levenshtein + trigram overlap) returns near-miss candidates with scores.
+    See ``design/PLAN_agent_api_improvements.md`` §4.
+    """
     model = _get_model(session_id, model_id, mgr)
-    results = _search_model(model, body.query, body.types)
-    return SearchResponse(results=results)
+    return _build_search_response(model, body.query, body.types)
 
 
 @router.get(
@@ -518,3 +554,126 @@ async def get_join_graph(
     """Return the join graph as an adjacency list."""
     model = _get_model(session_id, model_id, mgr)
     return _build_join_graph(model)
+
+
+# -- examples ----------------------------------------------------------------
+
+
+def _all_intent_tags(model: SemanticModel) -> list[str]:
+    """All distinct intent tags across the model's examples."""
+    tags: set[str] = set()
+    for ex in model.examples:
+        for t in ex.intent_tags:
+            tags.add(t)
+    return sorted(tags)
+
+
+def _filter_by_intent(model: SemanticModel, intent: str) -> list[ExampleSummary]:
+    """Return examples whose tags match ``intent`` (case-insensitive)."""
+    from orionbelt.service.fuzzy import fuzzy_search
+
+    target = intent.lower().strip()
+    direct: list[ExampleSummary] = []
+    for ex in model.examples:
+        if any(target == t.lower() for t in ex.intent_tags):
+            direct.append(
+                ExampleSummary(name=ex.name, description=ex.description, intent_tags=ex.intent_tags)
+            )
+    if direct:
+        return direct
+    # Fuzzy fallback: a partial substring still wins (e.g. "rev" matches "revenue")
+    contains: list[ExampleSummary] = []
+    for ex in model.examples:
+        if any(target in t.lower() for t in ex.intent_tags):
+            contains.append(
+                ExampleSummary(name=ex.name, description=ex.description, intent_tags=ex.intent_tags)
+            )
+    if contains:
+        return contains
+    # Final fallback: fuzzy match against the tag corpus
+    candidates: list[tuple[str, str, list[str]]] = [
+        (t, "tag", []) for t in _all_intent_tags(model)
+    ]
+    fuzzy = {m.name for m in fuzzy_search(intent, candidates, threshold=0.6)}
+    if not fuzzy:
+        return []
+    return [
+        ExampleSummary(name=ex.name, description=ex.description, intent_tags=ex.intent_tags)
+        for ex in model.examples
+        if any(t in fuzzy for t in ex.intent_tags)
+    ]
+
+
+@router.get(
+    "/{session_id}/models/{model_id}/examples",
+    response_model=ExampleListResponse,
+    tags=["model-discovery"],
+)
+async def list_examples(
+    session_id: str,
+    model_id: str,
+    intent: str | None = None,
+    mgr: SessionManager = Depends(get_session_manager),  # noqa: B008
+) -> ExampleListResponse:
+    """List canonical example queries authored alongside the model.
+
+    See ``design/PLAN_agent_api_improvements.md`` §5.
+    """
+    model = _get_model(session_id, model_id, mgr)
+    if intent:
+        matches = _filter_by_intent(model, intent)
+        if not matches:
+            tags = _all_intent_tags(model)
+            suggestion = (
+                f"no examples for '{intent}'; available tags: {', '.join(tags)}"
+                if tags
+                else f"no examples for '{intent}'; the model has no intent_tags defined"
+            )
+            return ExampleListResponse(examples=[], suggestion=suggestion)
+        return ExampleListResponse(examples=matches)
+    summaries = [
+        ExampleSummary(name=ex.name, description=ex.description, intent_tags=ex.intent_tags)
+        for ex in model.examples
+    ]
+    return ExampleListResponse(examples=summaries)
+
+
+@router.get(
+    "/{session_id}/models/{model_id}/examples/{example_name}",
+    response_model=ExampleDetail,
+    tags=["model-discovery"],
+)
+async def get_example(
+    session_id: str,
+    model_id: str,
+    example_name: str,
+    mgr: SessionManager = Depends(get_session_manager),  # noqa: B008
+) -> ExampleDetail:
+    """Return a single example by name, with an optional compiled SQL preview."""
+    store = _get_store(session_id, mgr)
+    model = _get_model(session_id, model_id, mgr)
+    example = next((e for e in model.examples if e.name == example_name), None)
+    if example is None:
+        raise HTTPException(status_code=404, detail=f"Example '{example_name}' not found in model")
+
+    compiled_sql_preview: str | None = None
+    try:
+        from orionbelt.api.deps import get_db_vendor
+        from orionbelt.api.routers.sessions import _resolve_dialect
+        from orionbelt.compiler.validator import format_sql
+        from orionbelt.models.query import QueryObject
+
+        dialect = _resolve_dialect(request_dialect=None, model=model, fallback=get_db_vendor())
+        query_obj = QueryObject.model_validate(example.query)
+        result = store.compile_query(model_id, query_obj, dialect)
+        compiled_sql_preview = format_sql(result.sql, result.dialect)
+    except Exception:
+        compiled_sql_preview = None
+
+    return ExampleDetail(
+        name=example.name,
+        description=example.description,
+        intent_tags=list(example.intent_tags),
+        query=dict(example.query),
+        compiled_sql_preview=compiled_sql_preview,
+    )

--- a/src/orionbelt/api/routers/oneshot.py
+++ b/src/orionbelt/api/routers/oneshot.py
@@ -33,7 +33,9 @@ from orionbelt.api.schemas import (
     OneshotBatchRequest,
     OneshotBatchResponse,
     QueryExecuteResponse,
+    StructuredWarning,
 )
+from orionbelt.api.warnings_adapter import semantic_error_to_warning
 from orionbelt.compiler.fanout import FanoutError
 from orionbelt.compiler.resolution import ResolutionError
 from orionbelt.compiler.validator import format_sql
@@ -203,7 +205,7 @@ async def _run_query(
 
         sql_str = format_sql(compile_result.sql, compile_result.dialect)
         explain = _build_explain_response(compile_result)
-        warnings = list(compile_result.warnings)
+        warnings = [semantic_error_to_warning(w) for w in compile_result.warnings]
 
         # Per-query execute decides on the merged flag (explicit override > batch default).
         wants_execute = item.execute if item.execute is not None else execute
@@ -314,7 +316,7 @@ async def oneshot_batch(
 
     See ``design/PLAN_oneshot_batch.md`` for the full design.
     """
-    batch_warnings: list[str] = []
+    batch_warnings: list[StructuredWarning] = []
 
     # Single-model mode disallows model uploads via this endpoint too.
     if body.model_yaml and is_single_model_mode():
@@ -334,7 +336,19 @@ async def oneshot_batch(
     parallelism = max(1, min(requested, cfg.max_parallelism))
     if body.max_parallelism and body.max_parallelism > cfg.max_parallelism:
         batch_warnings.append(
-            f"max_parallelism reduced from {body.max_parallelism} to {parallelism} (server cap)"
+            StructuredWarning(
+                code="MAX_PARALLELISM_CAPPED",
+                severity="warning",
+                message=(
+                    f"max_parallelism reduced from {body.max_parallelism} to "
+                    f"{parallelism} (server cap)"
+                ),
+                context={
+                    "requested": body.max_parallelism,
+                    "applied": parallelism,
+                    "cap": cfg.max_parallelism,
+                },
+            )
         )
 
     session_id, store, session_created = _resolve_session_and_store(body, mgr)
@@ -385,7 +399,14 @@ async def oneshot_batch(
                 timeout=batch_timeout_s,
             )
         except TimeoutError:
-            batch_warnings.append(f"Batch exceeded {batch_timeout_s}s — partial results returned")
+            batch_warnings.append(
+                StructuredWarning(
+                    code="BATCH_TIMEOUT",
+                    severity="warning",
+                    message=f"Batch exceeded {batch_timeout_s}s — partial results returned",
+                    context={"batch_timeout_s": batch_timeout_s},
+                )
+            )
             for i, q in enumerate(body.queries):
                 if results[i] is None:
                     results[i] = OneshotBatchQueryResult(

--- a/src/orionbelt/api/routers/oneshot.py
+++ b/src/orionbelt/api/routers/oneshot.py
@@ -1,0 +1,422 @@
+"""One-shot batch endpoint: POST /v1/oneshot/batch.
+
+Loads (or references) a model and runs N independent queries against it in
+a single round trip. See ``design/PLAN_oneshot_batch.md``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from orionbelt.api.deps import (
+    OneshotBatchConfig,
+    get_db_vendor,
+    get_oneshot_batch_config,
+    get_session_manager,
+    is_query_execute_enabled,
+    is_single_model_mode,
+)
+from orionbelt.api.routers.sessions import (
+    _build_execute_response,
+    _build_explain_response,
+    _resolve_dialect,
+)
+from orionbelt.api.schemas import (
+    OneshotBatchQueryError,
+    OneshotBatchQueryItem,
+    OneshotBatchQueryResult,
+    OneshotBatchRequest,
+    OneshotBatchResponse,
+    QueryExecuteResponse,
+)
+from orionbelt.compiler.fanout import FanoutError
+from orionbelt.compiler.resolution import ResolutionError
+from orionbelt.compiler.validator import format_sql
+from orionbelt.dialect.base import UnsupportedAggregationError
+from orionbelt.dialect.registry import UnsupportedDialectError
+from orionbelt.service.db_executor import (
+    ExecutionError,
+    ExecutionUnavailableError,
+    execute_sql,
+    resolve_timezone,
+)
+from orionbelt.service.model_store import (
+    ModelCapacityError,
+    ModelStore,
+    ModelValidationError,
+)
+from orionbelt.service.session_manager import (
+    SessionCapacityError,
+    SessionExpiredError,
+    SessionManager,
+    SessionNotFoundError,
+)
+
+logger = logging.getLogger("orionbelt.api.oneshot")
+
+router = APIRouter()
+
+
+def _resolve_session_and_store(
+    body: OneshotBatchRequest, mgr: SessionManager
+) -> tuple[str, ModelStore, bool]:
+    """Acquire or create a session, return (session_id, store, created).
+
+    ``created`` is True when this call created a new session (so we own its
+    lifecycle on failure paths).
+    """
+    if body.session_id:
+        try:
+            store = mgr.get_store(body.session_id)
+        except SessionExpiredError:
+            raise HTTPException(
+                status_code=410, detail=f"Session '{body.session_id}' has expired"
+            ) from None
+        except SessionNotFoundError:
+            raise HTTPException(
+                status_code=404, detail=f"Session '{body.session_id}' not found"
+            ) from None
+        return body.session_id, store, False
+
+    try:
+        info = mgr.create_session()
+    except SessionCapacityError:
+        raise HTTPException(
+            status_code=429,
+            detail="Too many active sessions. Please retry later.",
+            headers={"Retry-After": "60"},
+        ) from None
+    return info.session_id, mgr.get_store(info.session_id), True
+
+
+def _resolve_model(
+    *,
+    body: OneshotBatchRequest,
+    store: ModelStore,
+) -> tuple[str, str]:
+    """Resolve the model the batch should run against.
+
+    Returns ``(model_id, model_load)`` where ``model_load`` is one of
+    ``"fresh"``, ``"reused"``, or ``"referenced"`` (existing model_id supplied).
+    """
+    if body.model_id:
+        try:
+            store.get_model(body.model_id)
+        except KeyError:
+            raise HTTPException(
+                status_code=404, detail=f"Model '{body.model_id}' not found"
+            ) from None
+        return body.model_id, "referenced"
+
+    # body.model_yaml is non-empty (validated in OneshotBatchRequest)
+    assert body.model_yaml is not None
+    try:
+        result = store.load_model(body.model_yaml, dedup=body.dedup)
+    except ModelCapacityError as exc:
+        raise HTTPException(status_code=429, detail=str(exc)) from None
+    except ModelValidationError as exc:
+        error_lines = "; ".join(
+            f"[{e.code}] {e.message}" + (f" (at {e.path})" if e.path else "") for e in exc.errors
+        )
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "message": f"Invalid OBML model: {error_lines}",
+                "errors": [
+                    {"code": e.code, "message": e.message, "path": e.path} for e in exc.errors
+                ],
+                "warnings": [
+                    {"code": w.code, "message": w.message, "path": w.path} for w in exc.warnings
+                ],
+            },
+        ) from None
+    return result.model_id, result.model_load
+
+
+def _compile(
+    *,
+    store: ModelStore,
+    model_id: str,
+    item: OneshotBatchQueryItem,
+    default_dialect: str | None,
+) -> tuple[Any, str] | OneshotBatchQueryError:
+    """Compile a single query. Return ``(compile_result, dialect)`` or an error."""
+    try:
+        model = store.get_model(model_id)
+    except KeyError:
+        return OneshotBatchQueryError(
+            code="MODEL_NOT_FOUND",
+            message=f"Model '{model_id}' not found",
+        )
+    dialect = _resolve_dialect(
+        request_dialect=item.dialect or default_dialect,
+        model=model,
+        fallback=get_db_vendor(),
+    )
+    try:
+        compile_result = store.compile_query(model_id, item.query, dialect)
+    except UnsupportedDialectError:
+        return OneshotBatchQueryError(
+            code="UNSUPPORTED_DIALECT",
+            message=f"Unsupported dialect: '{dialect}'",
+        )
+    except ResolutionError as exc:
+        first = exc.errors[0] if exc.errors else None
+        return OneshotBatchQueryError(
+            code=first.code if first else "RESOLUTION_ERROR",
+            message=first.message if first else "Query resolution failed",
+            path=first.path if first else None,
+        )
+    except FanoutError as exc:
+        return OneshotBatchQueryError(code="FANOUT", message=exc.message)
+    except UnsupportedAggregationError as exc:
+        return OneshotBatchQueryError(
+            code="UNSUPPORTED_AGGREGATION",
+            message=str(exc),
+        )
+    return compile_result, dialect
+
+
+async def _run_query(
+    *,
+    store: ModelStore,
+    model_id: str,
+    item: OneshotBatchQueryItem,
+    default_dialect: str | None,
+    execute: bool,
+    semaphore: asyncio.Semaphore,
+    per_query_timeout_s: float,
+) -> OneshotBatchQueryResult:
+    """Compile + optionally execute a single query under a semaphore."""
+    async with semaphore:
+        outcome = _compile(
+            store=store, model_id=model_id, item=item, default_dialect=default_dialect
+        )
+        if isinstance(outcome, OneshotBatchQueryError):
+            return OneshotBatchQueryResult(id=item.id, status="error", error=outcome)
+        compile_result, dialect = outcome
+
+        sql_str = format_sql(compile_result.sql, compile_result.dialect)
+        explain = _build_explain_response(compile_result)
+        warnings = list(compile_result.warnings)
+
+        # Per-query execute decides on the merged flag (explicit override > batch default).
+        wants_execute = item.execute if item.execute is not None else execute
+        if not wants_execute:
+            return OneshotBatchQueryResult(
+                id=item.id,
+                status="ok",
+                sql=sql_str,
+                dialect=dialect,
+                sql_valid=compile_result.sql_valid,
+                explain=explain,
+                executed=False,
+                warnings=warnings,
+            )
+
+        if not is_query_execute_enabled():
+            return OneshotBatchQueryResult(
+                id=item.id,
+                status="error",
+                error=OneshotBatchQueryError(
+                    code="QUERY_EXECUTE_DISABLED",
+                    message=(
+                        "Query execution is not available. Set QUERY_EXECUTE=true "
+                        "and configure DB_VENDOR + credentials."
+                    ),
+                ),
+            )
+
+        model = store.get_model(model_id)
+        model_default_tz: str | None = None
+        override_db_tz = False
+        if model.settings:
+            model_default_tz = model.settings.default_timezone
+            override_db_tz = model.settings.override_database_timezone
+        tz = resolve_timezone(default_timezone=model_default_tz)
+
+        try:
+            exec_result = await asyncio.wait_for(
+                asyncio.to_thread(
+                    execute_sql,
+                    compile_result.sql,
+                    dialect=dialect,
+                    tz=tz,
+                    override_db_tz=override_db_tz,
+                ),
+                timeout=per_query_timeout_s,
+            )
+        except TimeoutError:
+            return OneshotBatchQueryResult(
+                id=item.id,
+                status="error",
+                error=OneshotBatchQueryError(
+                    code="QUERY_TIMEOUT",
+                    message=f"Query exceeded {per_query_timeout_s}s execution timeout",
+                ),
+            )
+        except ExecutionUnavailableError as exc:
+            return OneshotBatchQueryResult(
+                id=item.id,
+                status="error",
+                error=OneshotBatchQueryError(code="EXECUTION_UNAVAILABLE", message=str(exc)),
+            )
+        except ExecutionError as exc:
+            return OneshotBatchQueryResult(
+                id=item.id,
+                status="error",
+                error=OneshotBatchQueryError(code="EXECUTION_ERROR", message=str(exc)),
+            )
+
+        # Reuse the standard execute response builder so column metadata,
+        # type hints, and format strings stay consistent with /query/execute.
+        envelope = _build_execute_response(
+            compile_result=compile_result,
+            exec_result=exec_result,
+            model=model,
+            response_format="json",
+            format_values=False,
+            locale="",
+        )
+        # _build_execute_response can return a Response when format=tsv; we
+        # always pass json above so this is unreachable, but mypy/runtime
+        # wants the narrowing.
+        assert isinstance(envelope, QueryExecuteResponse)
+
+        return OneshotBatchQueryResult(
+            id=item.id,
+            status="ok",
+            sql=envelope.sql,
+            dialect=envelope.dialect,
+            sql_valid=envelope.sql_valid,
+            explain=envelope.explain,
+            columns=envelope.columns,
+            rows=envelope.rows,
+            row_count=envelope.row_count,
+            execution_time_ms=envelope.execution_time_ms,
+            executed=True,
+            warnings=warnings,
+        )
+
+
+@router.post("/batch", response_model=OneshotBatchResponse)
+async def oneshot_batch(
+    body: OneshotBatchRequest,
+    mgr: SessionManager = Depends(get_session_manager),  # noqa: B008
+    cfg: OneshotBatchConfig = Depends(get_oneshot_batch_config),  # noqa: B008
+) -> OneshotBatchResponse:
+    """Load a model and run multiple queries against it in a single round trip.
+
+    See ``design/PLAN_oneshot_batch.md`` for the full design.
+    """
+    batch_warnings: list[str] = []
+
+    # Single-model mode disallows model uploads via this endpoint too.
+    if body.model_yaml and is_single_model_mode():
+        raise HTTPException(
+            status_code=403,
+            detail="Single-model mode: model upload is disabled (use model_id)",
+        )
+
+    if len(body.queries) > cfg.max_queries:
+        raise HTTPException(
+            status_code=422,
+            detail=(f"Batch has {len(body.queries)} queries; server cap is {cfg.max_queries}"),
+        )
+
+    # Cap parallelism silently — see PLAN_oneshot_batch.md §10 question 3.
+    requested = body.max_parallelism or cfg.max_parallelism
+    parallelism = max(1, min(requested, cfg.max_parallelism))
+    if body.max_parallelism and body.max_parallelism > cfg.max_parallelism:
+        batch_warnings.append(
+            f"max_parallelism reduced from {body.max_parallelism} to {parallelism} (server cap)"
+        )
+
+    session_id, store, session_created = _resolve_session_and_store(body, mgr)
+
+    try:
+        model_id, model_load = _resolve_model(body=body, store=store)
+    except HTTPException:
+        # Don't leave a freshly-created session sitting around if model load fails.
+        if session_created:
+            with contextlib.suppress(SessionNotFoundError):
+                mgr.close_session(session_id)
+        raise
+
+    semaphore = asyncio.Semaphore(parallelism)
+    per_query_timeout_s = cfg.default_timeout_ms / 1000.0
+    batch_timeout_s = cfg.batch_timeout_ms / 1000.0
+
+    # Pre-allocate result slots so we can keep stable ordering by id.
+    results: list[OneshotBatchQueryResult | None] = [None] * len(body.queries)
+
+    async def _run_indexed(idx: int, item: OneshotBatchQueryItem) -> None:
+        results[idx] = await _run_query(
+            store=store,
+            model_id=model_id,
+            item=item,
+            default_dialect=body.dialect,
+            execute=body.execute,
+            semaphore=semaphore,
+            per_query_timeout_s=per_query_timeout_s,
+        )
+
+    if body.fail_fast:
+        # Sequential supervision: walk through queries in order, abort the rest
+        # on the first error. Independent execution still happens via the
+        # semaphore but we await in submission order so a failure short-
+        # circuits cleanly without leaking tasks.
+        for idx, item in enumerate(body.queries):
+            await _run_indexed(idx, item)
+            r = results[idx]
+            if r is not None and r.status == "error":
+                for j in range(idx + 1, len(body.queries)):
+                    results[j] = OneshotBatchQueryResult(id=body.queries[j].id, status="cancelled")
+                break
+    else:
+        try:
+            await asyncio.wait_for(
+                asyncio.gather(*(_run_indexed(i, q) for i, q in enumerate(body.queries))),
+                timeout=batch_timeout_s,
+            )
+        except TimeoutError:
+            batch_warnings.append(f"Batch exceeded {batch_timeout_s}s — partial results returned")
+            for i, q in enumerate(body.queries):
+                if results[i] is None:
+                    results[i] = OneshotBatchQueryResult(
+                        id=q.id,
+                        status="error",
+                        error=OneshotBatchQueryError(
+                            code="BATCH_TIMEOUT",
+                            message="Cancelled by whole-batch timeout",
+                        ),
+                    )
+
+    # Model lifecycle: if we loaded the model for this batch and persist is
+    # off, evict it. If model_id was supplied by the caller, never touch it.
+    model_was_loaded_here = model_load in ("fresh", "reused") and body.model_yaml is not None
+    persisted = True
+    if model_was_loaded_here and not body.persist_model:
+        try:
+            store.remove_model(model_id)
+            persisted = False
+        except KeyError:
+            persisted = False
+    elif not model_was_loaded_here:
+        # Caller-owned model — we don't decide its lifecycle.
+        persisted = True
+
+    final_results = [r for r in results if r is not None]
+    return OneshotBatchResponse(
+        session_id=session_id,
+        model_id=model_id,
+        model_persisted=persisted,
+        model_load=model_load,
+        results=final_results,
+        batch_warnings=batch_warnings,
+    )

--- a/src/orionbelt/api/routers/sessions.py
+++ b/src/orionbelt/api/routers/sessions.py
@@ -19,24 +19,34 @@ from orionbelt.api.deps import (
 )
 from orionbelt.api.schemas import (
     ColumnMetadata,
+    DatabaseExplain,
     DiagramResponse,
-    ErrorDetail,
     ExplainCflLegResponse,
     ExplainJoinResponse,
     ExplainPlanResponse,
+    JoinPathStep,
     ModelLoadRequest,
     ModelLoadResponse,
     ModelSummaryResponse,
     QueryCompileResponse,
     QueryExecuteResponse,
+    QueryPlanRequest,
+    QueryPlanResponse,
     ResolvedInfoResponse,
     SessionCreateRequest,
     SessionListResponse,
     SessionQueryExecuteRequest,
     SessionQueryRequest,
     SessionResponse,
+    StructuredWarning,
     ValidateRequest,
     ValidateResponse,
+)
+from orionbelt.api.warnings_adapter import (
+    error_info_to_detail,
+    error_info_to_warning,
+    health_summary_to_response,
+    semantic_error_to_warning,
 )
 from orionbelt.compiler.fanout import FanoutError
 from orionbelt.compiler.resolution import ResolutionError
@@ -47,6 +57,7 @@ from orionbelt.service.db_executor import (
     ExecutionError,
     ExecutionUnavailableError,
     execute_sql,
+    explain_sql,
     resolve_timezone,
 )
 from orionbelt.service.diagram import generate_mermaid_er
@@ -201,8 +212,9 @@ async def load_model(
         dimensions=result.dimensions,
         measures=result.measures,
         metrics=result.metrics,
-        warnings=result.warnings,
+        warnings=[error_info_to_warning(w) for w in result.warnings],
         model_load=result.model_load,
+        health=health_summary_to_response(result.health),
     )
 
 
@@ -298,10 +310,8 @@ async def validate_model(
     )
     return ValidateResponse(
         valid=summary.valid,
-        errors=[ErrorDetail(code=e.code, message=e.message, path=e.path) for e in summary.errors],
-        warnings=[
-            ErrorDetail(code=w.code, message=w.message, path=w.path) for w in summary.warnings
-        ],
+        errors=[error_info_to_detail(e) for e in summary.errors],
+        warnings=[error_info_to_detail(w) for w in summary.warnings],
     )
 
 
@@ -387,7 +397,7 @@ async def compile_query(
             dimensions=result.resolved.dimensions,
             measures=result.resolved.measures,
         ),
-        warnings=result.warnings,
+        warnings=[semantic_error_to_warning(w) for w in result.warnings],
         sql_valid=result.sql_valid,
         explain=explain_resp,
     )
@@ -560,7 +570,7 @@ def _build_execute_response(
             dimensions=compile_result.resolved.dimensions,
             measures=compile_result.resolved.measures,
         ),
-        warnings=compile_result.warnings,
+        warnings=[semantic_error_to_warning(w) for w in compile_result.warnings],
         sql_valid=compile_result.sql_valid,
         explain=_build_explain_response(compile_result),
     )
@@ -598,6 +608,146 @@ def _build_explain_response(result: Any) -> ExplainPlanResponse | None:
             for leg in result.explain.cfl_legs
         ],
     )
+
+
+@router.post("/{session_id}/query/plan", response_model=QueryPlanResponse)
+async def plan_query(
+    session_id: str,
+    body: QueryPlanRequest,
+    mgr: SessionManager = Depends(get_session_manager),  # noqa: B008
+) -> QueryPlanResponse:
+    """Return the planner's understanding of a query without executing it.
+
+    Cheap by default (no warehouse round trip). When
+    ``include_database_explain=true`` is set, also runs ``EXPLAIN <sql>``
+    against the configured warehouse and returns the raw text. See
+    ``design/PLAN_agent_api_improvements.md`` §2.
+    """
+    from orionbelt.api.deps import get_db_vendor
+
+    store = _get_store(session_id, mgr)
+    try:
+        model = store.get_model(body.model_id)
+    except KeyError:
+        raise HTTPException(status_code=404, detail=f"Model '{body.model_id}' not found") from None
+    dialect = _resolve_dialect(request_dialect=body.dialect, model=model, fallback=get_db_vendor())
+
+    try:
+        result = store.compile_query(body.model_id, body.query, dialect)
+    except UnsupportedDialectError:
+        raise HTTPException(status_code=400, detail=f"Unsupported dialect: '{dialect}'") from None
+    except ResolutionError as exc:
+        return QueryPlanResponse(
+            status="error",
+            warnings=[semantic_error_to_warning(e) for e in exc.errors],
+            would_compile=False,
+        )
+    except FanoutError as exc:
+        return QueryPlanResponse(
+            status="error",
+            warnings=[
+                StructuredWarning(
+                    code="FANOUT_ERROR",
+                    severity="error",
+                    message=exc.message,
+                )
+            ],
+            would_compile=False,
+        )
+    except UnsupportedAggregationError as exc:
+        return QueryPlanResponse(
+            status="error",
+            warnings=[
+                StructuredWarning(
+                    code="UNSUPPORTED_AGGREGATION",
+                    severity="error",
+                    message=str(exc),
+                    context={"dialect": exc.dialect, "aggregation": exc.aggregation},
+                )
+            ],
+            would_compile=False,
+        )
+
+    physical_tables = _physical_tables_for(model, result)
+    join_path = _join_path_steps(result)
+    plan_warnings = [semantic_error_to_warning(w) for w in result.warnings]
+    explain = result.explain
+    response = QueryPlanResponse(
+        status="ok",
+        planner=explain.planner if explain else "",
+        planner_reason=explain.planner_reason if explain else "",
+        physical_tables=physical_tables,
+        join_path=join_path,
+        filters_applied=(
+            (explain.where_filter_count + explain.having_filter_count) if explain else 0
+        ),
+        warnings=plan_warnings,
+        would_compile=True,
+        compiled_sql_length_estimate=len(result.sql),
+    )
+
+    if body.include_database_explain:
+        try:
+            raw = await asyncio.to_thread(explain_sql, result.sql, dialect=dialect)
+            response.database_explain = DatabaseExplain(
+                dialect=dialect,
+                compiled_sql=result.sql,
+                explain_output=raw,
+                explain_format="text",
+            )
+        except (ExecutionUnavailableError, ExecutionError) as exc:
+            response.warnings = response.warnings + [
+                StructuredWarning(
+                    code="DATABASE_EXPLAIN_FAILED",
+                    severity="warning",
+                    message=str(exc),
+                    hint=(
+                        "Database EXPLAIN is opt-in. Disable include_database_explain "
+                        "or check QUERY_EXECUTE / DB_VENDOR / driver setup."
+                    ),
+                )
+            ]
+
+    return response
+
+
+def _physical_tables_for(model: Any, result: Any) -> list[str]:
+    """Compute qualified physical tables touched by a compilation."""
+    names = list(dict.fromkeys(result.resolved.fact_tables))
+    if result.explain:
+        for j in result.explain.joins:
+            for nm in (j.from_object, j.to_object):
+                if nm not in names:
+                    names.append(nm)
+        for leg in result.explain.cfl_legs:
+            if leg.measure_source and leg.measure_source not in names:
+                names.append(leg.measure_source)
+    out: list[str] = []
+    for nm in names:
+        obj = model.data_objects.get(nm)
+        if obj is None:
+            out.append(nm)
+            continue
+        parts = [p for p in (obj.database, obj.schema_name, obj.code) if p]
+        out.append(".".join(parts) if parts else nm)
+    return out
+
+
+def _join_path_steps(result: Any) -> list[JoinPathStep]:
+    """Convert ExplainPlan joins → API JoinPathStep list."""
+    if not result.explain:
+        return []
+    steps: list[JoinPathStep] = []
+    for j in result.explain.joins:
+        steps.append(
+            JoinPathStep(
+                from_object=j.from_object,
+                to_object=j.to_object,
+                cardinality=j.cardinality or "many-to-one",
+                fk=", ".join(j.join_columns) if j.join_columns else None,
+            )
+        )
+    return steps
 
 
 @router.post("/{session_id}/query/execute", response_model=QueryExecuteResponse)

--- a/src/orionbelt/api/routers/sessions.py
+++ b/src/orionbelt/api/routers/sessions.py
@@ -175,6 +175,7 @@ async def load_model(
             raw_dict=cast("dict[str, object] | None", body.model_json),
             extends_yaml=body.extends,
             inherits_model_id=body.inherits,
+            dedup=body.dedup,
         )
     except ModelCapacityError as exc:
         raise HTTPException(status_code=429, detail=str(exc)) from None
@@ -201,6 +202,7 @@ async def load_model(
         measures=result.measures,
         metrics=result.metrics,
         warnings=result.warnings,
+        model_load=result.model_load,
     )
 
 

--- a/src/orionbelt/api/routers/settings.py
+++ b/src/orionbelt/api/routers/settings.py
@@ -11,6 +11,7 @@ from orionbelt import __version__
 from orionbelt.api.deps import (
     get_db_vendor,
     get_flight_info,
+    get_oneshot_batch_config,
     get_preload_model_yaml,
     get_session_manager,
     is_query_execute_enabled,
@@ -20,6 +21,7 @@ from orionbelt.api.schemas import (
     DialectResolutionInfo,
     FlightSettingsInfo,
     ModelSettingsInfo,
+    OneshotBatchLimits,
     SettingsResponse,
     TimezoneResolutionInfo,
 )
@@ -257,6 +259,14 @@ async def get_settings(
         effective=_resolve_effective_dialect(settings_block, db_vendor),
     )
 
+    batch_cfg = get_oneshot_batch_config()
+    batch_limits = OneshotBatchLimits(
+        max_queries=batch_cfg.max_queries,
+        max_parallelism=batch_cfg.max_parallelism,
+        default_timeout_ms=batch_cfg.default_timeout_ms,
+        batch_timeout_ms=batch_cfg.batch_timeout_ms,
+    )
+
     return SettingsResponse(
         version=__version__,
         api_version="v1",
@@ -271,4 +281,5 @@ async def get_settings(
         model_settings=model_settings_info,
         timezone=timezone_info,
         dialect=dialect_info,
+        oneshot_batch=batch_limits,
     )

--- a/src/orionbelt/api/routers/shortcuts.py
+++ b/src/orionbelt/api/routers/shortcuts.py
@@ -22,12 +22,11 @@ from orionbelt.api.routers.model_api import (
     _build_explain,
     _build_join_graph,
     _build_schema,
-    _search_model,
+    _build_search_response,
 )
 from orionbelt.api.schemas import (
     DiagramResponse,
     DimensionDetail,
-    ErrorDetail,
     ExplainCflLegResponse,
     ExplainJoinResponse,
     ExplainPlanResponse,
@@ -46,6 +45,7 @@ from orionbelt.api.schemas import (
     ValidateRequest,
     ValidateResponse,
 )
+from orionbelt.api.warnings_adapter import error_info_to_detail, semantic_error_to_warning
 from orionbelt.compiler.fanout import FanoutError
 from orionbelt.compiler.resolution import ResolutionError
 from orionbelt.compiler.validator import format_sql
@@ -283,8 +283,7 @@ async def shortcut_find(
 ) -> SearchResponse:
     """Search model artefacts (auto-resolves session/model)."""
     _, _, model = _resolve_single_model(mgr)
-    results = _search_model(model, body.query, body.types)
-    return SearchResponse(results=results)
+    return _build_search_response(model, body.query, body.types)
 
 
 @router.get("/join-graph", response_model=JoinGraphResponse, tags=["model-discovery"])
@@ -363,10 +362,8 @@ async def shortcut_validate(
     summary = store.validate(body.model_yaml, raw_dict=raw)
     return ValidateResponse(
         valid=summary.valid,
-        errors=[ErrorDetail(code=e.code, message=e.message, path=e.path) for e in summary.errors],
-        warnings=[
-            ErrorDetail(code=w.code, message=w.message, path=w.path) for w in summary.warnings
-        ],
+        errors=[error_info_to_detail(e) for e in summary.errors],
+        warnings=[error_info_to_detail(w) for w in summary.warnings],
     )
 
 
@@ -459,7 +456,7 @@ async def shortcut_compile_query(
             dimensions=result.resolved.dimensions,
             measures=result.resolved.measures,
         ),
-        warnings=result.warnings,
+        warnings=[semantic_error_to_warning(w) for w in result.warnings],
         sql_valid=result.sql_valid,
         explain=explain_resp,
     )

--- a/src/orionbelt/api/schemas.py
+++ b/src/orionbelt/api/schemas.py
@@ -4,10 +4,33 @@ from __future__ import annotations
 
 import json
 from datetime import datetime
+from typing import Any
 
 from pydantic import BaseModel, Field, model_validator
 
 from orionbelt.models.query import QueryObject
+
+
+class StructuredWarning(BaseModel):
+    """Structured warning shape used uniformly across the API.
+
+    Mirrors ``SemanticError`` from ``models/errors.py`` but is the public-facing
+    API model. Agents can branch on ``code`` (stable identifier from the
+    warning taxonomy in ``models/warnings.py``) without parsing ``message``.
+    """
+
+    code: str = Field(description="Stable identifier from the warning taxonomy")
+    severity: str = Field(default="warning", description="One of: error, warning, info")
+    message: str = Field(description="Human-readable description")
+    path: str | None = Field(
+        default=None,
+        description="JSON path into the request body or model location",
+    )
+    hint: str | None = Field(default=None, description="Optional remediation suggestion")
+    context: dict[str, Any] | None = Field(
+        default=None,
+        description="Optional structured detail (which measure, dataObject, etc.)",
+    )
 
 
 class ResolvedInfoResponse(BaseModel):
@@ -57,7 +80,7 @@ class QueryCompileResponse(BaseModel):
     sql: str
     dialect: str
     resolved: ResolvedInfoResponse
-    warnings: list[str] = Field(default_factory=list)
+    warnings: list[StructuredWarning] = Field(default_factory=list)
     sql_valid: bool = True
     explain: ExplainPlanResponse | None = None
 
@@ -87,7 +110,7 @@ class QueryExecuteResponse(BaseModel):
         description="IANA timezone used to label naive timestamps in results",
     )
     resolved: ResolvedInfoResponse = Field(default_factory=ResolvedInfoResponse)
-    warnings: list[str] = Field(default_factory=list)
+    warnings: list[StructuredWarning] = Field(default_factory=list)
     sql_valid: bool = True
     explain: ExplainPlanResponse | None = None
 
@@ -143,11 +166,19 @@ class ValidateResponse(BaseModel):
 
 
 class ErrorDetail(BaseModel):
-    """A single validation error detail."""
+    """A single validation error or warning detail.
+
+    Same shape as :class:`StructuredWarning`. Used by the validation endpoint
+    so callers see errors and warnings with the same fields.
+    """
 
     code: str
     message: str
     path: str | None = None
+    severity: str = "error"
+    hint: str | None = None
+    context: dict[str, Any] | None = None
+    suggestions: list[str] = Field(default_factory=list)
 
 
 class DialectInfo(BaseModel):
@@ -347,6 +378,36 @@ class SessionListResponse(BaseModel):
     sessions: list[SessionResponse]
 
 
+class FanTrapRisk(BaseModel):
+    """A potential fan-trap: two facts joined to a shared dim via the same FK."""
+
+    tables: list[str] = Field(description="Physical tables involved in the risk")
+    reason: str = Field(description="Plain-text explanation of the risk")
+    suggested_pattern: str = Field(
+        default="composite_fact_layer",
+        description="Recommended OBSL pattern for resolving the risk",
+    )
+
+
+class ModelHealth(BaseModel):
+    """Structural health summary of a loaded model's join graph.
+
+    Fields are computed during model load (no extra round trip needed). See
+    ``design/PLAN_agent_api_improvements.md`` §1.4.
+    """
+
+    status: str = Field(
+        default="ok",
+        description="One of: ok, warnings, errors",
+    )
+    data_objects: int = 0
+    joins: int = 0
+    orphan_data_objects: list[str] = Field(default_factory=list)
+    fan_trap_risks: list[FanTrapRisk] = Field(default_factory=list)
+    unreachable_dimensions: list[str] = Field(default_factory=list)
+    warnings_count: int = 0
+
+
 class ModelLoadRequest(BaseModel):
     """Request body for POST /sessions/{session_id}/models."""
 
@@ -391,12 +452,19 @@ class ModelLoadResponse(BaseModel):
     dimensions: int
     measures: int
     metrics: int
-    warnings: list[str] = Field(default_factory=list)
+    warnings: list[StructuredWarning] = Field(default_factory=list)
     model_load: str = Field(
         default="fresh",
         description=(
             "Whether the load parsed a fresh model or reused an existing one. "
             "Values: 'fresh' | 'reused'."
+        ),
+    )
+    health: ModelHealth | None = Field(
+        default=None,
+        description=(
+            "Structural health of the model's join graph: orphan dataObjects, "
+            "fan-trap risks, unreachable dimensions. Always present on a fresh load."
         ),
     )
 
@@ -434,6 +502,104 @@ class DiagramResponse(BaseModel):
 # ---------------------------------------------------------------------------
 # OSI ↔ OBML conversion schemas
 # ---------------------------------------------------------------------------
+
+
+class ExampleSummary(BaseModel):
+    """Short summary of a model example (list endpoint)."""
+
+    name: str
+    description: str
+    intent_tags: list[str] = Field(default_factory=list)
+
+
+class ExampleDetail(BaseModel):
+    """Full detail of a single example, including the query payload."""
+
+    name: str
+    description: str
+    intent_tags: list[str] = Field(default_factory=list)
+    query: dict[str, Any]
+    compiled_sql_preview: str | None = Field(
+        default=None,
+        description=(
+            "Compiled SQL when the example resolves cleanly against the loaded model. "
+            "Null when compilation fails."
+        ),
+    )
+
+
+class ExampleListResponse(BaseModel):
+    """Response body for GET .../examples and GET .../examples?intent=..."""
+
+    examples: list[ExampleSummary] = Field(default_factory=list)
+    suggestion: str | None = Field(
+        default=None,
+        description=(
+            "When ?intent= matches no examples, lists the available tags so callers "
+            "can adjust the query."
+        ),
+    )
+
+
+class JoinPathStep(BaseModel):
+    """A single step in the planner's join path."""
+
+    from_object: str
+    to_object: str
+    cardinality: str = Field(description="many-to-one, one-to-one, or many-to-many")
+    fk: str | None = Field(default=None, description="Join key columns as 'a, b'")
+
+
+class DatabaseExplain(BaseModel):
+    """Raw EXPLAIN output from the warehouse for the compiled SQL.
+
+    OBSL does not normalize across dialects — the ``explain_output`` is
+    opaque text in the dialect's native EXPLAIN format.
+    """
+
+    dialect: str
+    compiled_sql: str
+    explain_output: str
+    explain_format: str = Field(default="text", description="Format of explain_output")
+
+
+class QueryPlanRequest(BaseModel):
+    """Request body for POST /sessions/{sid}/query/plan.
+
+    See ``design/PLAN_agent_api_improvements.md`` §2.
+    """
+
+    model_id: str
+    query: QueryObject
+    dialect: str | None = Field(
+        default=None,
+        description=(
+            "SQL dialect. Resolution: explicit value → model.settings.defaultDialect → "
+            "DB_VENDOR env → 'postgres'."
+        ),
+    )
+    include_database_explain: bool = Field(
+        default=False,
+        description=(
+            "When true, also run EXPLAIN <sql> against the configured warehouse and "
+            "include the raw output. Off by default — opt in costs a warehouse round trip."
+        ),
+    )
+
+
+class QueryPlanResponse(BaseModel):
+    """Response body for POST /sessions/{sid}/query/plan."""
+
+    status: str = Field(default="ok", description="ok | error")
+    planner: str = ""
+    planner_reason: str = ""
+    physical_tables: list[str] = Field(default_factory=list)
+    join_path: list[JoinPathStep] = Field(default_factory=list)
+    filters_applied: int = 0
+    warnings: list[StructuredWarning] = Field(default_factory=list)
+    would_compile: bool = True
+    compiled_sql_length_estimate: int = 0
+    database_explain: DatabaseExplain | None = None
 
 
 class ConvertRequest(BaseModel):
@@ -618,10 +784,40 @@ class SearchResultItem(BaseModel):
     score: float = 1.0
 
 
-class SearchResponse(BaseModel):
-    """Response for POST /find."""
+class FuzzyMatch(BaseModel):
+    """A near-miss fuzzy match (no exact/synonym hit)."""
 
+    name: str
+    kind: str
+    score: float
+    reason: str
+
+
+class SearchResponse(BaseModel):
+    """Response for POST /find.
+
+    When the query produced zero exact and synonym matches, ``fuzzy_matches``
+    surfaces near-miss suggestions ordered by score. See
+    ``design/PLAN_agent_api_improvements.md`` §4.
+    """
+
+    query: str = ""
     results: list[SearchResultItem] = Field(default_factory=list)
+    exact_matches: list[SearchResultItem] = Field(
+        default_factory=list,
+        description="Subset of results matched on name (kept for clarity).",
+    )
+    synonym_matches: list[SearchResultItem] = Field(
+        default_factory=list,
+        description="Subset of results matched on a synonym.",
+    )
+    fuzzy_matches: list[FuzzyMatch] = Field(
+        default_factory=list,
+        description=(
+            "Near-miss candidates returned only when no exact or synonym "
+            "match was found. Ordered by score descending."
+        ),
+    )
 
 
 class JoinEdge(BaseModel):
@@ -799,7 +995,7 @@ class OneshotBatchQueryResult(BaseModel):
         default=None,
         description="Whether this query executed (vs compile-only). Only set when status='ok'.",
     )
-    warnings: list[str] = Field(default_factory=list)
+    warnings: list[StructuredWarning] = Field(default_factory=list)
     error: OneshotBatchQueryError | None = None
 
 
@@ -817,4 +1013,4 @@ class OneshotBatchResponse(BaseModel):
         ),
     )
     results: list[OneshotBatchQueryResult] = Field(default_factory=list)
-    batch_warnings: list[str] = Field(default_factory=list)
+    batch_warnings: list[StructuredWarning] = Field(default_factory=list)

--- a/src/orionbelt/api/schemas.py
+++ b/src/orionbelt/api/schemas.py
@@ -260,6 +260,15 @@ class DialectResolutionInfo(BaseModel):
     effective: str = Field(description="Dialect used when request omits `dialect`")
 
 
+class OneshotBatchLimits(BaseModel):
+    """Server-side limits for the one-shot batch endpoint."""
+
+    max_queries: int
+    max_parallelism: int
+    default_timeout_ms: int
+    batch_timeout_ms: int
+
+
 class SettingsResponse(BaseModel):
     """Response for GET /settings — public configuration for clients."""
 
@@ -302,6 +311,10 @@ class SettingsResponse(BaseModel):
     dialect: DialectResolutionInfo | None = Field(
         default=None,
         description="SQL dialect resolution chain",
+    )
+    oneshot_batch: OneshotBatchLimits | None = Field(
+        default=None,
+        description="Limits for POST /v1/oneshot/batch",
     )
 
 
@@ -354,6 +367,14 @@ class ModelLoadRequest(BaseModel):
         default=None,
         description="Optional model ID of an already-loaded parent model in the session",
     )
+    dedup: bool = Field(
+        default=True,
+        description=(
+            "When True (default), identical OBML content already loaded in this session "
+            "reuses the existing model_id (response.model_load == 'reused'). "
+            "When False, always loads fresh."
+        ),
+    )
 
     @model_validator(mode="after")
     def _parse_model_json_string(self) -> ModelLoadRequest:
@@ -371,6 +392,13 @@ class ModelLoadResponse(BaseModel):
     measures: int
     metrics: int
     warnings: list[str] = Field(default_factory=list)
+    model_load: str = Field(
+        default="fresh",
+        description=(
+            "Whether the load parsed a fresh model or reused an existing one. "
+            "Values: 'fresh' | 'reused'."
+        ),
+    )
 
 
 class ModelSummaryResponse(BaseModel):
@@ -635,3 +663,146 @@ class SPARQLResponse(BaseModel):
         default_factory=list, description="Rows of variable bindings"
     )
     boolean: bool | None = Field(default=None, description="ASK query result")
+
+
+# ---------------------------------------------------------------------------
+# One-shot batch schemas (PLAN_oneshot_batch.md)
+# ---------------------------------------------------------------------------
+
+
+class OneshotBatchQueryItem(BaseModel):
+    """A single query in a one-shot batch."""
+
+    id: str = Field(description="Caller-provided ID, must be unique within the batch")
+    query: QueryObject
+    execute: bool | None = Field(
+        default=None,
+        description="Per-query override for compile-only vs. execute (default inherits batch).",
+    )
+    dialect: str | None = Field(
+        default=None,
+        description="Per-query dialect override (default inherits batch).",
+    )
+
+
+class OneshotBatchRequest(BaseModel):
+    """Request body for POST /v1/oneshot/batch."""
+
+    session_id: str | None = Field(
+        default=None,
+        description="Existing session to use. If omitted, a new session is created.",
+    )
+    model_yaml: str | None = Field(
+        default=None,
+        description=(
+            "OBML YAML. Mutually exclusive with `model_id`. One of them must be provided."
+        ),
+        max_length=5_000_000,
+    )
+    model_id: str | None = Field(
+        default=None,
+        description=(
+            "ID of an already-loaded model in the given session. "
+            "Mutually exclusive with `model_yaml`."
+        ),
+    )
+    queries: list[OneshotBatchQueryItem] = Field(
+        description="List of queries to run. Min 1, server caps maximum.",
+        min_length=1,
+    )
+    dialect: str | None = Field(
+        default=None,
+        description="Default dialect for all queries in the batch.",
+    )
+    execute: bool = Field(
+        default=False,
+        description="Default execute flag for all queries.",
+    )
+    max_parallelism: int | None = Field(
+        default=None,
+        description="Max concurrent query executions. Server caps this.",
+        ge=1,
+    )
+    fail_fast: bool = Field(
+        default=False,
+        description="If true, cancel remaining queries on first failure.",
+    )
+    persist_model: bool = Field(
+        default=False,
+        description=(
+            "If true, a model loaded via `model_yaml` is kept in the session after the call. "
+            "Ignored when `model_id` is supplied."
+        ),
+    )
+    dedup: bool = Field(
+        default=True,
+        description=(
+            "When true, identical OBML content already loaded in the resolved session reuses "
+            "the existing model_id. When false, always loads fresh. Ignored when `model_id` "
+            "is supplied."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _validate_request(self) -> OneshotBatchRequest:
+        # Exactly one of model_yaml / model_id must be provided.
+        has_yaml = bool(self.model_yaml)
+        has_id = bool(self.model_id)
+        if has_yaml and has_id:
+            raise ValueError("Provide either model_yaml or model_id, not both")
+        if not has_yaml and not has_id:
+            raise ValueError("Provide either model_yaml or model_id")
+        # Reject duplicate query IDs early so callers get a clear error.
+        seen: set[str] = set()
+        for q in self.queries:
+            if q.id in seen:
+                raise ValueError(f"Duplicate query id: '{q.id}'")
+            seen.add(q.id)
+        return self
+
+
+class OneshotBatchQueryError(BaseModel):
+    """Error envelope for a single failed query in a batch."""
+
+    code: str
+    message: str
+    path: str | None = None
+    hint: str | None = None
+
+
+class OneshotBatchQueryResult(BaseModel):
+    """Result of a single query in a one-shot batch."""
+
+    id: str
+    status: str = Field(description="One of: 'ok', 'error', 'cancelled'")
+    sql: str | None = None
+    dialect: str | None = None
+    sql_valid: bool | None = None
+    explain: ExplainPlanResponse | None = None
+    columns: list[ColumnMetadata] | None = None
+    rows: list[list[object]] | None = None
+    row_count: int | None = None
+    execution_time_ms: float | None = None
+    executed: bool | None = Field(
+        default=None,
+        description="Whether this query executed (vs compile-only). Only set when status='ok'.",
+    )
+    warnings: list[str] = Field(default_factory=list)
+    error: OneshotBatchQueryError | None = None
+
+
+class OneshotBatchResponse(BaseModel):
+    """Response body for POST /v1/oneshot/batch."""
+
+    session_id: str
+    model_id: str
+    model_persisted: bool
+    model_load: str = Field(
+        default="fresh",
+        description=(
+            "How the model was acquired: 'fresh' (parsed and loaded), 'reused' (dedup hit), "
+            "or 'referenced' (existing model_id supplied by caller)."
+        ),
+    )
+    results: list[OneshotBatchQueryResult] = Field(default_factory=list)
+    batch_warnings: list[str] = Field(default_factory=list)

--- a/src/orionbelt/api/schemas.py
+++ b/src/orionbelt/api/schemas.py
@@ -673,7 +673,13 @@ class SPARQLResponse(BaseModel):
 class OneshotBatchQueryItem(BaseModel):
     """A single query in a one-shot batch."""
 
-    id: str = Field(description="Caller-provided ID, must be unique within the batch")
+    id: str | None = Field(
+        default=None,
+        description=(
+            "Optional caller-provided ID. Must be unique within the batch when supplied. "
+            "When omitted, the server assigns 'q0', 'q1', ... based on submission order."
+        ),
+    )
     query: QueryObject
     execute: bool | None = Field(
         default=None,
@@ -752,9 +758,15 @@ class OneshotBatchRequest(BaseModel):
             raise ValueError("Provide either model_yaml or model_id, not both")
         if not has_yaml and not has_id:
             raise ValueError("Provide either model_yaml or model_id")
-        # Reject duplicate query IDs early so callers get a clear error.
+        # Auto-assign an id (q0, q1, ...) for any query that omits one. Then
+        # check uniqueness across the resulting set so a caller-supplied
+        # "q3" can't collide silently with an auto-assigned "q3".
+        for idx, q in enumerate(self.queries):
+            if q.id is None:
+                q.id = f"q{idx}"
         seen: set[str] = set()
         for q in self.queries:
+            assert q.id is not None  # filled in above
             if q.id in seen:
                 raise ValueError(f"Duplicate query id: '{q.id}'")
             seen.add(q.id)

--- a/src/orionbelt/api/warnings_adapter.py
+++ b/src/orionbelt/api/warnings_adapter.py
@@ -1,0 +1,71 @@
+"""Adapters between internal error/warning shapes and API response shapes."""
+
+from __future__ import annotations
+
+from orionbelt.api.schemas import (
+    ErrorDetail,
+    FanTrapRisk,
+    ModelHealth,
+    StructuredWarning,
+)
+from orionbelt.models.errors import SemanticError
+from orionbelt.service.model_store import ErrorInfo, ModelHealthSummary
+
+
+def semantic_error_to_warning(e: SemanticError) -> StructuredWarning:
+    """Convert internal :class:`SemanticError` → public :class:`StructuredWarning`."""
+    return StructuredWarning(
+        code=e.code,
+        severity=e.severity or "warning",
+        message=e.message,
+        path=e.path,
+        hint=e.hint,
+        context=e.context,
+    )
+
+
+def error_info_to_warning(info: ErrorInfo) -> StructuredWarning:
+    """Convert service-layer :class:`ErrorInfo` → public :class:`StructuredWarning`."""
+    return StructuredWarning(
+        code=info.code,
+        severity=info.severity or "warning",
+        message=info.message,
+        path=info.path,
+        hint=info.hint,
+        context=info.context,
+    )
+
+
+def error_info_to_detail(info: ErrorInfo) -> ErrorDetail:
+    """Convert service-layer :class:`ErrorInfo` → :class:`ErrorDetail`."""
+    return ErrorDetail(
+        code=info.code,
+        message=info.message,
+        path=info.path,
+        severity=info.severity,
+        hint=info.hint,
+        context=info.context,
+        suggestions=list(info.suggestions),
+    )
+
+
+def health_summary_to_response(summary: ModelHealthSummary | None) -> ModelHealth | None:
+    """Convert service-layer :class:`ModelHealthSummary` → public :class:`ModelHealth`."""
+    if summary is None:
+        return None
+    return ModelHealth(
+        status=summary.status,
+        data_objects=summary.data_objects,
+        joins=summary.joins,
+        orphan_data_objects=summary.orphan_data_objects,
+        fan_trap_risks=[
+            FanTrapRisk(
+                tables=r.tables,
+                reason=r.reason,
+                suggested_pattern=r.suggested_pattern,
+            )
+            for r in summary.fan_trap_risks
+        ],
+        unreachable_dimensions=summary.unreachable_dimensions,
+        warnings_count=summary.warnings_count,
+    )

--- a/src/orionbelt/compiler/fanout.py
+++ b/src/orionbelt/compiler/fanout.py
@@ -7,6 +7,7 @@ import re
 from orionbelt.compiler.graph import JoinGraph, JoinStep
 from orionbelt.compiler.resolution import ResolvedQuery
 from orionbelt.models.semantic import Cardinality, SemanticModel
+from orionbelt.models.warnings import WarningCode, warning
 
 
 class FanoutError(Exception):
@@ -167,10 +168,24 @@ def detect_fanout(resolved: ResolvedQuery, model: SemanticModel) -> None:
                         agg = model_measure.aggregation.lower()
                         if agg in _ADDITIVE_AGGREGATIONS:
                             resolved.warnings.append(
-                                f"Measure '{measure_name}' ({agg.upper()}): "
-                                f"cross-join through '{junction}' — per-group "
-                                f"values are correct but grand totals may be "
-                                f"inflated"
+                                warning(
+                                    code=WarningCode.FAN_TRAP_RISK,
+                                    message=(
+                                        f"Measure '{measure_name}' ({agg.upper()}): "
+                                        f"cross-join through '{junction}' — per-group "
+                                        f"values are correct but grand totals may be "
+                                        f"inflated"
+                                    ),
+                                    hint=(
+                                        "Add the junction-table dimension to the GROUP BY, "
+                                        "or use the Composite Fact Layer pattern."
+                                    ),
+                                    context={
+                                        "measure": measure_name,
+                                        "aggregation": agg.upper(),
+                                        "junction": junction,
+                                    },
+                                )
                             )
                         continue
 

--- a/src/orionbelt/compiler/health.py
+++ b/src/orionbelt/compiler/health.py
@@ -1,0 +1,160 @@
+"""Compute structural health of a loaded model's join graph.
+
+See ``design/PLAN_agent_api_improvements.md`` §1.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from orionbelt.compiler.graph import JoinGraph
+from orionbelt.models.semantic import Cardinality, SemanticModel
+
+
+@dataclass
+class FanTrapRisk:
+    """Detected fan-trap risk between two facts sharing a dim."""
+
+    tables: list[str]
+    reason: str
+    suggested_pattern: str = "composite_fact_layer"
+
+
+@dataclass
+class HealthSummary:
+    """Structural health of a model's join graph."""
+
+    status: str = "ok"
+    data_objects: int = 0
+    joins: int = 0
+    orphan_data_objects: list[str] = field(default_factory=list)
+    fan_trap_risks: list[FanTrapRisk] = field(default_factory=list)
+    unreachable_dimensions: list[str] = field(default_factory=list)
+    warnings_count: int = 0
+
+
+def _qualified_table(model: SemanticModel, name: str) -> str:
+    """Return the physical SQL table reference for a dataObject by label."""
+    obj = model.data_objects.get(name)
+    if obj is None:
+        return name
+    parts = [p for p in (obj.database, obj.schema_name, obj.code) if p]
+    return ".".join(parts) if parts else name
+
+
+def _detect_orphans(model: SemanticModel) -> list[str]:
+    """DataObjects with no incoming or outgoing joins.
+
+    A model with one dataObject is treated as intentional (no orphans).
+    """
+    if len(model.data_objects) <= 1:
+        return []
+    referenced: set[str] = set()
+    for obj_name, obj in model.data_objects.items():
+        for join in obj.joins:
+            if join.join_to in model.data_objects:
+                referenced.add(obj_name)
+                referenced.add(join.join_to)
+    return sorted(set(model.data_objects.keys()) - referenced)
+
+
+def _detect_fan_trap_risks(model: SemanticModel) -> list[FanTrapRisk]:
+    """Two fact-like dataObjects joined to the same dim via the same FK columns.
+
+    Heuristic: dataObjects that have outgoing many-to-one joins to a shared
+    target are 'fact-like'. When two such facts both join to the SAME target
+    on the SAME local columns, a query touching both will produce row
+    multiplication unless a Composite Fact Layer is used.
+    """
+    # target -> list[(source, columns_from_tuple)]
+    inbound: dict[str, list[tuple[str, tuple[str, ...]]]] = {}
+    for obj_name, obj in model.data_objects.items():
+        for join in obj.joins:
+            if (
+                join.join_type == Cardinality.MANY_TO_ONE
+                and join.join_to in model.data_objects
+                and not join.secondary
+            ):
+                key = tuple(join.columns_from)
+                inbound.setdefault(join.join_to, []).append((obj_name, key))
+
+    risks: list[FanTrapRisk] = []
+    for target, sources in inbound.items():
+        if len(sources) < 2:
+            continue
+        # Group by columns_from signature; matching columns means shared FK
+        by_cols: dict[tuple[str, ...], list[str]] = {}
+        for src, cols in sources:
+            by_cols.setdefault(cols, []).append(src)
+        for cols, srcs in by_cols.items():
+            if len(srcs) < 2:
+                continue
+            tables = [_qualified_table(model, s) for s in sorted(srcs)]
+            risks.append(
+                FanTrapRisk(
+                    tables=tables,
+                    reason=(
+                        f"both fact tables join to {_qualified_table(model, target)} "
+                        f"via the same FK column(s) {list(cols)}"
+                    ),
+                    suggested_pattern="composite_fact_layer",
+                )
+            )
+    return risks
+
+
+def _detect_unreachable_dimensions(model: SemanticModel, graph: JoinGraph) -> list[str]:
+    """Dimensions whose dataObject has no incoming many-to-one joins from any fact.
+
+    A dimension is 'unreachable' when the dataObject it lives on cannot be
+    joined-to from any fact dataObject. We treat any dataObject that has at
+    least one outgoing many-to-one join as 'fact-like'.
+    """
+    fact_objects = {
+        name
+        for name, obj in model.data_objects.items()
+        if any(j.join_type == Cardinality.MANY_TO_ONE for j in obj.joins)
+    }
+    if not fact_objects:
+        return []
+
+    # Compute set of dataObjects reachable from any fact via directed paths
+    reachable: set[str] = set()
+    for fact in fact_objects:
+        reachable.add(fact)
+        reachable |= graph.descendants(fact)
+
+    unreachable: list[str] = []
+    for dim_name, dim in model.dimensions.items():
+        if dim.view not in reachable:
+            unreachable.append(dim_name)
+    return sorted(unreachable)
+
+
+def compute_health(model: SemanticModel) -> HealthSummary:
+    """Walk the join graph once and return structural health metrics."""
+    graph = JoinGraph(model)
+
+    join_count = sum(
+        1
+        for obj in model.data_objects.values()
+        for j in obj.joins
+        if j.join_to in model.data_objects and not j.secondary
+    )
+
+    orphans = _detect_orphans(model)
+    fan_traps = _detect_fan_trap_risks(model)
+    unreachable = _detect_unreachable_dimensions(model, graph)
+
+    warnings_count = len(orphans) + len(fan_traps) + len(unreachable)
+    status = "warnings" if warnings_count > 0 else "ok"
+
+    return HealthSummary(
+        status=status,
+        data_objects=len(model.data_objects),
+        joins=join_count,
+        orphan_data_objects=orphans,
+        fan_trap_risks=fan_traps,
+        unreachable_dimensions=unreachable,
+        warnings_count=warnings_count,
+    )

--- a/src/orionbelt/compiler/pipeline.py
+++ b/src/orionbelt/compiler/pipeline.py
@@ -16,8 +16,10 @@ from orionbelt.compiler.star import QueryPlan, StarSchemaPlanner
 from orionbelt.compiler.total_wrap import wrap_with_totals
 from orionbelt.compiler.validator import validate_sql
 from orionbelt.dialect.registry import DialectRegistry
+from orionbelt.models.errors import SemanticError
 from orionbelt.models.query import QueryObject
 from orionbelt.models.semantic import SemanticModel
+from orionbelt.models.warnings import WarningCode, warning
 
 
 @dataclass
@@ -37,6 +39,7 @@ class ExplainJoin:
     to_object: str
     join_columns: list[str]
     reason: str
+    cardinality: str = ""
 
 
 @dataclass
@@ -76,7 +79,7 @@ class CompilationResult:
     sql: str
     dialect: str
     resolved: ResolvedInfo
-    warnings: list[str] = field(default_factory=list)
+    warnings: list[SemanticError] = field(default_factory=list)
     sql_valid: bool = True
     explain: ExplainPlan | None = None
 
@@ -153,8 +156,22 @@ class CompilationPipeline:
             # PoP/cumulative wrappers depend on.
             if resolved.has_totals and (resolved.has_pop or resolved.has_cumulative):
                 resolved.warnings.append(
-                    "total=True measures are ignored when combined with "
-                    "period-over-period or cumulative metrics in the same query"
+                    warning(
+                        code=WarningCode.INCOMPATIBLE_COMBINATION,
+                        message=(
+                            "total=True measures are ignored when combined with "
+                            "period-over-period or cumulative metrics in the same query"
+                        ),
+                        hint=(
+                            "Drop total=True from the affected measures, or remove the "
+                            "PoP/cumulative metric from this query."
+                        ),
+                        context={
+                            "has_totals": True,
+                            "has_pop": resolved.has_pop,
+                            "has_cumulative": resolved.has_cumulative,
+                        },
+                    )
                 )
             else:
                 wrapped_ast = wrap_with_totals(wrapped_ast, resolved)
@@ -171,7 +188,13 @@ class CompilationPipeline:
         sql_valid = len(validation_errors) == 0
         warnings = resolved.warnings
         if not sql_valid:
-            warnings = warnings + [f"SQL validation: {e}" for e in validation_errors]
+            warnings = warnings + [
+                warning(
+                    code=WarningCode.SQL_VALIDATION,
+                    message=f"SQL validation: {e}",
+                )
+                for e in validation_errors
+            ]
 
         # Build explain plan
         explain = self._build_explain(resolved, model, use_cfl, plan)
@@ -280,6 +303,7 @@ class CompilationPipeline:
                         to_object=step.to_object,
                         join_columns=join_cols,
                         reason=reason,
+                        cardinality=step.cardinality.value,
                     )
                 )
 

--- a/src/orionbelt/compiler/resolution.py
+++ b/src/orionbelt/compiler/resolution.py
@@ -190,7 +190,7 @@ class ResolvedQuery:
     order_by_exprs: list[tuple[Expr, bool]] = field(default_factory=list)
     limit: int | None = None
     offset: int | None = None
-    warnings: list[str] = field(default_factory=list)
+    warnings: list[SemanticError] = field(default_factory=list)
     requires_cfl: bool = False
     measure_source_objects: set[str] = field(default_factory=set)
     metric_components: dict[str, ResolvedMeasure] = field(default_factory=dict)

--- a/src/orionbelt/models/__init__.py
+++ b/src/orionbelt/models/__init__.py
@@ -11,6 +11,7 @@ from orionbelt.models.semantic import (
     Measure,
     TimeGrain,
 )
+from orionbelt.models.warnings import WarningCode, warning
 
 __all__ = [
     "AggregationType",
@@ -27,4 +28,6 @@ __all__ = [
     "SemanticError",
     "SourceSpan",
     "TimeGrain",
+    "WarningCode",
+    "warning",
 ]

--- a/src/orionbelt/models/errors.py
+++ b/src/orionbelt/models/errors.py
@@ -1,8 +1,10 @@
-"""Structured error models with YAML source position tracking."""
+"""Structured error and warning models with YAML source position tracking."""
 
 from __future__ import annotations
 
-from pydantic import BaseModel
+from typing import Any
+
+from pydantic import BaseModel, Field
 
 
 class SourceSpan(BaseModel):
@@ -16,19 +18,34 @@ class SourceSpan(BaseModel):
 
 
 class SemanticError(BaseModel):
-    """A structured error with optional source position and suggestions."""
+    """A structured error or warning with optional source position and remediation.
+
+    Used uniformly for errors (``severity="error"``) and warnings (``severity="warning"``).
+    See ``models/warnings.py`` for the stable warning code taxonomy.
+    """
 
     code: str
     message: str
     path: str | None = None
     span: SourceSpan | None = None
-    suggestions: list[str] = []
+    suggestions: list[str] = Field(default_factory=list)
     severity: str = "error"
+    hint: str | None = Field(
+        default=None,
+        description="Optional remediation suggestion (single sentence)",
+    )
+    context: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Optional structured detail (e.g. which measure / dataObject / column) so "
+            "agents can branch on the data without parsing the message."
+        ),
+    )
 
 
 class ValidationResult(BaseModel):
     """Result of semantic model validation."""
 
     valid: bool
-    errors: list[SemanticError] = []
-    warnings: list[SemanticError] = []
+    errors: list[SemanticError] = Field(default_factory=list)
+    warnings: list[SemanticError] = Field(default_factory=list)

--- a/src/orionbelt/models/semantic.py
+++ b/src/orionbelt/models/semantic.py
@@ -522,6 +522,28 @@ class ModelFilter(BaseModel):
     model_config = {"populate_by_name": True}
 
 
+class ModelExample(BaseModel):
+    """Canonical example query authored alongside a model.
+
+    See ``design/PLAN_agent_api_improvements.md`` §5. Stored on the
+    :class:`SemanticModel` and surfaced via the examples endpoints so agents
+    can discover the kinds of questions a model is designed to answer.
+    """
+
+    name: str = Field(description="Snake_case identifier, unique within the model")
+    description: str = Field(description="One- or two-sentence explanation")
+    intent_tags: list[str] = Field(
+        default_factory=list,
+        alias="intentTags",
+        description="Free-form tags used by ?intent= filters",
+    )
+    query: dict[str, object] = Field(
+        description="Full QueryObject payload, valid against this model"
+    )
+
+    model_config = {"populate_by_name": True}
+
+
 class SemanticModel(BaseModel):
     """Complete semantic model parsed from OBML YAML."""
 
@@ -533,6 +555,7 @@ class SemanticModel(BaseModel):
     measures: dict[str, Measure] = {}
     metrics: dict[str, Metric] = {}
     filters: list[ModelFilter] = Field(default_factory=list)
+    examples: list[ModelExample] = Field(default_factory=list)
     extends_sources: list[str] = Field(default_factory=list)
     inherits_source: str | None = None
     owner: str | None = None

--- a/src/orionbelt/models/warnings.py
+++ b/src/orionbelt/models/warnings.py
@@ -1,0 +1,63 @@
+"""Stable warning code taxonomy for the OBSL API.
+
+These codes are part of the public API contract: agents may branch on them.
+Codes are extended over time; never repurposed.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from orionbelt.models.errors import SemanticError
+
+
+class WarningCode:
+    """Stable identifiers used in the ``code`` field of structured warnings.
+
+    Plan: ``design/PLAN_agent_api_improvements.md`` §3.4.
+    """
+
+    # Query-time grain / filter-context overrides that can't combine
+    GRAIN_OVERRIDE_INCOMPATIBLE = "GRAIN_OVERRIDE_INCOMPATIBLE"
+    FILTER_CONTEXT_OVERRIDE_INCOMPATIBLE = "FILTER_CONTEXT_OVERRIDE_INCOMPATIBLE"
+
+    # PoP / Cumulative metric constraint violations
+    POP_CONSTRAINT_VIOLATED = "POP_CONSTRAINT_VIOLATED"
+    CUMULATIVE_CONSTRAINT_VIOLATED = "CUMULATIVE_CONSTRAINT_VIOLATED"
+
+    # Multi-fact / fan-trap / structural risks
+    FAN_TRAP_RISK = "FAN_TRAP_RISK"
+    ORPHAN_DATA_OBJECT = "ORPHAN_DATA_OBJECT"
+    SHARED_TABLE_CONTRACT_DISAGREEMENT = "SHARED_TABLE_CONTRACT_DISAGREEMENT"
+
+    # Result / cache / cost guards
+    LARGE_RESULT_SET = "LARGE_RESULT_SET"
+    CACHE_TTL_FLOOR_HIT = "CACHE_TTL_FLOOR_HIT"
+
+    # Compile-time, post-codegen SQL validator emissions
+    SQL_VALIDATION = "SQL_VALIDATION"
+
+    # Generic merge-time warning (extends/inherits)
+    MERGE_WARNING = "MERGE_WARNING"
+
+    # Combination of options the planner ignored (e.g. totals + PoP)
+    INCOMPATIBLE_COMBINATION = "INCOMPATIBLE_COMBINATION"
+
+
+def warning(
+    code: str,
+    message: str,
+    *,
+    path: str | None = None,
+    hint: str | None = None,
+    context: dict[str, Any] | None = None,
+) -> SemanticError:
+    """Build a structured warning with severity='warning'."""
+    return SemanticError(
+        code=code,
+        message=message,
+        path=path,
+        hint=hint,
+        context=context,
+        severity="warning",
+    )

--- a/src/orionbelt/parser/resolver.py
+++ b/src/orionbelt/parser/resolver.py
@@ -24,6 +24,7 @@ from orionbelt.models.semantic import (
     MeasureFilterItem,
     Metric,
     MetricType,
+    ModelExample,
     ModelFilter,
     ModelSettings,
     PeriodOverPeriod,
@@ -676,6 +677,9 @@ class ReferenceResolver:
 
         settings = _parse_settings(raw.get("settings"))
 
+        # Parse examples block (PLAN_agent_api_improvements §5)
+        examples = self._parse_examples(raw.get("examples"), errors)
+
         model = SemanticModel(
             version=raw.get("version", 1.0),
             data_objects=data_objects,
@@ -683,6 +687,7 @@ class ReferenceResolver:
             measures=measures,
             metrics=metrics,
             filters=model_filters,
+            examples=examples,
             extends_sources=raw.get("_extends_sources", []),
             inherits_source=raw.get("_inherits_source"),
             owner=raw.get("owner"),
@@ -697,6 +702,97 @@ class ReferenceResolver:
         )
 
         return model, result
+
+    def _parse_examples(self, raw: object, errors: list[SemanticError]) -> list[ModelExample]:
+        """Parse the model-level ``examples:`` block.
+
+        Accepts a list of mapping entries. Each entry must have ``name``,
+        ``description``, and ``query``. ``intent_tags`` (alias ``intentTags``)
+        is optional. Names must be unique within the block.
+        """
+        if raw is None:
+            return []
+        if not isinstance(raw, list):
+            errors.append(
+                SemanticError(
+                    code="EXAMPLES_PARSE_ERROR",
+                    message="'examples' must be a YAML list of example entries",
+                    path="examples",
+                )
+            )
+            return []
+
+        out: list[ModelExample] = []
+        seen: set[str] = set()
+        for i, entry in enumerate(raw):
+            if not isinstance(entry, dict):
+                errors.append(
+                    SemanticError(
+                        code="EXAMPLES_PARSE_ERROR",
+                        message=f"examples[{i}] must be a mapping",
+                        path=f"examples[{i}]",
+                    )
+                )
+                continue
+            name = entry.get("name")
+            description = entry.get("description")
+            query = entry.get("query")
+            intent_tags = entry.get("intent_tags") or entry.get("intentTags") or []
+            if not isinstance(name, str) or not name:
+                errors.append(
+                    SemanticError(
+                        code="EXAMPLES_PARSE_ERROR",
+                        message=f"examples[{i}].name is required and must be a string",
+                        path=f"examples[{i}].name",
+                    )
+                )
+                continue
+            if name in seen:
+                errors.append(
+                    SemanticError(
+                        code="DUPLICATE_EXAMPLE_NAME",
+                        message=f"Duplicate example name '{name}'",
+                        path=f"examples[{i}].name",
+                    )
+                )
+                continue
+            if not isinstance(description, str):
+                errors.append(
+                    SemanticError(
+                        code="EXAMPLES_PARSE_ERROR",
+                        message=f"examples[{i}].description is required",
+                        path=f"examples[{i}].description",
+                    )
+                )
+                continue
+            if not isinstance(query, dict):
+                errors.append(
+                    SemanticError(
+                        code="EXAMPLES_PARSE_ERROR",
+                        message=f"examples[{i}].query must be a mapping (QueryObject payload)",
+                        path=f"examples[{i}].query",
+                    )
+                )
+                continue
+            if not isinstance(intent_tags, list):
+                errors.append(
+                    SemanticError(
+                        code="EXAMPLES_PARSE_ERROR",
+                        message=f"examples[{i}].intent_tags must be a list",
+                        path=f"examples[{i}].intent_tags",
+                    )
+                )
+                continue
+            seen.add(name)
+            out.append(
+                ModelExample(
+                    name=name,
+                    description=description,
+                    intent_tags=[str(t) for t in intent_tags],
+                    query=dict(query),
+                )
+            )
+        return out
 
     def _validate_expression_refs(
         self,

--- a/src/orionbelt/service/db_executor.py
+++ b/src/orionbelt/service/db_executor.py
@@ -652,6 +652,57 @@ def _fetch_result(cursor: Any, t0: float, *, tz: ZoneInfo | None = None) -> Exec
     )
 
 
+def explain_sql(sql: str, *, dialect: str) -> str:
+    """Run ``EXPLAIN <sql>`` against the configured warehouse and return raw text.
+
+    Returns the dialect-native EXPLAIN output as opaque text (newline-joined
+    rows). OBSL does not normalize across dialects — callers should treat
+    the output as a string in the named dialect's format.
+
+    Raises:
+        ExecutionUnavailableError: ob-flight or driver missing / not configured.
+        ExecutionError: warehouse rejected the EXPLAIN.
+    """
+    try:
+        from ob_flight.db_router import get_credentials
+    except ImportError:
+        raise ExecutionUnavailableError(
+            "ob-flight-extension package is not installed. Install with: uv sync --extra flight"
+        ) from None
+
+    explain_stmt = f"EXPLAIN {sql}"
+    try:
+        if dialect == "duckdb":
+            import duckdb
+
+            creds = get_credentials(dialect)
+            database = creds.get("database", ":memory:")
+            conn = duckdb.connect(database=database, read_only=True)
+            try:
+                rows = conn.execute(explain_stmt).fetchall()
+            finally:
+                conn.close()
+            return "\n".join("\t".join("" if c is None else str(c) for c in row) for row in rows)
+
+        from ob_flight.db_router import get_connection
+
+        with get_connection(dialect) as conn:
+            cursor = conn.cursor()
+            try:
+                cursor.execute(explain_stmt)
+                rows = cursor.fetchall() or []
+            finally:
+                with contextlib.suppress(Exception):
+                    cursor.close()
+        return "\n".join("\t".join("" if c is None else str(c) for c in row) for row in rows)
+    except ExecutionUnavailableError:
+        raise
+    except KeyError as exc:
+        raise ExecutionUnavailableError(str(exc)) from None
+    except Exception as exc:
+        raise ExecutionError(f"EXPLAIN failed: {exc}") from exc
+
+
 def _try_fetch_arrow(cursor: Any) -> Any:
     """Try to fetch results as an Arrow Table. Returns None on failure.
 

--- a/src/orionbelt/service/fuzzy.py
+++ b/src/orionbelt/service/fuzzy.py
@@ -1,0 +1,121 @@
+"""Fuzzy matching for /find recovery.
+
+Phase A: deterministic — Levenshtein + trigram overlap. No external deps.
+Phase B (semantic embeddings) is deferred per ``design/PLAN_agent_api_improvements.md`` §4.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class FuzzyMatch:
+    """A single fuzzy match candidate."""
+
+    name: str
+    kind: str
+    score: float
+    reason: str
+
+
+def _levenshtein(a: str, b: str) -> int:
+    """Pure-Python Levenshtein distance — small inputs only."""
+    if a == b:
+        return 0
+    if not a:
+        return len(b)
+    if not b:
+        return len(a)
+    prev = list(range(len(b) + 1))
+    for i, ca in enumerate(a, 1):
+        curr = [i]
+        for j, cb in enumerate(b, 1):
+            curr.append(
+                min(
+                    curr[j - 1] + 1,
+                    prev[j] + 1,
+                    prev[j - 1] + (0 if ca == cb else 1),
+                )
+            )
+        prev = curr
+    return prev[-1]
+
+
+def _normalize(text: str) -> str:
+    return text.lower().strip()
+
+
+def _trigrams(text: str) -> set[str]:
+    """3-character sliding window grams of a normalized string."""
+    n = _normalize(text)
+    if len(n) < 3:
+        return {n} if n else set()
+    return {n[i : i + 3] for i in range(len(n) - 2)}
+
+
+def _trigram_score(query: str, candidate: str) -> float:
+    """Jaccard similarity of trigrams. 0..1."""
+    qg = _trigrams(query)
+    cg = _trigrams(candidate)
+    if not qg or not cg:
+        return 0.0
+    overlap = qg & cg
+    union = qg | cg
+    return len(overlap) / len(union)
+
+
+def _edit_score(query: str, candidate: str) -> float:
+    """Normalized edit-distance score: 1 = identical, 0 = totally different."""
+    qn = _normalize(query)
+    cn = _normalize(candidate)
+    if not qn or not cn:
+        return 0.0
+    dist = _levenshtein(qn, cn)
+    longest = max(len(qn), len(cn))
+    return 1.0 - (dist / longest)
+
+
+def fuzzy_score(query: str, candidate: str) -> tuple[float, str]:
+    """Compute the combined fuzzy score and the dominant reason.
+
+    Weighted blend: trigram overlap (0.6) + edit-distance score (0.4).
+    Reason is the contributor that scored highest.
+    """
+    tri = _trigram_score(query, candidate)
+    edit = _edit_score(query, candidate)
+    score = 0.6 * tri + 0.4 * edit
+    if tri >= edit:
+        reason = "trigram overlap"
+    else:
+        qn, cn = _normalize(query), _normalize(candidate)
+        dist = _levenshtein(qn, cn)
+        reason = f"edit distance: {dist}"
+    return score, reason
+
+
+def fuzzy_search(
+    query: str,
+    candidates: list[tuple[str, str, list[str]]],
+    *,
+    threshold: float = 0.5,
+    max_results: int = 10,
+) -> list[FuzzyMatch]:
+    """Return the top fuzzy matches above ``threshold``.
+
+    ``candidates`` is a list of ``(name, kind, synonyms)`` tuples. The query
+    is matched against the name and each synonym; the best score wins.
+    """
+    scored: list[FuzzyMatch] = []
+    for name, kind, synonyms in candidates:
+        best_score, best_reason = fuzzy_score(query, name)
+        for syn in synonyms:
+            s, r = fuzzy_score(query, syn)
+            if s > best_score:
+                best_score, best_reason = s, f"synonym '{syn}', {r}"
+        if best_score >= threshold:
+            scored.append(
+                FuzzyMatch(name=name, kind=kind, score=round(best_score, 3), reason=best_reason)
+            )
+    scored.sort(key=lambda m: (-m.score, m.name))
+    return scored[:max_results]

--- a/src/orionbelt/service/model_store.py
+++ b/src/orionbelt/service/model_store.py
@@ -10,9 +10,11 @@ from dataclasses import dataclass, field
 
 from rdflib import Graph
 
+from orionbelt.compiler.health import compute_health
 from orionbelt.compiler.pipeline import CompilationPipeline, CompilationResult
 from orionbelt.models.query import QueryObject
 from orionbelt.models.semantic import SemanticModel
+from orionbelt.models.warnings import WarningCode
 from orionbelt.obsl.exporter import export_obsl
 from orionbelt.obsl.sparql import SPARQLResult, execute_sparql
 from orionbelt.parser.loader import TrackedLoader, YAMLSafetyError
@@ -34,8 +36,9 @@ class LoadResult:
     dimensions: int
     measures: int
     metrics: int
-    warnings: list[str]
+    warnings: list[ErrorInfo]
     model_load: str = "fresh"  # "fresh" | "reused" — see PLAN_model_load_dedup.md
+    health: ModelHealthSummary | None = None
 
 
 @dataclass
@@ -118,6 +121,34 @@ class ErrorInfo:
     message: str
     path: str | None = None
     suggestions: list[str] = field(default_factory=list)
+    severity: str = "error"
+    hint: str | None = None
+    context: dict[str, object] | None = None
+
+
+@dataclass
+class FanTrapRiskInfo:
+    """Detected fan-trap risk between two facts sharing a dim."""
+
+    tables: list[str]
+    reason: str
+    suggested_pattern: str = "composite_fact_layer"
+
+
+@dataclass
+class ModelHealthSummary:
+    """Structural health of a loaded model's join graph.
+
+    See ``design/PLAN_agent_api_improvements.md`` §1.
+    """
+
+    status: str = "ok"
+    data_objects: int = 0
+    joins: int = 0
+    orphan_data_objects: list[str] = field(default_factory=list)
+    fan_trap_risks: list[FanTrapRiskInfo] = field(default_factory=list)
+    unreachable_dimensions: list[str] = field(default_factory=list)
+    warnings_count: int = 0
 
 
 @dataclass
@@ -196,6 +227,27 @@ class ModelStore:
         return uuid.uuid4().hex[:8]
 
     @staticmethod
+    def _health_for(model: SemanticModel) -> ModelHealthSummary:
+        """Compute structural health for a loaded model."""
+        h = compute_health(model)
+        return ModelHealthSummary(
+            status=h.status,
+            data_objects=h.data_objects,
+            joins=h.joins,
+            orphan_data_objects=h.orphan_data_objects,
+            fan_trap_risks=[
+                FanTrapRiskInfo(
+                    tables=r.tables,
+                    reason=r.reason,
+                    suggested_pattern=r.suggested_pattern,
+                )
+                for r in h.fan_trap_risks
+            ],
+            unreachable_dimensions=h.unreachable_dimensions,
+            warnings_count=h.warnings_count,
+        )
+
+    @staticmethod
     def _content_hash(yaml_str: str) -> str:
         """SHA-256 of the OBML body, with surrounding whitespace stripped.
 
@@ -257,7 +309,13 @@ class ModelStore:
                     inherits_raw=inherits_raw,
                 )
                 for mw in merge_warnings:
-                    warnings.append(ErrorInfo(code="MERGE_WARNING", message=mw))
+                    warnings.append(
+                        ErrorInfo(
+                            code=WarningCode.MERGE_WARNING,
+                            message=mw,
+                            severity="warning",
+                        )
+                    )
                 source_map = None
         except MergeError as exc:
             errors.append(ErrorInfo(code=exc.code, message=exc.message))
@@ -280,6 +338,9 @@ class ModelStore:
                     message=e.message,
                     path=e.path,
                     suggestions=list(e.suggestions),
+                    severity=e.severity,
+                    hint=e.hint,
+                    context=e.context,
                 )
             )
         for w in resolution.warnings:
@@ -289,6 +350,9 @@ class ModelStore:
                     message=w.message,
                     path=w.path,
                     suggestions=list(w.suggestions),
+                    severity=w.severity or "warning",
+                    hint=w.hint,
+                    context=w.context,
                 )
             )
 
@@ -300,6 +364,9 @@ class ModelStore:
                 message=e.message,
                 path=e.path,
                 suggestions=list(e.suggestions),
+                severity=e.severity,
+                hint=e.hint,
+                context=e.context,
             )
             if e.severity == "warning":
                 warnings.append(info)
@@ -443,6 +510,8 @@ class ModelStore:
                 if existing_id is not None and existing_id in self._models:
                     summary = self._summaries.get(existing_id)
                     if summary is not None:
+                        existing_model = self._models[existing_id]
+                        existing_health = self._health_for(existing_model)
                         return LoadResult(
                             model_id=existing_id,
                             data_objects=summary.data_objects,
@@ -451,6 +520,7 @@ class ModelStore:
                             metrics=summary.metrics,
                             warnings=[],
                             model_load="reused",
+                            health=existing_health,
                         )
                 # Stale index entry — drop it and fall through to a fresh load.
                 if existing_id is not None:
@@ -505,8 +575,9 @@ class ModelStore:
             dimensions=summary.dimensions,
             measures=summary.measures,
             metrics=summary.metrics,
-            warnings=[w.message for w in warnings],
+            warnings=warnings,
             model_load="fresh",
+            health=self._health_for(model),
         )
 
     def get_model(self, model_id: str) -> SemanticModel:

--- a/src/orionbelt/service/model_store.py
+++ b/src/orionbelt/service/model_store.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import threading
 import time
 import uuid
@@ -34,6 +35,7 @@ class LoadResult:
     measures: int
     metrics: int
     warnings: list[str]
+    model_load: str = "fresh"  # "fresh" | "reused" — see PLAN_model_load_dedup.md
 
 
 @dataclass
@@ -170,7 +172,15 @@ class ModelStore:
         self._lock = threading.Lock()
         self._models: dict[str, SemanticModel] = {}
         self._graphs: dict[str, GraphArtifact] = {}
+        # Per-store summary cache so dedup hits can return the original
+        # data_objects/dimensions/measures/metrics counts without re-walking
+        # the model.
+        self._summaries: dict[str, ModelSummary] = {}
         self._max_models = max_models
+        # Dedup index: content_hash → model_id. Populated on every successful
+        # load and consulted before parsing on the next load. See
+        # design/PLAN_model_load_dedup.md.
+        self._content_hash_index: dict[str, str] = {}
 
         # Internal pipeline singletons (stateless, safe to share).
         self._loader = TrackedLoader()
@@ -184,6 +194,16 @@ class ModelStore:
     @staticmethod
     def _new_id() -> str:
         return uuid.uuid4().hex[:8]
+
+    @staticmethod
+    def _content_hash(yaml_str: str) -> str:
+        """SHA-256 of the OBML body, with surrounding whitespace stripped.
+
+        Stripping at the boundary makes a trailing newline difference
+        invisible to dedup; everything else (key order, comments, internal
+        whitespace) still produces a different hash.
+        """
+        return hashlib.sha256(yaml_str.strip().encode("utf-8")).hexdigest()
 
     def _parse_and_validate(
         self,
@@ -389,13 +409,53 @@ class ModelStore:
         raw_dict: dict[str, object] | None = None,
         extends_yaml: list[str] | None = None,
         inherits_model_id: str | None = None,
+        dedup: bool = True,
     ) -> LoadResult:
         """Parse, validate, and store a model.  Returns id + summary.
 
         Provide either ``yaml_str`` or ``raw_dict``.
         Raises ``ModelValidationError`` if the model has validation errors.
         Raises ``ModelCapacityError`` if the session's model cap is reached.
+
+        When ``dedup`` is True (default) and the same OBML bytes have already
+        been loaded into this store, the existing ``model_id`` is returned
+        and ``model_load`` is set to ``"reused"``. Dedup only applies to
+        plain ``yaml_str`` loads — when ``raw_dict``, ``extends_yaml``, or
+        ``inherits_model_id`` is supplied the load always runs fresh, since
+        the effective content depends on inputs not captured by the YAML
+        bytes alone.
         """
+        # Dedup is meaningful only for a stand-alone YAML body. The other
+        # input shapes either skip the YAML stage (raw_dict) or fold in
+        # additional state (extends/inherits) that the bytes don't capture.
+        dedup_eligible = (
+            dedup
+            and yaml_str is not None
+            and raw_dict is None
+            and not extends_yaml
+            and inherits_model_id is None
+        )
+        content_hash: str | None = None
+        if dedup_eligible:
+            content_hash = self._content_hash(yaml_str or "")
+            with self._lock:
+                existing_id = self._content_hash_index.get(content_hash)
+                if existing_id is not None and existing_id in self._models:
+                    summary = self._summaries.get(existing_id)
+                    if summary is not None:
+                        return LoadResult(
+                            model_id=existing_id,
+                            data_objects=summary.data_objects,
+                            dimensions=summary.dimensions,
+                            measures=summary.measures,
+                            metrics=summary.metrics,
+                            warnings=[],
+                            model_load="reused",
+                        )
+                # Stale index entry — drop it and fall through to a fresh load.
+                if existing_id is not None:
+                    self._content_hash_index.pop(content_hash, None)
+
         with self._lock:
             if len(self._models) >= self._max_models:
                 raise ModelCapacityError(f"Maximum models per session reached ({self._max_models})")
@@ -416,6 +476,14 @@ class ModelStore:
         turtle = graph.serialize(format="turtle")
         artifact = GraphArtifact(graph=graph, turtle=turtle, generated_at=time.monotonic())
 
+        summary = ModelSummary(
+            model_id=model_id,
+            data_objects=len(model.data_objects),
+            dimensions=len(model.dimensions),
+            measures=len(model.measures),
+            metrics=len(model.metrics),
+        )
+
         with self._lock:
             # Re-check capacity under lock — the first check (above) ran
             # outside the lock while parsing/exporting, so a concurrent
@@ -424,14 +492,21 @@ class ModelStore:
                 raise ModelCapacityError(f"Maximum models per session reached ({self._max_models})")
             self._models[model_id] = model
             self._graphs[model_id] = artifact
+            self._summaries[model_id] = summary
+            if content_hash is not None:
+                # If a concurrent request beat us to it, the last writer wins;
+                # the race is benign (both models work, the older one is just
+                # not reachable via the index). See PLAN_model_load_dedup.md §6.3.
+                self._content_hash_index[content_hash] = model_id
 
         return LoadResult(
             model_id=model_id,
-            data_objects=len(model.data_objects),
-            dimensions=len(model.dimensions),
-            measures=len(model.measures),
-            metrics=len(model.metrics),
+            data_objects=summary.data_objects,
+            dimensions=summary.dimensions,
+            measures=summary.measures,
+            metrics=summary.metrics,
             warnings=[w.message for w in warnings],
+            model_load="fresh",
         )
 
     def get_model(self, model_id: str) -> SemanticModel:
@@ -507,27 +582,24 @@ class ModelStore:
     def list_models(self) -> list[ModelSummary]:
         """Return a short summary for every loaded model."""
         with self._lock:
-            items = list(self._models.items())
-
-        return [
-            ModelSummary(
-                model_id=mid,
-                data_objects=len(m.data_objects),
-                dimensions=len(m.dimensions),
-                measures=len(m.measures),
-                metrics=len(m.metrics),
-            )
-            for mid, m in items
-        ]
+            return list(self._summaries.values())
 
     def remove_model(self, model_id: str) -> None:
-        """Unload a model and its cached OBSL graph.  Raises ``KeyError`` if not found."""
+        """Unload a model and its cached OBSL graph.  Raises ``KeyError`` if not found.
+
+        Also removes the model's entry from the dedup index so the next load
+        of the same OBML content runs fresh. PLAN_model_load_dedup.md §6.2.
+        """
         with self._lock:
             try:
                 del self._models[model_id]
             except KeyError:
                 raise KeyError(f"No model loaded with id '{model_id}'") from None
             self._graphs.pop(model_id, None)
+            self._summaries.pop(model_id, None)
+            stale_hashes = [h for h, mid in self._content_hash_index.items() if mid == model_id]
+            for h in stale_hashes:
+                del self._content_hash_index[h]
 
     def compile_query(
         self,

--- a/src/orionbelt/settings.py
+++ b/src/orionbelt/settings.py
@@ -75,3 +75,9 @@ class Settings(BaseSettings):
     flight_auth_mode: str = "none"  # "none" or "token"
     flight_api_token: str | None = None
     db_vendor: str = "duckdb"  # default vendor driver for Flight query execution
+
+    # One-shot batch endpoint (POST /v1/oneshot/batch). See PLAN_oneshot_batch.md.
+    oneshot_batch_max_queries: int = 50
+    oneshot_batch_max_parallelism: int = 8
+    oneshot_batch_default_timeout_ms: int = 30000  # per-query
+    oneshot_batch_batch_timeout_ms: int = 120000  # whole batch

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -383,6 +383,14 @@ class TestSessionModelFlow:
         assert data["data_objects"] == 2
         assert data["dimensions"] == 1
         assert data["measures"] == 3
+        # Phase 2: structural health is always present on a fresh load
+        assert "health" in data
+        health = data["health"]
+        assert health["status"] == "ok"
+        assert health["data_objects"] == 2
+        assert health["joins"] == 1
+        assert health["orphan_data_objects"] == []
+        assert health["fan_trap_risks"] == []
 
     async def test_load_model_json(self, client: AsyncClient) -> None:
         sid = (await client.post("/v1/sessions")).json()["session_id"]
@@ -533,6 +541,94 @@ class TestSessionModelFlow:
             json={"model_yaml": "}{bad"},
         )
         assert response.status_code == 422
+
+
+class TestQueryPlanEndpoint:
+    """POST /v1/sessions/{sid}/query/plan — see PLAN_agent_api_improvements §2."""
+
+    async def _setup(self, client: AsyncClient) -> tuple[str, str]:
+        sid = (await client.post("/v1/sessions")).json()["session_id"]
+        load = await client.post(
+            f"/v1/sessions/{sid}/models", json={"model_yaml": SAMPLE_MODEL_YAML}
+        )
+        return sid, load.json()["model_id"]
+
+    async def test_plan_default_no_database_explain(self, client: AsyncClient) -> None:
+        sid, mid = await self._setup(client)
+        r = await client.post(
+            f"/v1/sessions/{sid}/query/plan",
+            json={
+                "model_id": mid,
+                "query": {
+                    "select": {
+                        "dimensions": ["Customer Country"],
+                        "measures": ["Total Revenue"],
+                    },
+                },
+                "dialect": "postgres",
+            },
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["status"] == "ok"
+        assert data["would_compile"] is True
+        assert data["planner"] == "Star Schema"
+        assert data["compiled_sql_length_estimate"] > 0
+        assert data["database_explain"] is None
+        # Physical tables include both dataObjects involved
+        assert any("ORDERS" in t for t in data["physical_tables"])
+        assert any("CUSTOMERS" in t for t in data["physical_tables"])
+        # Join path has the expected step
+        assert len(data["join_path"]) >= 1
+        step = data["join_path"][0]
+        assert step["cardinality"] == "many-to-one"
+
+    async def test_plan_invalid_query_returns_error_status(self, client: AsyncClient) -> None:
+        sid, mid = await self._setup(client)
+        r = await client.post(
+            f"/v1/sessions/{sid}/query/plan",
+            json={
+                "model_id": mid,
+                "query": {
+                    "select": {
+                        "dimensions": ["No Such Dim"],
+                        "measures": ["Total Revenue"],
+                    },
+                },
+                "dialect": "postgres",
+            },
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["status"] == "error"
+        assert data["would_compile"] is False
+        assert len(data["warnings"]) > 0
+
+    async def test_plan_database_explain_unavailable_emits_warning(
+        self, client: AsyncClient
+    ) -> None:
+        sid, mid = await self._setup(client)
+        r = await client.post(
+            f"/v1/sessions/{sid}/query/plan",
+            json={
+                "model_id": mid,
+                "query": {
+                    "select": {
+                        "dimensions": ["Customer Country"],
+                        "measures": ["Total Revenue"],
+                    },
+                },
+                "dialect": "postgres",
+                "include_database_explain": True,
+            },
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["status"] == "ok"
+        # Without QUERY_EXECUTE the EXPLAIN call surfaces as a warning,
+        # but the OBSL plan is still returned.
+        if data["database_explain"] is None:
+            assert any(w["code"] == "DATABASE_EXPLAIN_FAILED" for w in data["warnings"])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_model_api.py
+++ b/tests/integration/test_model_api.py
@@ -280,6 +280,59 @@ class TestSearch:
         results = resp.json()["results"]
         assert all(r["type"] == "dimension" for r in results)
 
+    async def test_find_exact_synonym_buckets_present(
+        self, client: AsyncClient, session_with_model: tuple[str, str]
+    ) -> None:
+        """Phase 4: response splits exact / synonym / fuzzy."""
+        sid, mid = session_with_model
+        resp = await client.post(
+            f"/v1/sessions/{sid}/models/{mid}/find",
+            json={"query": "Revenue"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "exact_matches" in data
+        assert "synonym_matches" in data
+        assert "fuzzy_matches" in data
+        # Revenue produces exact name hits — fuzzy is empty
+        assert data["fuzzy_matches"] == []
+        assert len(data["exact_matches"]) >= 2
+
+    async def test_find_fuzzy_fallback_on_misspelling(
+        self, client: AsyncClient, session_with_model: tuple[str, str]
+    ) -> None:
+        """Phase 4: misspelled query with no exact hits returns fuzzy candidates."""
+        sid, mid = session_with_model
+        resp = await client.post(
+            f"/v1/sessions/{sid}/models/{mid}/find",
+            json={"query": "Custmr Cuntry"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["exact_matches"] == []
+        assert data["synonym_matches"] == []
+        assert len(data["fuzzy_matches"]) > 0
+        # Each fuzzy match has score and reason
+        m = data["fuzzy_matches"][0]
+        assert "score" in m
+        assert "reason" in m
+        assert 0.0 <= m["score"] <= 1.0
+
+    async def test_find_no_match_no_fuzzy(
+        self, client: AsyncClient, session_with_model: tuple[str, str]
+    ) -> None:
+        """Phase 4: garbage query returns all-empty buckets."""
+        sid, mid = session_with_model
+        resp = await client.post(
+            f"/v1/sessions/{sid}/models/{mid}/find",
+            json={"query": "ZZQQXZ_random_garbage_99"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["exact_matches"] == []
+        assert data["synonym_matches"] == []
+        assert data["fuzzy_matches"] == []
+
 
 class TestJoinGraph:
     async def test_join_graph(
@@ -295,6 +348,100 @@ class TestJoinGraph:
         assert edge["from_object"] == "Orders"
         assert edge["to_object"] == "Customers"
         assert edge["cardinality"] == "many-to-one"
+
+
+# ---------------------------------------------------------------------------
+# Examples — PLAN_agent_api_improvements §5
+# ---------------------------------------------------------------------------
+
+
+_MODEL_WITH_EXAMPLES = (
+    SAMPLE_MODEL_YAML
+    + """
+examples:
+  - name: revenue_by_country
+    description: Total completed-order revenue by customer country.
+    intent_tags: [revenue, geography]
+    query:
+      select:
+        dimensions: [Customer Country]
+        measures: [Total Revenue]
+
+  - name: order_count_by_country
+    description: Number of orders per customer country.
+    intent_tags: [orders, geography]
+    query:
+      select:
+        dimensions: [Customer Country]
+        measures: [Order Count]
+"""
+)
+
+
+class TestExamples:
+    async def _load_with_examples(self, client: AsyncClient) -> tuple[str, str]:
+        sid = (await client.post("/v1/sessions")).json()["session_id"]
+        load = await client.post(
+            f"/v1/sessions/{sid}/models", json={"model_yaml": _MODEL_WITH_EXAMPLES}
+        )
+        assert load.status_code == 201, load.text
+        return sid, load.json()["model_id"]
+
+    async def test_list_examples_returns_summaries(self, client: AsyncClient) -> None:
+        sid, mid = await self._load_with_examples(client)
+        resp = await client.get(f"/v1/sessions/{sid}/models/{mid}/examples")
+        assert resp.status_code == 200
+        data = resp.json()
+        names = [e["name"] for e in data["examples"]]
+        assert "revenue_by_country" in names
+        assert "order_count_by_country" in names
+
+    async def test_list_examples_intent_filter_match(self, client: AsyncClient) -> None:
+        sid, mid = await self._load_with_examples(client)
+        resp = await client.get(
+            f"/v1/sessions/{sid}/models/{mid}/examples", params={"intent": "revenue"}
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["examples"]) == 1
+        assert data["examples"][0]["name"] == "revenue_by_country"
+
+    async def test_list_examples_intent_filter_miss_returns_suggestion(
+        self, client: AsyncClient
+    ) -> None:
+        sid, mid = await self._load_with_examples(client)
+        resp = await client.get(
+            f"/v1/sessions/{sid}/models/{mid}/examples", params={"intent": "xyz_unknown"}
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["examples"] == []
+        assert data["suggestion"] is not None
+        assert "available tags" in data["suggestion"]
+
+    async def test_get_single_example_returns_compiled_sql(self, client: AsyncClient) -> None:
+        sid, mid = await self._load_with_examples(client)
+        resp = await client.get(f"/v1/sessions/{sid}/models/{mid}/examples/revenue_by_country")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["name"] == "revenue_by_country"
+        assert "select" in data["query"]
+        # Compiled SQL preview is best-effort but should succeed for the sample model
+        assert data["compiled_sql_preview"] is not None
+        assert "SELECT" in data["compiled_sql_preview"]
+
+    async def test_get_unknown_example_returns_404(self, client: AsyncClient) -> None:
+        sid, mid = await self._load_with_examples(client)
+        resp = await client.get(f"/v1/sessions/{sid}/models/{mid}/examples/no_such_example")
+        assert resp.status_code == 404
+
+    async def test_model_without_examples_returns_empty_list(
+        self, client: AsyncClient, session_with_model: tuple[str, str]
+    ) -> None:
+        sid, mid = session_with_model
+        resp = await client.get(f"/v1/sessions/{sid}/models/{mid}/examples")
+        assert resp.status_code == 200
+        assert resp.json()["examples"] == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_oneshot_batch.py
+++ b/tests/integration/test_oneshot_batch.py
@@ -394,4 +394,7 @@ class TestOneshotBatchSettings:
         )
         assert r.status_code == 200
         data = r.json()
-        assert any("max_parallelism reduced" in w for w in data["batch_warnings"])
+        assert any(
+            w["code"] == "MAX_PARALLELISM_CAPPED" or "max_parallelism reduced" in w["message"]
+            for w in data["batch_warnings"]
+        )

--- a/tests/integration/test_oneshot_batch.py
+++ b/tests/integration/test_oneshot_batch.py
@@ -1,0 +1,357 @@
+"""Integration tests for the one-shot batch endpoint and model dedup behavior."""
+
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from orionbelt.api.app import create_app
+from orionbelt.api.deps import init_session_manager, reset_session_manager
+from orionbelt.service.session_manager import SessionManager
+from orionbelt.settings import Settings
+from tests.conftest import SAMPLE_MODEL_YAML
+
+
+@pytest.fixture
+def app():
+    settings = Settings(session_ttl_seconds=3600, session_cleanup_interval=9999)
+    app = create_app(settings=settings)
+    mgr = SessionManager(
+        ttl_seconds=settings.session_ttl_seconds,
+        max_age_seconds=settings.session_max_age_seconds,
+        max_sessions=settings.max_sessions,
+        max_models_per_session=settings.max_models_per_session,
+        cleanup_interval=settings.session_cleanup_interval,
+    )
+    init_session_manager(mgr)
+    yield app
+    reset_session_manager()
+
+
+@pytest.fixture
+async def client(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/sessions/{sid}/models — dedup behavior
+# ---------------------------------------------------------------------------
+
+
+class TestModelLoadDedup:
+    async def test_default_dedup_reuses_id(self, client: AsyncClient) -> None:
+        sid = (await client.post("/v1/sessions")).json()["session_id"]
+        r1 = await client.post(f"/v1/sessions/{sid}/models", json={"model_yaml": SAMPLE_MODEL_YAML})
+        r2 = await client.post(f"/v1/sessions/{sid}/models", json={"model_yaml": SAMPLE_MODEL_YAML})
+        assert r1.status_code == 201
+        assert r2.status_code == 201
+        d1, d2 = r1.json(), r2.json()
+        assert d1["model_id"] == d2["model_id"]
+        assert d1["model_load"] == "fresh"
+        assert d2["model_load"] == "reused"
+
+    async def test_dedup_false_forces_fresh(self, client: AsyncClient) -> None:
+        sid = (await client.post("/v1/sessions")).json()["session_id"]
+        r1 = await client.post(f"/v1/sessions/{sid}/models", json={"model_yaml": SAMPLE_MODEL_YAML})
+        r2 = await client.post(
+            f"/v1/sessions/{sid}/models",
+            json={"model_yaml": SAMPLE_MODEL_YAML, "dedup": False},
+        )
+        assert r1.json()["model_id"] != r2.json()["model_id"]
+        assert r2.json()["model_load"] == "fresh"
+
+    async def test_dedup_isolated_per_session(self, client: AsyncClient) -> None:
+        s1 = (await client.post("/v1/sessions")).json()["session_id"]
+        s2 = (await client.post("/v1/sessions")).json()["session_id"]
+        r1 = await client.post(f"/v1/sessions/{s1}/models", json={"model_yaml": SAMPLE_MODEL_YAML})
+        r2 = await client.post(f"/v1/sessions/{s2}/models", json={"model_yaml": SAMPLE_MODEL_YAML})
+        # Different sessions = different models, even with identical YAML.
+        assert r1.json()["model_id"] != r2.json()["model_id"]
+        assert r2.json()["model_load"] == "fresh"
+
+    async def test_dedup_after_remove_loads_fresh(self, client: AsyncClient) -> None:
+        sid = (await client.post("/v1/sessions")).json()["session_id"]
+        r1 = await client.post(f"/v1/sessions/{sid}/models", json={"model_yaml": SAMPLE_MODEL_YAML})
+        mid = r1.json()["model_id"]
+        await client.delete(f"/v1/sessions/{sid}/models/{mid}")
+        r2 = await client.post(f"/v1/sessions/{sid}/models", json={"model_yaml": SAMPLE_MODEL_YAML})
+        assert r2.json()["model_id"] != mid
+        assert r2.json()["model_load"] == "fresh"
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/oneshot/batch
+# ---------------------------------------------------------------------------
+
+
+_TWO_QUERIES = [
+    {
+        "id": "q1",
+        "query": {
+            "select": {
+                "dimensions": ["Customer Country"],
+                "measures": ["Total Revenue"],
+            }
+        },
+    },
+    {
+        "id": "q2",
+        "query": {"select": {"dimensions": ["Customer Country"], "measures": ["Order Count"]}},
+    },
+]
+
+
+class TestOneshotBatchValidation:
+    async def test_neither_yaml_nor_id(self, client: AsyncClient) -> None:
+        r = await client.post(
+            "/v1/oneshot/batch",
+            json={"queries": _TWO_QUERIES},
+        )
+        assert r.status_code == 422
+
+    async def test_both_yaml_and_id(self, client: AsyncClient) -> None:
+        r = await client.post(
+            "/v1/oneshot/batch",
+            json={
+                "model_yaml": SAMPLE_MODEL_YAML,
+                "model_id": "abcd1234",
+                "queries": _TWO_QUERIES,
+            },
+        )
+        assert r.status_code == 422
+
+    async def test_duplicate_query_ids(self, client: AsyncClient) -> None:
+        r = await client.post(
+            "/v1/oneshot/batch",
+            json={
+                "model_yaml": SAMPLE_MODEL_YAML,
+                "queries": [
+                    {"id": "same", "query": _TWO_QUERIES[0]["query"]},
+                    {"id": "same", "query": _TWO_QUERIES[1]["query"]},
+                ],
+            },
+        )
+        assert r.status_code == 422
+
+    async def test_empty_queries(self, client: AsyncClient) -> None:
+        r = await client.post(
+            "/v1/oneshot/batch",
+            json={"model_yaml": SAMPLE_MODEL_YAML, "queries": []},
+        )
+        assert r.status_code == 422
+
+    async def test_invalid_yaml(self, client: AsyncClient) -> None:
+        r = await client.post(
+            "/v1/oneshot/batch",
+            json={"model_yaml": "key: [unclosed", "queries": _TWO_QUERIES},
+        )
+        assert r.status_code == 422
+
+
+class TestOneshotBatchHappyPath:
+    async def test_load_yaml_compile_only(self, client: AsyncClient) -> None:
+        r = await client.post(
+            "/v1/oneshot/batch",
+            json={"model_yaml": SAMPLE_MODEL_YAML, "queries": _TWO_QUERIES},
+        )
+        assert r.status_code == 200, r.text
+        data = r.json()
+        assert "session_id" in data
+        assert "model_id" in data
+        assert data["model_persisted"] is False  # default persist_model=false
+        assert data["model_load"] == "fresh"
+        assert len(data["results"]) == 2
+        ids = [res["id"] for res in data["results"]]
+        assert ids == ["q1", "q2"]
+        for res in data["results"]:
+            assert res["status"] == "ok"
+            assert res["sql"]
+            assert res["dialect"]
+            assert res["executed"] is False
+
+    async def test_persist_model_keeps_id_addressable(self, client: AsyncClient) -> None:
+        r = await client.post(
+            "/v1/oneshot/batch",
+            json={
+                "model_yaml": SAMPLE_MODEL_YAML,
+                "queries": _TWO_QUERIES,
+                "persist_model": True,
+            },
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["model_persisted"] is True
+        sid, mid = data["session_id"], data["model_id"]
+        # Model should be addressable via the existing endpoints.
+        r2 = await client.get(f"/v1/sessions/{sid}/models/{mid}")
+        assert r2.status_code == 200
+
+    async def test_persist_false_evicts_model(self, client: AsyncClient) -> None:
+        r = await client.post(
+            "/v1/oneshot/batch",
+            json={
+                "model_yaml": SAMPLE_MODEL_YAML,
+                "queries": _TWO_QUERIES,
+                "persist_model": False,
+            },
+        )
+        data = r.json()
+        sid, mid = data["session_id"], data["model_id"]
+        r2 = await client.get(f"/v1/sessions/{sid}/models/{mid}")
+        assert r2.status_code == 404
+
+    async def test_referenced_model_id(self, client: AsyncClient) -> None:
+        # Pre-load a model into a session, then batch against it via model_id.
+        sid = (await client.post("/v1/sessions")).json()["session_id"]
+        load = await client.post(
+            f"/v1/sessions/{sid}/models", json={"model_yaml": SAMPLE_MODEL_YAML}
+        )
+        mid = load.json()["model_id"]
+        r = await client.post(
+            "/v1/oneshot/batch",
+            json={
+                "session_id": sid,
+                "model_id": mid,
+                "queries": _TWO_QUERIES,
+            },
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["session_id"] == sid
+        assert data["model_id"] == mid
+        assert data["model_load"] == "referenced"
+        assert data["model_persisted"] is True
+        # The referenced model is left in place regardless of persist_model.
+        r2 = await client.get(f"/v1/sessions/{sid}/models/{mid}")
+        assert r2.status_code == 200
+
+    async def test_dedup_in_batch_reuses_loaded_model(self, client: AsyncClient) -> None:
+        sid = (await client.post("/v1/sessions")).json()["session_id"]
+        # Pre-load identical content with persist=true via the standard endpoint.
+        first = await client.post(
+            f"/v1/sessions/{sid}/models", json={"model_yaml": SAMPLE_MODEL_YAML}
+        )
+        original_mid = first.json()["model_id"]
+        # Batch with same yaml + persist_model=True should reuse, not re-parse.
+        r = await client.post(
+            "/v1/oneshot/batch",
+            json={
+                "session_id": sid,
+                "model_yaml": SAMPLE_MODEL_YAML,
+                "queries": _TWO_QUERIES,
+                "persist_model": True,
+            },
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["model_id"] == original_mid
+        assert data["model_load"] == "reused"
+
+    async def test_per_query_error_does_not_fail_batch(self, client: AsyncClient) -> None:
+        bad_queries = [
+            _TWO_QUERIES[0],
+            {
+                "id": "bad",
+                "query": {
+                    "select": {
+                        "dimensions": ["Nonexistent Dimension"],
+                        "measures": ["Total Revenue"],
+                    }
+                },
+            },
+        ]
+        r = await client.post(
+            "/v1/oneshot/batch",
+            json={"model_yaml": SAMPLE_MODEL_YAML, "queries": bad_queries},
+        )
+        assert r.status_code == 200
+        results = r.json()["results"]
+        assert results[0]["status"] == "ok"
+        assert results[1]["status"] == "error"
+        assert results[1]["error"]["code"]
+
+    async def test_fail_fast_cancels_remaining(self, client: AsyncClient) -> None:
+        bad_queries = [
+            {
+                "id": "bad",
+                "query": {
+                    "select": {
+                        "dimensions": ["Nonexistent Dimension"],
+                        "measures": ["Total Revenue"],
+                    }
+                },
+            },
+            _TWO_QUERIES[0],
+            _TWO_QUERIES[1],
+        ]
+        r = await client.post(
+            "/v1/oneshot/batch",
+            json={
+                "model_yaml": SAMPLE_MODEL_YAML,
+                "queries": bad_queries,
+                "fail_fast": True,
+            },
+        )
+        assert r.status_code == 200
+        results = r.json()["results"]
+        statuses = [res["status"] for res in results]
+        assert statuses[0] == "error"
+        assert statuses[1] == "cancelled"
+        assert statuses[2] == "cancelled"
+
+    async def test_dedup_false_in_batch(self, client: AsyncClient) -> None:
+        sid = (await client.post("/v1/sessions")).json()["session_id"]
+        first = await client.post(
+            f"/v1/sessions/{sid}/models", json={"model_yaml": SAMPLE_MODEL_YAML}
+        )
+        original_mid = first.json()["model_id"]
+        r = await client.post(
+            "/v1/oneshot/batch",
+            json={
+                "session_id": sid,
+                "model_yaml": SAMPLE_MODEL_YAML,
+                "queries": _TWO_QUERIES,
+                "dedup": False,
+                "persist_model": True,
+            },
+        )
+        data = r.json()
+        assert data["model_id"] != original_mid
+        assert data["model_load"] == "fresh"
+
+
+class TestOneshotBatchSettings:
+    async def test_settings_exposes_batch_limits(self, client: AsyncClient) -> None:
+        r = await client.get("/v1/settings")
+        assert r.status_code == 200
+        data = r.json()
+        assert "oneshot_batch" in data
+        cfg = data["oneshot_batch"]
+        assert cfg["max_queries"] >= 1
+        assert cfg["max_parallelism"] >= 1
+        assert cfg["default_timeout_ms"] > 0
+        assert cfg["batch_timeout_ms"] > 0
+
+    async def test_max_queries_enforced(self, client: AsyncClient) -> None:
+        # Crank in 51 queries — over the default cap of 50.
+        many = [{"id": f"q{i}", "query": _TWO_QUERIES[0]["query"]} for i in range(51)]
+        r = await client.post(
+            "/v1/oneshot/batch",
+            json={"model_yaml": SAMPLE_MODEL_YAML, "queries": many},
+        )
+        assert r.status_code == 422
+
+    async def test_max_parallelism_silently_capped(self, client: AsyncClient) -> None:
+        r = await client.post(
+            "/v1/oneshot/batch",
+            json={
+                "model_yaml": SAMPLE_MODEL_YAML,
+                "queries": _TWO_QUERIES,
+                "max_parallelism": 999,
+            },
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert any("max_parallelism reduced" in w for w in data["batch_warnings"])

--- a/tests/integration/test_oneshot_batch.py
+++ b/tests/integration/test_oneshot_batch.py
@@ -142,6 +142,46 @@ class TestOneshotBatchValidation:
         )
         assert r.status_code == 422
 
+    async def test_auto_assigned_ids(self, client: AsyncClient) -> None:
+        # Omit id on every query — server fills in q0, q1.
+        no_id_queries = [
+            {"query": _TWO_QUERIES[0]["query"]},
+            {"query": _TWO_QUERIES[1]["query"]},
+        ]
+        r = await client.post(
+            "/v1/oneshot/batch",
+            json={"model_yaml": SAMPLE_MODEL_YAML, "queries": no_id_queries},
+        )
+        assert r.status_code == 200, r.text
+        ids = [res["id"] for res in r.json()["results"]]
+        assert ids == ["q0", "q1"]
+
+    async def test_mixed_explicit_and_auto_ids(self, client: AsyncClient) -> None:
+        # Mix: explicit id on the second only — first gets auto "q0".
+        mixed = [
+            {"query": _TWO_QUERIES[0]["query"]},
+            {"id": "named", "query": _TWO_QUERIES[1]["query"]},
+        ]
+        r = await client.post(
+            "/v1/oneshot/batch",
+            json={"model_yaml": SAMPLE_MODEL_YAML, "queries": mixed},
+        )
+        assert r.status_code == 200
+        ids = [res["id"] for res in r.json()["results"]]
+        assert ids == ["q0", "named"]
+
+    async def test_explicit_id_collides_with_auto_pattern(self, client: AsyncClient) -> None:
+        # Slot 0 auto-assigns "q0"; the explicit "q0" at slot 1 collides.
+        clashing = [
+            {"query": _TWO_QUERIES[0]["query"]},
+            {"id": "q0", "query": _TWO_QUERIES[1]["query"]},
+        ]
+        r = await client.post(
+            "/v1/oneshot/batch",
+            json={"model_yaml": SAMPLE_MODEL_YAML, "queries": clashing},
+        )
+        assert r.status_code == 422
+
     async def test_invalid_yaml(self, client: AsyncClient) -> None:
         r = await client.post(
             "/v1/oneshot/batch",

--- a/tests/unit/test_fanout.py
+++ b/tests/unit/test_fanout.py
@@ -456,9 +456,10 @@ class TestJunctionTableFanout:
         detect_fanout(resolved, model)  # should NOT raise
         # COUNT is additive — two junctions produce two warnings
         assert len(resolved.warnings) == 2
-        assert all("cross-join" in w for w in resolved.warnings)
-        assert any("Movie Directors" in w for w in resolved.warnings)
-        assert any("Movie Producers" in w for w in resolved.warnings)
+        assert all("cross-join" in w.message for w in resolved.warnings)
+        assert all(w.code == "FAN_TRAP_RISK" for w in resolved.warnings)
+        assert any("Movie Directors" in w.message for w in resolved.warnings)
+        assert any("Movie Producers" in w.message for w in resolved.warnings)
 
     def test_junction_fanout_resolved_single_dim(self) -> None:
         """Director + Movies Cnt (no Producer): fanout through Movie Directors
@@ -509,7 +510,7 @@ class TestJunctionTableFanout:
         )
         detect_fanout(resolved, model)  # should NOT raise
         assert len(resolved.warnings) == 1
-        assert "Movie Directors" in resolved.warnings[0]
+        assert "Movie Directors" in resolved.warnings[0].message
 
     def test_junction_no_warning_for_non_additive(self) -> None:
         """MIN/MAX aggregations don't produce inflated totals — no warning."""

--- a/tests/unit/test_fuzzy.py
+++ b/tests/unit/test_fuzzy.py
@@ -1,0 +1,58 @@
+"""Tests for service.fuzzy — Levenshtein + trigram fuzzy matching."""
+
+from __future__ import annotations
+
+from orionbelt.service.fuzzy import fuzzy_score, fuzzy_search
+
+
+class TestFuzzyScore:
+    def test_identical_strings_score_one(self) -> None:
+        score, _ = fuzzy_score("Country", "Country")
+        assert score == 1.0
+
+    def test_one_character_off_scores_high(self) -> None:
+        score, _ = fuzzy_score("Country", "Countryy")
+        assert score > 0.7
+
+    def test_unrelated_strings_score_low(self) -> None:
+        score, _ = fuzzy_score("Region", "Sales Tax")
+        assert score < 0.3
+
+    def test_case_insensitive(self) -> None:
+        s1, _ = fuzzy_score("country", "COUNTRY")
+        s2, _ = fuzzy_score("Country", "Country")
+        assert s1 == s2 == 1.0
+
+
+class TestFuzzySearch:
+    def _candidates(self) -> list[tuple[str, str, list[str]]]:
+        return [
+            ("Customer Country", "dimension", []),
+            ("Sales Region", "dimension", ["region"]),
+            ("Product Category", "dimension", []),
+            ("Total Revenue", "measure", []),
+        ]
+
+    def test_misspelling_matches_close_candidate(self) -> None:
+        results = fuzzy_search("Region", self._candidates())
+        names = [m.name for m in results]
+        assert "Sales Region" in names
+
+    def test_threshold_filters_garbage(self) -> None:
+        results = fuzzy_search("XQZ123", self._candidates(), threshold=0.5)
+        assert results == []
+
+    def test_synonym_match_via_fuzzy(self) -> None:
+        # "regn" is close to the synonym "region" via trigrams
+        results = fuzzy_search("regn", self._candidates(), threshold=0.3)
+        assert any(m.name == "Sales Region" for m in results)
+
+    def test_max_results_caps_count(self) -> None:
+        large = [(f"Field {i}", "dimension", []) for i in range(20)]
+        results = fuzzy_search("Field", large, threshold=0.3, max_results=5)
+        assert len(results) <= 5
+
+    def test_results_sorted_by_score_desc(self) -> None:
+        results = fuzzy_search("Custome", self._candidates(), threshold=0.3)
+        scores = [m.score for m in results]
+        assert scores == sorted(scores, reverse=True)

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -1,0 +1,213 @@
+"""Tests for compiler.health — structural model health metrics."""
+
+from __future__ import annotations
+
+import pytest
+
+from orionbelt.compiler.health import compute_health
+from orionbelt.parser.loader import TrackedLoader
+from orionbelt.parser.resolver import ReferenceResolver
+
+_TWO_FACTS_SHARED_DIM = """\
+version: 1.0
+dataObjects:
+  Customers:
+    code: CUSTOMERS
+    database: WH
+    schema: PUBLIC
+    columns:
+      Customer ID:
+        code: CUSTOMER_ID
+        abstractType: string
+      Country:
+        code: COUNTRY
+        abstractType: string
+  Orders:
+    code: ORDERS
+    database: WH
+    schema: PUBLIC
+    columns:
+      Order ID:
+        code: ORDER_ID
+        abstractType: string
+      Customer ID:
+        code: CUSTOMER_ID
+        abstractType: string
+      Amount:
+        code: AMOUNT
+        abstractType: float
+    joins:
+      - joinType: many-to-one
+        joinTo: Customers
+        columnsFrom: [Customer ID]
+        columnsTo: [Customer ID]
+  Returns:
+    code: RETURNS
+    database: WH
+    schema: PUBLIC
+    columns:
+      Return ID:
+        code: RETURN_ID
+        abstractType: string
+      Customer ID:
+        code: CUSTOMER_ID
+        abstractType: string
+      Refund:
+        code: REFUND
+        abstractType: float
+    joins:
+      - joinType: many-to-one
+        joinTo: Customers
+        columnsFrom: [Customer ID]
+        columnsTo: [Customer ID]
+dimensions:
+  Country:
+    dataObject: Customers
+    column: Country
+    resultType: string
+measures:
+  Total Amount:
+    columns: [{dataObject: Orders, column: Amount}]
+    aggregation: sum
+    resultType: float
+  Total Refund:
+    columns: [{dataObject: Returns, column: Refund}]
+    aggregation: sum
+    resultType: float
+"""
+
+_ORPHAN_MODEL = """\
+version: 1.0
+dataObjects:
+  Orders:
+    code: ORDERS
+    database: WH
+    schema: PUBLIC
+    columns:
+      Order ID:
+        code: ORDER_ID
+        abstractType: string
+      Customer ID:
+        code: CUSTOMER_ID
+        abstractType: string
+      Amount:
+        code: AMOUNT
+        abstractType: float
+    joins:
+      - joinType: many-to-one
+        joinTo: Customers
+        columnsFrom: [Customer ID]
+        columnsTo: [Customer ID]
+  Customers:
+    code: CUSTOMERS
+    database: WH
+    schema: PUBLIC
+    columns:
+      Customer ID:
+        code: CUSTOMER_ID
+        abstractType: string
+      Country:
+        code: COUNTRY
+        abstractType: string
+  Marketing:
+    code: MARKETING
+    database: WH
+    schema: PUBLIC
+    columns:
+      Campaign ID:
+        code: CAMPAIGN_ID
+        abstractType: string
+      Spend:
+        code: SPEND
+        abstractType: float
+dimensions:
+  Country:
+    dataObject: Customers
+    column: Country
+    resultType: string
+measures:
+  Order Amount:
+    columns: [{dataObject: Orders, column: Amount}]
+    aggregation: sum
+    resultType: float
+"""
+
+
+@pytest.fixture
+def loader() -> TrackedLoader:
+    return TrackedLoader()
+
+
+@pytest.fixture
+def resolver() -> ReferenceResolver:
+    return ReferenceResolver()
+
+
+def _resolve(yaml_str: str, loader: TrackedLoader, resolver: ReferenceResolver):
+    raw, source_map = loader.load_string(yaml_str)
+    model, result = resolver.resolve(raw, source_map)
+    assert result.valid, result.errors
+    return model
+
+
+class TestComputeHealth:
+    def test_clean_model_returns_ok(
+        self, loader: TrackedLoader, resolver: ReferenceResolver
+    ) -> None:
+        from tests.conftest import SAMPLE_MODEL_YAML
+
+        model = _resolve(SAMPLE_MODEL_YAML, loader, resolver)
+        h = compute_health(model)
+        assert h.status == "ok"
+        assert h.data_objects == 2
+        assert h.joins == 1
+        assert h.orphan_data_objects == []
+        assert h.fan_trap_risks == []
+        assert h.unreachable_dimensions == []
+        assert h.warnings_count == 0
+
+    def test_orphan_data_object_detected(
+        self, loader: TrackedLoader, resolver: ReferenceResolver
+    ) -> None:
+        model = _resolve(_ORPHAN_MODEL, loader, resolver)
+        h = compute_health(model)
+        assert h.status == "warnings"
+        assert "Marketing" in h.orphan_data_objects
+        assert h.warnings_count >= 1
+
+    def test_fan_trap_risk_detected(
+        self, loader: TrackedLoader, resolver: ReferenceResolver
+    ) -> None:
+        model = _resolve(_TWO_FACTS_SHARED_DIM, loader, resolver)
+        h = compute_health(model)
+        assert len(h.fan_trap_risks) == 1
+        risk = h.fan_trap_risks[0]
+        assert "WH.PUBLIC.ORDERS" in risk.tables
+        assert "WH.PUBLIC.RETURNS" in risk.tables
+        assert risk.suggested_pattern == "composite_fact_layer"
+        assert h.status == "warnings"
+
+    def test_single_data_object_not_orphan(
+        self, loader: TrackedLoader, resolver: ReferenceResolver
+    ) -> None:
+        single = """\
+version: 1.0
+dataObjects:
+  Orders:
+    code: ORDERS
+    database: WH
+    schema: PUBLIC
+    columns:
+      Amount:
+        code: AMOUNT
+        abstractType: float
+measures:
+  Revenue:
+    columns: [{dataObject: Orders, column: Amount}]
+    aggregation: sum
+    resultType: float
+"""
+        model = _resolve(single, loader, resolver)
+        h = compute_health(model)
+        assert h.orphan_data_objects == []
+        assert h.status == "ok"

--- a/tests/unit/test_model_store.py
+++ b/tests/unit/test_model_store.py
@@ -124,8 +124,10 @@ class TestListModels:
         assert store.list_models() == []
 
     def test_list_after_load(self, store: ModelStore) -> None:
-        r1 = store.load_model(SAMPLE_MODEL_YAML)
-        r2 = store.load_model(SAMPLE_MODEL_YAML)
+        # dedup=False so each load creates a new model — needed to verify list semantics.
+        r1 = store.load_model(SAMPLE_MODEL_YAML, dedup=False)
+        r2 = store.load_model(SAMPLE_MODEL_YAML, dedup=False)
+        assert r1.model_id != r2.model_id
         models = store.list_models()
         assert len(models) == 2
         ids = {m.model_id for m in models}
@@ -176,6 +178,61 @@ dimensions:
 # ---------------------------------------------------------------------------
 # compile_query
 # ---------------------------------------------------------------------------
+
+
+class TestDedup:
+    """Cover the dedup behavior added in v2.2.0 (PLAN_model_load_dedup.md)."""
+
+    def test_same_yaml_reuses_model_id(self, store: ModelStore) -> None:
+        r1 = store.load_model(SAMPLE_MODEL_YAML)
+        r2 = store.load_model(SAMPLE_MODEL_YAML)
+        assert r1.model_id == r2.model_id
+        assert r1.model_load == "fresh"
+        assert r2.model_load == "reused"
+        # Counts on the reused result come from the cached summary.
+        assert r2.data_objects == r1.data_objects
+        assert r2.dimensions == r1.dimensions
+        assert r2.measures == r1.measures
+        assert r2.metrics == r1.metrics
+
+    def test_dedup_false_forces_fresh_load(self, store: ModelStore) -> None:
+        r1 = store.load_model(SAMPLE_MODEL_YAML)
+        r2 = store.load_model(SAMPLE_MODEL_YAML, dedup=False)
+        assert r1.model_id != r2.model_id
+        assert r2.model_load == "fresh"
+
+    def test_trailing_whitespace_normalized(self, store: ModelStore) -> None:
+        r1 = store.load_model(SAMPLE_MODEL_YAML)
+        r2 = store.load_model("\n\n" + SAMPLE_MODEL_YAML + "\n\n")
+        assert r1.model_id == r2.model_id
+
+    def test_different_yaml_loads_separately(self, store: ModelStore) -> None:
+        # Add a comment — different bytes, different hash, fresh load.
+        r1 = store.load_model(SAMPLE_MODEL_YAML)
+        r2 = store.load_model("# variant\n" + SAMPLE_MODEL_YAML)
+        assert r1.model_id != r2.model_id
+        assert r2.model_load == "fresh"
+
+    def test_remove_clears_index(self, store: ModelStore) -> None:
+        r1 = store.load_model(SAMPLE_MODEL_YAML)
+        store.remove_model(r1.model_id)
+        # No stale index entry — same content loads fresh.
+        r2 = store.load_model(SAMPLE_MODEL_YAML)
+        assert r2.model_id != r1.model_id
+        assert r2.model_load == "fresh"
+
+    def test_dedup_skipped_when_extends_provided(self, store: ModelStore) -> None:
+        # extends/inherits make the effective content depend on input the
+        # YAML bytes don't capture — dedup must not apply.
+        r1 = store.load_model(SAMPLE_MODEL_YAML)
+        r2 = store.load_model(SAMPLE_MODEL_YAML, extends_yaml=[])
+        # Empty extends list still bypasses dedup eligibility check
+        # (see load_model: `not extends_yaml` is True for [], so dedup runs).
+        # Verify the inverse: a non-empty extends bypasses dedup.
+        del r2  # unused
+        r3 = store.load_model(SAMPLE_MODEL_YAML, extends_yaml=["version: 1.0\n"])
+        assert r3.model_id != r1.model_id
+        assert r3.model_load == "fresh"
 
 
 class TestCompileQuery:

--- a/tests/unit/test_session_manager.py
+++ b/tests/unit/test_session_manager.py
@@ -206,10 +206,12 @@ class TestModelCap:
 
         from tests.conftest import SAMPLE_MODEL_YAML
 
-        store.load_model(SAMPLE_MODEL_YAML)
-        store.load_model(SAMPLE_MODEL_YAML)
+        # dedup=False so each load creates a fresh model and counts toward
+        # the per-session model cap.
+        store.load_model(SAMPLE_MODEL_YAML, dedup=False)
+        store.load_model(SAMPLE_MODEL_YAML, dedup=False)
         with pytest.raises(ModelCapacityError, match="Maximum"):
-            store.load_model(SAMPLE_MODEL_YAML)
+            store.load_model(SAMPLE_MODEL_YAML, dedup=False)
 
     def test_model_cap_frees_after_remove(self) -> None:
         mgr = SessionManager(
@@ -223,11 +225,11 @@ class TestModelCap:
 
         from tests.conftest import SAMPLE_MODEL_YAML
 
-        result = store.load_model(SAMPLE_MODEL_YAML)
+        result = store.load_model(SAMPLE_MODEL_YAML, dedup=False)
         with pytest.raises(ModelCapacityError):
-            store.load_model(SAMPLE_MODEL_YAML)
+            store.load_model(SAMPLE_MODEL_YAML, dedup=False)
         store.remove_model(result.model_id)
-        store.load_model(SAMPLE_MODEL_YAML)  # should succeed now
+        store.load_model(SAMPLE_MODEL_YAML, dedup=False)  # should succeed now
 
     def test_model_cap_enforced_under_concurrency(self) -> None:
         """Concurrent load_model() calls must not exceed the cap."""
@@ -246,7 +248,8 @@ class TestModelCap:
 
         def _load() -> object:
             try:
-                return store.load_model(SAMPLE_MODEL_YAML)
+                # dedup=False so each request actually competes for a model slot.
+                return store.load_model(SAMPLE_MODEL_YAML, dedup=False)
             except (ModelCapacityError, ModelValidationError) as exc:  # noqa: UP038
                 return exc
 

--- a/uv.lock
+++ b/uv.lock
@@ -2229,7 +2229,7 @@ wheels = [
 
 [[package]]
 name = "orionbelt-semantic-layer"
-version = "2.1.4"
+version = "2.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

Implements all five items in `design/PLAN_agent_api_improvements.md`. Each phase is independently shippable; bundled here because they share an audience (agents) and a common shape (structured warnings) that the other phases reuse.

## Phases

- **Phase 1 — Structured warnings.** `WarningCode` taxonomy (`FAN_TRAP_RISK`, `POP_CONSTRAINT_VIOLATED`, `GRAIN_OVERRIDE_INCOMPATIBLE`, …) and a public `StructuredWarning` shape (`code, severity, message, path, hint, context`). Replaces every plain-string `warnings` list across the API. Agents branch on stable codes instead of parsing message text.
- **Phase 2 — Join graph health.** `ModelLoadResponse` now carries a `health` block (status, counts, orphan dataObjects, fan-trap risks with qualified table names, unreachable dimensions). Computed during load — no extra round trip.
- **Phase 3 — Query plan endpoint.** `POST /v1/sessions/{sid}/query/plan` returns the planner's understanding (planner choice, physical tables, join path with cardinality, `would_compile`) without compiling SQL or executing. Opt-in `include_database_explain` flag adds the warehouse's raw `EXPLAIN` text; failures degrade to a `DATABASE_EXPLAIN_FAILED` warning rather than dropping the OBSL plan.
- **Phase 4 — Fuzzy `/find`.** Deterministic Levenshtein + trigram-Jaccard fallback (no new deps). Response splits `exact_matches` / `synonym_matches` / `fuzzy_matches`; fuzzy fires only when the first two are empty. Top 10 above a 0.5 threshold, with `score` and `reason`.
- **Phase 5 — Model examples.** Optional OBML `examples:` block (`name`, `description`, `intent_tags`, `query`). New endpoints `GET .../examples` (with `?intent=` filter — exact → contains → fuzzy fallback, plus a `suggestion` listing available tags on a miss) and `GET .../examples/{name}` returning the full payload with a best-effort `compiled_sql_preview`. JSON Schema updated.

## Breaking change

`warnings` lists in API responses now contain objects (`{code, severity, message, path, hint, context}`) instead of strings. Forward-compatible for clients reading `.message`; clients can now branch on `.code`.

## Files

- New: `models/warnings.py`, `compiler/health.py`, `service/fuzzy.py`, `api/warnings_adapter.py`
- Updated: `models/{errors,semantic,__init__}.py`, `compiler/{pipeline,fanout,resolution}.py`, `service/{model_store,db_executor}.py`, `api/{schemas,routers/sessions,routers/oneshot,routers/shortcuts,routers/model_api}.py`, `parser/resolver.py`, `schema/obml-schema.json`
- Docs: `README.md`, `docs/api/endpoints.md`, `docs/guide/model-format.md`

## Test plan

- [x] 1405 unit + integration tests pass (+25 new across `test_health.py`, `test_fuzzy.py`, plan/find/examples integration tests)
- [x] `uv run ruff check src/ tests/` clean
- [x] `uv run ruff format src/ tests/` applied
- [x] `uv run mypy src/` clean
- [x] `uv run mkdocs build --strict` clean
- [ ] Manual smoke: load model → check `health` block; call `/query/plan` with and without `include_database_explain`; misspell a name in `/find` and verify fuzzy fallback; load a model with `examples:` and call `/examples?intent=...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)