### PR TITLE
docs(comparison): wrap long inline code in <pre><code> blocks for table layout

### DIFF
--- a/docs/comparison/atscale.md
+++ b/docs/comparison/atscale.md
@@ -111,9 +111,9 @@ AtScale ships first-class enterprise primitives:
 | OBSL | AtScale | Notes |
 |---|---|---|
 | `Metric` `type: derived` | Calculated members (MDX expressions) | Both first-class |
-| `Metric` `type: cumulative` (running, rolling, grain-to-date, **per-dimension `partitionBy` v2.6+**) | Time-intelligence MDX (`Aggregate(YTD([Date].CurrentMember), [Sales])`) — idiomatic OLAP | Both expressive; OBSL is YAML-declarative, AtScale is MDX-declarative |
+| `Metric` `type: cumulative` (running, rolling, grain-to-date, **per-dimension `partitionBy` v2.6+**) | Time-intelligence MDX: <pre><code>Aggregate(<br>  YTD([Date].CurrentMember),<br>  [Sales]<br>)</code></pre> — idiomatic OLAP | Both expressive; OBSL is YAML-declarative, AtScale is MDX-declarative |
 | `Metric` `type: period_over_period` (4 comparison modes) | Calculated members using `ParallelPeriod` / `Lag` MDX functions | Both expressive; AtScale is more flexible (full MDX), OBSL is more turnkey |
-| `Metric` `type: window` (v2.6+) — `rank`, `dense_rank`, `row_number`, `ntile`, `lag`, `lead`, `first_value`, `last_value` | MDX `Rank()`, `Lag()`, `Lead()` in calculated members | OBSL exposes these as declarative metric types; AtScale expresses them via MDX |
+| `Metric` `type: window` (v2.6+) — <br>`rank`, `dense_rank`, `row_number`, `ntile`,<br>`lag`, `lead`, `first_value`, `last_value` | MDX `Rank()`, `Lag()`, `Lead()` in calculated members | OBSL exposes these as declarative metric types; AtScale expresses them via MDX |
 | Reusable filter context / filtered measures | Named sets, perspectives | Comparable |
 | Hierarchical aggregation | Limited (use grains) | First-class via hierarchies and `Aggregate()` |
 

--- a/docs/comparison/cube.md
+++ b/docs/comparison/cube.md
@@ -36,8 +36,8 @@ Cube is the closest peer to OBSL in the OSS space — both are self-hostable, bo
 | `Dimension` (model-scoped) | n/a — dimensions live inside cubes | OBSL has model-scoped dimensions; Cube does not |
 | `Measure` | `measures` on a cube | |
 | `Metric` `type: derived` | `measure: { type: number; sql: ... }` referencing other measures | Both first-class |
-| `Metric` `type: cumulative` | `measure: { type: sum; rolling_window: { trailing: '7 day' } }` | Cube has rolling windows but they live on individual measures, not as a separate metric type |
-| `Metric` `type: period_over_period` | `time_shift` in queries (`compareDateRange`, `time_shift: { interval: '1 year', type: 'prior' }`) | Cube does PoP at *query time*, not in the model |
+| `Metric` `type: cumulative` | <pre><code>measure:<br>  type: sum<br>  rolling_window:<br>    trailing: 7 day</code></pre> | Cube has rolling windows but they live on individual measures, not as a separate metric type |
+| `Metric` `type: period_over_period` | `time_shift` in queries (`compareDateRange`, or <pre><code>time_shift:<br>  interval: 1 year<br>  type: prior</code></pre>) | Cube does PoP at *query time*, not in the model |
 | `DataObjectJoin` | `joins:` inside a cube with `relationship: many_to_one`/`one_to_many`/`one_to_one` | Cube uses relationship-driven symmetric aggregates |
 | Combining multiple data objects in one query | Native via join graph + CFL | `view` entity required to combine cubes; views are first-class but distinct from cubes |
 | `secondary: true` + `pathName` | n/a — multiple joins between the same pair require workarounds | No path-name primitive |
