### PR TITLE
feat(pgwire): Step 1 — hello-world Postgres wire surface

### DIFF
--- a/src/orionbelt/api/app.py
+++ b/src/orionbelt/api/app.py
@@ -390,9 +390,20 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
                 "Install with: uv sync --extra flight"
             )
 
+    # Start Postgres wire surface if PGWIRE_ENABLED=true. Step 1 ships a
+    # hardcoded SELECT-1 handler; later steps wire the semantic router.
+    # See design/PLAN_postgres_wire.md.
+    pgwire_runtime = None
+    if settings.pgwire_enabled:
+        from orionbelt.pgwire.startup import start_pgwire
+
+        pgwire_runtime = await start_pgwire(settings)
+
     try:
         yield
     finally:
+        if pgwire_runtime is not None:
+            await pgwire_runtime.shutdown()
         if flight_thread is not None:
             from ob_flight.startup import stop_flight_server
 

--- a/src/orionbelt/pgwire/__init__.py
+++ b/src/orionbelt/pgwire/__init__.py
@@ -1,0 +1,12 @@
+"""Postgres v3 wire protocol surface for OBSL.
+
+See design/PLAN_postgres_wire.md. Step 1 ships the connection handshake
+and a hardcoded ``SELECT 1`` simple-query responder; later steps wire
+the semantic-SQL router, catalog emulation, and the extended protocol.
+"""
+
+from __future__ import annotations
+
+from orionbelt.pgwire.server import PgWireServer
+
+__all__ = ["PgWireServer"]

