### PR TITLE
feat: v2.9.0 - export OBML models to the OSI ontology layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to OrionBelt Semantic Layer are documented here.
 
+## [Unreleased]
+
+### Added
+
+- **OSI ontology export.** OBML models can now be exported to the OSI **ontology** layer (the conceptual EntityType/relationship layer defined by `ontology.json`), in addition to the existing OSI core-spec export. OSI validates the two layers with separate schemas and keeps them in separate documents, so the ontology is returned as a distinct, individually-valid artefact:
+  - `POST /v1/convert/obml-to-osi` accepts `include_ontology: true`.
+  - `GET /v1/sessions/{id}/models/{mid}/osi` accepts `?include_ontology=true`.
+  - When requested, the response carries `ontology_yaml` plus its own `ontology_validation`; the core-spec `output_yaml` is unchanged (default behaviour is fully backward-compatible).
+  - Mapping: each `dataObject` becomes an `EntityType` concept; each join becomes a relationship whose `multiplicity` derives from the join `joinType` (`many-to-one` to `ManyToOne`, `one-to-one` to `OneToOne`); `concept_mappings` bind concepts to physical columns. Many-to-many joins, named secondary paths, measures/metrics, and column-level value concepts are not represented and surface as conversion `warnings`. See `osi-obml/osi_obml_ontology_mapping_analysis.md`.
+  - The OSI ontology JSON Schema (`osi-obml/osi-ontology-schema.json`) is vendored and bundled into the wheel; its external core-spec `$ref`s resolve against the local vendored core schema so validation never touches the network.
+  - An ontology importer (OSI ontology to OBML) is intentionally deferred while OSI remains at `0.2.0.dev0`; import the OSI core spec instead.
+
 ## [2.8.0] - 2026-06-02
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,7 +180,7 @@ All API routes are prefixed with `/v1/` except `/health` and `/robots.txt`.
 | POST | `/v1/sessions/{id}/query/semantic-ql` | OrionBelt Semantic QL (OBSQL): translate BI-style SQL (SELECT dim, measure FROM `<model>`) → QueryObject → execute. Same response shape as `/query/execute` |
 | POST | `/v1/sessions/{id}/query/semantic-ql/compile` | OrionBelt Semantic QL: translate + compile only, returns compiled SQL + translated QueryObject JSON |
 | GET | `/v1/sessions/{id}/models/{mid}/diagram/er` | Mermaid ER diagram |
-| GET | `/v1/sessions/{id}/models/{mid}/osi` | Export the loaded model as OSI YAML. Optional `?model_name=`, `?model_description=`, `?ai_instructions=` overrides |
+| GET | `/v1/sessions/{id}/models/{mid}/osi` | Export the loaded model as OSI YAML. Optional `?model_name=`, `?model_description=`, `?ai_instructions=` overrides. `?include_ontology=true` also emits the OSI ontology document in `ontology_yaml` (separate artefact, with its own `ontology_validation`) |
 | GET | `/v1/sessions/{id}/models/{mid}/schema` | Full model as JSON |
 | GET | `/v1/sessions/{id}/models/{mid}/dimensions` | List dimensions |
 | GET | `/v1/sessions/{id}/models/{mid}/dimensions/{name}` | Get dimension |
@@ -194,7 +194,7 @@ All API routes are prefixed with `/v1/` except `/health` and `/robots.txt`.
 | GET | `/v1/sessions/{id}/models/{mid}/graph` | OBSL RDF graph (Turtle) |
 | POST | `/v1/sessions/{id}/models/{mid}/sparql` | SPARQL query (SELECT/ASK) |
 | POST | `/v1/convert/osi-to-obml` | Convert OSI YAML → OBML YAML |
-| POST | `/v1/convert/obml-to-osi` | Convert OBML YAML → OSI YAML |
+| POST | `/v1/convert/obml-to-osi` | Convert OBML YAML → OSI YAML. `include_ontology: true` also emits the OSI ontology document in `ontology_yaml` (separate artefact, with its own `ontology_validation`) |
 | POST | `/v1/oneshot/batch` | Load (or reference) a model and run N independent queries in one round trip |
 | GET | `/v1/cache/stats` | Result cache summary (entries, size, hit rate, oldest entry, next sweep) |
 | POST | `/v1/cache/sweep` | Trigger one TTL + capacity eviction pass on demand |

--- a/docs/guide/osi.md
+++ b/docs/guide/osi.md
@@ -36,10 +36,31 @@ curl -X POST http://127.0.0.1:8000/v1/convert/obml-to-osi \
 
 Both endpoints are stateless — no session required.
 