@@ -145,7 +145,7 @@ OBSL ships `static | scheduled | heartbeat | unknown` modes and exposes `GET /v1
 | Family | OBSL | Cube |
 |---|---|---|
 | Standard | `sum`, `count`, `count_distinct`, `avg`, `min`, `max` | `sum`, `count`, `count_distinct`, `count_distinct_approx`, `avg`, `min`, `max` |
-| Shape | `any_value`, `median`, `mode`, `listagg` | `string`, `time`, `boolean`, `number` (generic — wraps any aggregate SQL expression) |
+| Shape | `any_value`, `median`,<br>`mode`, `listagg` | `string`, `time`, `boolean`,<br>`number` (generic — wraps any<br>aggregate SQL expression) |
 | Statistical (v2.6+) | `stddev`, `stddev_pop`, `variance`, `var_pop` | Via `type: number` + raw `sql: STDDEV(...)` — not a first-class measure type |
 | Association / regression (v2.6+) | `corr`, `covar_pop`, `covar_samp`, `regr_slope`, `regr_intercept` | Via `type: number` + raw SQL — not a first-class measure type |
 | Grand totals | `total: bool` on the measure | n/a — done at query/visualization time |
@@ -156,11 +156,11 @@ OBSL ships `static | scheduled | heartbeat | unknown` modes and exposes `GET /v1
 
 | OBSL | Cube | Notes |
 |---|---|---|
-| `Metric` `type: derived` | `measure: { type: number; sql: ... }` referencing other measures | Both first-class |
-| `Metric` `type: cumulative` (running, rolling, grain-to-date, **per-dimension `partitionBy` v2.6+**) | `measure: { rolling_window: { trailing: '7 day', offset: 'end' } }` — rolling only | Cube has rolling windows but no grain-to-date, no unbounded cumulative, and no `partitionBy` as declarative types |
-| `Metric` `type: period_over_period` (4 comparison modes) | Query-side: `compareDateRange` parameter or `time_shift: { interval: '1 year', type: 'prior' }` | Cube does PoP at query time, not as a model-defined metric |
-| `Metric` `type: window` (v2.6+) — `rank`, `dense_rank`, `row_number`, `ntile`, `lag`, `lead`, `first_value`, `last_value` | Via `type: number` + raw window-function SQL | OBSL ships these as declarative metric types; Cube reaches them via the same `type: number` escape hatch |
-| Reusable filter context / filtered measures | `segments` (named, reusable filter sets) + `filters` on individual measure definitions | Comparable |
+| `Metric` `type: derived` | <pre><code>measure:<br>  type: number<br>  sql: "{revenue} / {orders}"</code></pre> | Both first-class |
+| `Metric` `type: cumulative` (running, rolling, grain-to-date, **per-dimension `partitionBy` v2.6+**) | <pre><code>measure:<br>  type: sum<br>  rolling_window:<br>    trailing: 7 day<br>    offset: end</code></pre> rolling only | Cube has rolling windows but no grain-to-date, no unbounded cumulative, and no `partitionBy` as declarative types |
+| `Metric` `type: period_over_period` (4 comparison modes) | Query-side: `compareDateRange` parameter, or <pre><code>time_shift:<br>  interval: 1 year<br>  type: prior</code></pre> | Cube does PoP at query time, not as a model-defined metric |
+| `Metric` `type: window` (v2.6+) — <br>`rank`, `dense_rank`, `row_number`, `ntile`,<br>`lag`, `lead`, `first_value`, `last_value` | Via `type: number` + raw window-function SQL | OBSL ships these as declarative metric types; Cube reaches them via the same `type: number` escape hatch |
+| Reusable filter context / filtered measures | `segments` + per-measure `filters` | Comparable |
 
 **Different philosophies**: OBSL bakes time-aware metrics into the model (write once, every query gets the comparison). Cube treats time comparisons as query-time concerns (more flexible, but the consumer has to know how to ask). Either fits depending on whether you're publishing a metrics catalog or empowering query authors.
 

