### PR TITLE
docs(comparison): reflect v2.6 metric/aggregation surface

### DIFF
--- a/docs/comparison/atscale.md
+++ b/docs/comparison/atscale.md
@@ -96,14 +96,15 @@ AtScale ships first-class enterprise primitives:
 
 | OBSL | AtScale | Notes |
 |---|---|---|
-| `Measure` (sum/avg/count/min/max, `total: bool`) | Measures with rich aggregation types (sum, count, distinct count, min, max, average, semi-additive measures) | Both first-class; AtScale has more built-in semi-additive types |
+| `Measure` — 10 standard aggregations (`sum`, `count`, `count_distinct`, `avg`, `min`, `max`, `any_value`, `median`, `mode`, `listagg`) **+ 9 statistical aggregations (v2.6+)** (`stddev`, `stddev_pop`, `variance`, `var_pop`, `corr`, `covar_pop`, `covar_samp`, `regr_slope`, `regr_intercept`) + `total: bool` for grand totals | Measures with rich aggregation types (sum, count, distinct count, min, max, average, semi-additive measures) | Both first-class. AtScale has stronger semi-additive types (last non-empty, etc.); OBSL has the wider statistical / regression surface as first-class declarative aggregates |
 | `Metric` `type: derived` | Calculated members (MDX expressions) | Both first-class |
-| `Metric` `type: cumulative` (running, rolling, grain-to-date) | Time-intelligence MDX (`Aggregate(YTD([Date].CurrentMember), [Sales])`) — idiomatic OLAP | Both expressive; OBSL is YAML-declarative, AtScale is MDX-declarative |
+| `Metric` `type: cumulative` (running, rolling, grain-to-date, **per-dimension `partitionBy` v2.6+**) | Time-intelligence MDX (`Aggregate(YTD([Date].CurrentMember), [Sales])`) — idiomatic OLAP | Both expressive; OBSL is YAML-declarative, AtScale is MDX-declarative |
 | `Metric` `type: period_over_period` (4 comparison modes) | Calculated members using `ParallelPeriod` / `Lag` MDX functions | Both expressive; AtScale is more flexible (full MDX), OBSL is more turnkey |
+| `Metric` `type: window` (v2.6+) — `rank`, `dense_rank`, `row_number`, `ntile`, `lag`, `lead`, `first_value`, `last_value` | MDX `Rank()`, `Lag()`, `Lead()` in calculated members | OBSL exposes these as declarative metric types; AtScale expresses them via MDX |
 | Reusable filter context / filtered measures | Named sets, perspectives | Comparable |
 | Hierarchical aggregation | Limited (use grains) | First-class via hierarchies and `Aggregate()` |
 
-For complex OLAP-style metrics (MDX is genuinely more expressive than any YAML format), AtScale wins on flexibility. For straightforward cumulative/PoP that you want declared once and reused everywhere, OBSL is more turnkey.
+For complex OLAP-style metrics (MDX is genuinely more expressive than any YAML format), AtScale wins on flexibility. For straightforward cumulative/PoP/window/statistical metrics that you want declared once and reused everywhere, OBSL is more turnkey. See [Trend Analysis](../guide/trend-analysis.md) for the full v2.6 metric / aggregation surface (dialect coverage matrix included).
 
 ---
 
@@ -211,7 +212,9 @@ The free **Developer Community Edition** lowers the barrier for evaluation, prot
 | Multi-rooted DAG modeling | ✅ via CFL | ❌ (cube-rooted) |
 | Named secondary join paths (per-query) | ✅ | Role-playing dimensions are model-time, not query-time |
 | First-class declarative PoP metric type | ✅ | Via MDX (more flexible but less turnkey) |
