### PR TITLE
docs(comparison): split aggregation surface into its own table; be precise about peer support

### DIFF
--- a/docs/comparison/atscale.md
+++ b/docs/comparison/atscale.md
@@ -94,9 +94,22 @@ AtScale ships first-class enterprise primitives:
 
 ## 4. Metric types
 
+### 4.1 Aggregation surface on `Measure`
+
+| Family | OBSL | AtScale |
+|---|---|---|
+| Standard | `sum`, `count`, `count_distinct`, `avg`, `min`, `max` | `sum`, `count`, `distinct count`, `avg`, `min`, `max` |
+| Shape | `any_value`, `median`, `mode`, `listagg` | Semi-additive measures (last non-empty, first non-empty) — OLAP-native |
+| Statistical (v2.6+) | `stddev`, `stddev_pop`, `variance`, `var_pop` | Via MDX calculated members (`Stdev`, `Var`) — not first-class measure types |
+| Association / regression (v2.6+) | `corr`, `covar_pop`, `covar_samp`, `regr_slope`, `regr_intercept` | Via MDX calculated members — not first-class measure types |
+| Grand totals | `total: bool` on the measure | Native to OLAP — every grain rolls up by construction |
+
+**The honest difference**: AtScale's OLAP heritage gives it stronger *semi-additive* primitives (last-value, opening / closing balances) that OBSL doesn't model. OBSL's statistical / regression aggregations are first-class declarative measure types with arity validation and dialect gating; AtScale reaches the same functions through MDX calculated members. Different mental models — both can compute the same SQL.
+
+### 4.2 Metric types
+
 | OBSL | AtScale | Notes |
 |---|---|---|
-| `Measure` — 10 standard aggregations (`sum`, `count`, `count_distinct`, `avg`, `min`, `max`, `any_value`, `median`, `mode`, `listagg`) **+ 9 statistical aggregations (v2.6+)** (`stddev`, `stddev_pop`, `variance`, `var_pop`, `corr`, `covar_pop`, `covar_samp`, `regr_slope`, `regr_intercept`) + `total: bool` for grand totals | Measures with rich aggregation types (sum, count, distinct count, min, max, average, semi-additive measures) | Both first-class. AtScale has stronger semi-additive types (last non-empty, etc.); OBSL has the wider statistical / regression surface as first-class declarative aggregates |
 | `Metric` `type: derived` | Calculated members (MDX expressions) | Both first-class |
 | `Metric` `type: cumulative` (running, rolling, grain-to-date, **per-dimension `partitionBy` v2.6+**) | Time-intelligence MDX (`Aggregate(YTD([Date].CurrentMember), [Sales])`) — idiomatic OLAP | Both expressive; OBSL is YAML-declarative, AtScale is MDX-declarative |
 | `Metric` `type: period_over_period` (4 comparison modes) | Calculated members using `ParallelPeriod` / `Lag` MDX functions | Both expressive; AtScale is more flexible (full MDX), OBSL is more turnkey |
@@ -104,7 +117,7 @@ AtScale ships first-class enterprise primitives:
 | Reusable filter context / filtered measures | Named sets, perspectives | Comparable |
 | Hierarchical aggregation | Limited (use grains) | First-class via hierarchies and `Aggregate()` |
 
-For complex OLAP-style metrics (MDX is genuinely more expressive than any YAML format), AtScale wins on flexibility. For straightforward cumulative/PoP/window/statistical metrics that you want declared once and reused everywhere, OBSL is more turnkey. See [Trend Analysis](../guide/trend-analysis.md) for the full v2.6 metric / aggregation surface (dialect coverage matrix included).
+For complex OLAP-style metrics (MDX is genuinely more expressive than any YAML format), AtScale wins on flexibility. For straightforward cumulative/PoP/window/statistical metrics that you want declared once and reused everywhere, OBSL is more turnkey. See [Trend Analysis](../guide/trend-analysis.md) for the full v2.6 metric / aggregation surface.
 
 ---
 
