### PR TITLE
docs: rephrase "freshness-driven" cache to "based on freshness inheritance" (SEO)

### DIFF
--- a/docs/comparison/atscale.md
+++ b/docs/comparison/atscale.md
@@ -236,7 +236,7 @@ The free **Developer Community Edition** lowers AtScale's barrier for evaluation
 | Interactive ontology-graph playground | ✅ Gradio | ❌ |
 | OSI interoperability | ✅ converter shipped | ✅ founding contributor |
 | MCP server (LLM/agent) | ✅ first-party | Limited |
-| Built-in caching | ✅ freshness-driven file cache (TTL derived from per-`dataObject` `refresh:` contracts; ETL heartbeat invalidation) | ✅ result cache + autonomous aggregates (warehouse-side) |
+| Built-in caching | ✅ file cache based on freshness inheritance (TTL derived from per-`dataObject` `refresh:` contracts; ETL heartbeat invalidation) | ✅ result cache + autonomous aggregates (warehouse-side) |
 | Visual model designer | ❌ | ✅ Design Center (polished) |
 | Open source / self-host without license | ✅ | ❌ |
 

--- a/docs/comparison/cube.md
+++ b/docs/comparison/cube.md
@@ -127,7 +127,7 @@ Both projects have caching, but they're solving adjacent problems with different
 
 **Cube** has a tiered caching architecture aimed at high-throughput dashboard serving: in-memory query cache, optional Redis, and **Cube Store** (its purpose-built rollup store backing pre-aggregations). TTL is configured on each cube/measure as a refresh-key SQL or interval — the model author decides when entries are stale, and Cube's scheduler refreshes pre-aggs in the background. This is built for embedded-analytics workloads serving thousands of requests per second.
 
-**OBSL** has a **freshness-driven result cache** (`CACHE_BACKEND=file`, off by default). The structural difference is where the freshness contract lives:
+**OBSL** has a **result cache based on freshness inheritance** (`CACHE_BACKEND=file`, off by default). The structural difference is where the freshness contract lives:
 
 - **Cube**: TTL is attached to the *abstraction* (cube / pre-agg / measure). Two cubes reading the same physical table each declare their own TTL — and they can drift.
 - **OBSL**: TTL is derived from the `refresh:` contract on each touched physical `dataObject`. The minimum contribution wins. Two `dataObject` entries on the same warehouse table inherit the same contract automatically. One ETL `POST /v1/heartbeat` invalidates every cached query that depends on the refreshed table — across every dataObject and every session, in one call.
@@ -253,7 +253,7 @@ Both projects ship a free OSS core and offer commercial extensions, but the spli
 | Operational footprint | Light: one process, in-memory sessions, optional file-backed result cache (DuckDB metadata + Parquet) on local disk | Heavier: API server + Cube Store + Redis (optional) + scheduler + refresh workers in production |
 | Self-host parity | OSS has full parity on the shipped v2.6 surface; enterprise tier adds enterprise-specific capabilities on top | Many advanced features (Studio, advanced workspaces, AI features) are Cube Cloud-only |
 
-For a small embedded-analytics use case OBSL is operationally simpler. For high-throughput multi-tenant production with heavy caching across replicas, Cube's architecture is purpose-built and Cube Cloud provides the managed experience. OBSL's freshness-driven file cache (v2.2.0) covers single-replica result-caching workloads — agents, dev/staging, modest production — without standing up Redis or a rollup store.
+For a small embedded-analytics use case OBSL is operationally simpler. For high-throughput multi-tenant production with heavy caching across replicas, Cube's architecture is purpose-built and Cube Cloud provides the managed experience. OBSL's file cache based on freshness inheritance (v2.2.0) covers single-replica result-caching workloads — agents, dev/staging, modest production — without standing up Redis or a rollup store.
 
 ---
 
@@ -308,7 +308,7 @@ For a small embedded-analytics use case OBSL is operationally simpler. For high-
 
 ### They could coexist
 
-A workable hybrid: use Cube as the production query gateway with pre-aggregations and a SQL API for BI tools, and OBSL as a complementary modeling/governance surface (RDF graph, OSI export, richer topology modeling, freshness-driven result cache for agent workloads) that you can keep authoritative and mirror into Cube definitions. Two semantic surfaces is operationally heavier, but it's defensible if you need both Cube's pre-aggs and OBSL's modeling primitives.
+A workable hybrid: use Cube as the production query gateway with pre-aggregations and a SQL API for BI tools, and OBSL as a complementary modeling/governance surface (RDF graph, OSI export, richer topology modeling, result cache based on freshness inheritance for agent workloads) that you can keep authoritative and mirror into Cube definitions. Two semantic surfaces is operationally heavier, but it's defensible if you need both Cube's pre-aggs and OBSL's modeling primitives.
 
 ---
 

--- a/docs/comparison/dbt.md
+++ b/docs/comparison/dbt.md
@@ -254,7 +254,7 @@ OBSL validates column arity at model-load time and gates dialect support at comp
 | Feature | OBSL | dbt SL |
 |---|---|---|
 | Sessions / multi-tenant runtime | TTL, max-age, rate limits, 410/429 | Cloud-managed |