-| First-class declarative cumulative metric type | ✅ | Via MDX time intelligence |
+| First-class declarative cumulative metric type | ✅ (running, rolling, grain-to-date, `partitionBy` v2.6+) | Via MDX time intelligence |
+| First-class declarative window metric type (rank / lag / lead / ntile / first_value / last_value) | ✅ (v2.6+) | Via MDX calculated members |
+| Statistical aggregates (`stddev`, `variance`, `corr`, `covar_*`, `regr_*`) | ✅ 9 functions (v2.6+) | Limited; not first-class as measure types |
 | Apache Arrow Flight SQL | ✅ | ❌ |
 | DB-API 2.0 drivers | ✅ 8 drivers | ❌ |
 | RDF/SPARQL graph view | ✅ | ❌ |

--- a/docs/comparison/cube.md
+++ b/docs/comparison/cube.md
@@ -142,14 +142,17 @@ OBSL ships `static | scheduled | heartbeat | unknown` modes and exposes `GET /v1
 
 | OBSL | Cube | Notes |
 |---|---|---|
-| `Measure` (sum/avg/count/min/max, `total: bool`) | `measures` (`type: sum/count/count_distinct/avg/min/max/number/string/time/boolean`) | Cube has more types out of the box |
+| `Measure` — 10 standard aggregations (`sum`, `count`, `count_distinct`, `avg`, `min`, `max`, `any_value`, `median`, `mode`, `listagg`) **+ 9 statistical aggregations (v2.6+)** (`stddev`, `stddev_pop`, `variance`, `var_pop`, `corr`, `covar_pop`, `covar_samp`, `regr_slope`, `regr_intercept`) + `total: bool` for grand totals | `measures` (`type: sum/count/count_distinct/avg/min/max/number/string/time/boolean`) | OBSL has the wider aggregate surface — Cube has no statistical / regression aggregates as first-class measure types |
 | `Metric` `type: derived` | `measure: { type: number; sql: ... }` referencing other measures | Both first-class |
-| `Metric` `type: cumulative` (running, rolling, grain-to-date) | `measure: { rolling_window: { trailing: '7 day', offset: 'end' } }` — rolling only | Cube has rolling windows but no grain-to-date or unbounded cumulative as a declarative type |
+| `Metric` `type: cumulative` (running, rolling, grain-to-date, **per-dimension `partitionBy` v2.6+**) | `measure: { rolling_window: { trailing: '7 day', offset: 'end' } }` — rolling only | Cube has rolling windows but no grain-to-date, no unbounded cumulative, and no partition-by surface as declarative types |
 | `Metric` `type: period_over_period` (4 comparison modes) | Query-side: `compareDateRange` parameter or `time_shift: { interval: '1 year', type: 'prior' }` | Cube does PoP at query time, not as a model-defined metric |
+| `Metric` `type: window` (v2.6+) — `rank`, `dense_rank`, `row_number`, `ntile`, `lag`, `lead`, `first_value`, `last_value` | — | **Gap in Cube** — no first-class rank / lag / lead surface; users compose raw SQL |
 | Reusable filter context / filtered measures | `segments` (named, reusable filter sets) + `filters` on individual measure definitions | Comparable |
 | Grand totals (`total: true`) | n/a — done at query/visualization time | OBSL has it as a measure attribute |
 
 **Different philosophies**: OBSL bakes time-aware metrics into the model (write once, every query gets the comparison). Cube treats time comparisons as query-time concerns (more flexible, but the consumer has to know how to ask). Either fits depending on whether you're publishing a metrics catalog or empowering query authors.
+
+See [Trend Analysis](../guide/trend-analysis.md) for the full v2.6 metric / aggregation surface (window functions, statistical aggregates, dialect coverage matrix).
 
 ---
 
@@ -256,7 +259,9 @@ For a small embedded-analytics use case OBSL is operationally simpler. For high-
 | Row-level security in model | ❌ | ✅ via `query_rewrite` |
 | Field-level masking | ❌ | ✅ via Twig conditionals |
 | First-class PoP metric type | ✅ (4 comparison modes) | ❌ (`time_shift` at query time) |
-| First-class cumulative metric type | ✅ (running, rolling, grain-to-date) | Partial (`rolling_window` only) |
+| First-class cumulative metric type | ✅ (running, rolling, grain-to-date, `partitionBy` v2.6+) | Partial (`rolling_window` only) |
+| First-class window metric type (rank / lag / lead / ntile / first_value / last_value) | ✅ (v2.6+) | ❌ |
+| Statistical aggregates (`stddev`, `variance`, `corr`, `covar_*`, `regr_*`) | ✅ 9 functions (v2.6+) | ❌ |
 | Multi-rooted DAG modeling | ✅ via CFL | ❌ (single-rooted cubes + views) |
 | Named secondary join paths | ✅ | ❌ |
 | Symmetric aggregates | ❌ (uses CFL) | ✅ |
@@ -309,14 +314,16 @@ A workable hybrid: use Cube as the production query gateway with pre-aggregation
 
 ### To match OBSL, Cube would need:
 
-1. **First-class cumulative & period-over-period metric types** — declarative versions of what's currently `rolling_window` and query-side `time_shift`.
-2. **Multi-rooted DAG modeling** — the ability to query across genuinely independent fact tables in one go without the consumer needing to pre-design a `view`.
-3. **Named secondary join paths** with per-query selection.
-4. **RDF/SPARQL graph surface** for governance/lineage.
-5. **Apache Arrow Flight SQL** as a columnar wire protocol option alongside Postgres wire — modern analytical payloads transfer more efficiently in Arrow.
-6. **First-class DB-API 2.0 drivers** for direct programmatic access from Python (PEP 249).
-7. **Interactive RDF/ontology graph visualization** in the playground (vis-network-style) — Cube Playground's schema browser is functional but not graph-shaped.
-8. **OSI ↔ Cube model round-trip** for portability between semantic layers.
+1. **First-class cumulative & period-over-period metric types** — declarative versions of what's currently `rolling_window` and query-side `time_shift`, including per-dimension `partitionBy` on cumulative.
+2. **First-class window metric type** — `rank`, `dense_rank`, `row_number`, `ntile`, `lag`, `lead`, `first_value`, `last_value` as declarative metric types instead of raw SQL.
+3. **Statistical aggregate functions** — `stddev`, `variance`, `corr`, `covar_*`, `regr_slope`, `regr_intercept` as first-class measure aggregations.
+4. **Multi-rooted DAG modeling** — the ability to query across genuinely independent fact tables in one go without the consumer needing to pre-design a `view`.
+5. **Named secondary join paths** with per-query selection.
+6. **RDF/SPARQL graph surface** for governance/lineage.
+7. **Apache Arrow Flight SQL** as a columnar wire protocol option alongside Postgres wire — modern analytical payloads transfer more efficiently in Arrow.
+8. **First-class DB-API 2.0 drivers** for direct programmatic access from Python (PEP 249).
+9. **Interactive RDF/ontology graph visualization** in the playground (vis-network-style) — Cube Playground's schema browser is functional but not graph-shaped.
+10. **OSI ↔ Cube model round-trip** for portability between semantic layers.
 
 ---
 

--- a/docs/comparison/index.md
+++ b/docs/comparison/index.md
@@ -13,8 +13,10 @@ How OrionBelt Semantic Layer (OBSL) stacks up against the leading semantic layer
 | Standalone (no transformation tool dep.) | ✅ | ❌ requires dbt | ✅ | ✅ | ✅ | ✅ |
 | Format | YAML (`OBML`) | YAML on dbt models | DSL (`.malloy`) | DSL (`.lkml`) | YAML / JS + Twig | Visual designer |
 | Query interface | **[OrionBelt Semantic QL](../guide/semantic-ql.md)** (OBSQL) + **Arrow Flight SQL** + **PostgreSQL wire** + REST + DB-API | GraphQL/JDBC (Cloud) | Malloy language | Looker UI / API | **Cube SQL API** (Postgres-wire) + REST + GraphQL | **MDX + DAX** + JDBC/ODBC + REST |
-| First-class cumulative metric | ✅ | ✅ | Per-query | Partial | Partial (`rolling_window`) | Via MDX |
+| First-class cumulative metric (running / rolling / grain-to-date, `partitionBy` v2.6+) | ✅ | ✅ (no `partitionBy`) | Per-query | Partial | Partial (`rolling_window`) | Via MDX |
 | First-class period-over-period metric | ✅ | Via `offset_window` | Per-query | Via table calc | Query-time `time_shift` | Via MDX |
+| First-class window metric (rank / lag / lead / ntile / first_value / last_value, v2.6+) | ✅ | ❌ | Per-query calculations | Table calcs (UI-side) | ❌ | Via MDX calculated members |
+| Statistical / regression aggregates (`stddev`, `variance`, `corr`, `covar_*`, `regr_*`, v2.6+) | ✅ 9 functions | Partial (basic `stddev` only) | Partial (basic `stddev` only) | Partial (via raw `sql:`) | ❌ | Limited |
 | Conversion / funnel metrics | ❌ | ✅ | Patterns | Patterns | Patterns | Patterns |
 | Symmetric aggregates | ❌ (uses CFL) | ❌ | ✅ | ✅ | ✅ | ✅ (OLAP) |
 | Hierarchical subtotals (`WITH ROLLUP` / `WITH CUBE`) | ✅ first-class in **Semantic QL** (trailing modifier + `GROUPING()` flag columns; dialect-portable across all 8 drivers) | ❌ presentation concern | ❌ | UI-only checkbox; no LookML construct | "Rollup" means pre-aggregation tables, not the SQL operator | Via MDX/DAX |

--- a/docs/comparison/lookml.md
+++ b/docs/comparison/lookml.md
@@ -119,13 +119,14 @@ LookML carries UI metadata: `drill_fields: [order_id, customer_name, ...]`, `val
 
 | OBSL | LookML | Notes |
 |---|---|---|