@@ -214,7 +227,8 @@ The free **Developer Community Edition** lowers the barrier for evaluation, prot
 | First-class declarative PoP metric type | ✅ | Via MDX (more flexible but less turnkey) |
 | First-class declarative cumulative metric type | ✅ (running, rolling, grain-to-date, `partitionBy` v2.6+) | Via MDX time intelligence |
 | First-class declarative window metric type (rank / lag / lead / ntile / first_value / last_value) | ✅ (v2.6+) | Via MDX calculated members |
-| Statistical aggregates (`stddev`, `variance`, `corr`, `covar_*`, `regr_*`) | ✅ 9 functions (v2.6+) | Limited; not first-class as measure types |
+| First-class statistical / regression aggregates (`stddev`, `variance`, `corr`, `covar_*`, `regr_*`) as measure types | ✅ 9 declarative aggregations (v2.6+) | Via MDX calculated members — not first-class measure types |
+| Semi-additive measures (last/first non-empty) | ❌ | ✅ first-class OLAP |
 | Apache Arrow Flight SQL | ✅ | ❌ |
 | DB-API 2.0 drivers | ✅ 8 drivers | ❌ |
 | RDF/SPARQL graph view | ✅ | ❌ |

--- a/docs/comparison/cube.md
+++ b/docs/comparison/cube.md
@@ -140,19 +140,31 @@ OBSL ships `static | scheduled | heartbeat | unknown` modes and exposes `GET /v1
 
 ## 4. Metric types
 
+### 4.1 Aggregation surface on `Measure`
+
+| Family | OBSL | Cube |
+|---|---|---|
+| Standard | `sum`, `count`, `count_distinct`, `avg`, `min`, `max` | `sum`, `count`, `count_distinct`, `count_distinct_approx`, `avg`, `min`, `max` |
+| Shape | `any_value`, `median`, `mode`, `listagg` | `string`, `time`, `boolean`, `number` (generic — wraps any aggregate SQL expression) |
+| Statistical (v2.6+) | `stddev`, `stddev_pop`, `variance`, `var_pop` | Via `type: number` + raw `sql: STDDEV(...)` — not a first-class measure type |
+| Association / regression (v2.6+) | `corr`, `covar_pop`, `covar_samp`, `regr_slope`, `regr_intercept` | Via `type: number` + raw SQL — not a first-class measure type |
+| Grand totals | `total: bool` on the measure | n/a — done at query/visualization time |
+
+**The honest difference**: Cube's `type: number` is a generic escape hatch — anything the warehouse can express in SQL is reachable, but the model authors write raw SQL that's dialect-specific, arity-unchecked, and opaque to validation. OBSL ships these as first-class declarative aggregations with arity validation (2-column for `corr` / `covar_*` / `regr_*`), per-dialect gating (`UNSUPPORTED_AGGREGATION_FOR_DIALECT` at compile time), and identical YAML across all 8 dialects. Both approaches reach the same SQL functions in the end; the difference is who owns dialect portability.
+
+### 4.2 Metric types
+
 | OBSL | Cube | Notes |
 |---|---|---|
-| `Measure` — 10 standard aggregations (`sum`, `count`, `count_distinct`, `avg`, `min`, `max`, `any_value`, `median`, `mode`, `listagg`) **+ 9 statistical aggregations (v2.6+)** (`stddev`, `stddev_pop`, `variance`, `var_pop`, `corr`, `covar_pop`, `covar_samp`, `regr_slope`, `regr_intercept`) + `total: bool` for grand totals | `measures` (`type: sum/count/count_distinct/avg/min/max/number/string/time/boolean`) | OBSL has the wider aggregate surface — Cube has no statistical / regression aggregates as first-class measure types |
 | `Metric` `type: derived` | `measure: { type: number; sql: ... }` referencing other measures | Both first-class |
-| `Metric` `type: cumulative` (running, rolling, grain-to-date, **per-dimension `partitionBy` v2.6+**) | `measure: { rolling_window: { trailing: '7 day', offset: 'end' } }` — rolling only | Cube has rolling windows but no grain-to-date, no unbounded cumulative, and no partition-by surface as declarative types |
+| `Metric` `type: cumulative` (running, rolling, grain-to-date, **per-dimension `partitionBy` v2.6+**) | `measure: { rolling_window: { trailing: '7 day', offset: 'end' } }` — rolling only | Cube has rolling windows but no grain-to-date, no unbounded cumulative, and no `partitionBy` as declarative types |
 | `Metric` `type: period_over_period` (4 comparison modes) | Query-side: `compareDateRange` parameter or `time_shift: { interval: '1 year', type: 'prior' }` | Cube does PoP at query time, not as a model-defined metric |
-| `Metric` `type: window` (v2.6+) — `rank`, `dense_rank`, `row_number`, `ntile`, `lag`, `lead`, `first_value`, `last_value` | — | **Gap in Cube** — no first-class rank / lag / lead surface; users compose raw SQL |
+| `Metric` `type: window` (v2.6+) — `rank`, `dense_rank`, `row_number`, `ntile`, `lag`, `lead`, `first_value`, `last_value` | Via `type: number` + raw window-function SQL | OBSL ships these as declarative metric types; Cube reaches them via the same `type: number` escape hatch |
 | Reusable filter context / filtered measures | `segments` (named, reusable filter sets) + `filters` on individual measure definitions | Comparable |
-| Grand totals (`total: true`) | n/a — done at query/visualization time | OBSL has it as a measure attribute |
 
 **Different philosophies**: OBSL bakes time-aware metrics into the model (write once, every query gets the comparison). Cube treats time comparisons as query-time concerns (more flexible, but the consumer has to know how to ask). Either fits depending on whether you're publishing a metrics catalog or empowering query authors.
 
-See [Trend Analysis](../guide/trend-analysis.md) for the full v2.6 metric / aggregation surface (window functions, statistical aggregates, dialect coverage matrix).
+See [Trend Analysis](../guide/trend-analysis.md) for OBSL's full v2.6 surface (window functions, statistical aggregates, dialect coverage matrix).
 
 ---
 
@@ -260,8 +272,8 @@ For a small embedded-analytics use case OBSL is operationally simpler. For high-
 | Field-level masking | ❌ | ✅ via Twig conditionals |
 | First-class PoP metric type | ✅ (4 comparison modes) | ❌ (`time_shift` at query time) |
 | First-class cumulative metric type | ✅ (running, rolling, grain-to-date, `partitionBy` v2.6+) | Partial (`rolling_window` only) |
-| First-class window metric type (rank / lag / lead / ntile / first_value / last_value) | ✅ (v2.6+) | ❌ |
-| Statistical aggregates (`stddev`, `variance`, `corr`, `covar_*`, `regr_*`) | ✅ 9 functions (v2.6+) | ❌ |
+| First-class window metric type (rank / lag / lead / ntile / first_value / last_value) | ✅ (v2.6+) | Via `type: number` + raw SQL |
+| Statistical aggregates (`stddev`, `variance`, `corr`, `covar_*`, `regr_*`) as first-class measure types | ✅ 9 declarative aggregations (v2.6+) | Via `type: number` + raw SQL |
 | Multi-rooted DAG modeling | ✅ via CFL | ❌ (single-rooted cubes + views) |
 | Named secondary join paths | ✅ | ❌ |
 | Symmetric aggregates | ❌ (uses CFL) | ✅ |
@@ -315,8 +327,8 @@ A workable hybrid: use Cube as the production query gateway with pre-aggregation
 ### To match OBSL, Cube would need:
 
 1. **First-class cumulative & period-over-period metric types** — declarative versions of what's currently `rolling_window` and query-side `time_shift`, including per-dimension `partitionBy` on cumulative.
-2. **First-class window metric type** — `rank`, `dense_rank`, `row_number`, `ntile`, `lag`, `lead`, `first_value`, `last_value` as declarative metric types instead of raw SQL.
-3. **Statistical aggregate functions** — `stddev`, `variance`, `corr`, `covar_*`, `regr_slope`, `regr_intercept` as first-class measure aggregations.
+2. **First-class window metric type** — `rank`, `dense_rank`, `row_number`, `ntile`, `lag`, `lead`, `first_value`, `last_value` as declarative metric types rather than reaching them through `type: number` + raw window-function SQL.
+3. **First-class statistical / regression aggregations** — `stddev`, `variance`, `corr`, `covar_*`, `regr_slope`, `regr_intercept` as declarative measure types with arity validation and per-dialect gating, rather than via `type: number` + raw SQL.
 4. **Multi-rooted DAG modeling** — the ability to query across genuinely independent fact tables in one go without the consumer needing to pre-design a `view`.
 5. **Named secondary join paths** with per-query selection.
 6. **RDF/SPARQL graph surface** for governance/lineage.

--- a/docs/comparison/index.md
+++ b/docs/comparison/index.md
@@ -15,8 +15,8 @@ How OrionBelt Semantic Layer (OBSL) stacks up against the leading semantic layer
 | Query interface | **[OrionBelt Semantic QL](../guide/semantic-ql.md)** (OBSQL) + **Arrow Flight SQL** + **PostgreSQL wire** + REST + DB-API | GraphQL/JDBC (Cloud) | Malloy language | Looker UI / API | **Cube SQL API** (Postgres-wire) + REST + GraphQL | **MDX + DAX** + JDBC/ODBC + REST |
 | First-class cumulative metric (running / rolling / grain-to-date, `partitionBy` v2.6+) | ✅ | ✅ (no `partitionBy`) | Per-query | Partial | Partial (`rolling_window`) | Via MDX |
 | First-class period-over-period metric | ✅ | Via `offset_window` | Per-query | Via table calc | Query-time `time_shift` | Via MDX |
-| First-class window metric (rank / lag / lead / ntile / first_value / last_value, v2.6+) | ✅ | ❌ | Per-query calculations | Table calcs (UI-side) | ❌ | Via MDX calculated members |
-| Statistical / regression aggregates (`stddev`, `variance`, `corr`, `covar_*`, `regr_*`, v2.6+) | ✅ 9 functions | Partial (basic `stddev` only) | Partial (basic `stddev` only) | Partial (via raw `sql:`) | ❌ | Limited |
+| First-class window metric (rank / lag / lead / ntile / first_value / last_value, v2.6+) | ✅ declarative | ❌ | Per-query calculations | Table calcs (UI-side) | Via `type: number` + raw SQL | Via MDX calculated members |
+| Statistical / regression aggregates as first-class measure types (`stddev`, `variance`, `corr`, `covar_*`, `regr_*`, v2.6+) | ✅ 9 declarative aggregations (arity-validated, per-dialect gated) | Basic `stddev` only as first-class | Basic `stddev` only as first-class | Via `type: number` + raw SQL | Via `type: number` + raw SQL | Via MDX calculated members |
 | Conversion / funnel metrics | ❌ | ✅ | Patterns | Patterns | Patterns | Patterns |
 | Symmetric aggregates | ❌ (uses CFL) | ❌ | ✅ | ✅ | ✅ | ✅ (OLAP) |
 | Hierarchical subtotals (`WITH ROLLUP` / `WITH CUBE`) | ✅ first-class in **Semantic QL** (trailing modifier + `GROUPING()` flag columns; dialect-portable across all 8 drivers) | ❌ presentation concern | ❌ | UI-only checkbox; no LookML construct | "Rollup" means pre-aggregation tables, not the SQL operator | Via MDX/DAX |

--- a/docs/comparison/lookml.md
+++ b/docs/comparison/lookml.md
@@ -117,16 +117,29 @@ LookML carries UI metadata: `drill_fields: [order_id, customer_name, ...]`, `val
 
 ## 4. Metric types
 
