### PR TITLE
Add docs deploy workflow on release

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,62 @@
+name: Deploy docs
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-docs
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout orionbelt-semantic-layer
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Install Python
+        run: uv python install 3.12
+
+      - name: Install docs dependencies
+        run: uv sync --extra docs
+
+      - name: Build MkDocs site
+        run: uv run mkdocs build --strict
+
+      - name: Checkout ralfbecher.github.io
+        uses: actions/checkout@v4
+        with:
+          repository: ralfbecher/ralfbecher.github.io
+          token: ${{ secrets.GH_PAGES_DEPLOY_TOKEN }}
+          path: github-io
+
+      - name: Sync built site into github.io
+        run: |
+          rm -rf github-io/public/orionbelt-semantic-layer
+          mv site github-io/public/orionbelt-semantic-layer
+
+      - name: Commit and push
+        working-directory: github-io
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add public/orionbelt-semantic-layer
+          if git diff --staged --quiet; then
+            echo "No docs changes to deploy"
+            exit 0
+          fi
+          REF="${{ github.event.release.tag_name || github.sha }}"
+          git commit -m "Deploy OrionBelt docs from ${REF}"
+          git push


### PR DESCRIPTION
Automates the docs deploy step. After this lands, every GH release publishes the latest MkDocs site to \`ralfbecher.github.io/public/orionbelt-semantic-layer/\` with no manual steps.

## How it works

1. Triggers on \`release: published\` (and \`workflow_dispatch\` for manual runs from the Actions tab)
2. Checks out the repo with \`fetch-depth: 0\` (full git history is required for the \`git-revision-date-localized\` plugin to read per-page commit dates)
3. \`uv sync --extra docs\` then \`uv run mkdocs build --strict\`
4. Checks out \`ralfbecher.github.io\` using a PAT secret
5. Replaces \`public/orionbelt-semantic-layer/\` with the fresh \`site/\` output
6. Commits and pushes if changes exist; no-ops cleanly otherwise

## Required setup before merging

This workflow needs a secret called \`GH_PAGES_DEPLOY_TOKEN\` with write access to \`ralfbecher.github.io\`.

**Recommended: fine-grained PAT** (scoped to one repo, minimal blast radius):
1. https://github.com/settings/personal-access-tokens/new
2. Repository access: only \`ralfbecher.github.io\`
3. Permissions -> Repository permissions: \`Contents: Read and write\`
4. Expiration: 1 year (set a calendar reminder)
5. In \`orionbelt-semantic-layer\` repo: Settings -> Secrets and variables -> Actions -> New repository secret
6. Name: \`GH_PAGES_DEPLOY_TOKEN\`, Value: the PAT

## After merge

You can test it immediately without cutting a new release:
- Actions tab -> \"Deploy docs\" -> \"Run workflow\"

That deploys current \`main\` to \`ralfbecher.github.io\` and is a clean way to ship the sitemap-plugin change from PR #99 without bumping to v2.7.10.

## Safety notes

- \`concurrency: deploy-docs\` prevents overlapping runs
- \`--strict\` fails the build on warnings (broken anchor links etc.), so docs errors block deploy
- \`if git diff --staged --quiet\` no-ops when there's nothing to commit