-| `Measure` (sum/avg/count/min/max, `total: bool`) | `measure: { type: sum/avg/count/count_distinct/... }` | LookML has more aggregate types out of the box (`sum_distinct`, `percentile`, `median`, etc.) |
+| `Measure` — 10 standard aggregations (`sum`, `count`, `count_distinct`, `avg`, `min`, `max`, `any_value`, `median`, `mode`, `listagg`) **+ 9 statistical aggregations (v2.6+)** (`stddev`, `stddev_pop`, `variance`, `var_pop`, `corr`, `covar_pop`, `covar_samp`, `regr_slope`, `regr_intercept`) + `total: bool` for grand totals | `measure: { type: sum/avg/count/count_distinct/sum_distinct/percentile/median/... }` | LookML has more "shape" aggregate variants (`sum_distinct`, `percentile_*`), OBSL has the wider statistical / regression surface (CORR / COVAR_* / REGR_* / STDDEV_* / VAR_*) as first-class declarative aggregates |
 | `Metric` `type: derived` | `measure: { type: number; sql: ...references other measures... }` | Both first-class |
-| `Metric` `type: cumulative` (running, rolling, grain-to-date) | `type: running_total` (basic), or table calculations in UI for richer cases | OBSL has richer **declarative** cumulative |
+| `Metric` `type: cumulative` (running, rolling, grain-to-date, **per-dimension `partitionBy` v2.6+**) | `type: running_total` (basic), or table calculations in UI for richer cases | OBSL has richer **declarative** cumulative |
 | `Metric` `type: period_over_period` (4 comparison modes) | Patterns: filtered measures (`{% if date.is_in_period %} ... {% endif %}`) or table calculations | OBSL has a dedicated metric type |