+### 4.1 Aggregation surface on `Measure`
+
+| Family | OBSL | LookML |
+|---|---|---|
+| Standard | `sum`, `count`, `count_distinct`, `avg`, `min`, `max` | `sum`, `count`, `count_distinct`, `average`, `min`, `max` |
+| Shape | `any_value`, `median`, `mode`, `listagg` | `sum_distinct`, `average_distinct`, `median`, `median_distinct`, `percentile`, `percentile_distinct`, `list`, `number`, `string`, `date`, `yesno` |
+| Statistical (v2.6+) | `stddev`, `stddev_pop`, `variance`, `var_pop` | Via `type: number` + raw `sql: STDDEV(...)` — not first-class measure types |
+| Association / regression (v2.6+) | `corr`, `covar_pop`, `covar_samp`, `regr_slope`, `regr_intercept` | Via `type: number` + raw SQL — not first-class measure types |
+| Grand totals | `total: bool` on the measure | Looker UI checkbox (`totals: yes`) — visualization-time, not the model |
+
+**The honest difference**: LookML wins decisively on aggregate-variant *shape* — `sum_distinct`, `percentile_*`, `median_distinct` are all first-class measure types Looker authors reach for daily. OBSL's `any_value` / `mode` / `listagg` cover a different slice. On the statistical side, OBSL ships 9 first-class declarative aggregations with arity validation and per-dialect gating; LookML reaches the same SQL through `type: number` + raw SQL — works, but not validated and not portable across dialects.
+
+### 4.2 Metric types
+
 | OBSL | LookML | Notes |
 |---|---|---|
