### PR TITLE
fix: COPY osi-ontology-schema.json into Docker build contexts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ COPY src/ src/
 COPY schema/ schema/
 COPY osi-obml/osi_obml_converter.py osi-obml/
 COPY osi-obml/osi-schema.json osi-obml/
+COPY osi-obml/osi-ontology-schema.json osi-obml/
 RUN uv sync --no-dev --no-editable --frozen --extra ${OB_EXTRA}
 
 # --- Runtime stage: minimal image ---

--- a/Dockerfile.flight
+++ b/Dockerfile.flight
@@ -17,6 +17,7 @@ COPY src/ src/
 COPY schema/ schema/
 COPY osi-obml/osi_obml_converter.py osi-obml/
 COPY osi-obml/osi-schema.json osi-obml/
+COPY osi-obml/osi-ontology-schema.json osi-obml/
 RUN uv sync --no-dev --no-editable --extra flight --frozen
 
 # --- Runtime stage: minimal image ---

--- a/Dockerfile.ui
+++ b/Dockerfile.ui
@@ -20,6 +20,7 @@ COPY schema/ schema/
 # "Forced include not found". Mirrors Dockerfile / Dockerfile.flight.
 COPY osi-obml/osi_obml_converter.py osi-obml/
 COPY osi-obml/osi-schema.json osi-obml/
+COPY osi-obml/osi-ontology-schema.json osi-obml/
 COPY examples/ examples/
 RUN uv sync --no-dev --extra ui --no-editable --frozen
 


### PR DESCRIPTION
## Summary

Completes the v2.9.0 release. The release published to PyPI + GitHub + docs successfully, but the Cloud Run / Docker Hub builds failed:

\`\`\`
FileNotFoundError: Forced include not found: /app/osi-obml/osi-ontology-schema.json
\`\`\`

v2.9.0 added \`osi-obml/osi-ontology-schema.json\` to the wheel \`force-include\` in \`pyproject.toml\`, but the Dockerfiles **selectively COPY individual \`osi-obml/\` files** (only \`osi_obml_converter.py\` + \`osi-schema.json\`) rather than the whole dir — so the in-image wheel build can't find the new schema. The PyPI wheel was unaffected (host build has the file).

Adds the missing \`COPY\` to **Dockerfile**, **Dockerfile.ui**, and **Dockerfile.flight**, mirroring the existing \`osi-schema.json\` lines. Same class of fix as #109.

After merge, the release is completed by redeploying Cloud Run + Docker Hub (\`release.sh --only 5,6\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)