### PR TITLE
docs(pgwire): document Dremio catalog flip + Calcite ROLLUP/MEASURE quirks

### DIFF
--- a/docs/guide/postgres-wire-bi-tools.md
+++ b/docs/guide/postgres-wire-bi-tools.md
@@ -131,6 +131,91 @@ Self-hosted Metabase ships a Postgres connector.
 | Aggregation queries return rows | ✅ |
 | Custom-SQL questions with raw SQL | ⚠ only OBSL-shaped SQL works |
 
+## 6. Dremio SQL Runner — catalog flip & Calcite quirks
+
+Dremio is a federated query engine, not a passive Postgres client: every
+query you write in its SQL Runner is parsed and validated by Apache
+Calcite before any pushdown to OBSL. That introduces two shape
+constraints that tools connecting directly to pgwire (DBeaver, Tableau,
+psql) never hit.
+
+### Address the model as `<schema>."model"`
+
+The v2.5 pgwire catalog layout is
+`database=<source>, schema=<model_name>, table=model`. Dremio's catalog
+reflection sees `<model_name>` as a **schema (CONTAINER)** — you cannot
+write `FROM <model_name>` in Dremio because Calcite will not bind a
+`FROM` clause to a schema. The pgwire surface exposes a special `model`
+view in each schema that routes through OBSQL — that's the queryable
+dataset.
+
+```sql
+-- ❌ wrong: Dremio resolves the schema, not a table
+SELECT "Country Name", "Total Sales"
+  FROM obsl_pg.orionbelt_1_commerce;
+-- Error: Object 'obsl_pg.orionbelt_1_commerce' not found
+
+-- ✅ right: 3-part name with the magic "model" table
+SELECT "Country Name", "Total Sales"
+  FROM obsl_pg.orionbelt_1_commerce."model";
+```
+
+Tools that connect direct to pgwire (`localhost:5432`, no Dremio in the
+middle) accept the bare model name because they do not pre-validate
+against pg_class — the bare name is unwrapped server-side. The 3-part
+form also works direct, so it's the portable shape.
+
+### Calcite ROLLUP / CUBE syntax, not MySQL `WITH ROLLUP`
+
+OBSL's pgwire accepts both MySQL trailing `... WITH ROLLUP` and standard
+`GROUP BY ROLLUP(...)`. Calcite only knows the standard form, so through
+Dremio:
+
+```sql
+-- ❌ MySQL syntax — Calcite parser error
+GROUP BY "Country Name" WITH ROLLUP
+
+-- ✅ Calcite-standard
+GROUP BY ROLLUP("Country Name")
+GROUP BY CUBE("Country Name", "Sales Year")
+GROUP BY GROUPING SETS (("Country Name"), ("Sales Year"), ())
+```
+
+### Wrap every measure in `SUM(...)` — even non-additive ones
+
+Calcite enforces "expression must be aggregated or appear in GROUP BY"
+whenever there is a `GROUP BY`. OBSL measures arrive on the wire as
+**already-aggregated values**, so any wrapper would double-aggregate in
+a normal warehouse — but OBSL recognizes the `SUM(<measure-label>)`
+pattern as a no-op shim and passes the measure through unchanged. The
+measure's own `aggregation:` field (defined in OBML) decides what
+actually runs.
+
+```sql
+-- ✅ The SUM is a syntactic shim, NOT a semantic instruction.
+-- "Total Sales" still resolves to its OBML-defined aggregation
+-- (which may be SUM, COUNT_DISTINCT, AVG, …).
+SELECT "Country Name", SUM("Total Sales") AS sales
+  FROM obsl_pg.orionbelt_1_commerce."model"
+  GROUP BY ROLLUP("Country Name");
+```
+
+`SUM` is the only wrapper OBSL recognizes. Everything else fails:
+
+| Through Dremio | Result |
+|---|---|
+| `SUM("Total Sales")` | ✅ wrapper stripped, OBML aggregation applied |
+| `"Total Sales"` (bare, in `GROUP BY` query) | ❌ Calcite: `Expression 'Total Sales' is not being grouped` |
+| `AVG("Total Sales")` | ❌ Dremio rewrites as `SUM(x)/COUNT(x)` in subqueries → OBSL: `Aggregate call SUM(...) outside the SELECT list is not supported` |
+| `COUNT(*)` | ❌ OBSL: `Aggregate COUNT(*) must wrap a single measure label` |
+| `MIN`, `MAX`, `COUNT(measure)` | ❌ same shape as `AVG`: not the recognized shim |
+
+Calcite (and Dremio) ship no support for ANSI SQL:2023's `MEASURE` /
+`AGG()` semantic-aware aggregation primitives, so the `SUM`-wrap shim
+is the only working bridge today. Clients that go direct to pgwire have
+no such constraint — bare measure labels work in `GROUP BY`,
+`ROLLUP`, and `HAVING`.
+
 ## Known limitations
 
 These constraints are documented in

