### PR TITLE
feat(pgwire): Step 3 — pg_catalog / information_schema emulation

### DIFF
--- a/src/orionbelt/pgwire/canned.py
+++ b/src/orionbelt/pgwire/canned.py
@@ -1,0 +1,156 @@
+"""Hand-written replies for Postgres protocol-level probes (Step 3).
+
+Many Postgres clients and BI tools fire a flurry of trivial queries
+before they let the user run anything:
+
+* ``SELECT 1``                                    — connectivity probe
+* ``SELECT version()``                            — server identity
+* ``SHOW <param>`` / ``SET <param> = <value>``    — session state
+* ``BEGIN`` / ``COMMIT`` / ``ROLLBACK`` / ``SAVEPOINT``
+                                                  — transaction wrappers
+* ``SELECT current_schema()`` / ``current_database()`` / ``current_user``
+* ``SELECT pg_catalog.set_config(...)``           — search_path tweaks
+
+OBSL is read-only and doesn't keep session state, so we accept these
+no-ops with a clean reply rather than letting them fall through to the
+semantic translator (which would treat them as a model query and
+error). DDL / DML / writes still hit the semantic router and bounce
+there per design/PLAN_postgres_wire.md §10.
+"""
+
+from __future__ import annotations
+
+import re
+
+from orionbelt.pgwire import protocol
+
+# Connectivity probes that don't need a model loaded.
+_CONNECTIVITY_PATTERNS: dict[str, tuple[str, str, str]] = {
+    # normalised SQL → (column name, postgres-typed OID name, value)
+    "select 1": ("?column?", "int4", "1"),
+}
+
+
+# Parameter values surfaced via ``SHOW``.  Mirrors the ParameterStatus
+# frames the server sends after AuthenticationOk so clients see a
+# consistent view of session state.
+_SHOW_VALUES: dict[str, str] = {
+    "server_version": "15.0 (orionbelt-pgwire 0.3)",
+    "server_encoding": "UTF8",
+    "client_encoding": "UTF8",
+    "datestyle": "ISO, MDY",
+    "timezone": "UTC",
+    "integer_datetimes": "on",
+    "standard_conforming_strings": "on",
+    "application_name": "",
+    "is_superuser": "off",
+    "session_authorization": "obsl",
+    "search_path": '"$user", public',
+    "transaction_isolation": "read committed",
+    "transaction_read_only": "off",
+    "default_transaction_isolation": "read committed",
+    "default_transaction_read_only": "off",
+    "extra_float_digits": "3",
+    "max_index_keys": "32",
+    "max_identifier_length": "63",
+    "block_size": "8192",
+}
+
+
+_VERSION_LITERAL = "PostgreSQL 15.0 on x86_64-pc-linux-gnu (OrionBelt pgwire 0.3)"
+
+
+_RE_SHOW = re.compile(r"^show\s+([a-z_][a-z0-9_]*)\s*$", re.IGNORECASE)
+_RE_SET = re.compile(r"^set\s+", re.IGNORECASE)
+_RE_RESET = re.compile(r"^reset\s+", re.IGNORECASE)
+_RE_DISCARD = re.compile(r"^discard\s+", re.IGNORECASE)
+_RE_BEGIN = re.compile(r"^(begin|start\s+transaction)\b", re.IGNORECASE)
+_RE_COMMIT = re.compile(r"^(commit|end)\b", re.IGNORECASE)
+_RE_ROLLBACK = re.compile(r"^rollback\b", re.IGNORECASE)
+_RE_SAVEPOINT = re.compile(r"^(savepoint|release\s+savepoint)\b", re.IGNORECASE)
+
+
+def match_canned(sql: str) -> bytes | None:
+    """Return wire bytes for a recognised protocol probe, else ``None``.
+
+    The caller appends ``ReadyForQuery``; we only emit the per-statement
+    reply (RowDescription + DataRow + CommandComplete or a bare
+    CommandComplete).  Returns ``None`` so the router falls through to
+    catalog / semantic dispatch.
+    """
+
+    normalised = _strip_terminator(sql).lower()
+    if not normalised:
+        # Empty / whitespace-only query — Postgres replies with
+        # EmptyQueryResponse; we approximate with a bare
+        # CommandComplete.  Behaviour matches what jdbc / psql expect.
+        return protocol.build_command_complete("")
+
+    # Connectivity probes (SELECT 1, etc.)
+    canned = _CONNECTIVITY_PATTERNS.get(normalised)
+    if canned is not None:
+        name, type_name, value = canned
+        oid = protocol.OID_INT4 if type_name == "int4" else protocol.OID_TEXT
+        return (
+            protocol.build_row_description([(name, oid)])
+            + protocol.build_data_row([value])
+            + protocol.build_command_complete("SELECT 1")
+        )
+
+    if normalised == "select version()":
+        return (
+            protocol.build_row_description([("version", protocol.OID_TEXT)])
+            + protocol.build_data_row([_VERSION_LITERAL])
+            + protocol.build_command_complete("SELECT 1")
+        )
+
+    if normalised in {
+        "select current_schema()",
+        "select current_schema",
+    }:
+        return _single_text_row("current_schema", "public")
+
+    if normalised in {"select current_database()", "select current_database"}:
+        return _single_text_row("current_database", _SHOW_VALUES["session_authorization"])
+
+    if normalised in {"select current_user", "select current_user()", "select user"}:
+        return _single_text_row("current_user", _SHOW_VALUES["session_authorization"])
+
+    show_match = _RE_SHOW.match(normalised)
+    if show_match is not None:
+        name = show_match.group(1).lower()
+        value = _SHOW_VALUES.get(name, "")
+        return _single_text_row(name, value)
+
+    # SET / RESET / DISCARD / transaction wrappers — accept and ignore.
+    if _RE_SET.match(normalised) is not None:
+        return protocol.build_command_complete("SET")
+    if _RE_RESET.match(normalised) is not None:
+        return protocol.build_command_complete("RESET")
+    if _RE_DISCARD.match(normalised) is not None:
+        return protocol.build_command_complete("DISCARD ALL")
+    if _RE_BEGIN.match(normalised) is not None:
+        return protocol.build_command_complete("BEGIN")
+    if _RE_COMMIT.match(normalised) is not None:
+        return protocol.build_command_complete("COMMIT")
+    if _RE_ROLLBACK.match(normalised) is not None:
+        return protocol.build_command_complete("ROLLBACK")
+    if _RE_SAVEPOINT.match(normalised) is not None:
+        return protocol.build_command_complete("SAVEPOINT")
+
+    return None
+
+
+def _strip_terminator(sql: str) -> str:
+    text = sql.strip()
+    while text.endswith(";"):
+        text = text[:-1].rstrip()
+    return text
+
+
+def _single_text_row(column_name: str, value: str) -> bytes:
+    return (
+        protocol.build_row_description([(column_name, protocol.OID_TEXT)])
+        + protocol.build_data_row([value])
+        + protocol.build_command_complete("SELECT 1")
+    )