+## OSI ontology export
+
+OSI defines two layers, validated by **separate** JSON Schemas and (per OSI's own `validate.py`) kept in **separate documents**:
+
+- the **core-spec** semantic model (datasets, fields, relationships, metrics) — the default `output_yaml`, and
+- the **ontology** layer (EntityType/ValueType concepts, relationships with multiplicity and verbalizations, plus mappings back to the logical model).
+
+Set `include_ontology=true` to additionally emit the ontology document. It is returned as a second, individually-valid artefact in `ontology_yaml`, with its own `ontology_validation`; the core-spec `output_yaml` is unchanged.
+
+```bash
+# Convert OBML -> OSI, also emitting the ontology document
+curl -X POST http://127.0.0.1:8000/v1/convert/obml-to-osi \
+  -H "Content-Type: application/json" \
+  -d '{"input_yaml": "version: 1.0\ndataObjects:\n  ...", "include_ontology": true}' | jq
+
+# Export a loaded model with its ontology
+curl "http://127.0.0.1:8000/v1/sessions/{id}/models/{mid}/osi?include_ontology=true" | jq
+```
+
+The OBML constructs map to the ontology as follows: each `dataObject` becomes an `EntityType` concept, each join becomes a relationship whose `multiplicity` derives from the join `joinType` (`many-to-one` -> `ManyToOne`, `one-to-one` -> `OneToOne`), and `concept_mappings` bind concepts to physical columns. Many-to-many joins, named secondary paths, measures/metrics, and column-level value concepts are not represented in the ontology layer and surface as conversion `warnings`. An ontology **importer** (OSI ontology -> OBML) is intentionally deferred while OSI remains at `0.2.0.dev0`; import the OSI core spec instead.
+
 ## Gradio UI
 
 The Gradio UI provides **Import OSI** / **Export to OSI** buttons that use these API endpoints, with validation feedback for both directions.
 
 ## Mapping Reference
 
-See the [OSI - OBML Mapping Analysis](https://github.com/ralfbecher/orionbelt-semantic-layer/blob/main/osi-obml/osi_obml_mapping_analysis.md) for a detailed comparison and conversion reference.
+See the [OSI - OBML Mapping Analysis](https://github.com/ralfbecher/orionbelt-semantic-layer/blob/main/osi-obml/osi_obml_mapping_analysis.md) for the core-spec mapping, and the [OBML -> OSI Ontology Mapping Analysis](https://github.com/ralfbecher/orionbelt-semantic-layer/blob/main/osi-obml/osi_obml_ontology_mapping_analysis.md) for the ontology-layer mapping and its documented gaps.

--- a/osi-obml/osi-ontology-schema.json
+++ b/osi-obml/osi-ontology-schema.json
@@ -1,0 +1,299 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/open-semantic-interchange/OSI/core-spec/osi-schema.json",
+  "title": "OSI Ontology Metadata Specification",
+  "description": "JSON Schema for validating OSI (Open Semantic Interoperability) ontology definitions",
+  "type": "object",
+  "properties": {
+    "version": {
+      "type": "string",
+      "const": "0.2.0.dev0",
+      "description": "Ontology specification version"
+    },
+    "name": {
+      "type": "string",
+      "description": "Unique identifier for the ontology"
+    },
+    "description": {
+      "type": "string",
+      "description": "Human-readable description"
+    },
+    "ai_context": {
+      "$ref": "https://raw.githubusercontent.com/open-semantic-interchange/OSI/main/core-spec/osi-schema.json#/$defs/AIContext"
+    },
+    "ontology": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/OntologyComponent"
+      },
+      "minItems": 1,
+      "description": "Components that define the concepts and relationships in this ontology"
+    },
+    "ontology_mappings": {
+      "type": "array",
+      "description": "Collection of ontology maps from logical models",
+      "items": {
+        "$ref": "#/$defs/OntologyMap"
+      }
+    }
+  },
+  "required": ["version", "name", "ontology"],
+  "additionalProperties": false,
+  "$defs": {
+    "OntologyComponent": {
+      "type": "object",
+      "description": "Ontology component that defines a single concept and any relationships that are keyed primarily by that concept",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of the component"
+        },
+        "concept": {
+          "$ref": "#/$defs/Concept"
+        },
+        "relationships": { 
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Relationship"
+          },
+          "description": "Defines relationships that pertain primarily to the concept defined in this component"
+        }
+      },
+      "required": ["concept"],
+      "additionalProperties": false
+    },
+    "Expression": {
+      "type": "string",
+      "description": "ANSI SQL expression"
+    },
+    "Relationship": {
+      "type": "object",
+      "description": "Relationship between concepts in the ontology",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the relationship"
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of the relationship"
+        },
+        "roles": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Role"
+          },
+          "description": "Additional roles in this relationship"
+        },
+        "multiplicity": {
+          "$ref": "#/$defs/Multiplicity"
+        },
+        "derived_by": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Expression"
+          },
+          "description": "Expressions that define how this concept is derived"
+        },
+        "verbalizes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Natural language expressions that verbalize this relationship"
+        }
+      },
+      "required": ["name", "verbalizes"],
+      "additionalProperties": false
+    },
+    "Concept": {
+      "type": "object",
+      "description": "Defines a concept in the ontology",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Unique identifier for the concept"
+        },
+        "type": {
+          "$ref": "#/$defs/ConceptType"
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of the concept"
+        },
+        "extends": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Indicates that this concept extends one or more other concepts"
+        },
+        "derived_by": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Expression"
+          },
+          "description": "Expressions that define how this concept is derived"
+        },
+        "identify_by": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Names of relationships to use as the preferred identifier of this concept"
+        },
+        "requires": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Expression"
+          },
+          "description": "Expressions that constrain the population of this concept"
+        }
+      },
+      "required": ["name", "type"],
+      "additionalProperties": false
+    },
+    "ConceptMapping": {
+      "type": "object",
+      "description": "Mappings from logical model constructs to some ontology component",
+      "properties": {
+        "concept": {
+          "type": "string",
+          "description": "Name of the concept whose part of the ontology we are mapping to"
+        },
+        "object_mappings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ObjectMapping"
+          },
+          "description": "Mappings from logical constructs that populate the concept in this component. Valid only when the concept is an entity type"
+        },         
+        "link_mappings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/LinkMapping"
+          },
+          "description": "Mappings from logical model relationships to ontology relationships pertaining to the mapped concept"
+        }
+      },
+      "required": ["concept"],
+      "additionalProperties": false
+    },
+    "ConceptType": {
+      "type": "string",
+      "enum": [ "EntityType", "ValueType" ],
+      "description": "A concept is either an entity type or a value type"
+    },
+    "ReferentMapping": {
+      "type": "object",
+      "description": "Mapping from logical model constructs to a relationship used to references some entity type in the ontology",
+      "properties": {
+        "relationship": {
+          "type": "string",
+          "description": "Name of referent relationship"
+        },
+        "expression": {
+          "$ref": "#/$defs/Expression"
+        },
+        "referent_mappings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ReferentMapping"
+          }
+        }
+      },
+      "required": ["relationship"],
+      "additionalProperties": false
+    },
+    "Role": {
+      "type": "object",
+      "description": "Role in some relationship (the container)",
+      "properties": {
+        "concept": {
+          "type": "string",
+          "description": "Name of the concept playing this role"
+        },
+        "name": {
+          "type": "string",
+          "description": "Optional name of this role, used when the same concept plays multiple roles in the same relationship"
+        }
+      },
+      "required": ["concept"],
+      "additionalProperties": false
+    },
+    "ObjectMapping": {
+      "type": "object",
+      "description": "Pattern of logical-level expressions for identifying objects of some concept using the values in one or more fields",
+      "properties": {
+        "concept": {
+          "type": "string",
+          "description": "Name of the concept whose objects we are mapping to"
+        },
+        "referent_mappings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ReferentMapping"
+          },
+          "description": "Maps logical-model constructs to referent relationships of this entity type"
+        },
+        "expression": {
+          "$ref": "#/$defs/Expression"
+        }
+      },
+      "additionalProperties": false
+    },
+    "LinkMapping": {
+      "type": "object",
+      "description": "Mapping from logical schema to the links of relationships in the ontology",
+      "properties": {
+        "relationship": {
+          "type": "string",
+          "description": "Name of relationship being populated by this mapping node"
+        },
+        "object_mapping": {
+            "$ref": "#/$defs/ObjectMapping"
+        },
+        "children": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/LinkMapping"
+          },
+          "description": "Relationship maps at the next level in this hierarchy"
+        }
+      },
+      "required": ["object_mapping"],
+      "additionalProperties": false
+    },
+    "Multiplicity": {
+      "type": "string",
+      "enum": [ "ManyToOne", "OneToOne" ],
+      "description": "Relationship multiplicity"
+    },
+    "OntologyMap": {
+      "type": "object",
+      "description": "Map from the constructs of some logical model to some ontology",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of this ontology map"
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of this ontology map"
+        },
+        "semantic_model": {
+          "$ref": "https://raw.githubusercontent.com/open-semantic-interchange/OSI/main/core-spec/osi-schema.json#/$defs/SemanticModel"
+        },
+        "concept_mappings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ConceptMapping"
+          },
+          "description": "Maps logical model constructs to some concept and its relationships in the ontology"
+        }
+      },
+      "required": ["semantic_model", "concept_mappings"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/osi-obml/osi_obml_converter.py
+++ b/osi-obml/osi_obml_converter.py
@@ -2055,6 +2055,204 @@ class OBMLtoOSI:
         return None
 
 
+class OBMLtoOSIOntology:
+    """Derive an OSI **ontology** document from an OBML semantic model.
+
+    Produces a document conforming to ``osi-ontology-schema.json`` (OSI version
+    ``0.2.0.dev0``) — a *separate* artefact from the OSI core-spec semantic
+    model. The OSI ``OntologyMap`` embeds the full core-spec model, so this
+    class reuses :class:`OBMLtoOSI` for that part and overlays a concept /
+    relationship ontology plus the logical-to-conceptual mappings.
+
+    See ``osi_obml_ontology_mapping_analysis.md`` for the full mapping rules
+    and the documented gaps that surface as ``warnings``.
+    """
+
+    # OBML join cardinality → OSI ontology multiplicity. ``many-to-many`` has
+    # no OSI equivalent (the enum is ManyToOne/OneToOne only) and is skipped.
+    _MULTIPLICITY_MAP = {
+        "many-to-one": "ManyToOne",
+        "one-to-one": "OneToOne",
+    }
+
+    def __init__(
+        self,
+        obml: dict,
+        model_name: str = "semantic_model",
+        model_description: str = "",
+        ai_instructions: str = "",
+    ):
+        self.obml = obml
+        self.model_name = model_name
+        self.model_description = model_description
+        self.ai_instructions = ai_instructions
+        self.warnings: list[str] = []
+
+    @staticmethod
+    def _table_ref(do_obj: dict, fallback: str) -> str:
+        """Best-effort physical table identifier for SQL mapping expressions."""
+        database = do_obj.get("database", "")
+        schema = do_obj.get("schema", "")
+        code = do_obj.get("code", "")
+        source = f"{database}.{schema}.{code}" if database else code
+        if source:
+            return source.split(".")[-1]
+        return fallback
+
+    @staticmethod
+    def _col_code(do_obj: dict, display: str) -> str:
+        col = (do_obj.get("columns", {}) or {}).get(display, {})
+        return col.get("code", display.lower().replace(" ", "_"))
+
+    def _entity_key_expr(self, do_name: str, do_obj: dict, table_ref: str) -> str | None:
+        """Identifying SQL expression for an entity (primary key, else first column)."""
+        cols = do_obj.get("columns", {}) or {}
+        pk = [c for c, col in cols.items() if col.get("primaryKey")]
+        if not pk:
+            if not cols:
+                return None
+            first = next(iter(cols))
+            self.warnings.append(
+                f"Entity '{do_name}' has no primary key; identified by first column '{first}'"
+            )
+            return f"{table_ref}.{self._col_code(do_obj, first)}"
+        if len(pk) > 1:
+            self.warnings.append(
+                f"Entity '{do_name}' has a composite primary key; ontology object "
+                f"mapping uses only the first key column '{pk[0]}'"
+            )
+        return f"{table_ref}.{self._col_code(do_obj, pk[0])}"
+
+    def convert(self) -> dict:
+        # 1. Core semantic model (embedded — required by OSI OntologyMap).
+        core_conv = OBMLtoOSI(
+            self.obml,
+            model_name=self.model_name,
+            model_description=self.model_description,
+            ai_instructions=self.ai_instructions,
+        )
+        sem_model = core_conv.convert()["semantic_model"][0]
+        self.warnings.extend(core_conv.warnings)
+
+        data_objects = self.obml.get("dataObjects", {}) or {}
+        table_refs = {n: self._table_ref(o, n) for n, o in data_objects.items()}
+
+        # 2. Ontology components (one EntityType concept per dataObject) plus
+        #    the outgoing relationships keyed by that concept. Collect link
+        #    info so concept_mappings can bind relationships to FK columns.
+        ontology: list[dict[str, Any]] = []
+        rel_links: dict[str, list[tuple[str, str, str | None]]] = {}
+
+        for do_name, do_obj in data_objects.items():
+            concept: dict[str, Any] = {"name": do_name, "type": "EntityType"}
+            desc = do_obj.get("description") or do_obj.get("comment")
+            if desc:
+                concept["description"] = desc
+            component: dict[str, Any] = {"concept": concept}
+
+            relationships: list[dict[str, Any]] = []
+            used_names: set[str] = set()
+            for join in do_obj.get("joins", []) or []:
+                to_name = join.get("joinTo", "")
+                if not to_name:
+                    continue
+                join_type = (join.get("joinType") or "").lower()
+                if join_type == "many-to-many":
+                    self.warnings.append(
+                        f"Join {do_name} -> {to_name} is many-to-many; skipped "
+                        f"(OSI ontology multiplicity supports only ManyToOne/OneToOne)"
+                    )
+                    continue
+                multiplicity = self._MULTIPLICITY_MAP.get(join_type)
+                if multiplicity is None:
+                    multiplicity = "ManyToOne"
+                    self.warnings.append(
+                        f"Join {do_name} -> {to_name} has unknown joinType "
+                        f"'{join.get('joinType', '')}'; defaulting multiplicity to ManyToOne"
+                    )
+
+                path_name = join.get("pathName", "")
+                rel_name = f"{do_name}_to_{to_name}"
+                if path_name:
+                    rel_name = f"{rel_name}_{path_name}"
+                    self.warnings.append(
+                        f"Join {do_name} -> {to_name} is a named/secondary path "
+                        f"('{path_name}'); emitted as an ordinary relationship "
+                        f"(named-path semantics are not represented in OSI ontology)"
+                    )
+                elif join.get("secondary"):
+                    self.warnings.append(
+                        f"Join {do_name} -> {to_name} is a secondary path; emitted as an "
+                        f"ordinary relationship (alternate-path semantics are lost)"
+                    )
+                base = rel_name
+                dedup = 1
+                while rel_name in used_names:
+                    rel_name = f"{base}_{dedup}"
+                    dedup += 1
+                used_names.add(rel_name)
+
+                relationships.append(
+                    {
+                        "name": rel_name,
+                        "roles": [{"concept": to_name}],
+                        "multiplicity": multiplicity,
+                        "verbalizes": [f"{{{do_name}}} relates to {{{to_name}}}"],
+                    }
+                )
+
+                from_cols = join.get("columnsFrom", []) or []
+                fk_expr: str | None = None
+                if from_cols:
+                    if len(from_cols) > 1:
+                        self.warnings.append(
+                            f"Join {do_name} -> {to_name} has a composite key; link "
+                            f"mapping uses only the first column '{from_cols[0]}'"
+                        )
+                    fk_expr = f"{table_refs[do_name]}.{self._col_code(do_obj, from_cols[0])}"
+                rel_links.setdefault(do_name, []).append((rel_name, to_name, fk_expr))
+
+            if relationships:
+                component["relationships"] = relationships
+            ontology.append(component)
+
+        # 3. Concept mappings: object_mappings identify each entity; link_mappings
+        #    bind each relationship to its foreign-key column.
+        concept_mappings: list[dict[str, Any]] = []
+        for do_name, do_obj in data_objects.items():
+            cm: dict[str, Any] = {"concept": do_name}
+            key_expr = self._entity_key_expr(do_name, do_obj, table_refs[do_name])
+            if key_expr:
+                cm["object_mappings"] = [{"expression": key_expr}]
+            links: list[dict[str, Any]] = []
+            for rel_name, to_name, fk_expr in rel_links.get(do_name, []):
+                obj_map: dict[str, Any] = {"concept": to_name}
+                if fk_expr:
+                    obj_map["expression"] = fk_expr
+                links.append({"relationship": rel_name, "object_mapping": obj_map})
+            if links:
+                cm["link_mappings"] = links
+            if "object_mappings" in cm or "link_mappings" in cm:
+                concept_mappings.append(cm)
+
+        # 4. Assemble the ontology document.
+        ontology_doc: dict[str, Any] = {"version": _OSI_VERSION, "name": self.model_name}
+        model_desc = self.obml.get("description", "") or self.model_description
+        if model_desc:
+            ontology_doc["description"] = model_desc
+        if self.ai_instructions:
+            ontology_doc["ai_context"] = {"instructions": self.ai_instructions}
+        ontology_doc["ontology"] = ontology
+        ontology_doc["ontology_mappings"] = [
+            {
+                "name": f"{self.model_name}_map",
+                "semantic_model": sem_model,
+                "concept_mappings": concept_mappings,
+            }
+        ]
+        return ontology_doc
+
+
 # ═══════════════════════════════════════════════════════════════════════════
 #  Validation
 # ═══════════════════════════════════════════════════════════════════════════
@@ -2064,6 +2262,14 @@ _SCRIPT_DIR = Path(__file__).resolve().parent
 # Locate schemas relative to this script
 _OBML_SCHEMA_PATH = _SCRIPT_DIR.parent / "schema" / "obml-schema.json"
 _OSI_SCHEMA_PATH = _SCRIPT_DIR / "osi-schema.json"
+_OSI_ONTOLOGY_SCHEMA_PATH = _SCRIPT_DIR / "osi-ontology-schema.json"
+
+# The OSI ontology schema $refs the core-spec schema by its public raw URL for
+# ``ai_context`` and the embedded ``semantic_model``. Resolve that URL against
+# the vendored local copy so validation never touches the network.
+_OSI_CORE_SPEC_RAW_URL = (
+    "https://raw.githubusercontent.com/open-semantic-interchange/OSI/main/core-spec/osi-schema.json"
+)
 
 
 class ValidationResult:
@@ -2101,9 +2307,17 @@ class ValidationResult:
 
 
 def _validate_json_schema(
-    data: dict[str, Any], schema_path: Path, result: ValidationResult, draft: str = "draft7"
+    data: dict[str, Any],
+    schema_path: Path,
+    result: ValidationResult,
+    draft: str = "draft7",
+    registry: Any | None = None,
 ) -> None:
-    """Run JSON Schema validation, appending errors to *result*."""
+    """Run JSON Schema validation, appending errors to *result*.
+
+    *registry* is an optional ``referencing.Registry`` used to resolve external
+    ``$ref`` URIs against local resources (avoids network fetches).
+    """
     try:
         import jsonschema
     except ImportError:
@@ -2124,10 +2338,34 @@ def _validate_json_schema(
     validator_cls = (
         jsonschema.Draft202012Validator if draft == "draft2020" else jsonschema.Draft7Validator
     )
-    validator = validator_cls(schema)
+    validator = validator_cls(schema, registry=registry) if registry else validator_cls(schema)
     for error in sorted(validator.iter_errors(data), key=lambda e: list(e.absolute_path)):
         path = ".".join(str(p) for p in error.absolute_path) or "(root)"
         result.schema_errors.append(f"[{path}] {error.message}")
+
+
+def _osi_core_registry() -> Any | None:
+    """Build a ``referencing.Registry`` that resolves the OSI core-spec schema
+    URL (referenced by the ontology schema) to the vendored local copy. Returns
+    ``None`` if the dependencies or the local core schema are unavailable, in
+    which case the caller falls back to default (network) resolution."""
+    try:
+        from referencing import Registry, Resource
+        from referencing.jsonschema import DRAFT202012
+    except ImportError:
+        return None
+    if not _OSI_SCHEMA_PATH.exists():
+        return None
+    with open(_OSI_SCHEMA_PATH) as f:
+        core = json.load(f)
+    core_res = Resource.from_contents(core, default_specification=DRAFT202012)
+    # Register under both the raw URL used by the ontology schema's $refs and
+    # the core schema's own canonical $id (so its internal #/$defs refs resolve).
+    resources = [(_OSI_CORE_SPEC_RAW_URL, core_res)]
+    core_id = core_res.id()
+    if core_id:
+        resources.append((core_id, core_res))
+    return Registry().with_resources(resources)
 
 
 # ── OBML Validation ──────────────────────────────────────────────────────
@@ -2262,6 +2500,61 @@ def validate_osi(osi_dict: dict[str, Any], schema_path: Path | None = None) -> V
                 result.semantic_errors.append(
                     f"[UNKNOWN_DATASET_REF] Relationship '{rel_name}' "
                     f"references unknown dataset '{to_ds}'"
+                )
+
+    return result
+
+
+def validate_osi_ontology(
+    onto_dict: dict[str, Any], schema_path: Path | None = None
+) -> ValidationResult:
+    """Validate an OSI ontology dict against JSON Schema and semantic rules.
+
+    1. **JSON Schema** — structural correctness against ``osi-ontology-schema.json``
+       (Draft 2020-12). External ``$ref``s to the core-spec schema are resolved
+       against the vendored local copy via a ``referencing`` registry.
+    2. **Unique concept names** across the ``ontology`` components.
+    3. **Reference integrity** — relationship roles and concept_mappings
+       reference concepts defined in the ontology.
+    """
+    result = ValidationResult("OSI-ONTOLOGY")
+
+    # 1. JSON Schema validation (offline external-ref resolution).
+    _validate_json_schema(
+        onto_dict,
+        schema_path or _OSI_ONTOLOGY_SCHEMA_PATH,
+        result,
+        draft="draft2020",
+        registry=_osi_core_registry(),
+    )
+
+    # 2. Unique concept names + collect the defined set.
+    defined: set[str] = set()
+    for comp in onto_dict.get("ontology", []):
+        name = comp.get("concept", {}).get("name", "")
+        if name in defined:
+            result.semantic_errors.append(f"[DUPLICATE_CONCEPT] Duplicate concept name '{name}'")
+        defined.add(name)
+
+    # 3. Reference integrity — roles reference defined concepts.
+    for comp in onto_dict.get("ontology", []):
+        for rel in comp.get("relationships", []):
+            rel_name = rel.get("name", "<unnamed>")
+            for role in rel.get("roles", []):
+                rc = role.get("concept")
+                if rc and rc not in defined:
+                    result.semantic_errors.append(
+                        f"[UNKNOWN_CONCEPT_REF] Relationship '{rel_name}' role "
+                        f"references unknown concept '{rc}'"
+                    )
+
+    # concept_mappings reference defined concepts.
+    for omap in onto_dict.get("ontology_mappings", []):
+        for cm in omap.get("concept_mappings", []):
+            cc = cm.get("concept")
+            if cc and cc not in defined:
+                result.semantic_errors.append(
+                    f"[UNKNOWN_CONCEPT_REF] Concept mapping references unknown concept '{cc}'"
                 )
 
     return result

--- a/osi-obml/osi_obml_ontology_mapping_analysis.md
+++ b/osi-obml/osi_obml_ontology_mapping_analysis.md
@@ -1,0 +1,82 @@
+# OBML → OSI Ontology Mapping Analysis
+
+This pins the rules used by `OBMLtoOSIOntology` to derive an **OSI ontology
+document** (validated against `osi-obml/osi-ontology-schema.json`, OSI version
+`0.2.0.dev0`) from an OBML semantic model.
+
+The OSI ontology is a **separate document** from the OSI core-spec semantic
+model (different `$id`, different required root). It is produced alongside the
+core export, never merged into it — OSI's own `validation/validate.py` validates
+one document against one schema and reads only the first YAML document, so a
+combined or multi-doc file is not portable. See the `include_ontology` flag on
+the export endpoints.
+
+## Document shape produced
+
+```yaml
+version: 0.2.0.dev0
+name: <model name>                 # required
+description: <model description>   # optional
+ai_context: { instructions: ... }  # optional, from ai_instructions / model
+ontology:                          # required, minItems 1
+  - concept:
+      name: <Entity>               # = OBML dataObject display name
+      type: EntityType
+      description: ...
+    relationships:                 # outgoing joins keyed by this entity
+      - name: <A>_to_<B>
+        roles: [{ concept: <B> }]  # declaring concept (A) is the implicit first role
+        multiplicity: ManyToOne | OneToOne
+        verbalizes: ["{<A>} relates to {<B>}"]
+ontology_mappings:
+  - name: <model name>_map
+    semantic_model: { ...full OSI core-spec model... }   # reused from OBMLtoOSI
+    concept_mappings:
+      - concept: <Entity>
+        object_mappings: [{ expression: "<table>.<key_col>" }]
+        link_mappings:
+          - relationship: <A>_to_<B>
+            object_mapping: { concept: <B>, expression: "<table_A>.<fk_col>" }
+```
+
+## Mapping rules
+
+| OBML construct | OSI ontology target | Notes |
+|----------------|---------------------|-------|
+| `dataObject` | `EntityType` `Concept` (one per object) | name = display name (matches OSI dataset name for ref consistency) |
+| `dataObject.description` / `.comment` | `concept.description` | first non-empty wins |
+| `join` (A → B) | `Relationship` under A's component | declaring concept A is the implicit first role; B is an explicit `role` |
+| `join.joinType` | `Relationship.multiplicity` | `many-to-one`→`ManyToOne`, `one-to-one`→`OneToOne` |
+| `column.primaryKey` | entity `object_mappings[].expression` | `<table>.<pk_code>`; identifies the entity |
+| `join.columnsFrom` (FK) | `link_mappings[].object_mapping.expression` | `<table_A>.<fk_code>`; binds the relationship to its far role |
+| whole core model | `ontology_mappings[].semantic_model` | embedded verbatim from `OBMLtoOSI.convert()` |
+
+`<table>` is the final identifier of the dataset `source` (e.g. `db.schema.t` → `t`),
+falling back to the dataset name when `source` has no dotted physical table.
+
+## Gaps and warnings (emitted to `warnings`)
+
+| OBML construct | Handling | Reason |
+|----------------|----------|--------|
+| `joinType: many-to-many` | relationship **skipped** + warning | OSI `Multiplicity` enum is only `ManyToOne`/`OneToOne` |
+| missing/unknown `joinType` | defaults to `ManyToOne` + warning | matches core-converter default |
+| secondary / `pathName` joins | emitted as ordinary relationships + warning | OSI ontology has no named-alternate-path concept |
+| composite primary/foreign keys | first column used + warning | `object_mapping.expression` is a single scalar SQL expression |
+| measures / metrics | **not** in the ontology layer | live only in the embedded core `semantic_model`; ontology models entities/relationships |
+| columns (non-key) as value concepts | not modeled (entities only) | keeps v1 valid and focused; ORM-style `ValueType` modeling deferred |
+| `verbalizes` / `derived_by` / `requires` / `identify_by` | `verbalizes` emitted as a generated stub; others omitted | OBML has no native source for fact-based verbalization or derivation |
+
+## Validation
+
+`validate_osi_ontology()` runs:
+1. JSON Schema (Draft 2020-12) against `osi-ontology-schema.json`.
+2. Semantic checks: unique concept names; relationship `roles` reference defined
+   concepts; `concept_mappings` reference defined concepts.
+
+## Stability note
+
+OSI ontology is `0.2.0.dev0` (pre-1.0). This exporter is the supported,
+schema-validated direction. An ontology **importer** (OSI ontology → OBML) is
+intentionally deferred until OSI drops the `dev` pre-release suffix, because the
+gaps above make the reverse direction lossy. Import the OSI **core spec**
+instead (already supported).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,6 +141,7 @@ packages = ["src/orionbelt"]
 "schema" = "orionbelt/schema"
 "osi-obml/osi_obml_converter.py" = "orionbelt/_osi_obml/osi_obml_converter.py"
 "osi-obml/osi-schema.json" = "orionbelt/_osi_obml/osi-schema.json"
+"osi-obml/osi-ontology-schema.json" = "orionbelt/_osi_obml/osi-ontology-schema.json"
 
 [tool.ruff]
 target-version = "py312"

--- a/src/orionbelt/api/routers/convert.py
+++ b/src/orionbelt/api/routers/convert.py
@@ -90,8 +90,32 @@ async def obml_to_osi(body: OBMLtoOSIRequest) -> ConvertResponse:
 
     validation = run_validation(mod.validate_osi, result)
 
+    ontology_yaml: str | None = None
+    ontology_validation = None
+    if body.include_ontology:
+        try:
+            onto_conv = mod.OBMLtoOSIOntology(
+                data,
+                model_name=body.model_name,
+                model_description=body.model_description,
+                ai_instructions=body.ai_instructions,
+            )
+            onto = onto_conv.convert()
+            warnings = warnings + list(onto_conv.warnings)
+        except Exception as exc:
+            logger.exception("OBML → OSI ontology conversion failed")
+            raise HTTPException(
+                status_code=422, detail=f"OBML → OSI ontology conversion failed: {exc}"
+            ) from exc
+        ontology_yaml = yaml.dump(
+            onto, default_flow_style=False, allow_unicode=True, sort_keys=False, width=120
+        )
+        ontology_validation = run_validation(mod.validate_osi_ontology, onto)
+
     return ConvertResponse(
         output_yaml=output_yaml,
         warnings=warnings,
         validation=validation,
+        ontology_yaml=ontology_yaml,
+        ontology_validation=ontology_validation,
     )

--- a/src/orionbelt/api/routers/sessions.py
+++ b/src/orionbelt/api/routers/sessions.py
@@ -383,6 +383,7 @@ async def export_model_to_osi(
     model_name: str = "semantic_model",
     model_description: str = "",
     ai_instructions: str = "",
+    include_ontology: bool = False,
     mgr: SessionManager = Depends(get_session_manager),  # noqa: B008
 ) -> ConvertResponse:
     """Export a loaded model from the model store as OSI YAML.
@@ -391,7 +392,9 @@ async def export_model_to_osi(
     time, falling back to a lossy reconstruction for programmatically
     built models) to Open Semantic Interchange (OSI) format. Optional
     query params override the OSI model name, description, and AI
-    instructions.
+    instructions. Set ``include_ontology=true`` to also emit the OSI
+    ontology document in ``ontology_yaml`` (a separate artefact with its
+    own ``ontology_validation``); the core-spec ``output_yaml`` is unchanged.
     """
     store = _get_store(session_id, mgr)
     try:
@@ -417,7 +420,36 @@ async def export_model_to_osi(
         osi_dict, default_flow_style=False, allow_unicode=True, sort_keys=False, width=120
     )
     validation = run_validation(mod.validate_osi, osi_dict)
-    return ConvertResponse(output_yaml=output_yaml, warnings=warnings, validation=validation)
+
+    ontology_yaml: str | None = None
+    ontology_validation = None
+    if include_ontology:
+        try:
+            onto_conv = mod.OBMLtoOSIOntology(
+                obml_dict,
+                model_name=model_name,
+                model_description=model_description,
+                ai_instructions=ai_instructions,
+            )
+            onto_dict = onto_conv.convert()
+            warnings = warnings + list(onto_conv.warnings)
+        except Exception as exc:
+            logger.exception("OBML → OSI ontology conversion failed")
+            raise HTTPException(
+                status_code=422, detail=f"OBML → OSI ontology conversion failed: {exc}"
+            ) from exc
+        ontology_yaml = yaml.dump(
+            onto_dict, default_flow_style=False, allow_unicode=True, sort_keys=False, width=120
+        )
+        ontology_validation = run_validation(mod.validate_osi_ontology, onto_dict)
+
+    return ConvertResponse(
+        output_yaml=output_yaml,
+        warnings=warnings,
+        validation=validation,
+        ontology_yaml=ontology_yaml,
+        ontology_validation=ontology_validation,
+    )
 
 
 @router.delete("/{session_id}/models/{model_id}", status_code=204)

--- a/src/orionbelt/api/schemas.py
+++ b/src/orionbelt/api/schemas.py
@@ -782,6 +782,14 @@ class OBMLtoOSIRequest(ConvertRequest):
     model_name: str = Field(default="semantic_model", description="Name for the OSI model")
     model_description: str = Field(default="", description="Description for the OSI model")
     ai_instructions: str = Field(default="", description="AI instructions for the OSI model")
+    include_ontology: bool = Field(
+        default=False,
+        description=(
+            "Also emit the OSI ontology document (separate ontology.json-schema "
+            "artefact) in 'ontology_yaml' with its own 'ontology_validation'. The "
+            "core-spec 'output_yaml' is unchanged."
+        ),
+    )
 
 
 class ValidationDetail(BaseModel):
@@ -811,6 +819,18 @@ class ConvertResponse(BaseModel):
             "input against the vendored OSI v0.2 schema). None when no input-side "
             "validation runs."
         ),
+    )
+    ontology_yaml: str | None = Field(
+        default=None,
+        description=(
+            "OSI ontology document (a separate artefact validated against the OSI "
+            "ontology schema), emitted only for OBML→OSI conversions when "
+            "'include_ontology' is requested. None otherwise."
+        ),
+    )
+    ontology_validation: ValidationDetail | None = Field(
+        default=None,
+        description="Validation results for 'ontology_yaml'. None when no ontology is emitted.",
     )
 
 

