### PR TITLE
docs: surface RALFORION commercial offerings

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ OrionBelt Semantic Layer is an **API-first** semantic engine and query planner f
 - [Gradio UI](#gradio-ui)
 - [Documentation](#documentation)
 - [Status & Roadmap](#status--roadmap)
+- [Commercial Offerings](#commercial-offerings)
 - [Companion Project](#companion-project)
 - [Development](#development)
 
@@ -488,6 +489,19 @@ API_BASE_URL=http://remote-api:8080 orionbelt-ui           # point UI to a remot
 | Shipped | 8 SQL dialects, REST API, MCP server, Gradio UI, DB-API drivers, Flight SQL, **PostgreSQL wire protocol (v2.5.0+)** — Tableau / DBeaver / Superset / Power BI / `psql` / **Dremio as a federated Postgres source**, OBSL/SPARQL, **OSI v0.2 interop (v2.6.0+)** with bidirectional schema validation, AI integrations (LangChain, CrewAI, ADK, etc.), model inheritance & extends, data types & numerical precision, timezone settings, grain & filter context overrides, **Trend Analysis (v2.6.0+)** — partitioned rolling windows, `MetricType.WINDOW` for rank/lag/lead/ntile, 9 statistical aggregates (CORR, COVAR_*, REGR_*, STDDEV_*, VAR_*) |
 | In progress | Additional dialects, CLI tool, pgwire SCRAM/password auth (unified auth subsystem) |
 | Planned | Authentication & API tokens, CLI for automation & CI/CD, DDL view generation (CREATE VIEW from queries), additional BI tool integrations, pre-aggregation / materialization layer |
+
+---
+
+## Commercial Offerings
+
+OrionBelt Semantic Layer is open by default — the OSS distribution has full parity on the shipped v2.6 surface and is production-grade for self-hosted use. For teams that want production support, a managed runtime, or embedded analytics terms, RALFORION offers:
+
+- **Embedded analytics license** — relicensing terms for shipping OBSL inside a commercial product
+- **Commercial cloud offering** — managed OrionBelt runtime with SLAs
+- **Enterprise features** — capabilities tailored for enterprise deployments
+- **Consulting + support** — implementation, modeling, and production support
+
+Contact [RALFORION d.o.o.](https://ralforion.com) for details.
 
 ---
 

--- a/docs/comparison/atscale.md
+++ b/docs/comparison/atscale.md
@@ -200,12 +200,13 @@ AtScale's MDX/DAX support is unique and a genuine advantage for Microsoft-stack 
 |---|---|---|
 | License | Source-available (BSL) | Proprietary; **free Developer Community Edition** for non-production / individual use |
 | Self-hostable | ✅ (one Python service) | ✅ — Developer Edition is free to install; production deployment requires enterprise license |
-| Pricing | Free (OSS) | **Developer Edition: free** (with feature/scale limits). Enterprise: typical six-figure annual licensing for production |
+| Pricing | OSS is free for self-hosted production; commercial tiers available for embedded analytics, managed cloud, and enterprise features | **Developer Edition: free** (with feature/scale limits). Enterprise: typical six-figure annual licensing for production |
+| Commercial offering | Embedded analytics license · commercial cloud offering · enterprise features · consulting + support | Enterprise license — production deployments, autonomous aggregates at scale, enterprise governance, vendor support |
 | Vendor lock-in | None (plain YAML, OSI-portable) | High — model lives in AtScale's proprietary format (mitigated for OSI-aware exports) |
 | Air-gapped deploy | ✅ supported | ✅ supported (enterprise) |
-| Self-host parity | Full feature parity in OSS | Full features in licensed enterprise tier; Developer Edition has feature/scale restrictions |
+| Self-host parity | OSS has full parity on the shipped v2.6 surface; enterprise tier adds enterprise-specific capabilities on top | Full features in licensed enterprise tier; Developer Edition has feature/scale restrictions |
 
-The free **Developer Community Edition** lowers the barrier for evaluation, prototyping, and individual learning — you can model, run MDX queries from Excel, and explore AtScale without a contract. For production multi-user deployments, autonomous aggregates at scale, or enterprise governance/support, the licensed tier is required. For OBSL the free OSS tier *is* the production tier — no upgrade path needed.
+The free **Developer Community Edition** lowers AtScale's barrier for evaluation, prototyping, and individual learning — you can model, run MDX queries from Excel, and explore AtScale without a contract. For production multi-user deployments, autonomous aggregates at scale, or enterprise governance/support, the licensed AtScale tier is required. For OBSL the OSS tier is fully production-grade for self-hosted use; commercial offerings (embedded analytics license, managed cloud, enterprise features, consulting + support) are available alongside if you want them, not as an upgrade gate for OSS capabilities.
 
 ---
 

--- a/docs/comparison/cube.md
+++ b/docs/comparison/cube.md
@@ -249,9 +249,9 @@ Both projects ship a free OSS core and offer commercial extensions, but the spli
 |---|---|---|
 | Core license | Source-available (BSL 1.1) | Apache 2.0 |
 | Self-hostable | ✅ (one Python service) | ✅ (Cube Core: Node.js + optional Cube Store + optional Redis) |
-| Commercial offering | Hosted instance (the public demo on Cloud Run) | Cube Cloud — managed runtime, multi-cluster, advanced security, Studio IDE, paid |
+| Commercial offering | Embedded analytics license · commercial cloud offering · enterprise features · consulting + support | Cube Cloud — managed runtime, multi-cluster, advanced security, Studio IDE, paid |
 | Operational footprint | Light: one process, in-memory sessions, optional file-backed result cache (DuckDB metadata + Parquet) on local disk | Heavier: API server + Cube Store + Redis (optional) + scheduler + refresh workers in production |
-| Self-host parity | Full feature parity in OSS | Many advanced features (Studio, advanced workspaces, AI features) are Cube Cloud-only |
+| Self-host parity | OSS has full parity on the shipped v2.6 surface; enterprise tier adds enterprise-specific capabilities on top | Many advanced features (Studio, advanced workspaces, AI features) are Cube Cloud-only |
 
 For a small embedded-analytics use case OBSL is operationally simpler. For high-throughput multi-tenant production with heavy caching across replicas, Cube's architecture is purpose-built and Cube Cloud provides the managed experience. OBSL's freshness-driven file cache (v2.2.0) covers single-replica result-caching workloads — agents, dev/staging, modest production — without standing up Redis or a rollup store.
 

--- a/docs/comparison/lookml.md
+++ b/docs/comparison/lookml.md
@@ -220,9 +220,11 @@ This is the most consequential difference and worth calling out separately.
 
 | | OBSL | LookML |
 |---|---|---|
-| License | Open source | Proprietary (Google Cloud / Looker) |
+| License | Source-available (BSL) | Proprietary (Google Cloud / Looker) |
 | Self-hostable | Yes — runs anywhere Python runs | Limited: Looker is a hosted SaaS; "Looker (original)" had a self-hosted option but is being deprecated |
-| Cost | Free | Per-user licensing on the Looker platform |
+| Cost | OSS is free for self-hosted production; commercial tiers available for embedded analytics, managed cloud, and enterprise features | Per-user licensing on the Looker platform |
+| Commercial offering | Embedded analytics license · commercial cloud offering · enterprise features · consulting + support | Looker platform — per-user licensing, hosted by Google Cloud |
+| Self-host parity | OSS has full parity on the shipped v2.6 surface; enterprise tier adds enterprise-specific capabilities on top | n/a — Looker is not self-hostable in the modern offering |
 | Vendor lock-in | None | LookML files only run inside Looker |
 | Air-gapped deploy | Possible | Not supported |
 | Format portability | OBML is plain YAML, can be read by any tool | LookML is a Looker-specific DSL with no widely-adopted external parser other than `pylookml` |

--- a/docs/index.md
+++ b/docs/index.md
@@ -157,6 +157,17 @@ GROUP BY "Customers"."COUNTRY"
 
 Ready to dive in? Start with [Installation](getting-started/installation.md) and then follow the [Quick Start](getting-started/quickstart.md) tutorial.
 
+## Commercial Offerings
+
+OrionBelt Semantic Layer is open by default — the OSS distribution has full parity on the shipped v2.6 surface and is production-grade for self-hosted use. For teams that want production support, a managed runtime, or embedded analytics terms, RALFORION offers:
+
+- **Embedded analytics license** — relicensing terms for shipping OBSL inside a commercial product
+- **Commercial cloud offering** — managed OrionBelt runtime with SLAs
+- **Enterprise features** — capabilities tailored for enterprise deployments
+- **Consulting + support** — implementation, modeling, and production support
+
+Contact [RALFORION d.o.o.](https://ralforion.com) for details.
+
 ---
 
 <p align="center">


### PR DESCRIPTION
## Summary

Add a "Commercial Offerings" section on the highest-traffic surfaces (README, docs/index.md) and update the comparison-page §9 tables to mention the four RALFORION offerings:

- **Embedded analytics license** — relicensing for shipping OBSL inside a commercial product
- **Commercial cloud offering** — managed runtime with SLAs
- **Enterprise features** — capabilities tailored for enterprise deployments
- **Consulting + support** — implementation, modeling, production support

Phrasing kept generic on "enterprise features" per request — no specific feature list invented.

## What changed

- **README.md** — new "Commercial Offerings" section between "Status & Roadmap" and "Companion Project"; TOC updated.
- **docs/index.md** — same section above the License footer.
- **cube.md / atscale.md / lookml.md §9** — Commercial offering row added with the four bullets. Pricing / Cost cells revised. The OSS-only paragraph on atscale.md rewritten so it accurately reflects "OSS is fully production-grade for self-hosted; commercial sits alongside, not as a feature gate".
- **Self-host parity rows** — softened from "Full feature parity in OSS" to "OSS has full parity on the shipped v2.6 surface; enterprise tier adds enterprise-specific capabilities on top" (Mixed framing — chosen by user).
- **lookml.md drive-by**: corrected stale "License | Open source" → "Source-available (BSL)" so it matches every other page.

Skipped (per scope question): malloy.md, dbt.md, index.md at-a-glance, dedicated `docs/commercial.md` page.

## Test plan

- [x] `uv run mkdocs build --strict` — passes (only pre-existing INFO warnings)
- [x] Visual check on live site after deploy
- [x] After merge: `scripts/deploy-docs.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)