+| `Metric` `type: window` (v2.6+) — `rank`, `dense_rank`, `row_number`, `ntile`, `lag`, `lead`, `first_value`, `last_value` | Looker table calculations (`rank()`, `offset()`, `pivot_offset()`) — UI-side, not LookML model | OBSL ships these as declarative metric types reusable across every consumer; Looker's equivalents live in the dashboard layer |
 | `Measure.filterContext` / `filteredMeasures` | Filtered measure pattern: `measure: { type: sum; filters: [is_paid: "yes"] }` | Comparable |
 
-Bottom line: LookML's **breadth of aggregate types** is wider; OBSL's **time-aware metric types** (cumulative/PoP) are more declarative and reusable. Looker-style PoP usually ends up as a *table calculation* in the UI — not portable to other consumers.
+Bottom line: LookML wins on aggregate-variant *shape* (sum_distinct, percentile families) and on UI-side table-calc breadth; OBSL wins on **statistical/regression aggregates** and on **time/window/PoP/cumulative as declarative metric types** that survive across every consumer (BI tool, agent, JSON API) without re-implementing the table calc. See [Trend Analysis](../guide/trend-analysis.md) for the full v2.6 metric / aggregation surface.
 
 ---
 
@@ -229,7 +230,9 @@ For embedded SaaS, multi-tenant analytics, or air-gapped/on-prem use cases, OBSL
 | Drill fields / UI metadata | Minimal | ✅ |
 | Symmetric aggregates | ❌ (uses CFL instead) | ✅ |
 | First-class PoP metric type | ✅ | ❌ (table calc / filtered measures) |