--- a/tests/integration/test_api_convert.py
+++ b/tests/integration/test_api_convert.py
@@ -224,3 +224,54 @@ class TestObmlToOsiBackwardCompat:
         # doesn't currently run input-side schema validation.
         assert "input_validation" in body
         assert body["input_validation"] is None
+        # No ontology unless explicitly requested.
+        assert body["ontology_yaml"] is None
+        assert body["ontology_validation"] is None
+
+
+class TestObmlToOsiOntology:
+    """include_ontology=true adds a separate, individually-valid OSI ontology
+    document alongside the unchanged core-spec export."""
+
+    _OBML = {
+        "version": 1.0,
+        "dataObjects": {
+            "Orders": {
+                "code": "ORDERS",
+                "columns": {
+                    "Order ID": {"code": "ORDER_ID", "primaryKey": True},
+                    "Customer Ref": {"code": "CUSTOMER_ID"},
+                },
+                "joins": [
+                    {
+                        "joinType": "many-to-one",
+                        "joinTo": "Customers",
+                        "columnsFrom": ["Customer Ref"],
+                        "columnsTo": ["Customer ID"],
+                    }
+                ],
+            },
+            "Customers": {
+                "code": "CUSTOMERS",
+                "columns": {"Customer ID": {"code": "CUSTOMER_ID", "primaryKey": True}},
+            },
+        },
+    }
+
+    async def test_include_ontology_emits_valid_document(self, client: AsyncClient) -> None:
+        response = await client.post(
+            "/v1/convert/obml-to-osi",
+            json={"input_yaml": yaml.safe_dump(self._OBML), "include_ontology": True},
+        )
+        assert response.status_code == 200, response.text
+        body = response.json()
+        # Core export still present and valid.
+        assert "semantic_model" in yaml.safe_load(body["output_yaml"])
+        assert body["validation"]["schema_valid"] is True
+        # Ontology is a distinct, valid document (not merged into the core doc).
+        onto = yaml.safe_load(body["ontology_yaml"])
+        assert onto["version"] == "0.2.0.dev0"
+        assert {c["concept"]["name"] for c in onto["ontology"]} == {"Orders", "Customers"}
+        assert "semantic_model" not in onto
+        assert body["ontology_validation"]["schema_valid"] is True
+        assert body["ontology_validation"]["semantic_valid"] is True