--- a/docs/comparison/lookml.md
+++ b/docs/comparison/lookml.md
@@ -122,7 +122,7 @@ LookML carries UI metadata: `drill_fields: [order_id, customer_name, ...]`, `val
 | Family | OBSL | LookML |
 |---|---|---|
 | Standard | `sum`, `count`, `count_distinct`, `avg`, `min`, `max` | `sum`, `count`, `count_distinct`, `average`, `min`, `max` |
-| Shape | `any_value`, `median`, `mode`, `listagg` | `sum_distinct`, `average_distinct`, `median`, `median_distinct`, `percentile`, `percentile_distinct`, `list`, `number`, `string`, `date`, `yesno` |
+| Shape | `any_value`, `median`,<br>`mode`, `listagg` | `sum_distinct`, `average_distinct`,<br>`median`, `median_distinct`,<br>`percentile`, `percentile_distinct`,<br>`list`, `number`, `string`,<br>`date`, `yesno` |
 | Statistical (v2.6+) | `stddev`, `stddev_pop`, `variance`, `var_pop` | Via `type: number` + raw `sql: STDDEV(...)` — not first-class measure types |
 | Association / regression (v2.6+) | `corr`, `covar_pop`, `covar_samp`, `regr_slope`, `regr_intercept` | Via `type: number` + raw SQL — not first-class measure types |
 | Grand totals | `total: bool` on the measure | Looker UI checkbox (`totals: yes`) — visualization-time, not the model |
@@ -133,11 +133,11 @@ LookML carries UI metadata: `drill_fields: [order_id, customer_name, ...]`, `val
 
 | OBSL | LookML | Notes |
 |---|---|---|
-| `Metric` `type: derived` | `measure: { type: number; sql: ...references other measures... }` | Both first-class |
+| `Metric` `type: derived` | <pre><code>measure: revenue_per_order {<br>  type: number<br>  sql: ${revenue} / ${orders} ;;<br>}</code></pre> | Both first-class |
 | `Metric` `type: cumulative` (running, rolling, grain-to-date, **per-dimension `partitionBy` v2.6+**) | `type: running_total` (basic), or table calculations in UI for richer cases | OBSL has richer **declarative** cumulative |
-| `Metric` `type: period_over_period` (4 comparison modes) | Patterns: filtered measures (`{% if date.is_in_period %} ... {% endif %}`) or table calculations | OBSL has a dedicated metric type |
-| `Metric` `type: window` (v2.6+) — `rank`, `dense_rank`, `row_number`, `ntile`, `lag`, `lead`, `first_value`, `last_value` | Looker table calculations (`rank()`, `offset()`, `pivot_offset()`) — UI-side, not LookML model | OBSL ships these as declarative metric types reusable across every consumer; Looker's equivalents live in the dashboard layer |
-| `Measure.filterContext` / `filteredMeasures` | Filtered measure pattern: `measure: { type: sum; filters: [is_paid: "yes"] }` | Comparable |
+| `Metric` `type: period_over_period` (4 comparison modes) | Filtered measures with Liquid: <pre><code>{% if date.is_in_period %}<br>  ...<br>{% endif %}</code></pre> or table calculations | OBSL has a dedicated metric type |
+| `Metric` `type: window` (v2.6+) — <br>`rank`, `dense_rank`, `row_number`, `ntile`,<br>`lag`, `lead`, `first_value`, `last_value` | Looker table calculations (`rank()`, `offset()`, `pivot_offset()`) — UI-side, not LookML model | OBSL ships these as declarative metric types reusable across every consumer; Looker's equivalents live in the dashboard layer |
+| `Measure.filterContext` / `filteredMeasures` | <pre><code>measure: paid_revenue {<br>  type: sum<br>  filters: [is_paid: "yes"]<br>}</code></pre> | Comparable |
 
 Bottom line: LookML wins on aggregate-variant *shape* (`sum_distinct`, `percentile_*`, `median_distinct`) and on UI-side table-calc breadth; OBSL wins on **first-class statistical/regression aggregates** and on **time/window/PoP/cumulative as declarative metric types** that survive across every consumer (BI tool, agent, JSON API) without re-implementing the table calc. See [Trend Analysis](../guide/trend-analysis.md) for the full v2.6 metric / aggregation surface.
 

--- a/docs/comparison/malloy.md
+++ b/docs/comparison/malloy.md
@@ -17,9 +17,9 @@ A feature comparison between **OrionBelt Semantic Layer (OBSL)** and **Malloy** 
 | Aspect | OBSL (OBML) | Malloy |
 |---|---|---|
 | Format | Declarative YAML (`OBML`) | A purpose-built **language** (`.malloy` files) — both modeling *and* querying |