-| First-class cumulative metric type | ✅ | Partial (`running_total` only) |
+| First-class cumulative metric type | ✅ (running, rolling, grain-to-date, `partitionBy` v2.6+) | Partial (`running_total` only) |
+| First-class window metric type (rank / lag / lead / ntile / first_value / last_value) | ✅ (v2.6+) | ❌ (table calculations only — dashboard-side) |
+| Statistical aggregates (`stddev`, `variance`, `corr`, `covar_*`, `regr_*`) | ✅ 9 functions (v2.6+) | Partial — some via raw `sql:`, none as first-class measure types |
 | RDF/SPARQL graph view | ✅ | ❌ |
 | Named secondary join paths | ✅ | ❌ |
 | Explicit CFL multi-fact planner | ✅ | n/a |

--- a/docs/comparison/malloy.md
+++ b/docs/comparison/malloy.md
@@ -119,12 +119,13 @@ OBSL has no named-view-with-refinements concept. Queries are constructed fresh e
 
 | OBSL | Malloy | Notes |
 |---|---|---|
-| `Measure` (sum/avg/count/min/max, `total: bool` for grand totals) | `measure:` declarations inside `source` | Both first-class |
+| `Measure` — 10 standard aggregations (`sum`, `count`, `count_distinct`, `avg`, `min`, `max`, `any_value`, `median`, `mode`, `listagg`) **+ 9 statistical aggregations (v2.6+)** (`stddev`, `stddev_pop`, `variance`, `var_pop`, `corr`, `covar_pop`, `covar_samp`, `regr_slope`, `regr_intercept`) + `total: bool` for grand totals | `measure:` declarations inside `source` (`sum`, `count`, `count_distinct`, `avg`, `min`, `max`, `stddev`, etc.) | Both first-class. OBSL has a wider statistical / regression surface (`corr`, `covar_pop`, `covar_samp`, `regr_slope`, `regr_intercept`) as declarative measure aggregations |
 | `Metric` `type: derived` (`{[Measure A]}/{[Measure B]}`) | Composed by referencing other measures inside aggregate expressions | Both first-class |
-| `Metric` `type: cumulative` (running, rolling, grain-to-date) | Express via **calculations** (window functions) inside queries | OBSL is declarative; Malloy is per-query |
+| `Metric` `type: cumulative` (running, rolling, grain-to-date, **per-dimension `partitionBy` v2.6+**) | Express via **calculations** (window functions) inside queries | OBSL is declarative; Malloy is per-query |
 | `Metric` `type: period_over_period` with 4 comparison modes | Pattern via `prior_period` style queries; renderer has a `big_value { comparison_field=... }` for visual deltas | OBSL has a dedicated metric type; Malloy treats it as "just write the query" |
+| `Metric` `type: window` (v2.6+) — `rank`, `dense_rank`, `row_number`, `ntile`, `lag`, `lead`, `first_value`, `last_value` | Calculations (`rank()`, `lag()`, `first_value()`) inside queries | OBSL exposes these as declarative reusable metric types; Malloy keeps them per-query (matches the "expressive queries" philosophy) |
 