--- a/src/orionbelt/pgwire/catalog.py
+++ b/src/orionbelt/pgwire/catalog.py
@@ -1,0 +1,360 @@
+"""Embedded ``pg_catalog`` / ``information_schema`` emulator (Step 3).
+
+Builds an in-memory DuckDB and registers each loaded OBSL model as an
+empty TABLE so DuckDB's native ``pg_catalog`` (auto-populated from the
+schema) answers Postgres introspection probes — ``\\dt``, DBeaver schema
+trees, Tableau's pre-flight checks — without us hand-rolling pg_class /
+pg_namespace / pg_attribute.
+
+Why a TABLE and not a VIEW: ``psql \\dt`` filters
+``c.relkind IN ('r','p','')`` so views (``relkind='v'``) are skipped.
+The tables hold zero rows; they exist purely so the catalog views
+describe them. Semantic queries against the same model never reach
+this connection — they're routed to the real warehouse by the router.
+
+Caveat: DuckDB's ``pg_attribute.atttypid`` returns DuckDB's internal
+type ids, not real Postgres OIDs. ``\\d <table>`` in psql will show
+mislabeled types; clients that consult ``information_schema.columns``
+instead (DBeaver, Tableau, Power BI) get the correct DuckDB SQL types.
+Step 5 of design/PLAN_postgres_wire.md addresses this for BI-tool
+fidelity.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import re
+import threading
+import time
+from collections.abc import Iterator
+from typing import Any
+
+import duckdb
+
+from orionbelt.models.semantic import DataType, Dimension, Measure, Metric, SemanticModel
+from orionbelt.service.db_executor import ColumnMeta, ExecutionResult
+from orionbelt.service.session_manager import SessionManager
+
+logger = logging.getLogger(__name__)
+
+
+# OBML DataType → DuckDB SQL type. Coarse mapping; column-level
+# ``dataType`` overrides (e.g. ``decimal(18,2)``) are ignored on
+# purpose — pg_attribute's mis-typing makes finer types invisible
+# anyway and the catalog only needs to round-trip the *column* shape.
+_DATATYPE_TO_DUCKDB: dict[DataType, str] = {
+    DataType.STRING: "VARCHAR",
+    DataType.JSON: "JSON",
+    DataType.INT: "BIGINT",
+    DataType.FLOAT: "DOUBLE",
+    DataType.DATE: "DATE",
+    DataType.TIME: "TIME",
+    DataType.TIME_TZ: "TIMETZ",
+    DataType.TIMESTAMP: "TIMESTAMP",
+    DataType.TIMESTAMP_TZ: "TIMESTAMPTZ",
+    DataType.BOOLEAN: "BOOLEAN",
+}
+
+# DuckDB identifier safety. Postgres allows arbitrary quoted names, so
+# any printable Unicode is fair game inside the model.  We pre-validate
+# the *model* name (used as the table name) more strictly because BI
+# tools sometimes refuse quoted identifiers; column names stay quoted.
+_SAFE_TABLE_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,62}$")
+
+
+# Stub Postgres catalog functions referenced by psql ``\\dt`` / ``\\d``.
+# DuckDB exposes ``pg_class`` / ``pg_namespace`` / ``pg_attribute`` as
+# native views but stops short of these helper scalars; we hand-roll
+# them as macros in the main schema and pair with a SQL pre-processor
+# that strips ``pg_catalog.`` from function references (DuckDB rejects
+# qualified function lookups into a system schema).
+_STUB_MACROS: tuple[str, ...] = (
+    "CREATE OR REPLACE MACRO pg_get_userbyid(uid) AS 'obsl'",
+    "CREATE OR REPLACE MACRO pg_table_is_visible(oid) AS true",
+    "CREATE OR REPLACE MACRO pg_type_is_visible(oid) AS true",
+    "CREATE OR REPLACE MACRO pg_get_partkeydef(oid) AS NULL",
+    "CREATE OR REPLACE MACRO pg_get_indexdef(oid) AS NULL",
+    "CREATE OR REPLACE MACRO pg_get_constraintdef(oid) AS NULL",
+    "CREATE OR REPLACE MACRO pg_get_expr(expr, oid) AS NULL",
+    "CREATE OR REPLACE MACRO pg_relation_is_publishable(oid) AS false",
+    "CREATE OR REPLACE MACRO obj_description(oid, catalog) AS NULL",
+    "CREATE OR REPLACE MACRO col_description(oid, col) AS NULL",
+    "CREATE OR REPLACE MACRO format_type(oid, typemod) AS 'unknown'",
+    "CREATE OR REPLACE MACRO pg_encoding_to_char(enc) AS 'UTF8'",
+)
+
+
+# Rewrites we apply to the SQL before handing it to DuckDB.  Each
+# pattern targets a specific psql / pgAdmin quirk.  Order matters: the
+# more specific rules (``OPERATOR(pg_catalog.~)``) run before the
+# generic ``pg_catalog.<ident>`` prefix strip.
+_REWRITES: tuple[tuple[re.Pattern[str], str], ...] = (
+    # COLLATE pg_catalog.default → drop entirely.  DuckDB has no notion
+    # of named collations and the default collation is implicit anyway.
+    (re.compile(r"\bCOLLATE\s+pg_catalog\.\w+\b", re.IGNORECASE), ""),
+    # OPERATOR(pg_catalog.~) → OPERATOR(~), and the same for other
+    # comparison / regex operators psql wraps with the qualifier.
+    (re.compile(r"OPERATOR\(\s*pg_catalog\.", re.IGNORECASE), "OPERATOR("),
+    # ::pg_catalog.text / ::pg_catalog.regtype / ::pg_catalog.name —
+    # collapse Postgres-specific type names that don't exist in DuckDB
+    # to VARCHAR. The cast result type is only used for display, so the
+    # loose coercion is fine for catalog probes.
+    (
+        re.compile(
+            r"::\s*pg_catalog\.(text|name|regtype|regclass|regprocedure|oid|char)\b",
+            re.IGNORECASE,
+        ),
+        "::VARCHAR",
+    ),
+    # Function / operator references prefixed with pg_catalog. — strip
+    # the prefix so DuckDB resolves against the unqualified built-in or
+    # our stub macros.  We deliberately don't touch table references
+    # like ``pg_catalog.pg_class`` because DuckDB handles those itself.
+    (
+        re.compile(
+            r"pg_catalog\.(pg_[a-z_]+|format_type|obj_description|col_description)\s*\(",
+            re.IGNORECASE,
+        ),
+        r"\1(",
+    ),
+)
+
+
+def _rewrite_for_duckdb(sql: str) -> str:
+    """Best-effort SQL rewrite so psql introspection runs on DuckDB.
+
+    Touches only the patterns documented in ``_REWRITES``.  Unrecognised
+    constructs are left alone — the catalog branch is best-effort by
+    design, and the caller's error response will surface anything we
+    miss so we can extend the rule list incrementally.
+    """
+
+    out = sql
+    for pattern, replacement in _REWRITES:
+        out = pattern.sub(replacement, out)
+    return out
+
+
+class CatalogEmulator:
+    """Wraps an in-memory DuckDB connection used only for catalog probes.
+
+    The emulator is intended to be created once and shared across all
+    pgwire connections.  ``refresh()`` rebuilds the schema from the
+    current :class:`SessionManager` state; ``execute()`` runs an
+    arbitrary SQL string against the connection and returns an
+    :class:`ExecutionResult` so the router can encode rows uniformly
+    with the semantic path.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._con: duckdb.DuckDBPyConnection = duckdb.connect(database=":memory:")
+        self._registered_tables: list[str] = []
+        for ddl in _STUB_MACROS:
+            with contextlib.suppress(Exception):
+                self._con.execute(ddl)
+
+    # ------------------------------------------------------------------
+    # Refresh — rebuild the in-memory schema from a SessionManager.
+    # ------------------------------------------------------------------
+
+    def refresh(self, session_manager: SessionManager) -> None:
+        """Drop and recreate one empty TABLE per loaded model.
+
+        Called on every catalog probe — the cost is dominated by the
+        DDL round-trip (~microseconds for a handful of models) and the
+        simpler design is worth more than a stale-cache invalidation
+        protocol.
+        """
+
+        with self._lock:
+            # Drop everything we registered last time first.
+            for table in self._registered_tables:
+                with contextlib.suppress(Exception):
+                    self._con.execute(f'DROP TABLE IF EXISTS "{table}"')
+            self._registered_tables = []
+
+            for store_target, model in _iter_loaded_models(session_manager):
+                table_name = _safe_model_table_name(store_target)
+                ddl = _build_table_ddl(table_name, model)
+                if ddl is None:
+                    continue
+                try:
+                    self._con.execute(ddl)
+                except duckdb.Error:  # pragma: no cover — defensive guard
+                    logger.exception(
+                        "Failed to register catalog table for model '%s'", store_target
+                    )
+                    continue
+                self._registered_tables.append(table_name)
+
+    # ------------------------------------------------------------------
+    # Execute — run a catalog/info-schema query through DuckDB.
+    # ------------------------------------------------------------------
+
+    def execute(self, sql: str) -> ExecutionResult:
+        """Run ``sql`` against the embedded DuckDB.
+
+        DuckDB's pg_catalog and information_schema are auto-populated
+        from the schema we registered in :meth:`refresh`, so the
+        caller doesn't need to special-case which table is being
+        queried.  Errors bubble as ``duckdb.Error``.
+        """
+
+        t0 = time.monotonic()
+        rewritten = _rewrite_for_duckdb(sql)
+        with self._lock:
+            cursor = self._con.execute(rewritten)
+            rows_raw = cursor.fetchall()
+            description = cursor.description or []
+        elapsed_ms = (time.monotonic() - t0) * 1000.0
+        columns = [
+            ColumnMeta(name=str(d[0]), type_hint=_duckdb_desc_to_hint(d)) for d in description
+        ]
+        rows = [list(row) for row in rows_raw]
+        return ExecutionResult(
+            columns=columns,
+            raw_rows=rows,
+            row_count=len(rows),
+            execution_time_ms=elapsed_ms,
+        )
+
+    # ------------------------------------------------------------------
+
+    def close(self) -> None:
+        with self._lock, contextlib.suppress(Exception):
+            self._con.close()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _iter_loaded_models(session_manager: SessionManager) -> Iterator[tuple[str, SemanticModel]]:
+    """Yield ``(target_name, SemanticModel)`` for every loaded model.
+
+    ``target_name`` is the addressing name BI tools use as the Postgres
+    ``database`` parameter:
+
+    * multi-model (``MODEL_FILES``): each preload sits in its own
+      *protected* session whose id IS the OBML name; iterated via
+      :meth:`SessionManager.list_protected_session_ids`.
+    * single-model legacy (``MODEL_FILE``): the model lives in the
+      ``__default__`` session, exposed under that name.
+    * user-created sessions: iterated via
+      :meth:`SessionManager.list_sessions` so models loaded over REST
+      still light up the catalog.
+
+    ``list_sessions()`` filters out the default + protected sets, so we
+    union all three sources manually to cover production layouts.
+    """
+
+    candidate_ids: list[str] = []
+    candidate_ids.extend(session_manager.list_protected_session_ids())
+    candidate_ids.append("__default__")
+    candidate_ids.extend(s.session_id for s in session_manager.list_sessions())
+
+    seen_names: set[str] = set()
+    for session_id in candidate_ids:
+        if session_id in seen_names:
+            continue
+        try:
+            store = session_manager.get_store(session_id)
+        except Exception:
+            continue
+        models = store.list_models()
+        if not models:
+            continue
+        try:
+            model = store.get_model(models[0].model_id)
+        except KeyError:
+            continue
+        seen_names.add(session_id)
+        yield session_id, model
+
+
+def _safe_model_table_name(name: str) -> str:
+    """Coerce a model addressing name into a DuckDB-safe table name.
+
+    The pgwire surface accepts arbitrary Postgres database parameters,
+    but DuckDB DDL is friendlier with simple identifiers. Names that
+    don't match the canonical pattern fall through unchanged inside
+    double quotes — DuckDB tolerates that fine; we just pre-check so
+    common cases produce predictable bare identifiers.
+    """
+
+    if _SAFE_TABLE_NAME.match(name):
+        return name
+    return name.replace('"', '""')
+
+
+def _build_table_ddl(table_name: str, model: SemanticModel) -> str | None:
+    """Build the ``CREATE TABLE`` for a model.
+
+    Columns: every dimension, measure, and metric exposed by the
+    model.  Names are quoted because OBSL labels routinely contain
+    spaces and punctuation.  Returns ``None`` if no columns survive
+    deduplication — DuckDB rejects empty column lists.
+    """
+
+    columns: list[str] = []
+    seen: set[str] = set()
+    for label, sql_type in _model_columns(model):
+        if label in seen:
+            continue
+        seen.add(label)
+        quoted = label.replace('"', '""')
+        columns.append(f'"{quoted}" {sql_type}')
+    if not columns:
+        return None
+    quoted_table = table_name.replace('"', '""')
+    return f'CREATE TABLE "{quoted_table}" ({", ".join(columns)})'
+
+
+def _model_columns(model: SemanticModel) -> Iterator[tuple[str, str]]:
+    for label, dim in model.dimensions.items():
+        yield label, _dim_sql_type(dim)
+    for label, measure in model.measures.items():
+        yield label, _measure_sql_type(measure)
+    for label, metric in model.metrics.items():
+        yield label, _metric_sql_type(metric)
+
+
+def _dim_sql_type(dim: Dimension) -> str:
+    return _DATATYPE_TO_DUCKDB.get(dim.result_type, "VARCHAR")
+
+
+def _measure_sql_type(measure: Measure) -> str:
+    return _DATATYPE_TO_DUCKDB.get(measure.result_type, "DOUBLE")
+
+
+def _metric_sql_type(_metric: Metric) -> str:
+    # Metrics produce a single derived value — float is the safe
+    # default the OBSL compiler also uses.  Step 7's finer type story
+    # can revisit per-metric output typing.
+    return "DOUBLE"
+
+
+def _duckdb_desc_to_hint(description_row: tuple[Any, ...]) -> str:
+    """Coarse DuckDB type-code → executor type_hint.
+
+    DuckDB's cursor description carries a string type name in slot 1.
+    We collapse it onto the same four-hint vocabulary the executor
+    uses so the encoder in pgwire/types.py is shared between the
+    catalog and semantic paths.
+    """
+
+    if len(description_row) < 2 or description_row[1] is None:
+        return "string"
+    name = str(description_row[1]).lower()
+    if any(token in name for token in ("int", "decimal", "numeric", "float", "double", "real")):
+        return "number"
+    if any(token in name for token in ("timestamp", "date", "time")):
+        return "datetime"
+    if name == "boolean" or name == "bool":
+        return "string"  # text-format bool encoder picks 't'/'f' from python bool
+    if "blob" in name or "binary" in name:
+        return "binary"
+    return "string"