--- a/tests/integration/test_api_osi_models.py
+++ b/tests/integration/test_api_osi_models.py
@@ -152,6 +152,43 @@ class TestExportModelToOsi:
         resp = await client.get(f"/v1/sessions/{sid}/models/nope/osi")
         assert resp.status_code == 404
 
+    async def test_export_without_ontology_omits_fields(self, client: AsyncClient) -> None:
+        sid = await _new_session(client)
+        load = await client.post(
+            f"/v1/sessions/{sid}/models/from-osi",
+            json={"osi_yaml": yaml.safe_dump(_OSI_V02_MINIMAL)},
+        )
+        model_id = load.json()["model_id"]
+        export = await client.get(f"/v1/sessions/{sid}/models/{model_id}/osi")
+        body = export.json()
+        assert body["ontology_yaml"] is None
+        assert body["ontology_validation"] is None
+
+    async def test_export_with_ontology_returns_valid_doc(self, client: AsyncClient) -> None:
+        sid = await _new_session(client)
+        load = await client.post(
+            f"/v1/sessions/{sid}/models/from-osi",
+            json={"osi_yaml": yaml.safe_dump(_OSI_V02_MINIMAL)},
+        )
+        model_id = load.json()["model_id"]
+
+        export = await client.get(
+            f"/v1/sessions/{sid}/models/{model_id}/osi",
+            params={"model_name": "demo", "include_ontology": "true"},
+        )
+        assert export.status_code == 200, export.text
+        body = export.json()
+        # Core export is unchanged and still a valid OSI core-spec doc.
+        assert "semantic_model" in yaml.safe_load(body["output_yaml"])
+        assert body["validation"]["schema_valid"] is True
+        # Ontology is a separate, individually-valid document.
+        onto = yaml.safe_load(body["ontology_yaml"])
+        assert onto["version"] == "0.2.0.dev0"
+        assert "ontology" in onto and "ontology_mappings" in onto
+        assert "semantic_model" not in onto  # not merged into the ontology root
+        assert body["ontology_validation"]["schema_valid"] is True
+        assert body["ontology_validation"]["semantic_valid"] is True
+
     async def test_export_unknown_session_returns_404(self, client: AsyncClient) -> None:
         resp = await client.get("/v1/sessions/does-not-exist/models/m1/osi")
         assert resp.status_code == 404