-| Caching | Freshness-driven result cache (file backend, off by default): TTL derived from per-`dataObject` `refresh:` contract; ETL `POST /v1/heartbeat` invalidates dependent entries by physical table | dbt Cloud query cache |
+| Caching | Result cache based on freshness inheritance (file backend, off by default): TTL derived from per-`dataObject` `refresh:` contract; ETL `POST /v1/heartbeat` invalidates dependent entries by physical table | dbt Cloud query cache |
 | Versioned governance, lineage to upstream models | No (model is standalone) | Strong — inherits dbt's lineage, tests, docs, exposures |
 | Filter ergonomics | `MeasureFilter`, `FilterContext`, `GrainOverride`, query-level `where`/`having` | Per-metric `filter:`, `metric_time` |
 | Vendor-agnostic | Yes — pure OSS | Practical lock-in: production query APIs require dbt Cloud |

--- a/docs/comparison/index.md
+++ b/docs/comparison/index.md
@@ -38,7 +38,7 @@ How OrionBelt Semantic Layer (OBSL) stacks up against the leading semantic layer
 | Notebook authoring (VS Code / Colab) | ✅ `quickstart.ipynb` runs natively in VS Code or Colab | Via dbt-cli in any notebook | Notebook tutorials | ❌ | ❌ | ❌ |
 | Built-in BI dashboards | ❌ | ❌ | VS Code | ✅ Looker | ❌ | Via MDX in Tableau/Excel |
 | Pre-aggregations / materialization | ❌ | Via dbt models | ❌ | ✅ (PDTs) | ✅ flagship | ✅ autonomous |
-| Result cache | ✅ freshness-driven file cache (TTL from `dataObject.refresh`; ETL heartbeat invalidation) | dbt Cloud query cache | ❌ | Looker query cache (`persist_for`) + aggregate awareness | Tiered (in-memory + optional Redis + Cube Store) with refresh-key TTL | Built-in cache + autonomous aggregates |
+| Result cache | ✅ file cache based on freshness inheritance (TTL from `dataObject.refresh`; ETL heartbeat invalidation) | dbt Cloud query cache | ❌ | Looker query cache (`persist_for`) + aggregate awareness | Tiered (in-memory + optional Redis + Cube Store) with refresh-key TTL | Built-in cache + autonomous aggregates |
 | Row-level security in model | ❌ | Via dbt | ❌ | ✅ | ✅ (`query_rewrite`) | ✅ enterprise |
 | Multi-tenancy primitives | Sessions only | Cloud-managed | ❌ | ❌ | ✅ first-class | ✅ enterprise |
 | OSI interoperability | ✅ converter | ❌ | ❌ | ❌ | ❌ | ✅ founding contributor |

--- a/docs/guide/result-cache.md
+++ b/docs/guide/result-cache.md
@@ -1,11 +1,11 @@
-# Freshness-driven result cache
+# Result cache based on freshness inheritance
 
-OrionBelt's result cache is **freshness-driven**: instead of asking callers to pick a TTL, the cache derives one from the refresh contracts of the **physical source tables** a query touched. A heartbeat from the warehouse invalidates every cached query that depends on that table, regardless of how many semantic facets the model split it into.
+OrionBelt's result cache is **based on freshness inheritance**: instead of asking callers to pick a TTL, the cache derives one from the refresh contracts of the **physical source tables** a query touched. A heartbeat from the warehouse invalidates every cached query that depends on that table, regardless of how many semantic facets the model split it into.
 
 This page explains how it works and how to enable it. For the underlying design, see `design/PLAN_freshness_driven_cache.md`.
 
 !!! note "Not 'semantic caching'"
-    The phrase "semantic cache" in AI/LLM contexts means embedding-based similarity matching of natural-language queries — a completely unrelated concept. OBSL uses **freshness-driven cache** or **source-aware result cache**.
+    The phrase "semantic cache" in AI/LLM contexts means embedding-based similarity matching of natural-language queries — a completely unrelated concept. OBSL uses a **cache based on freshness inheritance** or **source-aware result cache**.
 
 ## Why source-level
 


### PR DESCRIPTION
## What

Rephrases the result-cache terminology from "freshness-driven" to "based on freshness inheritance" across the docs, for SEO clarity.

- `docs/guide/result-cache.md`: H1 title, intro sentence, and the "Not semantic caching" note
- `docs/comparison/cube.md`: 3 references (section text, v2.2.0 line, hybrid line)
- `docs/comparison/atscale.md`: caching table row
- `docs/comparison/dbt.md`: caching table row
- `docs/comparison/index.md`: result-cache table row

## Why

The new wording matches the inheritance mechanism the page already describes: two `dataObject` entries on the same physical table inherit one `refresh:` contract, so a single ETL heartbeat invalidates every dependent cached query. It also targets a clearer search phrase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)