-| `Measure` — 10 standard aggregations (`sum`, `count`, `count_distinct`, `avg`, `min`, `max`, `any_value`, `median`, `mode`, `listagg`) **+ 9 statistical aggregations (v2.6+)** (`stddev`, `stddev_pop`, `variance`, `var_pop`, `corr`, `covar_pop`, `covar_samp`, `regr_slope`, `regr_intercept`) + `total: bool` for grand totals | `measure: { type: sum/avg/count/count_distinct/sum_distinct/percentile/median/... }` | LookML has more "shape" aggregate variants (`sum_distinct`, `percentile_*`), OBSL has the wider statistical / regression surface (CORR / COVAR_* / REGR_* / STDDEV_* / VAR_*) as first-class declarative aggregates |
 | `Metric` `type: derived` | `measure: { type: number; sql: ...references other measures... }` | Both first-class |
 | `Metric` `type: cumulative` (running, rolling, grain-to-date, **per-dimension `partitionBy` v2.6+**) | `type: running_total` (basic), or table calculations in UI for richer cases | OBSL has richer **declarative** cumulative |
 | `Metric` `type: period_over_period` (4 comparison modes) | Patterns: filtered measures (`{% if date.is_in_period %} ... {% endif %}`) or table calculations | OBSL has a dedicated metric type |
 | `Metric` `type: window` (v2.6+) — `rank`, `dense_rank`, `row_number`, `ntile`, `lag`, `lead`, `first_value`, `last_value` | Looker table calculations (`rank()`, `offset()`, `pivot_offset()`) — UI-side, not LookML model | OBSL ships these as declarative metric types reusable across every consumer; Looker's equivalents live in the dashboard layer |
 | `Measure.filterContext` / `filteredMeasures` | Filtered measure pattern: `measure: { type: sum; filters: [is_paid: "yes"] }` | Comparable |
 