-| Source of truth | YAML model file | `.malloy` source files; `source: foo is duckdb.table('...') extend { ... }` |
-| Top-level objects | `dataObjects`, `dimensions`, `measures`, `metrics`, `filters` | `source` (with extensions: `dimension:`, `measure:`, `view:`, `join_one:`, `join_many:`) |
-| Queries | JSON `QueryObject` (`select`, `where`, `having`, `order_by`, ...) | Malloy query syntax: `run: source -> { group_by: ...; aggregate: ...; nest: ... }` |
+| Source of truth | YAML model file | `.malloy` source files: <pre><code>source: foo is<br>  duckdb.table('...')<br>  extend { ... }</code></pre> |
+| Top-level objects | `dataObjects`, `dimensions`, `measures`, `metrics`, `filters` | `source` with extensions: `dimension:`, `measure:`, `view:`, `join_one:`, `join_many:` |
+| Queries | JSON `QueryObject` (`select`, `where`, `having`, `order_by`, ...) | Malloy query syntax: <pre><code>run: source -> {<br>  group_by: ...<br>  aggregate: ...<br>  nest: ...<br>}</code></pre> |
 | Embedding | Drop-in compiler, no client language needed | Requires a Malloy-aware client/parser |
 
 **Key cultural difference**: Malloy is a *language*; OBSL is a *contract*. Malloy gives expressiveness in a `.malloy` file. OBSL gives a stable JSON over HTTP that any tool, agent, or LLM can call without learning a DSL.
@@ -135,8 +135,8 @@ OBSL has no named-view-with-refinements concept. Queries are constructed fresh e
 |---|---|---|
 | `Metric` `type: derived` (`{[Measure A]}/{[Measure B]}`) | Composed by referencing other measures inside aggregate expressions | Both first-class |
 | `Metric` `type: cumulative` (running, rolling, grain-to-date, **per-dimension `partitionBy` v2.6+**) | Express via **calculations** (window functions) inside queries | OBSL is declarative; Malloy is per-query |
-| `Metric` `type: period_over_period` with 4 comparison modes | Pattern via `prior_period` style queries; renderer has a `big_value { comparison_field=... }` for visual deltas | OBSL has a dedicated metric type; Malloy treats it as "just write the query" |
-| `Metric` `type: window` (v2.6+) — `rank`, `dense_rank`, `row_number`, `ntile`, `lag`, `lead`, `first_value`, `last_value` | Calculations (`rank()`, `lag()`, `first_value()`) inside queries | OBSL exposes these as declarative reusable metric types; Malloy keeps them per-query (matches the "expressive queries" philosophy) |
+| `Metric` `type: period_over_period` with 4 comparison modes | Pattern via `prior_period` style queries; renderer's <pre><code>big_value {<br>  comparison_field = ...<br>}</code></pre> for visual deltas | OBSL has a dedicated metric type; Malloy treats it as "just write the query" |
+| `Metric` `type: window` (v2.6+) — <br>`rank`, `dense_rank`, `row_number`, `ntile`,<br>`lag`, `lead`, `first_value`, `last_value` | Calculations (`rank()`, `lag()`, `first_value()`) inside queries | OBSL exposes these as declarative reusable metric types; Malloy keeps them per-query (matches the "expressive queries" philosophy) |
 
 **Different philosophies**: OBSL prefers reusable metric definitions (write once, every query gets PoP / window / cumulative). Malloy prefers expressive ad-hoc queries (write the comparison in the query itself). Either fits depending on whether you're publishing a metrics catalog or empowering analysts. See [Trend Analysis](../guide/trend-analysis.md) for the full v2.6 metric / aggregation surface.
 


### PR DESCRIPTION
## Summary

Follow-up to #67. Inline `code` spans don't wrap (the browser treats them as atomic non-breaking text), so the longest snippet in a row sets the column width and squashes the peer column.

Two patterns applied:

- **Lists of function names** (window metric row across all 4 vendor pages, the LookML Shape row with 11 inline codes) — split with `<br>` between inline-code groups so the cell wraps at the break point.
- **YAML / JSON / MDX examples** (Cube cumulative + PoP, LookML derived + PoP + filterContext, Malloy source + run + big_value, AtScale cumulative MDX) — converted to `<pre><code>…<br>…</code></pre>` blocks. Renders as a multi-line monospace block in MkDocs Material without breaking the surrounding Markdown table (fenced ``` blocks would have).

## Test plan

- [x] `uv run mkdocs build --strict` — passes (only the pre-existing INFO warnings)
- [x] Spot-check rendered HTML: `<pre><code>` nodes survive Markdown-table parsing intact, `<br>` tags preserved
- [ ] Visual check on live site — peer columns should breathe

🤖 Generated with [Claude Code](https://claude.com/claude-code)