--- a/src/orionbelt/pgwire/router.py
+++ b/src/orionbelt/pgwire/router.py
@@ -1,20 +1,28 @@
-"""Semantic-SQL dispatcher for the Postgres wire surface (Step 2).
+"""Semantic-SQL dispatcher for the Postgres wire surface.
 
 The router takes a raw SQL string + the ``database`` value from the
-Postgres StartupMessage and runs the same translate / compile / execute
-pipeline as the REST ``/v1/query/semantic-ql`` endpoint, then encodes
-the result as Postgres wire frames.
+Postgres StartupMessage and dispatches:
 
-Step 2 ships a "semantic-only" router: anything other than the canned
-``SELECT 1`` connectivity probe is routed through the OBSQL pipeline.
-Step 3 adds the catalog branch (``pg_catalog.*`` / ``information_schema.*``)
-and Step 4 adds the extended query protocol on top.
+1. Canned protocol probes (``SELECT 1``, ``SHOW``, ``SET``,
+   transaction wrappers, ``SELECT version()`` …) — handled in
+   :mod:`pgwire.canned`.
+2. Catalog probes (anything referencing ``pg_catalog.*`` or
+   ``information_schema.*``) — routed to the embedded DuckDB
+   in :mod:`pgwire.catalog`.
+3. Semantic SQL — the same translate / compile / execute pipeline as
+   the REST ``/v1/query/semantic-ql`` endpoint, then encoded as
+   Postgres wire frames.
+
+Step 4 adds the extended query protocol on top.
 """
 
 from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+
+import sqlglot
+import sqlglot.expressions as exp
 
 from orionbelt.compiler.fanout import FanoutError
 from orionbelt.compiler.resolution import ResolutionError
@@ -23,6 +31,8 @@ from orionbelt.dialect.base import UnsupportedAggregationError, UnsupportedGroup
 from orionbelt.dialect.registry import UnsupportedDialectError
 from orionbelt.models.semantic import SemanticModel
 from orionbelt.pgwire import protocol
+from orionbelt.pgwire.canned import match_canned
+from orionbelt.pgwire.catalog import CatalogEmulator
 from orionbelt.pgwire.types import encode_text_value, oid_for_type_hint
 from orionbelt.service.db_executor import (
     ExecutionError,
@@ -73,9 +83,11 @@ class SemanticRouter:
         *,
         session_manager: SessionManager,
         default_dialect: str,
+        catalog: CatalogEmulator | None = None,
     ) -> None:
         self._sessions = session_manager
         self._default_dialect = default_dialect
+        self._catalog = catalog if catalog is not None else CatalogEmulator()
 
     async def handle(self, sql: str, database: str) -> bytes:
         """Top-level entry point used by the pgwire server loop.