-Bottom line: LookML wins on aggregate-variant *shape* (sum_distinct, percentile families) and on UI-side table-calc breadth; OBSL wins on **statistical/regression aggregates** and on **time/window/PoP/cumulative as declarative metric types** that survive across every consumer (BI tool, agent, JSON API) without re-implementing the table calc. See [Trend Analysis](../guide/trend-analysis.md) for the full v2.6 metric / aggregation surface.
+Bottom line: LookML wins on aggregate-variant *shape* (`sum_distinct`, `percentile_*`, `median_distinct`) and on UI-side table-calc breadth; OBSL wins on **first-class statistical/regression aggregates** and on **time/window/PoP/cumulative as declarative metric types** that survive across every consumer (BI tool, agent, JSON API) without re-implementing the table calc. See [Trend Analysis](../guide/trend-analysis.md) for the full v2.6 metric / aggregation surface.
 
 ---
 
@@ -232,7 +245,8 @@ For embedded SaaS, multi-tenant analytics, or air-gapped/on-prem use cases, OBSL
 | First-class PoP metric type | ✅ | ❌ (table calc / filtered measures) |
 | First-class cumulative metric type | ✅ (running, rolling, grain-to-date, `partitionBy` v2.6+) | Partial (`running_total` only) |
 | First-class window metric type (rank / lag / lead / ntile / first_value / last_value) | ✅ (v2.6+) | ❌ (table calculations only — dashboard-side) |