--- a/src/orionbelt/pgwire/auth.py
+++ b/src/orionbelt/pgwire/auth.py
@@ -1,0 +1,58 @@
+"""Authentication seam for the Postgres wire surface.
+
+Step 1 supports ``trust`` mode only — the server accepts every
+StartupMessage and responds with AuthenticationOk. The function
+signature is shaped so the unified-auth keystore (see
+design/PLAN_unified_auth.md) drops in at Step 6 without touching
+``server.py``:
+
+* ``trust``       → returns ``AuthResult(ok=True)`` immediately.
+* ``password``    → server sends AuthenticationCleartextPassword,
+                    reads the PasswordMessage, and calls this with the
+                    raw password. The keystore validator goes here.
+* ``scram-sha-256`` → multi-step SASL exchange — caller drives the
+                      handshake and consults this module to compare
+                      stored verifiers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from orionbelt.pgwire.protocol import StartupMessage
+
+
+@dataclass(frozen=True)
+class AuthResult:
+    """Outcome of an authentication attempt."""
+
+    ok: bool
+    error_message: str = ""
+
+
+def authenticate(
+    *,
+    auth_mode: str,
+    startup: StartupMessage,
+    password: str | None = None,
+) -> AuthResult:
+    """Validate a connection attempt.
+
+    Step 1 implements only ``trust``. Future modes share this signature.
+    """
+
+    if auth_mode == "trust":
+        return AuthResult(ok=True)
+
+    if auth_mode in {"password", "scram-sha-256"}:
+        # Step 6 wiring. Calling these today is a programmer error rather
+        # than a client error — fail loudly so the misconfig is obvious.
+        raise NotImplementedError(
+            f"pgwire auth_mode={auth_mode!r} lands in Step 6 alongside "
+            "the unified auth keystore (design/PLAN_unified_auth.md)."
+        )
+
+    return AuthResult(
+        ok=False,
+        error_message=f"Unknown pgwire auth_mode: {auth_mode!r}",
+    )

--- a/src/orionbelt/pgwire/protocol.py
+++ b/src/orionbelt/pgwire/protocol.py
@@ -1,0 +1,219 @@
+"""Postgres v3 wire-protocol frame readers and writers.
+
+Pure I/O helpers — no business logic. The protocol is described in
+PostgreSQL docs §52. Step 1 implements only the messages the
+``SELECT 1`` happy path needs:
+
+* Reads  — StartupMessage, Query (Q), Terminate (X), SSLRequest (peek)
+* Writes — AuthenticationOk, ParameterStatus, BackendKeyData,
+           ReadyForQuery, RowDescription, DataRow, CommandComplete,
+           ErrorResponse, NoticeResponse
+
+Subsequent steps grow this module; keep additions framework-free so the
+server loop stays the only place that owns sockets.
+"""
+
+from __future__ import annotations
+
+import struct
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Final
+
+ReadExactly = Callable[[int], Awaitable[bytes]]
+
+# Postgres protocol version 3.0 == 0x00030000.
+PROTOCOL_VERSION_3: Final[int] = 196608
+
+# SSLRequest sentinel — Postgres clients negotiate TLS by sending an
+# 8-byte packet with this magic int as the protocol version slot.
+SSL_REQUEST_CODE: Final[int] = 80877103
+
+# Common type OIDs (subset, full mapping lives in pgwire/types.py later).
+OID_TEXT: Final[int] = 25
+OID_INT4: Final[int] = 23
+
+# Transaction status flags returned in ReadyForQuery.
+TX_IDLE: Final[bytes] = b"I"
+
+
+class ProtocolError(Exception):
+    """Raised on malformed or unsupported wire frames."""
+
+
+@dataclass(frozen=True)
+class StartupMessage:
+    """Parsed StartupMessage payload."""
+
+    protocol_version: int
+    parameters: dict[str, str]
+
+    @property
+    def user(self) -> str:
+        return self.parameters.get("user", "")
+
+    @property
+    def database(self) -> str:
+        return self.parameters.get("database", self.user)
+
+
+@dataclass(frozen=True)
+class QueryMessage:
+    """Simple-query Q frame payload."""
+
+    sql: str
+
+
+# ---------------------------------------------------------------------------
+# Readers
+# ---------------------------------------------------------------------------
+
+
+async def read_startup_message(reader_read_exactly: ReadExactly) -> StartupMessage | None:
+    """Read the initial StartupMessage / SSLRequest from a client.
+
+    ``reader_read_exactly`` is any awaitable accepting an int byte count
+    (asyncio.StreamReader.readexactly).  Returns ``None`` when the client
+    sent an SSLRequest — caller responds with single byte ``N`` (reject)
+    and re-invokes this function for the real StartupMessage.
+    """
+
+    length_bytes = await reader_read_exactly(4)
+    (length,) = struct.unpack("!I", length_bytes)
+    if length < 8 or length > 10_000:
+        raise ProtocolError(f"Startup length out of bounds: {length}")
+    body = await reader_read_exactly(length - 4)
+    (code,) = struct.unpack("!I", body[:4])
+
+    if code == SSL_REQUEST_CODE:
+        return None
+
+    if code != PROTOCOL_VERSION_3:
+        raise ProtocolError(f"Unsupported protocol version: {code:#x}")
+
+    # Body is a series of NUL-terminated UTF-8 key/value pairs followed
+    # by a final empty key.
+    params: dict[str, str] = {}
+    parts = body[4:].split(b"\x00")
+    # Trailing empty element from the final NUL.
+    i = 0
+    while i + 1 < len(parts):
+        key = parts[i].decode("utf-8", errors="replace")
+        if not key:
+            break
+        value = parts[i + 1].decode("utf-8", errors="replace")
+        params[key] = value
+        i += 2
+    return StartupMessage(protocol_version=code, parameters=params)
+
+
+async def read_message(reader_read_exactly: ReadExactly) -> tuple[bytes, bytes]:
+    """Read a single tagged message frame.
+
+    Returns ``(tag, body)`` where ``tag`` is the 1-byte message type and
+    ``body`` excludes the 4-byte length prefix.  Caller dispatches on
+    ``tag``.
+    """
+
+    tag = await reader_read_exactly(1)
+    length_bytes = await reader_read_exactly(4)
+    (length,) = struct.unpack("!I", length_bytes)
+    if length < 4:
+        raise ProtocolError(f"Message length too small: {length}")
+    body = await reader_read_exactly(length - 4) if length > 4 else b""
+    return tag, body
+
+
+def parse_query(body: bytes) -> QueryMessage:
+    """Parse the body of a Simple Query ``Q`` frame."""
+
+    if not body.endswith(b"\x00"):
+        raise ProtocolError("Query body not NUL-terminated")
+    return QueryMessage(sql=body[:-1].decode("utf-8", errors="replace"))
+
+
+# ---------------------------------------------------------------------------
+# Writers — each returns bytes; caller writes to the socket.
+# ---------------------------------------------------------------------------
+
+
+def _frame(tag: bytes, payload: bytes) -> bytes:
+    """Wrap ``payload`` in a tagged Postgres frame."""
+
+    return tag + struct.pack("!I", 4 + len(payload)) + payload
+
+
+def build_authentication_ok() -> bytes:
+    return _frame(b"R", struct.pack("!I", 0))
+
+
+def build_parameter_status(name: str, value: str) -> bytes:
+    payload = name.encode("utf-8") + b"\x00" + value.encode("utf-8") + b"\x00"
+    return _frame(b"S", payload)
+
+
+def build_backend_key_data(pid: int, secret: int) -> bytes:
+    return _frame(b"K", struct.pack("!II", pid, secret))
+
+
+def build_ready_for_query(status: bytes = TX_IDLE) -> bytes:
+    if len(status) != 1:
+        raise ValueError("ReadyForQuery status must be a single byte")
+    return _frame(b"Z", status)
+
+
+def build_row_description(columns: list[tuple[str, int]]) -> bytes:
+    """RowDescription frame.
+
+    ``columns`` is a list of ``(name, type_oid)`` pairs. Type-size /
+    type-modifier / format columns are filled with sensible defaults for
+    text-format results — Step 1 only emits text.
+    """
+
+    payload = struct.pack("!H", len(columns))
+    for name, oid in columns:
+        payload += name.encode("utf-8") + b"\x00"
+        # table_oid, column_attr, type_oid, type_size, type_modifier, format_code
+        payload += struct.pack("!IhIhih", 0, 0, oid, -1, -1, 0)
+    return _frame(b"T", payload)
+
+
+def build_data_row(values: list[str | None]) -> bytes:
+    payload = struct.pack("!H", len(values))
+    for value in values:
+        if value is None:
+            payload += struct.pack("!i", -1)
+        else:
+            encoded = value.encode("utf-8")
+            payload += struct.pack("!I", len(encoded)) + encoded
+    return _frame(b"D", payload)
+
+
+def build_command_complete(tag: str) -> bytes:
+    return _frame(b"C", tag.encode("utf-8") + b"\x00")
+
+
+def build_error_response(*, severity: str, code: str, message: str) -> bytes:
+    """ErrorResponse frame.
+
+    Postgres uses SQLSTATE codes; ``XX000`` (internal error) is a safe
+    catch-all when we don't have a more specific class. The router will
+    map OBSL ``ErrorCode`` values onto SQLSTATEs in later steps.
+    """
+
+    fields = (
+        b"S"
+        + severity.encode("ascii")
+        + b"\x00"
+        + b"V"
+        + severity.encode("ascii")
+        + b"\x00"
+        + b"C"
+        + code.encode("ascii")
+        + b"\x00"
+        + b"M"
+        + message.encode("utf-8")
+        + b"\x00"
+        + b"\x00"
+    )
+    return _frame(b"E", fields)

--- a/src/orionbelt/pgwire/server.py
+++ b/src/orionbelt/pgwire/server.py
@@ -1,0 +1,295 @@
+"""Asyncio Postgres wire server — Step 1.
+
+One task per connection; the lifecycle is:
+
+1. (optional) SSLRequest → reply ``N`` and continue plaintext.
+2. StartupMessage → authenticate → AuthenticationOk + ParameterStatus
+   + BackendKeyData + ReadyForQuery.
+3. Loop on Simple Query (``Q``) frames; reply with a canned answer for
+   ``SELECT 1`` and an ErrorResponse for everything else. The router
+   replaces this hardcoded behaviour in Step 2.
+4. Terminate (``X``) or EOF closes the connection.
+
+Connection cap is enforced with an ``asyncio.Semaphore``; per-query wall
+clock with ``asyncio.wait_for``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import secrets
+from collections.abc import Awaitable, Callable
+
+from orionbelt.pgwire import protocol
+from orionbelt.pgwire.auth import authenticate
+
+logger = logging.getLogger(__name__)
+
+
+# Type alias for the query handler. Step 1 ships a hardcoded
+# ``SELECT 1`` responder; Step 2 swaps in the router. Handlers return
+# raw bytes to write — a sequence of one or more protocol frames
+# terminated by the per-statement reply (CommandComplete or
+# ErrorResponse). The caller appends ReadyForQuery.
+QueryHandler = Callable[[str], Awaitable[bytes]]
+
+
+async def _hello_world_handler(sql: str) -> bytes:
+    """Step 1 responder.
+
+    Recognises ``SELECT 1`` (case-insensitive, optional trailing
+    semicolon) and returns a single-row text result. Everything else
+    becomes an ErrorResponse so misuse is loud rather than silent.
+    """
+
+    normalised = sql.strip().rstrip(";").strip().lower()
+    if normalised == "select 1":
+        return (
+            protocol.build_row_description([("?column?", protocol.OID_INT4)])
+            + protocol.build_data_row(["1"])
+            + protocol.build_command_complete("SELECT 1")
+        )
+    return protocol.build_error_response(
+        severity="ERROR",
+        code="0A000",  # feature_not_supported
+        message=(
+            "pgwire Step 1 only answers 'SELECT 1'. "
+            "Semantic-SQL routing lands in Step 2 "
+            "(design/PLAN_postgres_wire.md §6)."
+        ),
+    )
+
+
+class PgWireServer:
+    """Owns the asyncio server object and the connection-cap semaphore.
+
+    Use ``start()`` to bind the socket and ``stop()`` to drain. The
+    server is reusable across tests — each ``start()`` returns the
+    actual bound port, which is useful for ``port=0`` ephemeral binds.
+    """
+
+    def __init__(
+        self,
+        *,
+        host: str,
+        port: int,
+        auth_mode: str = "trust",
+        max_connections: int = 64,
+        query_timeout_seconds: float = 60.0,
+        query_handler: QueryHandler | None = None,
+    ) -> None:
+        self.host = host
+        self.port = port
+        self.auth_mode = auth_mode
+        self.query_timeout = query_timeout_seconds
+        self._semaphore = asyncio.Semaphore(max_connections)
+        self._handler: QueryHandler = query_handler or _hello_world_handler
+        self._server: asyncio.base_events.Server | None = None
+
+    @property
+    def bound_port(self) -> int:
+        """Return the port the server actually bound to (post-start)."""
+
+        if self._server is None:
+            raise RuntimeError("PgWireServer not started")
+        sockets = list(self._server.sockets or ())
+        if not sockets:
+            raise RuntimeError("PgWireServer has no bound sockets")
+        return int(sockets[0].getsockname()[1])
+
+    async def start(self) -> int:
+        self._server = await asyncio.start_server(
+            self._handle_connection, host=self.host, port=self.port
+        )
+        bound = self.bound_port
+        logger.info("pgwire listening on %s:%d (auth=%s)", self.host, bound, self.auth_mode)
+        return bound
+
+    async def serve_forever(self) -> None:
+        if self._server is None:
+            raise RuntimeError("PgWireServer not started")
+        async with self._server:
+            await self._server.serve_forever()
+
+    async def stop(self) -> None:
+        if self._server is None:
+            return
+        self._server.close()
+        await self._server.wait_closed()
+        self._server = None
+
+    # ------------------------------------------------------------------
+    # Connection lifecycle
+    # ------------------------------------------------------------------
+
+    async def _handle_connection(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        peer = writer.get_extra_info("peername")
+        if self._semaphore.locked():
+            logger.warning("pgwire rejecting connection from %s — at capacity", peer)
+            await self._safe_send_error(
+                writer,
+                code="53300",  # too_many_connections
+                message="pgwire connection limit reached",
+            )
+            try:
+                writer.close()
+                await writer.wait_closed()
+            except Exception:
+                pass
+            return
+        await self._semaphore.acquire()
+        try:
+            await self._drive_session(reader, writer, peer)
+        except protocol.ProtocolError as exc:
+            logger.info("pgwire protocol error from %s: %s", peer, exc)
+            await self._safe_send_error(writer, code="08P01", message=str(exc))
+        except (asyncio.IncompleteReadError, ConnectionError):
+            logger.debug("pgwire connection from %s dropped", peer)
+        except Exception:
+            logger.exception("pgwire unhandled error from %s", peer)
+        finally:
+            self._semaphore.release()
+            try:
+                writer.close()
+                await writer.wait_closed()
+            except Exception:
+                pass
+
+    async def _drive_session(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+        peer: object,
+    ) -> None:
+        startup = await protocol.read_startup_message(reader.readexactly)
+        if startup is None:
+            # SSLRequest — reject (Step 1 has no TLS in-process), then
+            # read the real StartupMessage on the same socket.
+            writer.write(b"N")
+            await writer.drain()
+            startup = await protocol.read_startup_message(reader.readexactly)
+            if startup is None:
+                raise protocol.ProtocolError("Repeated SSLRequest on same socket")
+
+        auth = authenticate(auth_mode=self.auth_mode, startup=startup)
+        if not auth.ok:
+            writer.write(
+                protocol.build_error_response(
+                    severity="FATAL",
+                    code="28P01",  # invalid_password
+                    message=auth.error_message or "authentication failed",
+                )
+            )
+            await writer.drain()
+            return
+
+        # Handshake complete: AuthOk + a small set of ParameterStatus
+        # frames + BackendKeyData + ReadyForQuery.
+        writer.write(protocol.build_authentication_ok())
+        for name, value in _startup_parameters().items():
+            writer.write(protocol.build_parameter_status(name, value))
+        writer.write(
+            protocol.build_backend_key_data(pid=_fake_backend_pid(), secret=secrets.randbits(31))
+        )
+        writer.write(protocol.build_ready_for_query())
+        await writer.drain()
+
+        logger.info(
+            "pgwire session opened peer=%s user=%s database=%s",
+            peer,
+            startup.user,
+            startup.database,
+        )
+
+        # Simple-query loop. Extended protocol arrives in Step 4.
+        while True:
+            tag, body = await protocol.read_message(reader.readexactly)
+            if tag == b"X":  # Terminate
+                return
+            if tag == b"Q":
+                query = protocol.parse_query(body)
+                try:
+                    reply = await asyncio.wait_for(
+                        self._handler(query.sql), timeout=self.query_timeout
+                    )
+                    writer.write(reply)
+                except TimeoutError:
+                    writer.write(
+                        protocol.build_error_response(
+                            severity="ERROR",
+                            code="57014",  # query_canceled
+                            message=(f"pgwire query exceeded timeout of {self.query_timeout:g}s"),
+                        )
+                    )
+                writer.write(protocol.build_ready_for_query())
+                await writer.drain()
+                continue
+            # Unknown / not-yet-supported tag (Parse, Bind, …).  Reply
+            # with a clean error but keep the session alive — clients
+            # that send an extended-query sequence will probably reset.
+            writer.write(
+                protocol.build_error_response(
+                    severity="ERROR",
+                    code="0A000",
+                    message=(
+                        f"pgwire Step 1 only supports the Simple Query "
+                        f"protocol (received frame tag {tag!r}). Extended "
+                        "protocol lands in Step 4."
+                    ),
+                )
+            )
+            writer.write(protocol.build_ready_for_query())
+            await writer.drain()
+
+    async def _safe_send_error(
+        self,
+        writer: asyncio.StreamWriter,
+        *,
+        code: str,
+        message: str,
+    ) -> None:
+        try:
+            writer.write(
+                protocol.build_error_response(severity="FATAL", code=code, message=message)
+            )
+            await writer.drain()
+        except Exception:
+            pass
+
+
+def _startup_parameters() -> dict[str, str]:
+    """The ParameterStatus payload reported to clients after AuthOk.
+
+    These mirror real Postgres values enough for BI tool driver
+    handshakes. Step 3's catalog emulation expands the set.
+    """
+
+    return {
+        "server_version": "15.0 (orionbelt-pgwire 0.1)",
+        "server_encoding": "UTF8",
+        "client_encoding": "UTF8",
+        "DateStyle": "ISO, MDY",
+        "TimeZone": "UTC",
+        "integer_datetimes": "on",
+        "standard_conforming_strings": "on",
+        "application_name": "",
+    }
+
+
+_BACKEND_PID_BASE = 10_000
+
+
+def _fake_backend_pid() -> int:
+    """Stable-ish PID-shaped int for BackendKeyData.
+
+    Real Postgres uses an OS PID. We don't need cancel support yet, so
+    a 31-bit random value is fine — the cancel key is paired with this
+    PID in CancelRequest, which Step 1 doesn't honour.
+    """
+
+    return _BACKEND_PID_BASE + secrets.randbelow(50_000)

--- a/src/orionbelt/pgwire/startup.py
+++ b/src/orionbelt/pgwire/startup.py
@@ -1,0 +1,67 @@
+"""FastAPI lifespan integration for the pgwire surface.
+
+Unlike the Flight server (which runs in a background thread because
+``pyarrow.flight`` is blocking), pgwire is asyncio-native so it shares
+the FastAPI event loop directly. Step 1 wires only the start/stop seam;
+Steps 2+ pass a real router as the ``query_handler``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+
+from orionbelt.pgwire.server import PgWireServer, QueryHandler
+from orionbelt.settings import Settings
+
+logger = logging.getLogger(__name__)
+
+
+class PgWireRuntime:
+    """Holds the server + the asyncio task running ``serve_forever``."""
+
+    def __init__(self, server: PgWireServer, task: asyncio.Task[None]) -> None:
+        self.server = server
+        self.task = task
+
+    async def shutdown(self) -> None:
+        await self.server.stop()
+        if not self.task.done():
+            self.task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await self.task
+
+
+async def start_pgwire(
+    settings: Settings,
+    *,
+    query_handler: QueryHandler | None = None,
+) -> PgWireRuntime | None:
+    """Bind the pgwire TCP socket and spawn the ``serve_forever`` task.
+
+    Returns ``None`` if ``PGWIRE_ENABLED`` is false. The Step 1 default
+    ``query_handler`` answers only ``SELECT 1`` — callers in Step 2+
+    pass a router bound to the active ``SessionManager``.
+    """
+
+    if not settings.pgwire_enabled:
+        return None
+
+    server = PgWireServer(
+        host=settings.pgwire_host,
+        port=settings.pgwire_port,
+        auth_mode=settings.pgwire_auth_mode,
+        max_connections=settings.pgwire_max_connections,
+        query_timeout_seconds=float(settings.pgwire_query_timeout_seconds),
+        query_handler=query_handler,
+    )
+    bound = await server.start()
+    task = asyncio.create_task(server.serve_forever(), name="pgwire-server")
+    logger.info(
+        "pgwire surface enabled on %s:%d (auth=%s)",
+        settings.pgwire_host,
+        bound,
+        settings.pgwire_auth_mode,
+    )
+    return PgWireRuntime(server=server, task=task)

--- a/src/orionbelt/settings.py
+++ b/src/orionbelt/settings.py
@@ -95,6 +95,17 @@ class Settings(BaseSettings):
     # OBSL is a semantic layer, not a JDBC proxy. There are no env flags
     # that allow arbitrary SQL through to the warehouse.
 
+    # Postgres wire surface (see design/PLAN_postgres_wire.md).
+    # Step 1 (Hello world): trust auth only, simple-query protocol.
+    # Auth modes "password" / "scram-sha-256" land in Step 6 alongside the
+    # unified auth subsystem (see design/PLAN_unified_auth.md).
+    pgwire_enabled: bool = False
+    pgwire_host: str = "0.0.0.0"  # noqa: S104 — server bind address
+    pgwire_port: int = 5432
+    pgwire_auth_mode: str = "trust"  # "trust" (Step 1) | "password" | "scram-sha-256" (Step 6)
+    pgwire_max_connections: int = 64
+    pgwire_query_timeout_seconds: int = 60
+
     # One-shot batch endpoint (POST /v1/oneshot/batch). See PLAN_oneshot_batch.md.
     oneshot_batch_max_queries: int = 50
     oneshot_batch_max_parallelism: int = 8

--- a/tests/integration/test_pgwire_server.py
+++ b/tests/integration/test_pgwire_server.py
@@ -1,0 +1,146 @@
+"""Integration tests for the pgwire surface — Step 1.
+
+Drives a live ``PgWireServer`` on an ephemeral port using raw asyncio
+sockets. This avoids a hard dependency on psycopg/JDBC for the
+hello-world cycle; client-library tests join in Step 4 once the
+extended-query protocol exists.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import struct
+
+import pytest
+
+from orionbelt.pgwire import protocol
+from orionbelt.pgwire.server import PgWireServer
+
+
+def _startup_payload(params: dict[str, str]) -> bytes:
+    body = struct.pack("!I", protocol.PROTOCOL_VERSION_3)
+    for key, value in params.items():
+        body += key.encode() + b"\x00" + value.encode() + b"\x00"
+    body += b"\x00"
+    return struct.pack("!I", 4 + len(body)) + body
+
+
+def _query_frame(sql: str) -> bytes:
+    payload = sql.encode() + b"\x00"
+    return b"Q" + struct.pack("!I", 4 + len(payload)) + payload
+
+
+def _terminate_frame() -> bytes:
+    return b"X" + struct.pack("!I", 4)
+
+
+async def _drain_until_ready(reader: asyncio.StreamReader) -> list[tuple[bytes, bytes]]:
+    """Read frames until a ReadyForQuery (``Z``) arrives."""
+
+    frames: list[tuple[bytes, bytes]] = []
+    while True:
+        tag = await reader.readexactly(1)
+        (length,) = struct.unpack("!I", await reader.readexactly(4))
+        body = await reader.readexactly(length - 4) if length > 4 else b""
+        frames.append((tag, body))
+        if tag == b"Z":
+            return frames
+
+
+@pytest.fixture
+async def pgwire_server() -> PgWireServer:
+    server = PgWireServer(host="127.0.0.1", port=0, max_connections=8)
+    await server.start()
+    serve_task = asyncio.create_task(server.serve_forever())
+    try:
+        yield server
+    finally:
+        await server.stop()
+        serve_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError, Exception):
+            await serve_task
+
+
+async def test_select_one_round_trip(pgwire_server: PgWireServer) -> None:
+    reader, writer = await asyncio.open_connection("127.0.0.1", pgwire_server.bound_port)
+    try:
+        writer.write(_startup_payload({"user": "obsl", "database": "__default__"}))
+        await writer.drain()
+        handshake = await _drain_until_ready(reader)
+        tags = [tag for tag, _ in handshake]
+        assert tags[0] == b"R"  # AuthenticationOk
+        assert b"S" in tags  # at least one ParameterStatus
+        assert b"K" in tags  # BackendKeyData
+        assert tags[-1] == b"Z"  # ReadyForQuery
+
+        writer.write(_query_frame("SELECT 1"))
+        await writer.drain()
+        reply = await _drain_until_ready(reader)
+        reply_tags = [tag for tag, _ in reply]
+        assert reply_tags == [b"T", b"D", b"C", b"Z"]
+
+        # Row description should describe a single int4 column.
+        _, row_desc = reply[0]
+        (n_cols,) = struct.unpack("!H", row_desc[:2])
+        assert n_cols == 1
+
+        # Data row carries the literal text "1".
+        _, data_row = reply[1]
+        (n_vals,) = struct.unpack("!H", data_row[:2])
+        assert n_vals == 1
+        (col_len,) = struct.unpack("!I", data_row[2:6])
+        assert col_len == 1
+        assert data_row[6:7] == b"1"
+
+        # CommandComplete carries the SELECT tag.
+        _, cmd_complete = reply[2]
+        assert cmd_complete.startswith(b"SELECT 1")
+    finally:
+        writer.write(_terminate_frame())
+        await writer.drain()
+        writer.close()
+        await writer.wait_closed()
+
+
+async def test_unknown_query_returns_error_response(pgwire_server: PgWireServer) -> None:
+    reader, writer = await asyncio.open_connection("127.0.0.1", pgwire_server.bound_port)
+    try:
+        writer.write(_startup_payload({"user": "obsl", "database": "__default__"}))
+        await writer.drain()
+        await _drain_until_ready(reader)
+
+        writer.write(_query_frame("SELECT * FROM nope"))
+        await writer.drain()
+        reply = await _drain_until_ready(reader)
+        reply_tags = [tag for tag, _ in reply]
+        assert reply_tags == [b"E", b"Z"]
+        _, err_body = reply[0]
+        assert b"M" in err_body  # message field
+    finally:
+        writer.write(_terminate_frame())
+        await writer.drain()
+        writer.close()
+        await writer.wait_closed()
+
+
+async def test_ssl_request_is_rejected_then_startup_continues(
+    pgwire_server: PgWireServer,
+) -> None:
+    reader, writer = await asyncio.open_connection("127.0.0.1", pgwire_server.bound_port)
+    try:
+        # SSLRequest: length=8, code=80877103.
+        writer.write(struct.pack("!II", 8, protocol.SSL_REQUEST_CODE))
+        await writer.drain()
+        reject = await reader.readexactly(1)
+        assert reject == b"N"
+
+        writer.write(_startup_payload({"user": "obsl"}))
+        await writer.drain()
+        handshake = await _drain_until_ready(reader)
+        assert handshake[0][0] == b"R"
+    finally:
+        writer.write(_terminate_frame())
+        await writer.drain()
+        writer.close()
+        await writer.wait_closed()