@@ -85,19 +97,24 @@ class SemanticRouter:
         + CommandComplete frames, or a single ErrorResponse.
         """
 
-        normalised = sql.strip().rstrip(";").strip()
-        if not normalised:
-            return protocol.build_command_complete("")
+        # 1. Canned protocol probes (SELECT 1, SHOW, SET, BEGIN, …).
+        canned = match_canned(sql)
+        if canned is not None:
+            return canned
 
-        # Cheap connectivity probe. Step 3 routes pg_catalog / version()
-        # / SET / SHOW through the catalog emulator; for now we only
-        # answer the most common BI-tool ping.
-        if normalised.lower() == "select 1":
-            return (
-                protocol.build_row_description([("?column?", protocol.OID_INT4)])
-                + protocol.build_data_row(["1"])
-                + protocol.build_command_complete("SELECT 1")
-            )
+        # 2. Catalog probes (pg_catalog.*, information_schema.*).
+        if references_catalog(sql):
+            try:
+                self._catalog.refresh(self._sessions)
+                result = self._catalog.execute(sql)
+            except Exception as exc:  # noqa: BLE001 — protocol boundary
+                logger.info("pgwire catalog probe failed: %s", exc)
+                return protocol.build_error_response(
+                    severity="ERROR",
+                    code=SQLSTATE_SYNTAX_ERROR,
+                    message=f"catalog query failed: {exc}",
+                )
+            return _encode_result(result)
 
         try:
             target = self._resolve_target(database)
@@ -254,6 +271,52 @@ class SemanticRouter:
         except KeyError:
             return None
         return _ResolvedTarget(store=store, model_id=chosen_id, model=model)
+
+
+_CATALOG_SCHEMAS: frozenset[str] = frozenset({"pg_catalog", "information_schema"})
+
+
+def references_catalog(sql: str) -> bool:
+    """Return ``True`` when the query needs the catalog emulator.
+
+    Detects two shapes:
+
+    * a ``FROM`` / ``JOIN`` target whose schema or database is
+      ``pg_catalog`` or ``information_schema``; and
+    * a function reference like ``pg_catalog.set_config(...)``.
+
+    Falls back to a cheap substring test if sqlglot can't parse the
+    query — Postgres clients sometimes emit dialect-specific snippets
+    (e.g. operator classes) sqlglot doesn't fully understand.
+    """
+
+    try:
+        parsed = sqlglot.parse_one(sql, read="postgres")
+    except Exception:
+        lowered = sql.lower()
+        return "pg_catalog" in lowered or "information_schema" in lowered
+
+    for table in parsed.find_all(exp.Table):
+        if (table.db or "").lower() in _CATALOG_SCHEMAS:
+            return True
+        if (table.text("db") or "").lower() in _CATALOG_SCHEMAS:
+            return True
+        if (table.text("catalog") or "").lower() in _CATALOG_SCHEMAS:
+            return True
+    for column in parsed.find_all(exp.Column):
+        if (column.text("table") or "").lower() in _CATALOG_SCHEMAS:
+            return True
+        if (column.text("db") or "").lower() in _CATALOG_SCHEMAS:
+            return True
+    for func in parsed.find_all(exp.Anonymous):
+        if (func.text("this") or "").lower() in _CATALOG_SCHEMAS:
+            return True
+    # Some catalog functions parse as Dot expressions (schema.func()).
+    for dot in parsed.find_all(exp.Dot):
+        left = dot.args.get("this")
+        if isinstance(left, exp.Identifier) and (left.name or "").lower() in _CATALOG_SCHEMAS:
+            return True
+    return False
 
 
 def _encode_translation_error(exc: SQLTranslationError) -> bytes:

--- a/tests/integration/test_pgwire_server.py
+++ b/tests/integration/test_pgwire_server.py
@@ -232,6 +232,68 @@ async def test_semantic_query_returns_real_rows(pgwire_with_router: PgWireServer
         await writer.wait_closed()
 
 
+async def test_catalog_probe_lists_loaded_model(pgwire_with_router: PgWireServer) -> None:
+    """psql `\\dt`-style query surfaces the loaded model as a relation."""
+
+    reader, writer = await asyncio.open_connection("127.0.0.1", pgwire_with_router.bound_port)
+    try:
+        writer.write(_startup_payload({"user": "obsl", "database": "commerce"}))
+        await writer.drain()
+        await _drain_until_ready(reader)
+
+        sql = (
+            "SELECT n.nspname, c.relname, c.relkind "
+            "FROM pg_catalog.pg_class c "
+            "LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace "
+            "WHERE c.relkind IN ('r','p','') "
+            "AND n.nspname NOT IN ('pg_catalog','information_schema') "
+            "ORDER BY 1,2"
+        )
+        writer.write(_query_frame(sql))
+        await writer.drain()
+        reply = await _drain_until_ready(reader)
+        tags = [t for t, _ in reply]
+        # Expect RowDescription + at least one DataRow + CommandComplete + Z.
+        assert tags[0] == b"T"
+        assert b"D" in tags
+        assert tags[-1] == b"Z"
+
+        # At least one row, and one of them carries the model name.
+        data_rows = [body for tag, body in reply if tag == b"D"]
+        names_present = False
+        for body in data_rows:
+            if b"commerce" in body:
+                names_present = True
+                break
+        assert names_present
+    finally:
+        writer.write(_terminate_frame())
+        await writer.drain()
+        writer.close()
+        await writer.wait_closed()
+
+
+async def test_show_server_version_returns_canned_string(
+    pgwire_with_router: PgWireServer,
+) -> None:
+    reader, writer = await asyncio.open_connection("127.0.0.1", pgwire_with_router.bound_port)
+    try:
+        writer.write(_startup_payload({"user": "obsl", "database": "commerce"}))
+        await writer.drain()
+        await _drain_until_ready(reader)
+
+        writer.write(_query_frame("SHOW server_version"))
+        await writer.drain()
+        reply = await _drain_until_ready(reader)
+        tags = [t for t, _ in reply]
+        assert tags == [b"T", b"D", b"C", b"Z"]
+    finally:
+        writer.write(_terminate_frame())
+        await writer.drain()
+        writer.close()
+        await writer.wait_closed()
+
+
 async def test_unknown_database_returns_3d000(pgwire_with_router: PgWireServer) -> None:
     reader, writer = await asyncio.open_connection("127.0.0.1", pgwire_with_router.bound_port)
     try:

--- a/tests/unit/test_pgwire_canned.py
+++ b/tests/unit/test_pgwire_canned.py
@@ -1,0 +1,106 @@
+"""Unit tests for pgwire/canned.py — protocol-level probe replies."""
+
+from __future__ import annotations
+
+import struct
+
+from orionbelt.pgwire import protocol
+from orionbelt.pgwire.canned import match_canned
+
+
+def _parse_frames(blob: bytes) -> list[tuple[bytes, bytes]]:
+    frames: list[tuple[bytes, bytes]] = []
+    offset = 0
+    while offset < len(blob):
+        tag = blob[offset : offset + 1]
+        (length,) = struct.unpack("!I", blob[offset + 1 : offset + 5])
+        body = blob[offset + 5 : offset + 1 + length]
+        frames.append((tag, body))
+        offset += 1 + length
+    return frames
+
+
+def test_select_one_returns_int4_row() -> None:
+    reply = match_canned("SELECT 1")
+    assert reply is not None
+    frames = _parse_frames(reply)
+    assert [t for t, _ in frames] == [b"T", b"D", b"C"]
+    # RowDescription advertises a single column with OID 23 (int4).
+    _, desc = frames[0]
+    (n_cols,) = struct.unpack("!H", desc[:2])
+    assert n_cols == 1
+    name, rest = desc[2:].split(b"\x00", 1)
+    assert name == b"?column?"
+    _, _, oid, *_ = struct.unpack("!IhIhih", rest[:18])
+    assert oid == protocol.OID_INT4
+
+
+def test_select_version_returns_postgres_flavored_string() -> None:
+    reply = match_canned("SELECT version()")
+    assert reply is not None
+    frames = _parse_frames(reply)
+    assert [t for t, _ in frames] == [b"T", b"D", b"C"]
+    _, data_row = frames[1]
+    (n_vals,) = struct.unpack("!H", data_row[:2])
+    assert n_vals == 1
+    (col_len,) = struct.unpack("!I", data_row[2:6])
+    value = data_row[6 : 6 + col_len].decode()
+    assert "PostgreSQL" in value
+    assert "OrionBelt" in value
+
+
+def test_show_server_version_uses_postgres_value() -> None:
+    reply = match_canned("SHOW server_version")
+    assert reply is not None
+    frames = _parse_frames(reply)
+    _, data_row = frames[1]
+    (col_len,) = struct.unpack("!I", data_row[2:6])
+    value = data_row[6 : 6 + col_len].decode()
+    assert value.startswith("15.0")
+
+
+def test_show_unknown_param_returns_empty_string() -> None:
+    reply = match_canned("SHOW nonexistent_param")
+    assert reply is not None
+    frames = _parse_frames(reply)
+    _, data_row = frames[1]
+    (col_len,) = struct.unpack("!I", data_row[2:6])
+    assert col_len == 0
+
+
+def test_set_is_no_op() -> None:
+    reply = match_canned("SET extra_float_digits = 3")
+    assert reply is not None
+    frames = _parse_frames(reply)
+    assert [t for t, _ in frames] == [b"C"]
+    assert frames[0][1] == b"SET\x00"
+
+
+def test_transaction_wrappers_accepted() -> None:
+    for sql, tag_expected in [
+        ("BEGIN", b"BEGIN\x00"),
+        ("START TRANSACTION", b"BEGIN\x00"),
+        ("COMMIT", b"COMMIT\x00"),
+        ("END", b"COMMIT\x00"),
+        ("ROLLBACK", b"ROLLBACK\x00"),
+        ("SAVEPOINT a", b"SAVEPOINT\x00"),
+        ("RELEASE SAVEPOINT a", b"SAVEPOINT\x00"),
+    ]:
+        reply = match_canned(sql)
+        assert reply is not None, f"no canned reply for {sql!r}"
+        frames = _parse_frames(reply)
+        assert [t for t, _ in frames] == [b"C"]
+        assert frames[0][1] == tag_expected, sql
+
+
+def test_unknown_query_returns_none() -> None:
+    assert match_canned("SELECT * FROM commerce") is None
+    assert match_canned("SELECT pg_table_is_visible(1)") is None
+
+
+def test_empty_query_returns_empty_command_complete() -> None:
+    reply = match_canned("   ;  ")
+    assert reply is not None
+    frames = _parse_frames(reply)
+    assert [t for t, _ in frames] == [b"C"]
+    assert frames[0][1] == b"\x00"

--- a/tests/unit/test_pgwire_catalog.py
+++ b/tests/unit/test_pgwire_catalog.py
@@ -1,0 +1,94 @@
+"""Unit tests for pgwire/catalog.py — CatalogEmulator (DuckDB-backed)."""
+
+from __future__ import annotations
+
+import pytest
+
+from orionbelt.pgwire.catalog import CatalogEmulator
+from orionbelt.service.session_manager import SessionManager
+from tests.conftest import SAMPLE_MODEL_YAML
+
+
+@pytest.fixture
+def manager_with_model() -> SessionManager:
+    mgr = SessionManager()
+    store = mgr.get_or_create_named("commerce")
+    store.load_model(SAMPLE_MODEL_YAML)
+    return mgr
+
+
+def test_refresh_creates_one_table_per_model(manager_with_model: SessionManager) -> None:
+    emu = CatalogEmulator()
+    emu.refresh(manager_with_model)
+    result = emu.execute(
+        "SELECT relname FROM pg_catalog.pg_class WHERE relkind='r' ORDER BY relname"
+    )
+    table_names = [row[0] for row in result.rows]
+    assert "commerce" in table_names
+
+
+def test_table_has_expected_columns(manager_with_model: SessionManager) -> None:
+    """All model dimensions, measures, and metrics are exposed as columns."""
+
+    emu = CatalogEmulator()
+    emu.refresh(manager_with_model)
+    result = emu.execute(
+        "SELECT column_name FROM information_schema.columns "
+        "WHERE table_name='commerce' ORDER BY ordinal_position"
+    )
+    columns = [row[0] for row in result.rows]
+    # SAMPLE_MODEL_YAML exposes one dim, three measures, and two metrics.
+    assert "Customer Country" in columns
+    assert "Total Revenue" in columns
+    assert "Order Count" in columns
+    assert "Grand Total Revenue" in columns
+    assert "Revenue per Order" in columns
+    assert "Revenue Share" in columns
+
+
+def test_refresh_is_idempotent(manager_with_model: SessionManager) -> None:
+    emu = CatalogEmulator()
+    emu.refresh(manager_with_model)
+    emu.refresh(manager_with_model)
+    result = emu.execute("SELECT count(*) FROM pg_catalog.pg_class WHERE relname='commerce'")
+    assert result.rows[0][0] == 1
+
+
+def test_refresh_drops_stale_models() -> None:
+    """A model removed from the SessionManager disappears from the catalog."""
+
+    mgr = SessionManager()
+    store = mgr.get_or_create_named("temp")
+    store.load_model(SAMPLE_MODEL_YAML)
+    emu = CatalogEmulator()
+    emu.refresh(mgr)
+    # Reset SessionManager to empty and refresh.
+    empty = SessionManager()
+    emu.refresh(empty)
+    result = emu.execute("SELECT count(*) FROM pg_catalog.pg_class WHERE relname='temp'")
+    assert result.rows[0][0] == 0
+
+
+def test_psql_dt_style_query_returns_rows(manager_with_model: SessionManager) -> None:
+    """\\dt's actual SQL must surface the model table."""
+
+    emu = CatalogEmulator()
+    emu.refresh(manager_with_model)
+    sql = (
+        "SELECT n.nspname AS schema, c.relname AS name "
+        "FROM pg_catalog.pg_class c "
+        "LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace "
+        "WHERE c.relkind IN ('r','p','') "
+        "AND n.nspname NOT IN ('pg_catalog','information_schema') "
+        "ORDER BY 1,2"
+    )
+    result = emu.execute(sql)
+    names = [row[1] for row in result.rows]
+    assert "commerce" in names
+
+
+def test_empty_session_manager_yields_no_tables() -> None:
+    emu = CatalogEmulator()
+    emu.refresh(SessionManager())
+    result = emu.execute("SELECT relname FROM pg_catalog.pg_class WHERE relkind='r'")
+    assert result.rows == []