-**Different philosophies**: OBSL prefers reusable metric definitions (write once, every query gets PoP). Malloy prefers expressive ad-hoc queries (write the comparison in the query itself). Either fits depending on whether you're publishing a metrics catalog or empowering analysts.
+**Different philosophies**: OBSL prefers reusable metric definitions (write once, every query gets PoP / window / cumulative). Malloy prefers expressive ad-hoc queries (write the comparison in the query itself). Either fits depending on whether you're publishing a metrics catalog or empowering analysts. See [Trend Analysis](../guide/trend-analysis.md) for the full v2.6 metric / aggregation surface.
 
 ---
 
@@ -224,7 +225,9 @@ Malloy's time syntax is more ergonomic in a query; OBSL's metric types are more 
 | Explicit CFL multi-fact planner | ✅ | n/a (symmetric aggregates) |
 | OSI ↔ OBML conversion | ✅ | ❌ |
 | First-class PoP metric type | ✅ | ❌ (ad-hoc) |
-| First-class cumulative metric type | ✅ | ❌ (calculations) |
+| First-class cumulative metric type | ✅ (running, rolling, grain-to-date, `partitionBy` v2.6+) | ❌ (calculations) |
+| First-class window metric type (rank / lag / lead / ntile / first_value / last_value) | ✅ (v2.6+) | ❌ (calculations per-query) |
+| Statistical aggregates (`corr`, `covar_*`, `regr_*` in addition to `stddev` / `variance`) | ✅ 9 functions (v2.6+) | Partial — Malloy ships basic `stddev` / `variance` but no `corr` / `covar_*` / `regr_*` as first-class measure types |
 | Dialect breadth (ClickHouse/Databricks/Dremio) | ✅ | ❌ |
 | Trino/Presto | ❌ | ✅ |
 | VS Code-native authoring | ✅ via Jupyter notebook (also one-click in Colab) | ✅ first-party extension with autocomplete + inline viz |


### PR DESCRIPTION
## Summary

The vendor comparison pages (`docs/comparison/{cube,atscale,lookml,malloy}.md` and the at-a-glance `index.md`) still described OBSL's metric surface as `sum/avg/count/min/max` + cumulative + PoP. v2.6 shipped a much wider surface that wasn't reflected in the tables, so the published pages understated what OBSL does and overstated several peers (e.g. cube.md still said "Cube has more aggregate types out of the box" — no longer true).

Updates per page:

- **cube.md / atscale.md / lookml.md / malloy.md** — §4 Metric types tables now list:
  - **10 standard aggregations** + **9 statistical aggregations (v2.6+)** — `stddev`, `stddev_pop`, `variance`, `var_pop`, `corr`, `covar_pop`, `covar_samp`, `regr_slope`, `regr_intercept`
  - **`MetricType.WINDOW` (v2.6+)** — `rank`, `dense_rank`, `row_number`, `ntile`, `lag`, `lead`, `first_value`, `last_value`
  - **`partitionBy` on cumulative metrics (v2.6+)**
  - "Other distinctives" tables get matching new rows
- **index.md** — at-a-glance table gains two new rows (window metric, statistical aggregates) and the cumulative row notes `partitionBy`.
- **dbt.md** — already up-to-date (has §3a window metrics and §6a statistical aggregates). Untouched.

Source of truth: `src/orionbelt/models/semantic.py` (`AggregationType`, `MetricType`, `WindowFunctionKind`) and `docs/guide/model-format.md` §"Aggregation Types".

## Test plan

- [x] `uv run mkdocs build --strict` — passes (only pre-existing INFO warnings about a `#statistical-aggregates-on-measure` anchor in unmodified `dbt.md` / `model-format.md`)
- [ ] Spot-check rendered pages on PR-preview / Cloud Run docs
- [ ] After merge: `scripts/deploy-docs.sh` to push to gh-pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)