-| Statistical aggregates (`stddev`, `variance`, `corr`, `covar_*`, `regr_*`) | ✅ 9 functions (v2.6+) | Partial — some via raw `sql:`, none as first-class measure types |
+| First-class statistical / regression aggregates as measure types | ✅ 9 declarative aggregations (v2.6+) | Via `type: number` + raw SQL — not first-class measure types |
+| First-class `sum_distinct` / `percentile_*` / `median_distinct` measure types | ❌ | ✅ |
 | RDF/SPARQL graph view | ✅ | ❌ |
 | Named secondary join paths | ✅ | ❌ |
 | Explicit CFL multi-fact planner | ✅ | n/a |

--- a/docs/comparison/malloy.md
+++ b/docs/comparison/malloy.md
@@ -117,9 +117,22 @@ OBSL has no named-view-with-refinements concept. Queries are constructed fresh e
 
 ## 4. Metric types
 
+### 4.1 Aggregation surface on `Measure`
+
+| Family | OBSL | Malloy |
+|---|---|---|
+| Standard | `sum`, `count`, `count_distinct`, `avg`, `min`, `max` | `sum`, `count`, `count(distinct ...)`, `avg`, `min`, `max` |
+| Shape | `any_value`, `median`, `mode`, `listagg` | `string_agg`, `percent`, `avg_moving` (built-in helpers) |
+| Statistical (v2.6+) | `stddev`, `stddev_pop`, `variance`, `var_pop` | `stddev` (basic) |
+| Association / regression (v2.6+) | `corr`, `covar_pop`, `covar_samp`, `regr_slope`, `regr_intercept` | Via raw SQL in `sql:` literal — not first-class |
+| Grand totals | `total: bool` on the measure | Via query-level `nest:` patterns |
+
+**The honest difference**: Malloy and OBSL both expose declarative measure aggregations (this is closer parity than with Cube / LookML / AtScale). The structural gap is the **association / regression family** (`corr`, `covar_*`, `regr_*`) — first-class in OBSL v2.6+, not in Malloy. Both can compute them; OBSL gates them per-dialect at compile time and validates 2-column arity, Malloy expects you to drop into raw SQL.
+
+### 4.2 Metric types
+
 | OBSL | Malloy | Notes |
 |---|---|---|
-| `Measure` — 10 standard aggregations (`sum`, `count`, `count_distinct`, `avg`, `min`, `max`, `any_value`, `median`, `mode`, `listagg`) **+ 9 statistical aggregations (v2.6+)** (`stddev`, `stddev_pop`, `variance`, `var_pop`, `corr`, `covar_pop`, `covar_samp`, `regr_slope`, `regr_intercept`) + `total: bool` for grand totals | `measure:` declarations inside `source` (`sum`, `count`, `count_distinct`, `avg`, `min`, `max`, `stddev`, etc.) | Both first-class. OBSL has a wider statistical / regression surface (`corr`, `covar_pop`, `covar_samp`, `regr_slope`, `regr_intercept`) as declarative measure aggregations |
 | `Metric` `type: derived` (`{[Measure A]}/{[Measure B]}`) | Composed by referencing other measures inside aggregate expressions | Both first-class |
 | `Metric` `type: cumulative` (running, rolling, grain-to-date, **per-dimension `partitionBy` v2.6+**) | Express via **calculations** (window functions) inside queries | OBSL is declarative; Malloy is per-query |
 | `Metric` `type: period_over_period` with 4 comparison modes | Pattern via `prior_period` style queries; renderer has a `big_value { comparison_field=... }` for visual deltas | OBSL has a dedicated metric type; Malloy treats it as "just write the query" |