--- a/tests/unit/test_pgwire_detection.py
+++ b/tests/unit/test_pgwire_detection.py
@@ -1,0 +1,56 @@
+"""Unit tests for pgwire/router.py:references_catalog detection helper."""
+
+from __future__ import annotations
+
+import pytest
+
+from orionbelt.pgwire.router import references_catalog
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "SELECT * FROM pg_catalog.pg_class",
+        (
+            "select c.relname FROM pg_catalog.pg_class c "
+            "LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace"
+        ),
+        "SELECT table_name FROM information_schema.tables WHERE table_schema='public'",
+        "SELECT pg_catalog.set_config('search_path', 'public', false)",
+        # Mixed-case variants — Postgres clients sometimes emit caps.
+        "SELECT * FROM PG_CATALOG.PG_CLASS",
+    ],
+)
+def test_references_catalog_positive(sql: str) -> None:
+    assert references_catalog(sql) is True
+
+
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "SELECT 1",
+        'SELECT "Region", "Total Sales" FROM commerce',
+        "SELECT count(*) FROM orders WHERE created_at > '2024-01-01'",
+        "SHOW server_version",
+        "SET extra_float_digits = 3",
+    ],
+)
+def test_references_catalog_negative(sql: str) -> None:
+    assert references_catalog(sql) is False
+
+
+def test_references_catalog_falls_back_on_parse_error() -> None:
+    """Unparseable SQL with catalog tokens still routes to the catalog branch."""
+
+    sql = "SELECT FROM PG_CATALOG.PG_ATTRIBUTE WHERE ;;;"
+    assert references_catalog(sql) is True
+
+
+def test_references_catalog_no_false_positive_on_string_literal() -> None:
+    """A literal containing 'pg_catalog' inside a string must not trigger."""
+
+    # The fallback substring scan only fires when sqlglot can't parse,
+    # so this query (well-formed) goes through the AST path and the
+    # literal stays out of the catalog branch.
+    sql = "SELECT 'pg_catalog is a real schema' AS note"
+    assert references_catalog(sql) is False


