### PR TITLE
feat(pgwire): Step 2 — semantic-SQL routing through the wire

### DIFF
--- a/src/orionbelt/api/app.py
+++ b/src/orionbelt/api/app.py
@@ -390,14 +390,16 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
                 "Install with: uv sync --extra flight"
             )
 
-    # Start Postgres wire surface if PGWIRE_ENABLED=true. Step 1 ships a
-    # hardcoded SELECT-1 handler; later steps wire the semantic router.
+    # Start Postgres wire surface if PGWIRE_ENABLED=true. The startup
+    # helper builds a SemanticRouter bound to the live SessionManager,
+    # so SELECT statements over the wire run through the same
+    # translate→compile→execute pipeline as REST /query/semantic-ql.
     # See design/PLAN_postgres_wire.md.
     pgwire_runtime = None
     if settings.pgwire_enabled:
         from orionbelt.pgwire.startup import start_pgwire
 
-        pgwire_runtime = await start_pgwire(settings)
+        pgwire_runtime = await start_pgwire(settings, session_manager=mgr)
 
     try:
         yield

--- a/src/orionbelt/pgwire/router.py
+++ b/src/orionbelt/pgwire/router.py
@@ -1,0 +1,300 @@
+"""Semantic-SQL dispatcher for the Postgres wire surface (Step 2).
+
+The router takes a raw SQL string + the ``database`` value from the
+Postgres StartupMessage and runs the same translate / compile / execute
+pipeline as the REST ``/v1/query/semantic-ql`` endpoint, then encodes
+the result as Postgres wire frames.
+
+Step 2 ships a "semantic-only" router: anything other than the canned
+``SELECT 1`` connectivity probe is routed through the OBSQL pipeline.
+Step 3 adds the catalog branch (``pg_catalog.*`` / ``information_schema.*``)
+and Step 4 adds the extended query protocol on top.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from orionbelt.compiler.fanout import FanoutError
+from orionbelt.compiler.resolution import ResolutionError
+from orionbelt.compiler.sql_translator import SQLTranslationError, translate_sql_to_query
+from orionbelt.dialect.base import UnsupportedAggregationError, UnsupportedGroupingError
+from orionbelt.dialect.registry import UnsupportedDialectError
+from orionbelt.models.semantic import SemanticModel
+from orionbelt.pgwire import protocol
+from orionbelt.pgwire.types import encode_text_value, oid_for_type_hint
+from orionbelt.service.db_executor import (
+    ExecutionError,
+    ExecutionResult,
+    ExecutionUnavailableError,
+    execute_sql,
+)
+from orionbelt.service.model_store import ModelStore
+from orionbelt.service.session_manager import SessionManager
+
+logger = logging.getLogger(__name__)
+
+
+# Postgres SQLSTATE codes used by the router. Keep in one place so the
+# mapping is auditable; codes are documented in PostgreSQL Appendix A.
+SQLSTATE_FEATURE_NOT_SUPPORTED = "0A000"
+SQLSTATE_SYNTAX_ERROR = "42601"
+SQLSTATE_UNDEFINED_COLUMN = "42703"
+SQLSTATE_DATA_EXCEPTION = "22000"
+SQLSTATE_INVALID_AUTHORIZATION = "28000"
+SQLSTATE_UNDEFINED_DATABASE = "3D000"
+SQLSTATE_INVALID_CATALOG_NAME = "3D000"
+SQLSTATE_SYSTEM_ERROR = "58000"
+SQLSTATE_CANNOT_CONNECT_NOW = "57P03"
+
+
+class _ModelNotFoundError(Exception):
+    """Raised when the Postgres ``database`` parameter resolves to nothing."""
+
+
+@dataclass(frozen=True)
+class _ResolvedTarget:
+    store: ModelStore
+    model_id: str
+    model: SemanticModel
+
+
+class SemanticRouter:
+    """Per-process semantic-SQL router bound to a SessionManager.
+
+    Instances are reusable across many client connections; all state is
+    derived from the SessionManager at request time so model reloads are
+    picked up immediately.
+    """
+
+    def __init__(
+        self,
+        *,
+        session_manager: SessionManager,
+        default_dialect: str,
+    ) -> None:
+        self._sessions = session_manager
+        self._default_dialect = default_dialect
+
+    async def handle(self, sql: str, database: str) -> bytes:
+        """Top-level entry point used by the pgwire server loop.
+
+        Returns the raw bytes that go on the wire **before** the trailing
+        ``ReadyForQuery`` — i.e., a sequence of RowDescription + DataRow
+        + CommandComplete frames, or a single ErrorResponse.
+        """
+
+        normalised = sql.strip().rstrip(";").strip()
+        if not normalised:
+            return protocol.build_command_complete("")
+
+        # Cheap connectivity probe. Step 3 routes pg_catalog / version()
+        # / SET / SHOW through the catalog emulator; for now we only
+        # answer the most common BI-tool ping.
+        if normalised.lower() == "select 1":
+            return (
+                protocol.build_row_description([("?column?", protocol.OID_INT4)])
+                + protocol.build_data_row(["1"])
+                + protocol.build_command_complete("SELECT 1")
+            )
+
+        try:
+            target = self._resolve_target(database)
+        except _ModelNotFoundError as exc:
+            return protocol.build_error_response(
+                severity="ERROR",
+                code=SQLSTATE_UNDEFINED_DATABASE,
+                message=str(exc),
+            )
+
+        try:
+            query = translate_sql_to_query(sql, target.model)
+        except SQLTranslationError as exc:
+            return _encode_translation_error(exc)
+        except Exception as exc:  # noqa: BLE001 — broad guard at protocol boundary
+            logger.exception("pgwire translator failed")
+            return protocol.build_error_response(
+                severity="ERROR",
+                code=SQLSTATE_SYSTEM_ERROR,
+                message=f"semantic translator error: {exc}",
+            )
+
+        try:
+            compile_result = target.store.compile_query(
+                target.model_id, query, self._default_dialect
+            )
+        except UnsupportedDialectError as exc:
+            return protocol.build_error_response(
+                severity="ERROR",
+                code=SQLSTATE_FEATURE_NOT_SUPPORTED,
+                message=f"unsupported dialect: {exc}",
+            )
+        except ResolutionError as exc:
+            message = "; ".join(e.message for e in exc.errors) or "query resolution failed"
+            return protocol.build_error_response(
+                severity="ERROR",
+                code=SQLSTATE_UNDEFINED_COLUMN,
+                message=message,
+            )
+        except FanoutError as exc:
+            return protocol.build_error_response(
+                severity="ERROR",
+                code=SQLSTATE_FEATURE_NOT_SUPPORTED,
+                message=f"fanout detected: {exc.message}",
+            )
+        except (UnsupportedAggregationError, UnsupportedGroupingError) as exc:
+            return protocol.build_error_response(
+                severity="ERROR",
+                code=SQLSTATE_FEATURE_NOT_SUPPORTED,
+                message=str(exc),
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("pgwire compiler failed")
+            return protocol.build_error_response(
+                severity="ERROR",
+                code=SQLSTATE_SYSTEM_ERROR,
+                message=f"compiler error: {exc}",
+            )
+
+        logger.info(
+            "pgwire compiled SQL (dialect=%s):\n%s", self._default_dialect, compile_result.sql
+        )
+
+        try:
+            result = execute_sql(compile_result.sql, dialect=self._default_dialect)
+        except ExecutionUnavailableError as exc:
+            return protocol.build_error_response(
+                severity="ERROR",
+                code=SQLSTATE_CANNOT_CONNECT_NOW,
+                message=f"execution unavailable: {exc}",
+            )
+        except ExecutionError as exc:
+            return protocol.build_error_response(
+                severity="ERROR",
+                code=SQLSTATE_DATA_EXCEPTION,
+                message=f"execution failed: {exc}",
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("pgwire executor failed")
+            return protocol.build_error_response(
+                severity="ERROR",
+                code=SQLSTATE_SYSTEM_ERROR,
+                message=f"executor error: {exc}",
+            )
+
+        return _encode_result(result)
+
+    # ------------------------------------------------------------------
+    # Resolution
+    # ------------------------------------------------------------------
+
+    def _resolve_target(self, database: str) -> _ResolvedTarget:
+        """Pick a (store, model_id, model) tuple for the requested DB.
+
+        Resolution order, matching the Flight surface's behaviour:
+
+        1. ``database`` matches a SessionManager session id directly
+           (multi-model preload uses the model name as the session id).
+        2. ``__default__`` session (single-model preload, MCP stdio,
+           tests).
+        3. Any other session with at least one loaded model — only
+           when exactly one match exists, so we never silently pick.
+
+        Raises ``_ModelNotFoundError`` with a message that surfaces in the
+        Postgres ErrorResponse on miss.
+        """
+
+        candidate_ids: list[str] = []
+        if database:
+            candidate_ids.append(database)
+        if "__default__" not in candidate_ids:
+            candidate_ids.append("__default__")
+
+        for session_id in candidate_ids:
+            target = self._first_model_in(session_id)
+            if target is not None:
+                return target
+
+        # Last-resort scan across all sessions for the case where the
+        # client passed a database name that doesn't match a session id
+        # but does identify a model in some other session.
+        matches: list[_ResolvedTarget] = []
+        for session_summary in self._sessions.list_sessions():
+            target = self._first_model_in(session_summary.session_id, model_id=database or None)
+            if target is not None:
+                matches.append(target)
+        if len(matches) == 1:
+            return matches[0]
+        if len(matches) > 1:
+            raise _ModelNotFoundError(
+                f"database='{database}' is ambiguous — multiple sessions hold a model "
+                "with that name; supply a unique database parameter."
+            )
+
+        raise _ModelNotFoundError(
+            f"no model is available for database='{database}'. "
+            "Load a model via REST /v1/sessions/{id}/models or start the server "
+            "with MODEL_FILES=<path,...>."
+        )
+
+    def _first_model_in(
+        self, session_id: str, *, model_id: str | None = None
+    ) -> _ResolvedTarget | None:
+        try:
+            store = self._sessions.get_store(session_id)
+        except Exception:
+            return None
+        summaries = store.list_models()
+        if not summaries:
+            return None
+        chosen_id = model_id or summaries[0].model_id
+        try:
+            model = store.get_model(chosen_id)
+        except KeyError:
+            return None
+        return _ResolvedTarget(store=store, model_id=chosen_id, model=model)
+
+
+def _encode_translation_error(exc: SQLTranslationError) -> bytes:
+    """Map a SQLTranslationError to a Postgres ErrorResponse frame."""
+
+    if not exc.errors:
+        return protocol.build_error_response(
+            severity="ERROR",
+            code=SQLSTATE_SYNTAX_ERROR,
+            message="OBSQL translation failed",
+        )
+    # Use the first error's code as the SQLSTATE driver; the message
+    # carries every diagnostic so users can fix multi-clause mistakes
+    # in one pass.
+    first = exc.errors[0]
+    sqlstate = _translation_code_to_sqlstate(first.code)
+    message = "; ".join(f"[{e.code}] {e.message}" for e in exc.errors)
+    return protocol.build_error_response(
+        severity="ERROR",
+        code=sqlstate,
+        message=message,
+    )
+
+
+def _translation_code_to_sqlstate(code: str) -> str:
+    if code in {"UNKNOWN_SELECT_ITEM", "UNKNOWN_COLUMN", "UNKNOWN_ORDER_BY_FIELD"}:
+        return SQLSTATE_UNDEFINED_COLUMN
+    if code == "UNSUPPORTED_SQL_FEATURE":
+        return SQLSTATE_FEATURE_NOT_SUPPORTED
+    return SQLSTATE_SYNTAX_ERROR
+
+
+def _encode_result(result: ExecutionResult) -> bytes:
+    """Encode an ``ExecutionResult`` as RowDescription + DataRow* + CommandComplete."""
+
+    columns_for_desc = [(col.name, oid_for_type_hint(col.type_hint)) for col in result.columns]
+    out = protocol.build_row_description(columns_for_desc)
+    for row in result.rows:
+        encoded: list[str | None] = []
+        for value, col in zip(row, result.columns, strict=True):
+            encoded.append(encode_text_value(value, col.type_hint))
+        out += protocol.build_data_row(encoded)
+    out += protocol.build_command_complete(f"SELECT {len(result.rows)}")
+    return out

--- a/src/orionbelt/pgwire/server.py
+++ b/src/orionbelt/pgwire/server.py
@@ -27,22 +27,25 @@ from orionbelt.pgwire.auth import authenticate
 logger = logging.getLogger(__name__)
 
 
-# Type alias for the query handler. Step 1 ships a hardcoded
-# ``SELECT 1`` responder; Step 2 swaps in the router. Handlers return
-# raw bytes to write — a sequence of one or more protocol frames
-# terminated by the per-statement reply (CommandComplete or
-# ErrorResponse). The caller appends ReadyForQuery.
-QueryHandler = Callable[[str], Awaitable[bytes]]
+# Type alias for the query handler. The server passes the literal SQL
+# string from the Query frame and the ``database`` parameter captured
+# from the client's StartupMessage. Handlers return raw bytes — a
+# sequence of one or more protocol frames terminated by the per-statement
+# reply (CommandComplete or ErrorResponse). The caller appends
+# ReadyForQuery. Steps 3+ extend this signature (parameters, portals).
+QueryHandler = Callable[[str, str], Awaitable[bytes]]
 
 
-async def _hello_world_handler(sql: str) -> bytes:
-    """Step 1 responder.
+async def _hello_world_handler(sql: str, database: str) -> bytes:
+    """Fallback responder used when no router is wired in.
 
-    Recognises ``SELECT 1`` (case-insensitive, optional trailing
-    semicolon) and returns a single-row text result. Everything else
-    becomes an ErrorResponse so misuse is loud rather than silent.
+    Recognises ``SELECT 1`` so connectivity probes still work in
+    tests/dev when the server has no SessionManager attached. Every
+    other query gets a clear ErrorResponse pointing at the missing
+    handler so misuse is loud rather than silent.
     """
 
