### PR TITLE
docs: fix broken anchor to trend-analysis statistical-aggregates section

### DIFF
--- a/docs/comparison/dbt.md
+++ b/docs/comparison/dbt.md
@@ -204,7 +204,7 @@ OBSL `Measure.aggregation` ships 9 statistical functions that dbt SL doesn't exp
 | `covar_pop`, `covar_samp` | `COVAR_POP(x, y)`, `COVAR_SAMP(x, y)` | 2 |
 | `regr_slope`, `regr_intercept` | `REGR_SLOPE(y, x)`, `REGR_INTERCEPT(y, x)` | 2 |
 
-OBSL validates column arity at model-load time and gates dialect support at compile time (MySQL rejects correlation/covariance/regression; BigQuery + ClickHouse reject linear regression — all with a hard `UnsupportedAggregationError`, no silent fallback). See [Trend Analysis](../guide/trend-analysis.md#statistical-aggregates-on-measure) for the full coverage matrix.
+OBSL validates column arity at model-load time and gates dialect support at compile time (MySQL rejects correlation/covariance/regression; BigQuery + ClickHouse reject linear regression — all with a hard `UnsupportedAggregationError`, no silent fallback). See [Trend Analysis](../guide/trend-analysis.md#3-statistical-aggregates-on-measure) for the full coverage matrix.
 
 ---
 

--- a/docs/guide/model-format.md
+++ b/docs/guide/model-format.md
@@ -409,7 +409,7 @@ measures:
 
 #### Statistical aggregates
 
-Single-column aggregates take exactly one entry in `columns`; two-column aggregates take exactly two (arity is enforced at model-load time, error code `INVALID_AGGREGATION_INPUTS`). Dialect coverage varies — MySQL has no correlation / covariance / regression; BigQuery and ClickHouse lack the linear-regression family. Unsupported combinations raise `UNSUPPORTED_AGGREGATION_FOR_DIALECT` at compile time. See [Trend Analysis](trend-analysis.md#statistical-aggregates-on-measure) for the full coverage matrix and a worked example.
+Single-column aggregates take exactly one entry in `columns`; two-column aggregates take exactly two (arity is enforced at model-load time, error code `INVALID_AGGREGATION_INPUTS`). Dialect coverage varies — MySQL has no correlation / covariance / regression; BigQuery and ClickHouse lack the linear-regression family. Unsupported combinations raise `UNSUPPORTED_AGGREGATION_FOR_DIALECT` at compile time. See [Trend Analysis](trend-analysis.md#3-statistical-aggregates-on-measure) for the full coverage matrix and a worked example.
 
 | Type | SQL | Arity |
 |------|-----|:---:|


### PR DESCRIPTION
## What

Fixes two links pointing to `trend-analysis.md#statistical-aggregates-on-measure`. The heading is numbered (`## 3. Statistical aggregates on Measure`), so its generated anchor is `#3-statistical-aggregates-on-measure`. The links omitted the `3-` prefix.

- `docs/comparison/dbt.md`
- `docs/guide/model-format.md`

## Why

These were the two pre-existing `mkdocs build --strict` INFO link notes. Both now resolve to the correct anchor (verified against the live page id).

🤖 Generated with [Claude Code](https://claude.com/claude-code)