### PR DESCRIPTION
Implements Step 3 of [design/PLAN_postgres_wire.md](design/PLAN_postgres_wire.md) §6 — psql `\dt`, DBeaver schema trees, and BI-tool pre-flight probes that look for `pg_catalog.*` / `information_schema.*` can now introspect the loaded models.

## Summary
- **`pgwire/catalog.py`** (`CatalogEmulator`) — in-memory DuckDB connection that holds one empty TABLE per loaded model. DuckDB's native `pg_catalog` / `information_schema` views auto-populate from the schema, so `pg_class` / `pg_namespace` / `pg_attribute` / `information_schema.columns` come for free.
- **`pgwire/canned.py`** — hand-written replies for the connectivity probes BI tools fire constantly: `SELECT 1`, `SELECT version()`, `SHOW <param>`, `SET … = …`, `BEGIN` / `COMMIT` / `ROLLBACK` / `SAVEPOINT`, `SELECT current_schema()` / `current_database()` / `current_user`.
- **`pgwire/router.py`** — pipeline is now **canned → catalog → semantic**. `references_catalog(sql)` uses sqlglot to spot `pg_catalog.` / `information_schema.` references; a substring fallback covers Postgres-specific snippets sqlglot can't parse.
- 12 stub macros (`pg_get_userbyid`, `pg_table_is_visible`, `format_type`, …) and a regex SQL rewriter (`_rewrite_for_duckdb`) smooth over psql quirks DuckDB doesn't natively handle: `COLLATE pg_catalog.default`, `OPERATOR(pg_catalog.~)`, `::pg_catalog.regtype` casts, `pg_catalog.<func>()` calls.

