### PR TITLE
docs: add commercial licensing contact to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,6 +564,8 @@ Licensed under the [Business Source License 1.1](LICENSE). The Licensed Work wil
 
 By contributing to this project, you agree to the [Contributor License Agreement](CLA.md).
 
+For commercial licensing inquiries, contact: licensing@ralforion.com
+
 ---
 
 <p align="center">


### PR DESCRIPTION
Adds a commercial licensing contact line (licensing@ralforion.com) to the licensing section of the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)