--- a/tests/unit/test_osi_converter_ontology.py
+++ b/tests/unit/test_osi_converter_ontology.py
@@ -1,0 +1,184 @@
+"""Tests for the OBML → OSI **ontology** converter (OBMLtoOSIOntology).
+
+Validates that the derived ontology document conforms to the vendored
+``osi-ontology-schema.json`` (with external core-spec refs resolved offline),
+that OBML join cardinality maps to OSI multiplicity, and that the documented
+gaps (many-to-many, composite keys, missing PK) surface as warnings.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+_CONVERTER_DIR = str(Path(__file__).resolve().parents[2] / "osi-obml")
+if _CONVERTER_DIR not in sys.path:
+    sys.path.insert(0, _CONVERTER_DIR)
+
+import osi_obml_converter as conv  # noqa: E402
+
+_OBML: dict[str, Any] = {
+    "version": 1.0,
+    "description": "Sales model",
+    "dataObjects": {
+        "Customers": {
+            "code": "CUSTOMERS",
+            "database": "WH",
+            "schema": "PUBLIC",
+            "columns": {
+                "Customer ID": {
+                    "code": "CUSTOMER_ID",
+                    "abstractType": "string",
+                    "primaryKey": True,
+                },
+                "Name": {"code": "NAME", "abstractType": "string"},
+            },
+        },
+        "Products": {
+            "code": "PRODUCTS",
+            "columns": {
+                "Product ID": {"code": "PRODUCT_ID", "abstractType": "string", "primaryKey": True},
+            },
+        },
+        "Orders": {
+            "code": "ORDERS",
+            "columns": {
+                "Order ID": {"code": "ORDER_ID", "abstractType": "string", "primaryKey": True},
+                "Customer Ref": {"code": "CUSTOMER_ID", "abstractType": "string"},
+                "Product Ref": {"code": "PRODUCT_ID", "abstractType": "string"},
+            },
+            "joins": [
+                {
+                    "joinType": "many-to-one",
+                    "joinTo": "Customers",
+                    "columnsFrom": ["Customer Ref"],
+                    "columnsTo": ["Customer ID"],
+                },
+                {
+                    "joinType": "many-to-one",
+                    "joinTo": "Products",
+                    "columnsFrom": ["Product Ref"],
+                    "columnsTo": ["Product ID"],
+                },
+            ],
+        },
+    },
+}
+
+
+class TestOntologyStructure:
+    def test_entities_and_relationships(self) -> None:
+        doc = conv.OBMLtoOSIOntology(_OBML, model_name="sales").convert()
+
+        assert doc["version"] == "0.2.0.dev0"
+        assert doc["name"] == "sales"
+
+        names = {c["concept"]["name"] for c in doc["ontology"]}
+        assert names == {"Customers", "Products", "Orders"}
+        assert all(c["concept"]["type"] == "EntityType" for c in doc["ontology"])
+
+        orders = next(c for c in doc["ontology"] if c["concept"]["name"] == "Orders")
+        rels = {r["name"]: r for r in orders["relationships"]}
+        assert set(rels) == {"Orders_to_Customers", "Orders_to_Products"}
+        assert rels["Orders_to_Customers"]["multiplicity"] == "ManyToOne"
+        assert rels["Orders_to_Customers"]["roles"] == [{"concept": "Customers"}]
+        assert rels["Orders_to_Customers"]["verbalizes"]  # non-empty stub
+
+    def test_embeds_core_semantic_model(self) -> None:
+        doc = conv.OBMLtoOSIOntology(_OBML, model_name="sales").convert()
+        omap = doc["ontology_mappings"][0]
+        assert omap["name"] == "sales_map"
+        assert "semantic_model" in omap
+        assert omap["semantic_model"]["name"] == "sales"
+        assert {d["name"] for d in omap["semantic_model"]["datasets"]} == {
+            "Customers",
+            "Products",
+            "Orders",
+        }
+
+    def test_concept_mappings_bind_keys_and_fks(self) -> None:
+        doc = conv.OBMLtoOSIOntology(_OBML, model_name="sales").convert()
+        cms = {cm["concept"]: cm for cm in doc["ontology_mappings"][0]["concept_mappings"]}
+
+        # Entity identity from primary key.
+        assert cms["Customers"]["object_mappings"] == [{"expression": "CUSTOMERS.CUSTOMER_ID"}]
+
+        # Relationship link mapping binds to the FK column in the from-table.
+        links = {lm["relationship"]: lm for lm in cms["Orders"]["link_mappings"]}
+        assert links["Orders_to_Customers"]["object_mapping"] == {
+            "concept": "Customers",
+            "expression": "ORDERS.CUSTOMER_ID",
+        }
+
+    def test_validates_against_ontology_schema_offline(self) -> None:
+        doc = conv.OBMLtoOSIOntology(_OBML, model_name="sales").convert()
+        result = conv.validate_osi_ontology(doc)
+        assert result.valid, result.schema_errors + result.semantic_errors
+        assert not result.schema_errors
+        assert not result.semantic_errors
+
+    def test_one_to_one_multiplicity(self) -> None:
+        obml = {
+            "version": 1.0,
+            "dataObjects": {
+                "A": {
+                    "code": "A",
+                    "columns": {"Id": {"code": "ID", "primaryKey": True}},
+                    "joins": [
+                        {
+                            "joinType": "one-to-one",
+                            "joinTo": "B",
+                            "columnsFrom": ["Id"],
+                            "columnsTo": ["Id"],
+                        }
+                    ],
+                },
+                "B": {"code": "B", "columns": {"Id": {"code": "ID", "primaryKey": True}}},
+            },
+        }
+        doc = conv.OBMLtoOSIOntology(obml).convert()
+        a = next(c for c in doc["ontology"] if c["concept"]["name"] == "A")
+        assert a["relationships"][0]["multiplicity"] == "OneToOne"
+        assert conv.validate_osi_ontology(doc).valid
+
+
+class TestOntologyGaps:
+    def test_many_to_many_skipped_with_warning(self) -> None:
+        obml = {
+            "version": 1.0,
+            "dataObjects": {
+                "A": {
+                    "code": "A",
+                    "columns": {"Id": {"code": "ID", "primaryKey": True}},
+                    "joins": [
+                        {
+                            "joinType": "many-to-many",
+                            "joinTo": "B",
+                            "columnsFrom": ["Id"],
+                            "columnsTo": ["Id"],
+                        }
+                    ],
+                },
+                "B": {"code": "B", "columns": {"Id": {"code": "ID", "primaryKey": True}}},
+            },
+        }
+        c = conv.OBMLtoOSIOntology(obml)
+        doc = c.convert()
+        a = next(comp for comp in doc["ontology"] if comp["concept"]["name"] == "A")
+        assert "relationships" not in a  # m2m join skipped
+        assert any("many-to-many" in w for w in c.warnings)
+        assert conv.validate_osi_ontology(doc).valid
+
+    def test_missing_primary_key_warns_and_uses_first_column(self) -> None:
+        obml = {
+            "version": 1.0,
+            "dataObjects": {
+                "A": {"code": "A", "columns": {"Label": {"code": "LABEL"}}},
+            },
+        }
+        c = conv.OBMLtoOSIOntology(obml)
+        doc = c.convert()
+        cm = doc["ontology_mappings"][0]["concept_mappings"][0]
+        assert cm["object_mappings"] == [{"expression": "A.LABEL"}]
+        assert any("no primary key" in w for w in c.warnings)


### PR DESCRIPTION
## Summary

Adds an **opt-in OSI ontology export** alongside the existing OSI core-spec export. OSI defines two layers (the logical core-spec semantic model and the conceptual ontology) validated by **separate** JSON Schemas and, per OSI's own \`validation/validate.py\`, kept in **separate documents** (it validates one schema per file and reads only the first YAML document). So the ontology is returned as a distinct, individually-valid artefact rather than merged into the core doc.

## What changed

- **\`OBMLtoOSIOntology\` converter** (\`osi-obml/osi_obml_converter.py\`): each \`dataObject\` becomes an \`EntityType\` concept; each join becomes a relationship whose \`multiplicity\` derives from \`joinType\` (\`many-to-one\` -> \`ManyToOne\`, \`one-to-one\` -> \`OneToOne\`); \`concept_mappings\` bind concepts to physical columns. The OSI \`OntologyMap\` requires an embedded core \`semantic_model\`, which is reused from \`OBMLtoOSI\`.
- **\`validate_osi_ontology()\`**: schema (Draft 2020-12) + semantic checks. The ontology schema's external core-spec \`\$ref\`s are resolved **offline** against the vendored core schema via a \`referencing\` registry, so validation never hits the network.
- **API**: \`include_ontology\` on \`POST /v1/convert/obml-to-osi\` and \`GET /v1/sessions/{id}/models/{mid}/osi\`. Response gains \`ontology_yaml\` + \`ontology_validation\`. **Default off, fully backward-compatible.**
- Vendored \`osi-ontology-schema.json\` bundled into the wheel (hatch force-include).
- Mapping-analysis doc, \`docs/guide/osi.md\`, CHANGELOG (Unreleased), unit + integration tests.

## Documented gaps (surface as conversion \`warnings\`)

Many-to-many joins (no OSI multiplicity), named secondary join paths, measures/metrics, and column-level value concepts are not represented in the ontology layer. An ontology **importer** (OSI ontology -> OBML) is intentionally deferred while OSI remains at \`0.2.0.dev0\`.

## Tests

- \`tests/unit/test_osi_converter_ontology.py\` (structure, multiplicity, offline schema validation, gap warnings)
- API coverage in \`test_api_convert.py\` + \`test_api_osi_models.py\`
- Full suite: 2396 passed, 167 skipped. \`ruff\`/\`mypy\` clean.

## Note

No version bump in this PR (CHANGELOG entry is under \`[Unreleased]\`) - release is a separate step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)