+    del database  # unused — see SemanticRouter for the real path
     normalised = sql.strip().rstrip(";").strip().lower()
     if normalised == "select 1":
         return (
@@ -54,9 +57,9 @@ async def _hello_world_handler(sql: str) -> bytes:
         severity="ERROR",
         code="0A000",  # feature_not_supported
         message=(
-            "pgwire Step 1 only answers 'SELECT 1'. "
-            "Semantic-SQL routing lands in Step 2 "
-            "(design/PLAN_postgres_wire.md §6)."
+            "pgwire server has no query handler attached. "
+            "Construct a SemanticRouter (orionbelt.pgwire.router) and "
+            "pass it as query_handler= when starting the server."
         ),
     )
 
@@ -215,7 +218,8 @@ class PgWireServer:
                 query = protocol.parse_query(body)
                 try:
                     reply = await asyncio.wait_for(
-                        self._handler(query.sql), timeout=self.query_timeout
+                        self._handler(query.sql, startup.database),
+                        timeout=self.query_timeout,
                     )
                     writer.write(reply)
                 except TimeoutError:

--- a/src/orionbelt/pgwire/startup.py
+++ b/src/orionbelt/pgwire/startup.py
@@ -12,7 +12,9 @@ import asyncio
 import contextlib
 import logging
 