@@ -227,7 +240,7 @@ Malloy's time syntax is more ergonomic in a query; OBSL's metric types are more 
 | First-class PoP metric type | ✅ | ❌ (ad-hoc) |
 | First-class cumulative metric type | ✅ (running, rolling, grain-to-date, `partitionBy` v2.6+) | ❌ (calculations) |
 | First-class window metric type (rank / lag / lead / ntile / first_value / last_value) | ✅ (v2.6+) | ❌ (calculations per-query) |
-| Statistical aggregates (`corr`, `covar_*`, `regr_*` in addition to `stddev` / `variance`) | ✅ 9 functions (v2.6+) | Partial — Malloy ships basic `stddev` / `variance` but no `corr` / `covar_*` / `regr_*` as first-class measure types |
+| First-class association / regression aggregates (`corr`, `covar_*`, `regr_*`) | ✅ (v2.6+) | ❌ — Malloy ships basic `stddev` but `corr` / `covar_*` / `regr_*` require raw SQL |
 | Dialect breadth (ClickHouse/Databricks/Dremio) | ✅ | ❌ |
 | Trino/Presto | ❌ | ✅ |
 | VS Code-native authoring | ✅ via Jupyter notebook (also one-click in Colab) | ✅ first-party extension with autocomplete + inline viz |


### PR DESCRIPTION
## Summary

Follow-up to #66. Two issues raised:

1. **Layout** — packing 19 aggregations inline into a single OBSL cell made the OBSL column dominate and squashed the peer column.
2. **Accuracy** — Cube, LookML, and AtScale can all reach `stddev` / `corr` / `covar` / `regr` in SQL (verified via Cube's [percentiles recipe](https://cube.dev/docs/product/data-modeling/recipes/percentiles) — they ship `type: number` + raw SQL as the documented pattern). My prior "❌" or "no support" wording was misleading.

### Fix

Each vendor page (`cube`, `atscale`, `lookml`, `malloy`) now has §4.1 **"Aggregation surface on `Measure`"** as a dedicated table with these rows:

| Family | OBSL | Peer |
|---|---|---|
| Standard | … | … |
| Shape | … | … |
| Statistical (v2.6+) | … | … |
| Association / regression (v2.6+) | … | … |
| Grand totals | … | … |

Honest per-vendor wording:

- **Cube, LookML** — "via `type: number` + raw SQL — not first-class measure types"
- **AtScale** — "via MDX calculated members — not first-class measure types"
- **Malloy** — "basic `stddev` only as first-class; rest via raw SQL"

Plus a follow-up sentence acknowledging where each peer wins on aggregate *shape* (LookML: `sum_distinct` / `percentile_*` / `median_distinct`; AtScale: semi-additive measures; Malloy: closer overall parity).

§4.2 keeps the Metric-types comparison (`derived` / `cumulative` / `period_over_period` / `window`) separate and concise.

`index.md` at-a-glance: flat `❌` cells become specific ("via `type: number` + raw SQL", "via MDX calculated members") so the table tells the truth about what each peer can and cannot do declaratively.

## Test plan

- [x] `uv run mkdocs build --strict` — passes (only pre-existing INFO warnings)
- [ ] Visual check: peer column should no longer be squashed on the live site
- [ ] After merge: `scripts/deploy-docs.sh` → gh-pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)