--- a/tests/unit/test_pgwire_protocol.py
+++ b/tests/unit/test_pgwire_protocol.py
@@ -1,0 +1,158 @@
+"""Unit tests for pgwire frame readers and writers."""
+
+from __future__ import annotations
+
+import asyncio
+import struct
+
+import pytest
+
+from orionbelt.pgwire import protocol
+
+
+def test_build_authentication_ok() -> None:
+    frame = protocol.build_authentication_ok()
+    assert frame[:1] == b"R"
+    (length,) = struct.unpack("!I", frame[1:5])
+    assert length == 8
+    (auth_type,) = struct.unpack("!I", frame[5:9])
+    assert auth_type == 0
+
+
+def test_build_parameter_status_roundtrip() -> None:
+    frame = protocol.build_parameter_status("server_encoding", "UTF8")
+    assert frame[:1] == b"S"
+    (length,) = struct.unpack("!I", frame[1:5])
+    payload = frame[5 : 1 + length]
+    assert payload == b"server_encoding\x00UTF8\x00"
+
+
+def test_build_ready_for_query_idle() -> None:
+    frame = protocol.build_ready_for_query()
+    assert frame == b"Z" + struct.pack("!I", 5) + b"I"
+
+
+def test_build_ready_for_query_rejects_multi_byte_status() -> None:
+    with pytest.raises(ValueError):
+        protocol.build_ready_for_query(status=b"IDLE")
+
+
+def test_build_row_description_single_int4_column() -> None:
+    frame = protocol.build_row_description([("?column?", protocol.OID_INT4)])
+    assert frame[:1] == b"T"
+    (length,) = struct.unpack("!I", frame[1:5])
+    payload = frame[5 : 1 + length]
+    (n_cols,) = struct.unpack("!H", payload[:2])
+    assert n_cols == 1
+    # Name + NUL + (table_oid I, col_attr h, type_oid I, type_size h,
+    # type_mod i, format h) = 4+2+4+2+4+2 = 18 bytes after the name.
+    name, rest = payload[2:].split(b"\x00", 1)
+    assert name == b"?column?"
+    table_oid, col_attr, type_oid, type_size, type_mod, fmt = struct.unpack("!IhIhih", rest[:18])
+    assert table_oid == 0
+    assert col_attr == 0
+    assert type_oid == protocol.OID_INT4
+    assert type_size == -1
+    assert type_mod == -1
+    assert fmt == 0
+
+
+def test_build_data_row_text_value() -> None:
+    frame = protocol.build_data_row(["1"])
+    assert frame[:1] == b"D"
+    (length,) = struct.unpack("!I", frame[1:5])
+    payload = frame[5 : 1 + length]
+    (n,) = struct.unpack("!H", payload[:2])
+    assert n == 1
+    (col_len,) = struct.unpack("!I", payload[2:6])
+    assert col_len == 1
+    assert payload[6:7] == b"1"
+
+
+def test_build_data_row_null() -> None:
+    frame = protocol.build_data_row([None])
+    payload = frame[5:]
+    (n,) = struct.unpack("!H", payload[:2])
+    assert n == 1
+    (col_len,) = struct.unpack("!i", payload[2:6])
+    assert col_len == -1
+
+
+def test_build_command_complete() -> None:
+    frame = protocol.build_command_complete("SELECT 1")
+    assert frame[:1] == b"C"
+    assert frame.endswith(b"SELECT 1\x00")
+
+
+def test_build_error_response_carries_required_fields() -> None:
+    frame = protocol.build_error_response(severity="ERROR", code="0A000", message="not supported")
+    assert frame[:1] == b"E"
+    payload = frame[5:]
+    assert b"SERROR\x00" in payload
+    assert b"C0A000\x00" in payload
+    assert b"Mnot supported\x00" in payload
+    assert payload.endswith(b"\x00\x00")
+
+
+def test_parse_query_strips_nul() -> None:
+    msg = protocol.parse_query(b"SELECT 1\x00")
+    assert msg.sql == "SELECT 1"
+
+
+def test_parse_query_rejects_unterminated() -> None:
+    with pytest.raises(protocol.ProtocolError):
+        protocol.parse_query(b"SELECT 1")
+
+
+# ---------------------------------------------------------------------------
+# StartupMessage reader — drive it from an in-memory byte buffer.
+# ---------------------------------------------------------------------------
+
+
+class _ByteReader:
+    """Minimal stand-in for asyncio.StreamReader.readexactly."""
+
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+        self._offset = 0
+
+    async def readexactly(self, n: int) -> bytes:
+        chunk = self._data[self._offset : self._offset + n]
+        if len(chunk) != n:
+            raise asyncio.IncompleteReadError(chunk, n)
+        self._offset += n
+        return chunk
+
+
+def _build_startup_payload(params: dict[str, str]) -> bytes:
+    body = struct.pack("!I", protocol.PROTOCOL_VERSION_3)
+    for key, value in params.items():
+        body += key.encode() + b"\x00" + value.encode() + b"\x00"
+    body += b"\x00"
+    return struct.pack("!I", 4 + len(body)) + body
+
+
+def test_read_startup_message_parses_parameters() -> None:
+    payload = _build_startup_payload({"user": "obsl", "database": "__default__"})
+    reader = _ByteReader(payload)
+    startup = asyncio.run(protocol.read_startup_message(reader.readexactly))
+    assert startup is not None
+    assert startup.protocol_version == protocol.PROTOCOL_VERSION_3
+    assert startup.user == "obsl"
+    assert startup.database == "__default__"
+
+
+def test_read_startup_message_returns_none_on_ssl_request() -> None:
+    body = struct.pack("!I", protocol.SSL_REQUEST_CODE)
+    payload = struct.pack("!I", 4 + len(body)) + body
+    reader = _ByteReader(payload)
+    result = asyncio.run(protocol.read_startup_message(reader.readexactly))
+    assert result is None
+
+
+def test_read_startup_message_rejects_unknown_protocol() -> None:
+    body = struct.pack("!I", 0xDEADBEEF)
+    payload = struct.pack("!I", 4 + len(body)) + body
+    reader = _ByteReader(payload)
+    with pytest.raises(protocol.ProtocolError):
+        asyncio.run(protocol.read_startup_message(reader.readexactly))