+from orionbelt.pgwire.router import SemanticRouter
 from orionbelt.pgwire.server import PgWireServer, QueryHandler
+from orionbelt.service.session_manager import SessionManager
 from orionbelt.settings import Settings
 
 logger = logging.getLogger(__name__)
@@ -36,17 +38,28 @@ class PgWireRuntime:
 async def start_pgwire(
     settings: Settings,
     *,
+    session_manager: SessionManager | None = None,
     query_handler: QueryHandler | None = None,
 ) -> PgWireRuntime | None:
     """Bind the pgwire TCP socket and spawn the ``serve_forever`` task.
 
-    Returns ``None`` if ``PGWIRE_ENABLED`` is false. The Step 1 default
-    ``query_handler`` answers only ``SELECT 1`` — callers in Step 2+
-    pass a router bound to the active ``SessionManager``.
+    Returns ``None`` if ``PGWIRE_ENABLED`` is false. When
+    ``query_handler`` is omitted and a ``session_manager`` is supplied
+    we build a :class:`SemanticRouter` bound to the manager — that is
+    the production path used by the FastAPI lifespan. Tests that don't
+    need semantic routing can pass a stub handler directly.
     """
 
     if not settings.pgwire_enabled:
         return None
+
+    handler: QueryHandler | None = query_handler
+    if handler is None and session_manager is not None:
+        router = SemanticRouter(
+            session_manager=session_manager,
+            default_dialect=settings.db_vendor,
+        )
+        handler = router.handle
 
     server = PgWireServer(
         host=settings.pgwire_host,
@@ -54,14 +67,15 @@ async def start_pgwire(
         auth_mode=settings.pgwire_auth_mode,
         max_connections=settings.pgwire_max_connections,
         query_timeout_seconds=float(settings.pgwire_query_timeout_seconds),
-        query_handler=query_handler,
+        query_handler=handler,
     )
     bound = await server.start()
     task = asyncio.create_task(server.serve_forever(), name="pgwire-server")
     logger.info(
-        "pgwire surface enabled on %s:%d (auth=%s)",
+        "pgwire surface enabled on %s:%d (auth=%s, semantic=%s)",
         settings.pgwire_host,
         bound,
         settings.pgwire_auth_mode,
+        handler is not None,
     )
     return PgWireRuntime(server=server, task=task)

--- a/src/orionbelt/pgwire/types.py
+++ b/src/orionbelt/pgwire/types.py
@@ -1,0 +1,94 @@
+"""OBSL ``ExecutionResult`` → Postgres wire type mapping (text format).
+
+Step 2 lives here. The executor reports column types as one of four
+coarse hints — ``number`` / ``string`` / ``datetime`` / ``binary`` —
+which we collapse onto a small set of Postgres OIDs that every BI tool
+handles. Step 7 lands binary-format encoders and finer-grained OIDs
+(int4 vs int8, float8 vs numeric, timestamp vs date) once we surface
+the underlying Arrow types through ``ColumnMeta``.
+
+Postgres wire text format is described in §52.2 of the PostgreSQL docs.
+Roughly: integers and floats use their literal decimal representation;
+timestamps use ``YYYY-MM-DD HH:MM:SS[.ffffff][+TZ]``; ``bytea`` uses the
+``\\xHEX`` form; booleans use ``t`` / ``f``; NULLs use the wire-level
+length-prefix sentinel ``-1`` (handled by ``build_data_row``, not here).
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from datetime import time as dt_time
+from decimal import Decimal
+from typing import Final
+
+# OIDs from PostgreSQL's pg_type catalog. We pick the widest variant per
+# family so BI tools don't truncate on the edges.
+OID_BOOL: Final[int] = 16
+OID_BYTEA: Final[int] = 17
+OID_INT8: Final[int] = 20
+OID_TEXT: Final[int] = 25
+OID_FLOAT8: Final[int] = 701
+OID_NUMERIC: Final[int] = 1700
+OID_DATE: Final[int] = 1082
+OID_TIME: Final[int] = 1083
+OID_TIMESTAMP: Final[int] = 1114
+OID_TIMESTAMPTZ: Final[int] = 1184
+
+
+def oid_for_type_hint(type_hint: str) -> int:
+    """Pick a Postgres OID for one of the executor's coarse type hints.
+
+    The hints come from ``service/db_executor.py``; ``"number"`` covers
+    everything from int4 to numeric, so we use NUMERIC's OID — it is the
+    only Postgres numeric type that BI tools never narrow.
+    """
+
+    if type_hint == "number":
+        return OID_NUMERIC
+    if type_hint == "datetime":
+        return OID_TIMESTAMP
+    if type_hint == "binary":
+        return OID_BYTEA
+    # "string" and anything we don't yet recognise — TEXT is the safe
+    # default that every Postgres client accepts as a text-format value.
+    return OID_TEXT
+
+
+def encode_text_value(value: object, type_hint: str) -> str | None:
+    """Render ``value`` for transmission in a Postgres text-format DataRow.
+
+    Returns ``None`` when ``value`` is ``None`` so the caller (the wire
+    framer) can emit the ``-1`` NULL sentinel.
+    """
+
+    if value is None:
+        return None
+
+    if isinstance(value, bool):
+        return "t" if value else "f"
+
+    if isinstance(value, (int, float, Decimal)):
+        return str(value)
+
+    if isinstance(value, datetime):
+        # ``isoformat`` uses ``T`` between the date and time; real
+        # Postgres uses a space.  BI tools accept both, but matching the
+        # canonical form keeps drivers happy.
+        formatted = value.isoformat(sep=" ")
+        # Postgres uses ``+00`` / ``+05:30`` style offsets — Python emits
+        # ``+00:00``; both parse cleanly so we leave it as-is.
+        return formatted
+
+    if isinstance(value, date):
+        return value.isoformat()
+
+    if isinstance(value, dt_time):
+        return value.isoformat()
+
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        if type_hint == "binary":
+            return "\\x" + bytes(value).hex()
+        # Non-binary column carrying bytes — fall back to UTF-8 decode.
+        return bytes(value).decode("utf-8", errors="replace")
+
+    return str(value)

--- a/tests/integration/test_pgwire_server.py
+++ b/tests/integration/test_pgwire_server.py
@@ -1,9 +1,14 @@
-"""Integration tests for the pgwire surface — Step 1.
+"""Integration tests for the pgwire surface.
 
 Drives a live ``PgWireServer`` on an ephemeral port using raw asyncio
-sockets. This avoids a hard dependency on psycopg/JDBC for the
-hello-world cycle; client-library tests join in Step 4 once the
-extended-query protocol exists.
+sockets. This avoids a hard dependency on psycopg/JDBC for the simple-
+query cycle; client-library tests land alongside the extended-query
+protocol in Step 4.
+
+Step 1 (handshake + canned ``SELECT 1``) lives below.  Step 2 adds
+end-to-end coverage that drives a :class:`SemanticRouter` through the
+same socket — the router's translate/compile path is exercised for
+real; execution is stubbed so the test doesn't need a live warehouse.
 """
 
 from __future__ import annotations
@@ -11,11 +16,16 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import struct
+from typing import Any
 
 import pytest
 
 from orionbelt.pgwire import protocol
+from orionbelt.pgwire.router import SemanticRouter
 from orionbelt.pgwire.server import PgWireServer
+from orionbelt.service.db_executor import ColumnMeta, ExecutionResult
+from orionbelt.service.session_manager import SessionManager
+from tests.conftest import SAMPLE_MODEL_YAML
 
 
 def _startup_payload(params: dict[str, str]) -> bytes:
@@ -139,6 +149,103 @@ async def test_ssl_request_is_rejected_then_startup_continues(
         await writer.drain()
         handshake = await _drain_until_ready(reader)
         assert handshake[0][0] == b"R"
+    finally:
+        writer.write(_terminate_frame())
+        await writer.drain()
+        writer.close()
+        await writer.wait_closed()
+
+
+# ---------------------------------------------------------------------------
+# Step 2: SemanticRouter end-to-end over a live socket.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def pgwire_with_router(monkeypatch: pytest.MonkeyPatch) -> PgWireServer:
+    """Live server with a SemanticRouter handler bound to a loaded model.
+
+    ``execute_sql`` is monkeypatched to return a deterministic stub —
+    the test exercises the translate/compile/encode path; live database
+    execution is covered by the vendor-specific integration suites.
+    """
+
+    mgr = SessionManager()
+    store = mgr.get_or_create_named("commerce")
+    store.load_model(SAMPLE_MODEL_YAML)
+
+    def fake_execute(sql: str, **_: Any) -> ExecutionResult:
+        return ExecutionResult(
+            columns=[
+                ColumnMeta(name="Customer Country", type_hint="string"),
+                ColumnMeta(name="Total Revenue", type_hint="number"),
+            ],
+            raw_rows=[["DE", 1234], ["US", 9876]],
+            row_count=2,
+        )
+
+    monkeypatch.setattr("orionbelt.pgwire.router.execute_sql", fake_execute)
+
+    router = SemanticRouter(session_manager=mgr, default_dialect="duckdb")
+    server = PgWireServer(
+        host="127.0.0.1",
+        port=0,
+        max_connections=8,
+        query_handler=router.handle,
+    )
+    await server.start()
+    serve_task = asyncio.create_task(server.serve_forever())
+    try:
+        yield server
+    finally:
+        await server.stop()
+        serve_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError, Exception):
+            await serve_task
+
+
+async def test_semantic_query_returns_real_rows(pgwire_with_router: PgWireServer) -> None:
+    reader, writer = await asyncio.open_connection("127.0.0.1", pgwire_with_router.bound_port)
+    try:
+        writer.write(_startup_payload({"user": "obsl", "database": "commerce"}))
+        await writer.drain()
+        await _drain_until_ready(reader)
+
+        writer.write(_query_frame('SELECT "Customer Country", "Total Revenue" FROM commerce'))
+        await writer.drain()
+        reply = await _drain_until_ready(reader)
+        tags = [t for t, _ in reply]
+        assert tags == [b"T", b"D", b"D", b"C", b"Z"]
+
+        # RowDescription advertises both columns.
+        _, desc = reply[0]
+        (n_cols,) = struct.unpack("!H", desc[:2])
+        assert n_cols == 2
+
+        # CommandComplete carries the row count.
+        _, cmd = reply[3]
+        assert cmd.startswith(b"SELECT 2")
+    finally:
+        writer.write(_terminate_frame())
+        await writer.drain()
+        writer.close()
+        await writer.wait_closed()
+
+
+async def test_unknown_database_returns_3d000(pgwire_with_router: PgWireServer) -> None:
+    reader, writer = await asyncio.open_connection("127.0.0.1", pgwire_with_router.bound_port)
+    try:
+        # Database name doesn't match any session and __default__ is
+        # empty — router should return an undefined_database error.
+        writer.write(_startup_payload({"user": "obsl", "database": "ghost"}))
+        await writer.drain()
+        await _drain_until_ready(reader)
+
+        writer.write(_query_frame('SELECT "Customer Country" FROM ghost'))
+        await writer.drain()
+        reply = await _drain_until_ready(reader)
+        assert reply[0][0] == b"E"
+        assert b"C3D000\x00" in reply[0][1]
     finally:
         writer.write(_terminate_frame())
         await writer.drain()

--- a/tests/unit/test_pgwire_router.py
+++ b/tests/unit/test_pgwire_router.py
@@ -1,0 +1,223 @@
+"""Unit tests for pgwire/router.py — SemanticRouter orchestration."""
+
+from __future__ import annotations
+
+import asyncio
+import struct
+from typing import Any
+
+import pytest
+
+from orionbelt.pgwire.router import SemanticRouter
+from orionbelt.service.db_executor import ColumnMeta, ExecutionResult
+from orionbelt.service.session_manager import SessionManager
+from tests.conftest import SAMPLE_MODEL_YAML
+
+# ---------------------------------------------------------------------------
+# Helpers — parse the wire bytes we get back so assertions can be readable.
+# ---------------------------------------------------------------------------
+
+
+def _parse_frames(blob: bytes) -> list[tuple[bytes, bytes]]:
+    """Decompose a router reply into (tag, body) frames."""
+
+    frames: list[tuple[bytes, bytes]] = []
+    offset = 0
+    while offset < len(blob):
+        tag = blob[offset : offset + 1]
+        (length,) = struct.unpack("!I", blob[offset + 1 : offset + 5])
+        body = blob[offset + 5 : offset + 1 + length]
+        frames.append((tag, body))
+        offset += 1 + length
+    return frames
+
+
+def _make_manager_with_model() -> tuple[SessionManager, str]:
+    """Single-session manager holding the SAMPLE_MODEL_YAML model.
+
+    Returns ``(manager, model_id)``. Caller is responsible for stop().
+    """
+
+    mgr = SessionManager()
+    store = mgr.get_or_create_named("commerce")
+    result = store.load_model(SAMPLE_MODEL_YAML)
+    return mgr, result.model_id
+
+
+# ---------------------------------------------------------------------------
+# Canned responses
+# ---------------------------------------------------------------------------
+
+
+def test_select_one_does_not_need_a_model() -> None:
+    mgr = SessionManager()
+    router = SemanticRouter(session_manager=mgr, default_dialect="duckdb")
+    reply = asyncio.run(router.handle("SELECT 1", database=""))
+    frames = _parse_frames(reply)
+    tags = [t for t, _ in frames]
+    assert tags == [b"T", b"D", b"C"]
+
+
+def test_blank_query_returns_command_complete_only() -> None:
+    mgr = SessionManager()
+    router = SemanticRouter(session_manager=mgr, default_dialect="duckdb")
+    reply = asyncio.run(router.handle("   ;  ", database=""))
+    frames = _parse_frames(reply)
+    assert [t for t, _ in frames] == [b"C"]
+
+
+# ---------------------------------------------------------------------------
+# Target resolution
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_target_finds_named_session() -> None:
+    mgr, _model_id = _make_manager_with_model()
+    router = SemanticRouter(session_manager=mgr, default_dialect="duckdb")
+    target = router._resolve_target("commerce")  # noqa: SLF001 — unit test reaches into private API
+    assert target.model_id
+
+
+def test_resolve_target_falls_back_to_default_session() -> None:
+    mgr = SessionManager()
+    default_store = mgr.get_or_create_default()
+    result = default_store.load_model(SAMPLE_MODEL_YAML)
+    router = SemanticRouter(session_manager=mgr, default_dialect="duckdb")
+    target = router._resolve_target("unknown-name")  # noqa: SLF001
+    assert target.model_id == result.model_id
+
+
+def test_resolve_target_raises_when_no_model_loaded() -> None:
+    mgr = SessionManager()
+    router = SemanticRouter(session_manager=mgr, default_dialect="duckdb")
+    reply = asyncio.run(router.handle('SELECT "Customer Country" FROM m', database=""))
+    frames = _parse_frames(reply)
+    assert [t for t, _ in frames] == [b"E"]
+    # ErrorResponse body carries fields; SQLSTATE = undefined_database.
+    assert b"C3D000\x00" in frames[0][1]
+
+
+# ---------------------------------------------------------------------------
+# Translate → compile → execute pipeline (execute_sql mocked)
+# ---------------------------------------------------------------------------
+
+
+def _stub_execute_two_rows() -> ExecutionResult:
+    """Mimic what execute_sql would return for a 'country, revenue' query."""
+
+    return ExecutionResult(
+        columns=[
+            ColumnMeta(name="Customer Country", type_hint="string"),
+            ColumnMeta(name="Total Revenue", type_hint="number"),
+        ],
+        raw_rows=[["DE", 1234.5], ["US", 9876]],
+        row_count=2,
+    )
+
+
+def test_semantic_query_round_trips_to_data_rows(monkeypatch: pytest.MonkeyPatch) -> None:
+    mgr, _ = _make_manager_with_model()
+    router = SemanticRouter(session_manager=mgr, default_dialect="duckdb")
+
+    def fake_execute(sql: str, **_: Any) -> ExecutionResult:
+        assert "SELECT" in sql.upper()
+        return _stub_execute_two_rows()
+
+    monkeypatch.setattr("orionbelt.pgwire.router.execute_sql", fake_execute)
+
+    reply = asyncio.run(
+        router.handle(
+            'SELECT "Customer Country", "Total Revenue" FROM commerce',
+            database="commerce",
+        )
+    )
+    frames = _parse_frames(reply)
+    tags = [t for t, _ in frames]
+    assert tags == [b"T", b"D", b"D", b"C"]
+
+    # RowDescription — two columns with the expected names.
+    _, desc = frames[0]
+    (n_cols,) = struct.unpack("!H", desc[:2])
+    assert n_cols == 2
+
+    # DataRow values — two columns each.
+    for tag, body in frames[1:3]:
+        assert tag == b"D"
+        (n_vals,) = struct.unpack("!H", body[:2])
+        assert n_vals == 2
+
+    # CommandComplete carries the row count.
+    _, cmd = frames[3]
+    assert cmd.startswith(b"SELECT 2")
+
+
+def test_translator_error_surfaces_as_error_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    mgr, _ = _make_manager_with_model()
+    router = SemanticRouter(session_manager=mgr, default_dialect="duckdb")
+
+    # Reference a column the model doesn't expose — the translator will
+    # reject it before we ever call execute_sql.
+    def fake_execute(*_args: Any, **_kwargs: Any) -> ExecutionResult:
+        raise AssertionError("execute_sql must not be called on translation failure")
+
+    monkeypatch.setattr("orionbelt.pgwire.router.execute_sql", fake_execute)
+
+    reply = asyncio.run(
+        router.handle('SELECT "Nonexistent Column" FROM commerce', database="commerce")
+    )
+    frames = _parse_frames(reply)
+    assert [t for t, _ in frames] == [b"E"]
+
+
+def test_execution_unavailable_surfaces_as_57p03(monkeypatch: pytest.MonkeyPatch) -> None:
+    from orionbelt.service.db_executor import ExecutionUnavailableError
+
+    mgr, _ = _make_manager_with_model()
+    router = SemanticRouter(session_manager=mgr, default_dialect="duckdb")
+
+    def fake_execute(*_args: Any, **_kwargs: Any) -> ExecutionResult:
+        raise ExecutionUnavailableError("driver missing")
+
+    monkeypatch.setattr("orionbelt.pgwire.router.execute_sql", fake_execute)
+
+    reply = asyncio.run(
+        router.handle('SELECT "Customer Country" FROM commerce', database="commerce")
+    )
+    frames = _parse_frames(reply)
+    assert frames[0][0] == b"E"
+    assert b"C57P03\x00" in frames[0][1]
+
+
+def test_execution_error_surfaces_as_22000(monkeypatch: pytest.MonkeyPatch) -> None:
+    from orionbelt.service.db_executor import ExecutionError
+
+    mgr, _ = _make_manager_with_model()
+    router = SemanticRouter(session_manager=mgr, default_dialect="duckdb")
+
+    def fake_execute(*_args: Any, **_kwargs: Any) -> ExecutionResult:
+        raise ExecutionError("syntax error at the end of input")
+
+    monkeypatch.setattr("orionbelt.pgwire.router.execute_sql", fake_execute)
+
+    reply = asyncio.run(
+        router.handle('SELECT "Customer Country" FROM commerce', database="commerce")
+    )
+    frames = _parse_frames(reply)
+    assert frames[0][0] == b"E"
+    assert b"C22000\x00" in frames[0][1]
+
+
+def test_uses_default_dialect_when_compiling(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The default_dialect set at router construction is passed through."""
+
+    mgr, _ = _make_manager_with_model()
+    router = SemanticRouter(session_manager=mgr, default_dialect="postgres")
+    seen: dict[str, Any] = {}
+
+    def fake_execute(sql: str, *, dialect: str, **_: Any) -> ExecutionResult:
+        seen["dialect"] = dialect
+        return _stub_execute_two_rows()
+
+    monkeypatch.setattr("orionbelt.pgwire.router.execute_sql", fake_execute)
+    asyncio.run(router.handle('SELECT "Customer Country" FROM commerce', database="commerce"))
+    assert seen["dialect"] == "postgres"

--- a/tests/unit/test_pgwire_types.py
+++ b/tests/unit/test_pgwire_types.py
@@ -1,0 +1,70 @@
+"""Unit tests for pgwire/types.py — OID mapping and text encoding."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from datetime import time as dt_time
+from decimal import Decimal
+
+from orionbelt.pgwire import types as pgtypes
+
+
+def test_oid_for_known_hints() -> None:
+    assert pgtypes.oid_for_type_hint("number") == pgtypes.OID_NUMERIC
+    assert pgtypes.oid_for_type_hint("string") == pgtypes.OID_TEXT
+    assert pgtypes.oid_for_type_hint("datetime") == pgtypes.OID_TIMESTAMP
+    assert pgtypes.oid_for_type_hint("binary") == pgtypes.OID_BYTEA
+
+
+def test_oid_for_unknown_hint_falls_back_to_text() -> None:
+    assert pgtypes.oid_for_type_hint("something-new") == pgtypes.OID_TEXT
+
+
+def test_encode_none_returns_none() -> None:
+    assert pgtypes.encode_text_value(None, "string") is None
+    assert pgtypes.encode_text_value(None, "number") is None
+
+
+def test_encode_bool_emits_postgres_letters() -> None:
+    assert pgtypes.encode_text_value(True, "string") == "t"
+    assert pgtypes.encode_text_value(False, "string") == "f"
+
+
+def test_encode_numeric_types() -> None:
+    assert pgtypes.encode_text_value(42, "number") == "42"
+    assert pgtypes.encode_text_value(3.14, "number") == "3.14"
+    assert pgtypes.encode_text_value(Decimal("12345.6789"), "number") == "12345.6789"
+
+
+def test_encode_datetime_uses_space_separator() -> None:
+    ts = datetime(2024, 5, 16, 12, 34, 56, 789000)
+    encoded = pgtypes.encode_text_value(ts, "datetime")
+    assert encoded == "2024-05-16 12:34:56.789000"
+
+
+def test_encode_datetime_with_timezone_preserves_offset() -> None:
+    ts = datetime(2024, 5, 16, 12, 34, 56, tzinfo=UTC)
+    encoded = pgtypes.encode_text_value(ts, "datetime")
+    assert encoded is not None
+    assert encoded.startswith("2024-05-16 12:34:56")
+    assert encoded.endswith("+00:00")
+
+
+def test_encode_date() -> None:
+    assert pgtypes.encode_text_value(date(2024, 1, 31), "datetime") == "2024-01-31"
+
+
+def test_encode_time() -> None:
+    assert pgtypes.encode_text_value(dt_time(9, 5, 0), "string") == "09:05:00"
+
+
+def test_encode_binary_uses_hex_prefix() -> None:
+    assert pgtypes.encode_text_value(b"\x00\xff", "binary") == "\\x00ff"
+
+
+def test_encode_string_falls_back_to_str() -> None:
+    class _Custom:
+        def __str__(self) -> str:
+            return "custom-repr"
+
+    assert pgtypes.encode_text_value(_Custom(), "string") == "custom-repr"


### PR DESCRIPTION
Implements Step 2 of [design/PLAN_postgres_wire.md](design/PLAN_postgres_wire.md) §6 — BI-style queries flowing over the Postgres wire run through the same OBSQL pipeline as the REST \`/v1/query/semantic-ql\` endpoint.

## Summary
- New \`pgwire/router.py\` (\`SemanticRouter\`) — resolves the Postgres \`database\` startup parameter to a model, translates SQL via \`translate_sql_to_query\`, compiles via \`store.compile_query\`, executes via \`service.db_executor.execute_sql\`, encodes the result as Postgres wire frames.
- New \`pgwire/types.py\` — OBSL \`type_hint\` → Postgres OID + text-format value encoder. Coarse mapping (numeric/text/timestamp/bytea); binary format + finer OIDs land in Step 7.
- \`pgwire/server.py\` — \`QueryHandler\` grew the \`database\` arg so the router sees the client's startup database. Step 1 \`SELECT 1\` responder is repurposed as the no-handler fallback.
- \`pgwire/startup.py\` — when no explicit handler is supplied but a SessionManager is, builds a \`SemanticRouter\` from it. The FastAPI lifespan passes the live manager through.
- \`SELECT 1\` remains a canned response (no model required) for BI-tool connectivity probes.

## Error mapping

| OBSL exception | Postgres SQLSTATE | Class |
|---|---|---|
| \`SQLTranslationError\` (UNKNOWN_COLUMN) | \`42703\` | undefined_column |
| \`SQLTranslationError\` (UNSUPPORTED_SQL_FEATURE) | \`0A000\` | feature_not_supported |
| \`ResolutionError\` | \`42703\` | undefined_column |
| \`FanoutError\` | \`0A000\` | feature_not_supported |
| \`UnsupportedDialectError\` / \`UnsupportedAggregationError\` / \`UnsupportedGroupingError\` | \`0A000\` | feature_not_supported |
| \`ExecutionUnavailableError\` | \`57P03\` | cannot_connect_now |
| \`ExecutionError\` | \`22000\` | data_exception |
| Model not found for \`database\` | \`3D000\` | invalid_catalog_name |
| Anything else | \`58000\` | system_error |

## Verification — live psql against the baked DuckDB seed

\`\`\`
\$ MODEL_FILES=examples/orionbelt_1_commerce.yaml \\
  DB_VENDOR=duckdb DUCKDB_DATABASE=examples/orionbelt_1_commerce.duckdb \\
  QUERY_EXECUTE=true PGWIRE_ENABLED=true uv run orionbelt-api

\$ psql -h 127.0.0.1 -p 5432 -U obsl -d orionbelt_1_commerce \\
       -c 'SELECT \"Sales Year\", \"Total Sales\" FROM m LIMIT 5'
        Sales Year         | Total Sales
---------------------------+-------------
 2021-01-01T00:00:00+01:00 |  6492897.82
 2022-01-01T00:00:00+01:00 |  6778394.62
 2023-01-01T00:00:00+01:00 |  7174810.49
 2024-01-01T00:00:00+01:00 |  9938669.99
 2025-01-01T00:00:00+01:00 | 12073736.69
(5 rows)
\`\`\`

## Test coverage
- 10 unit tests in \`tests/unit/test_pgwire_types.py\` — OID lookup + text encoding for all hint families.
- 10 unit tests in \`tests/unit/test_pgwire_router.py\` — canned \`SELECT 1\`, target resolution rules, translate / compile / execute paths with \`execute_sql\` monkeypatched, error→SQLSTATE mapping.
- 2 new integration tests in \`tests/integration/test_pgwire_server.py\` — live socket round-trip of a real semantic query, and the \`3D000\` undefined-database path.
- Full suite: **1899 passed, 60 skipped, 0 regressions** (was 1876 in Step 1).

## Not in this PR (Steps 3–8)
- \`pg_catalog\` / \`information_schema\` emulation — Step 3.
- Extended query protocol (Parse/Bind/Describe/Execute) — Step 4.
- Tableau / Power BI / DBeaver integration tests — Step 5.
- \`password\` + \`scram-sha-256\` auth — Step 6.
- Binary format encoding + finer-grained OIDs — Step 7.
- Docs page \`docs/guide/postgres-wire.md\` + comparison matrix update — Step 8.

## Test plan
- [x] \`uv run pytest tests/unit/test_pgwire_router.py tests/unit/test_pgwire_types.py tests/integration/test_pgwire_server.py\`
- [x] Full suite green
- [x] \`ruff check\`, \`ruff format --check\`, \`mypy\` all clean
- [x] Live psql semantic query returns real rows from baked DuckDB seed

🤖 Generated with [Claude Code](https://claude.com/claude-code)