--- a/tests/integration/dremio/docker-compose.yml
+++ b/tests/integration/dremio/docker-compose.yml
@@ -50,6 +50,7 @@ services:
       DREMIO_PASSWORD: obsl_admin_pw_123!
     volumes:
       - ./stage2:/app/stage2:ro
+      - raw_export:/app/raw_export
     ports:
       - "18080:8080"
       - "15432:5432"
@@ -60,6 +61,20 @@ services:
       retries: 30
       start_period: 5s
 
+  ui:
+    build:
+      context: ../../..
+      dockerfile: Dockerfile.ui
+    image: orionbelt-ui:dremio-test
+    environment:
+      PORT: "7860"
+      API_BASE_URL: http://obsl:8080
+    ports:
+      - "17860:7860"
+    depends_on:
+      obsl:
+        condition: service_healthy
+
   dremio:
     image: dremio/dremio-oss:latest
     ports:
@@ -67,6 +82,8 @@ services:
       - "31010:31010"
     environment:
       DREMIO_JAVA_SERVER_EXTRA_OPTS: -Xms1g -Xmx2g
+    volumes:
+      - raw_export:/raw_export:ro
     healthcheck:
       test: ["CMD-SHELL", "curl -fsS http://localhost:9047/apiv2/server_status || exit 1"]
       interval: 5s
@@ -76,3 +93,6 @@ services:
     depends_on:
       obsl:
         condition: service_healthy
+
+volumes:
+  raw_export:


### PR DESCRIPTION
## Summary

Querying OBSL through Dremio's SQL Runner has three non-obvious constraints that direct pgwire clients (DBeaver, Tableau, psql) never hit, because Calcite validates the SQL before any pushdown to OBSL. Discovered during manual testing of the v2.5 pgwire surface end-to-end.

- **Address the model as `<schema>."model"`** — the v2.5 catalog flip put the model name at the schema level (CONTAINER), so `FROM <model_name>` fails in Calcite. Each schema's `model` view routes through OBSQL.
- **Calcite ROLLUP / CUBE syntax** — no MySQL trailing `WITH ROLLUP`. Use `GROUP BY ROLLUP(...)`, `CUBE(...)`, `GROUPING SETS(...)`.
- **Wrap every measure in `SUM(...)`** — Calcite enforces "expression must be aggregated or in GROUP BY". OBSL recognizes `SUM(<measure-label>)` as a syntactic shim and strips it; the measure's OBML `aggregation:` is what actually runs. `AVG`/`MIN`/`MAX`/`COUNT(*)`/`COUNT(measure)` all break (Dremio rewrites `AVG` as `SUM/COUNT` in subqueries; OBSL only honors the `SUM(<label>)` shape). Calcite has parser tokens for SQL:2023 `MEASURE` / `AGG()` but no implementation, so this shim is the only semantic-aware aggregation bridge through Dremio today.

Also extends the dremio integration test compose — the source-of-truth for the Dremio + OBSL manual-test stack — to surface both layers in Dremio side-by-side:

- new `ui` sibling service (Gradio at `:17860`, `API_BASE_URL=http://obsl:8080`)
- shared `raw_export` named volume to host a parquet export of the demo DuckDB so the underlying business tables can be registered as a second Dremio NAS source (`obsl_raw`) alongside the semantic Postgres source (`obsl_pg`)

## Test plan

- [x] `mkdocs build --strict` passes (no new anchor / link / nav issues)
- [x] Manual verify in Dremio SQL Runner: `SELECT "Country Name", SUM("Total Sales") FROM obsl_pg.orionbelt_1_commerce."model" GROUP BY ROLLUP("Country Name")` returns 30 rows incl. grand total
- [x] Manual verify each negative case in the new doc table matches the actual Dremio / OBSL error
- [x] Manual verify `docker compose -f tests/integration/dremio/docker-compose.yml up -d` brings up obsl + ui + dremio cleanly with the new volume

🤖 Generated with [Claude Code](https://claude.com/claude-code)