### PR DESCRIPTION
Implements Step 1 of [design/PLAN_postgres_wire.md](design/PLAN_postgres_wire.md) §6 — the minimum viable Postgres v3 wire server.

## Summary
- New package `src/orionbelt/pgwire/` with `protocol.py` (frame readers/writers), `auth.py` (trust-mode stub, designed so the unified-auth keystore drops in at Step 6 without touching `server.py`), `server.py` (asyncio TCP loop), `startup.py` (FastAPI lifespan).
- `PGWIRE_ENABLED` settings family added; default off so the surface is opt-in.
- 17 new tests — 14 unit covering frame round-trips + StartupMessage parsing, 3 integration driving a real server on an ephemeral port over raw sockets.

## Verification
- Live psql round-trip:
  ```
  $ psql -h 127.0.0.1 -p 15432 -U obsl -d __default__ -c 'SELECT 1'
   ?column?
  ----------
          1
  (1 row)
  ```
- Full suite: 1876 passed, 60 skipped, 0 regressions.
- `ruff check`, `ruff format`, `mypy` all clean.

## Auth note
Step 1 only ships `trust` mode (server replies `AuthenticationOk` immediately). The `auth.authenticate()` seam already accepts `password` / `scram-sha-256` mode strings and raises `NotImplementedError` for them — the unified-auth keystore from `design/PLAN_unified_auth.md` slots in at Step 6 without changes to `server.py`.

## Not in this PR (Steps 2–8)
- Semantic-SQL routing (`SELECT dim, measure FROM <model>`) — Step 2.
- `pg_catalog` / `information_schema` emulation — Step 3.
- Extended query protocol (Parse/Bind/Describe/Execute) — Step 4.
- BI tool integration tests (Tableau / Power BI / DBeaver) — Step 5.
- `password` + `scram-sha-256` auth — Step 6.
- Binary format encoding — Step 7.
- Docs + comparison-matrix updates — Step 8.

## Test plan
- [x] `uv run pytest tests/unit/test_pgwire_protocol.py tests/integration/test_pgwire_server.py`
- [x] Full suite: `uv run pytest`
- [x] Manual: `PGWIRE_ENABLED=true uv run orionbelt-api` + `psql -h localhost -p 5432 -U obsl -d __default__ -c 'SELECT 1'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)