## Live verification against the baked DuckDB seed

| Probe | Result |
|---|---|
| `\dt` | ✓ Lists `orionbelt_1_commerce \| table \| obsl` |
| `information_schema.columns` | ✓ Returns 70 columns with correct types (VARCHAR, etc.) |
| `SHOW server_version` | ✓ Returns `15.0` |
| `SELECT version()` | ✓ Returns Postgres-flavored string |
| `BEGIN` / `COMMIT` | ✓ Accept-and-ignore (BI tools wrap SELECTs) |
| Semantic SELECT after catalog probes | ✓ Still works |
| `\d <table>` | ✗ Documented gap — see below |

\`\`\`
\$ psql -h 127.0.0.1 -p 5432 -U obsl -d orionbelt_1_commerce -c '\dt'
               List of relations
 Schema |         Name         | Type  | Owner
--------+----------------------+-------+-------
 main   | orionbelt_1_commerce | table | obsl
(1 row)
\`\`\`

## Known gaps (deferred to Step 5)

| Gap | Scope | Why deferred |
|---|---|---|
| psql `\d <table>` fails | psql 16+ expects ~30 `pg_class` columns DuckDB doesn't expose (`relforcerowsecurity`, `relhasoids`, …) | BI tools use `information_schema.columns` which is correct; rolling our own pg_catalog is 400–600 LOC |
| `pg_attribute.atttypid` mislabels types | DuckDB's internal type ids ≠ Postgres OIDs | `information_schema.columns` (BI-tool path) is unaffected |

## Test coverage
- 8 unit tests in `tests/unit/test_pgwire_canned.py` — SELECT 1 / version / SHOW / SET / BEGIN-COMMIT-ROLLBACK / SAVEPOINT, empty query handling.
- 6 unit tests in `tests/unit/test_pgwire_catalog.py` — table creation, column coverage, refresh idempotency, stale-model cleanup, real `\dt` SQL.
- 12 unit tests in `tests/unit/test_pgwire_detection.py` — `references_catalog` AST + fallback behaviour, mixed-case, false-positive guards.
- 2 new integration tests in `tests/integration/test_pgwire_server.py` — live `\dt`-style query over the socket, `SHOW server_version`.
- Full suite: **1927 passed, 60 skipped, 0 regressions** (was 1899 after Step 2).

## Not in this PR (Steps 4–8)
- Extended query protocol (Parse/Bind/Describe/Execute) — Step 4.
- Tableau / Power BI / DBeaver integration tests + richer `pg_catalog` if needed — Step 5.
- `password` + `scram-sha-256` auth — Step 6.
- Binary format encoding — Step 7.
- Docs page `docs/guide/postgres-wire.md` + comparison matrix — Step 8.

## Test plan
- [x] `uv run pytest tests/unit/test_pgwire_canned.py tests/unit/test_pgwire_catalog.py tests/unit/test_pgwire_detection.py tests/integration/test_pgwire_server.py`
- [x] Full suite green
- [x] `ruff check`, `ruff format --check`, `mypy` all clean
- [x] Live `psql \dt` against baked DuckDB seed
- [x] Live `psql -c "SELECT column_name, data_type FROM information_schema.columns WHERE table_name='...'"` returns correct types

🤖 Generated with [Claude Code](https://claude.com/claude-code)