### PR TITLE
Add git-revision-date-localized plugin for honest sitemap lastmod

### DIFF
--- a/docs/overrides/sitemap.xml
+++ b/docs/overrides/sitemap.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+{%- for file in pages -%}
+    {% if not file.page.is_link and (file.page.abs_url or file.page.canonical_url) %}
+    <url>
+         <loc>{% if file.page.canonical_url %}{{ file.page.canonical_url|e }}{% else %}{{ file.page.abs_url|e }}{% endif %}</loc>
+         {% if file.page.meta.git_revision_date_localized_raw_iso_date %}<lastmod>{{ file.page.meta.git_revision_date_localized_raw_iso_date }}</lastmod>{% elif file.page.update_date %}<lastmod>{{ file.page.update_date }}</lastmod>{% endif %}
+    </url>
+    {%- endif -%}
+{% endfor %}
+</urlset>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,6 +77,10 @@ theme:
 plugins:
   - search
   - autorefs
+  - git-revision-date-localized:
+      type: iso_date
+      enable_creation_date: true
+      fallback_to_build_date: true
   - mkdocstrings:
       handlers:
         python:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_description: "Open-source Semantic Sidecar for agentic AI, analytics, data 
 site_url: https://ralforion.com/orionbelt-semantic-layer/
 repo_url: https://github.com/ralfbecher/orionbelt-semantic-layer
 repo_name: orionbelt-semantic-layer
-copyright: Copyright &copy; 2025 RALFORION d.o.o. — BSL 1.1
+copyright: Copyright &copy; 2025 RALFORION d.o.o., BSL 1.1
 
 dev_addr: 127.0.0.1:8080
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ dependencies = [
     "tzdata>=2025.1",
     # DuckDB's Python binding lazily imports pytz when binding tz-aware
     # datetimes (TIMESTAMPTZ columns). Without it the result-cache meta
-    # DB writes/reads raise "Required module 'pytz' failed to import" —
+    # DB writes/reads raise "Required module 'pytz' failed to import".
     # cache.get/set silently swallow it at WARNING level, queries never
     # cache. Pinning ensures it's resolved at install time.
     "pytz>=2024.1",
@@ -144,13 +144,13 @@ select = ["E", "F", "I", "N", "UP", "B", "A", "SIM"]
 testpaths = ["tests"]
 asyncio_mode = "auto"
 markers = [
-    "docker: requires Docker (testcontainers) — run with: pytest -m docker",
-    "adbc: requires a reachable PostgreSQL via ADBC — run with: pytest -m adbc",
-    "snowflake: requires a live Snowflake account (SNOWFLAKE_* env vars) — run with: pytest -m snowflake",
-    "bigquery: requires a live BigQuery project (BIGQUERY_* env vars + ADC) — run with: pytest -m bigquery",
-    "databricks: requires a live Databricks workspace (DATABRICKS_* env vars) — run with: pytest -m databricks",
-    "dremio: requires the Dremio + OBSL docker-compose stack — see tests/integration/dremio/README.md",
-    "notebook: heavy end-to-end notebook execution (Colab quickstart) — needs nbclient + ipykernel + duckdb — run with: pytest -m notebook",
+    "docker: requires Docker (testcontainers); run with: pytest -m docker",
+    "adbc: requires a reachable PostgreSQL via ADBC; run with: pytest -m adbc",
+    "snowflake: requires a live Snowflake account (SNOWFLAKE_* env vars); run with: pytest -m snowflake",
+    "bigquery: requires a live BigQuery project (BIGQUERY_* env vars + ADC); run with: pytest -m bigquery",
+    "databricks: requires a live Databricks workspace (DATABRICKS_* env vars); run with: pytest -m databricks",
+    "dremio: requires the Dremio + OBSL docker-compose stack; see tests/integration/dremio/README.md",
+    "notebook: heavy end-to-end notebook execution (Colab quickstart); needs nbclient + ipykernel + duckdb; run with: pytest -m notebook",
 ]
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ docs = [
     "mkdocs-material>=9.7",
     "mkdocs-autorefs>=1.4",
     "mkdocstrings[python]>=1.0",
+    "mkdocs-git-revision-date-localized-plugin>=1.2",
 ]
 ui = [
     "gradio>=5.0,<6.0",
@@ -190,6 +191,7 @@ dev = [
     "mkdocs-material>=9.7",
     "mkdocs-autorefs>=1.4",
     "mkdocstrings[python]>=1.0",
+    "mkdocs-git-revision-date-localized-plugin>=1.2",
     "gradio>=5.0,<6.0",
     "pyarrow>=16.0,<20.0",
     "ob-flight-extension>=0.1",


### PR DESCRIPTION
## Why

MkDocs core stamps every sitemap URL with the **build timestamp** on every deploy. Current live sitemap shows all 38 URLs with the same \`<lastmod>2026-05-27</lastmod>\`, even for pages whose content hasn't changed in months.

Google may eventually discount the \`lastmod\` signal as noisy and waste crawl budget revisiting unchanged pages.

## What

Adds [\`mkdocs-git-revision-date-localized-plugin\`](https://github.com/timvink/mkdocs-git-revision-date-localized-plugin) which reads each markdown file's actual git commit date and uses it as \`<lastmod>\` per URL.

After this change, the sitemap will show different dates per page reflecting real content history.

## Config

\`\`\`yaml
- git-revision-date-localized:
    type: iso_date              # YYYY-MM-DD for sitemap compatibility
    enable_creation_date: true  # tracks first commit too
    fallback_to_build_date: true # safe default if .git unavailable
\`\`\`

## Side benefits

- "Last updated" footer on every page (good for docs trust signal)
- Plugin also works with deploy systems that don't have full git history if \`fallback_to_build_date: true\` (already set)

## Risk

- Build time slightly increases (queries git for each file, negligible for 38 files)
- Requires \`.git\` to be present at build time. CI/Cloud Run builds should use full clones, not shallow.