### PR TITLE
fix: stop Mermaid ER label clipping by pinning fontFamily

### DIFF
--- a/src/orionbelt/service/diagram.py
+++ b/src/orionbelt/service/diagram.py
@@ -74,8 +74,20 @@ def generate_mermaid_er(
     # the parent container — the host #er-diagram has overflow:auto for
     # horizontal scroll, so wider-than-viewport diagrams scroll cleanly
     # instead of clipping edge labels.
+    #
+    # Pin an explicit, local-only fontFamily. Mermaid pre-measures each ER
+    # column (and edge label) width with the theme's fontFamily, but the
+    # browser paints the SVG text with whatever font the host page's CSS
+    # cascades in. When the two differ — or when a late-loading web font
+    # replaces the fallback used at measure time — every label is painted
+    # wider than its measured box and clips its last character ("string" →
+    # "strin"). Pinning a system font stack (no async web-font load) makes
+    # measure-time and paint-time use the identical font, eliminating the
+    # clip. The UI CSS forces the same family on the rendered text as a
+    # guard against the host cascade.
     init_cfg = (
         "{'theme': '" + theme + "', "
+        "'themeVariables': {'fontFamily': 'Helvetica, Arial, sans-serif'}, "
         "'flowchart': {'useMaxWidth': false}, "
         "'er': {'useMaxWidth': false}}"
     )

--- a/src/orionbelt/ui/app.py
+++ b/src/orionbelt/ui/app.py
@@ -370,6 +370,15 @@ _CSS = """\
    with its own font and clips at the measured width. Inflating the
    rendered font past the measured width was the cause of the per-row
    right-edge clipping. */
+/* Force the same font family Mermaid measures column widths with (pinned
+   in the diagram's %%{init}%% themeVariables.fontFamily) so the host page
+   CSS can't cascade a wider font onto the painted text and re-introduce
+   the per-cell right-edge clipping ("string" → "strin"). */
+#er-diagram svg text,
+#er-diagram svg .er .entityLabel,
+#er-diagram svg .er.relationshipLabel {
+  font-family: Helvetica, Arial, sans-serif !important;
+}
 /* ── Ontology Graph tab ── */
 #ob-ontology-graph-container {
   overflow: auto;

--- a/tests/unit/test_diagram.py
+++ b/tests/unit/test_diagram.py
@@ -91,6 +91,14 @@ class TestGenerateMermaidER:
         result = generate_mermaid_er(model, theme="dark")
         assert "'theme': 'dark'" in result
 
+    def test_pins_fontfamily_to_prevent_label_clip(self) -> None:
+        # Mermaid measures ER column/edge-label widths with the theme
+        # fontFamily; if the painted font differs, every label clips its
+        # last character. Pin a local-only stack so measure == paint.
+        model = _sample_model()
+        result = generate_mermaid_er(model)
+        assert "'fontFamily': 'Helvetica, Arial, sans-serif'" in result
+
     def test_entities_present(self) -> None:
         model = _sample_model()
         result = generate_mermaid_er(model)

--- a/uv.lock
+++ b/uv.lock
@@ -782,6 +782,30 @@ wheels = [
 ]
 
 [[package]]
+name = "gitdb"
+version = "4.0.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "smmap" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/63b0fc47eb32792c7ba1fe1b694daec9a63620db1e313033d18140c2320a/gitdb-4.0.12.tar.gz", hash = "sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571", size = 394684, upload-time = "2025-01-02T07:20:46.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/61/5c78b91c3143ed5c14207f463aecfc8f9dbb5092fb2869baf37c273b2705/gitdb-4.0.12-py3-none-any.whl", hash = "sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf", size = 62794, upload-time = "2025-01-02T07:20:43.624Z" },
+]
+
+[[package]]
+name = "gitpython"
+version = "3.1.50"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gitdb" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", size = 219798, upload-time = "2026-05-06T04:01:26.571Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9", size = 212507, upload-time = "2026-05-06T04:01:23.799Z" },
+]
+
+[[package]]
 name = "google-api-core"
 version = "2.30.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1585,6 +1609,21 @@ wheels = [
 ]
 
 [[package]]
+name = "mkdocs-git-revision-date-localized-plugin"
+version = "1.5.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "babel" },
+    { name = "gitpython" },
+    { name = "mkdocs" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/5c/098e733fc8aa9371d21ff56aa97b587ffb5e28803cb9cb58ae1e7da7e3c6/mkdocs_git_revision_date_localized_plugin-1.5.2.tar.gz", hash = "sha256:0b3d65abdb8b82591d724c1d5ece6af7bb3cd305bdd47e2fadd430886a9a2513", size = 451991, upload-time = "2026-05-13T07:13:51.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/c8/64c36918723be26d866cd2cc3e8a38a353f8966734ffde268f8490626e96/mkdocs_git_revision_date_localized_plugin-1.5.2-py3-none-any.whl", hash = "sha256:4f3175e039bc4fe0055cac97d295ce8d0d233a13d65986d42fd5324e4985acc2", size = 26151, upload-time = "2026-05-13T07:13:49.841Z" },
+]
+
+[[package]]
 name = "mkdocs-material"
 version = "9.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2229,7 +2268,7 @@ wheels = [
 
 [[package]]
 name = "orionbelt-semantic-layer"
-version = "2.7.9"
+version = "2.7.10"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
@@ -2267,6 +2306,7 @@ dev = [
 ]
 docs = [
     { name = "mkdocs-autorefs" },
+    { name = "mkdocs-git-revision-date-localized-plugin" },
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
 ]
@@ -2300,6 +2340,7 @@ dev = [
     { name = "gradio" },
     { name = "httpx" },
     { name = "mkdocs-autorefs" },
+    { name = "mkdocs-git-revision-date-localized-plugin" },
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
     { name = "mypy" },
@@ -2338,6 +2379,7 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.28" },
     { name = "jsonschema", specifier = ">=4.23,<5.0" },
     { name = "mkdocs-autorefs", marker = "extra == 'docs'", specifier = ">=1.4" },
+    { name = "mkdocs-git-revision-date-localized-plugin", marker = "extra == 'docs'", specifier = ">=1.2" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.7" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=1.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.19" },
@@ -2387,6 +2429,7 @@ dev = [
     { name = "gradio", specifier = ">=5.0,<6.0" },
     { name = "httpx", specifier = ">=0.28" },
     { name = "mkdocs-autorefs", specifier = ">=1.4" },
+    { name = "mkdocs-git-revision-date-localized-plugin", specifier = ">=1.2" },
     { name = "mkdocs-material", specifier = ">=9.7" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=1.0" },
     { name = "mypy", specifier = ">=1.19" },
@@ -3480,6 +3523,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "smmap"
+version = "5.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/ea/49c993d6dfdd7338c9b1000a0f36817ed7ec84577ae2e52f890d1a4ff909/smmap-5.0.3.tar.gz", hash = "sha256:4d9debb8b99007ae47165abc08670bd74cb74b5227dda7f643eccc4e9eb5642c", size = 22506, upload-time = "2026-03-09T03:43:26.1Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl", hash = "sha256:c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f", size = 24390, upload-time = "2026-03-09T03:43:24.361Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

The ER diagram clipped the last character off **every** label: column names, type names, entity titles, and relationship edge labels. Examples from a user screenshot: `string` -> `strin`, `float` -> `floa`, `Supplier` -> `Supplie`, `Purchase` -> `Purchas`, edge `Purchase Supplier` -> `Purchase Supp`.

This had been fixed before (v2.2.1, v2.7.6) for the SVG-scaling variant of the bug, but a residual font-driven variant regressed.

## Root cause

Mermaid pre-measures each ER column width (and edge-label background) with the theme `fontFamily`, then the browser paints the SVG text with whatever font the host page CSS cascades in. When the painted font is wider than the measuring font (or a late-loading web font replaces the fallback used at measure time), every label is painted wider than its measured box and clips its last character.

## Fix

Pin an explicit, local-only font stack so measure-time and paint-time use the identical font with no async web-font load:

- `service/diagram.py`: add `'themeVariables': {'fontFamily': 'Helvetica, Arial, sans-serif'}` to the diagram's `%%{init}%%` directive (covers all consumers of the diagram endpoint, not just the Gradio UI).
- `ui/app.py`: force the same family on `#er-diagram svg text` via `!important` as a guard against the host page cascade.

The point is consistency, not a specific typeface: a system stack avoids the web-font load race, and whatever physical font the browser substitutes, it substitutes the same one for both measure and paint.

## Tests

- New regression test `test_pins_fontfamily_to_prevent_label_clip` locks the directive.
- `tests/unit/test_diagram.py`: 17 passed. ruff check + format clean, mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)