### PR TITLE
fix: COPY osi-obml into Dockerfile.ui build context

### DIFF
--- a/Dockerfile.ui
+++ b/Dockerfile.ui
@@ -14,6 +14,12 @@ RUN uv sync --no-dev --extra ui --no-install-project --frozen
 # Copy source and install the project itself
 COPY src/ src/
 COPY schema/ schema/
+# The OSI converter is force-included into the wheel (see pyproject
+# [tool.hatch.build.targets.wheel.force-include]); the build backend
+# needs these files present in the context or it fails with
+# "Forced include not found". Mirrors Dockerfile / Dockerfile.flight.
+COPY osi-obml/osi_obml_converter.py osi-obml/
+COPY osi-obml/osi-schema.json osi-obml/
 COPY examples/ examples/
 RUN uv sync --no-dev --extra ui --no-editable --frozen
 


### PR DESCRIPTION
The OSI converter `force-include` added in v2.8.0 makes every wheel build require `osi-obml/osi_obml_converter.py` and `osi-obml/osi-schema.json` in the build context. `Dockerfile` and `Dockerfile.flight` already COPY them, but `Dockerfile.ui` did not, so its `uv sync --no-editable` failed with `Forced include not found: /app/osi-obml/osi-schema.json` during the v2.8.0 Cloud Run and Docker Hub image builds (the UI Cloud Run service and all Docker Hub images were left on the previous version).

Adds the two COPY lines to the builder stage, mirroring the other Dockerfiles. Verified the builder stage builds clean. No version bump: this is a build-context fix, the published 2.8.0 wheel is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)