### PR TITLE
fix(osi): never silently drop OSI metrics on import; emit schema-conformant OSI

### DIFF
--- a/packages/osi-orionbelt/README.md
+++ b/packages/osi-orionbelt/README.md
@@ -99,6 +99,14 @@ OBML, but are not interpreted by other OSI consumers:
   pair of objects are an OBML-specific topology feature.
 - **Measures / metrics and column-level value concepts in the ontology layer** -
   not represented in the OSI ontology export.
+- **OSI metrics with no OBML representation** - a metric whose only expression is
+  in a non-SQL dialect (`MDX`, `TABLEAU`, `MAQL`), or whose SQL expression cannot
+  be decomposed into OBML measures/metrics, is **not** dropped: the original OSI
+  metric is preserved verbatim in a model-level `OSI`-vendor `custom_extension`
+  (`obml_unconverted_metrics`) and re-emitted on OBML to OSI, so the OSI to OBML
+  to OSI roundtrip stays lossless. A `LOSSY:` warning is raised for each such
+  metric because it is **not queryable through OBML**. SQL expressions in the
+  `ANSI_SQL`, `SNOWFLAKE`, and `DATABRICKS` dialects are all read on import.
 
 OSI v0.1.x inputs are accepted on read via a legacy normalization shim; output
 targets OSI **v0.2.0.dev0**.

--- a/packages/osi-orionbelt/osi_obml_mapping_analysis.md
+++ b/packages/osi-orionbelt/osi_obml_mapping_analysis.md
@@ -1,10 +1,10 @@
 # OSI ↔ OBML Mapping Analysis
 
-> Bidirectional conversion between [Open Semantic Interchange (OSI)](https://github.com/open-semantic-interchange/OSI) v0.1.1 and [OrionBelt ML (OBML)](https://github.com/ralfbecher/orionbelt-semantic-layer) v1.0 semantic model formats.
+> Bidirectional conversion between [Open Semantic Interchange (OSI)](https://github.com/open-semantic-interchange/OSI) v0.2.0.dev0 and [OrionBelt ML (OBML)](https://github.com/ralfbecher/orionbelt-semantic-layer) v1.0 semantic model formats. OSI v0.1.x inputs are still accepted on read via a legacy normalization shim; output targets v0.2.0.dev0.
 
 ## 1. Structural Comparison
 
-| Aspect | OSI v0.1.1 | OBML v1.0 |
+| Aspect | OSI v0.2.0.dev0 | OBML v1.0 |
 |---|---|---|
 | **Top-level** | `semantic_model[]` (array of models) | Single model with `dataObjects`, `dimensions`, `measures`, `metrics` sections |
 | **Tables / Entities** | `datasets[]` (flat array) | `dataObjects{}` (named dictionary) |
@@ -126,12 +126,13 @@ These OBML features have no direct OSI equivalent. Where possible, metadata is p
 - Locale settings — not yet preserved
 - `abstractType` (OBML type system) — preserved in field `custom_extensions` (`obml_abstract_type`)
 
-### 2.6 OSI-Specific Features (Not Representable in OBML)
+### 2.6 OSI-Specific Features and How They Map to OBML
 
-- **Multi-dialect expressions** — only `ANSI_SQL` dialect is used during conversion
-- **`primary_key` / `unique_keys`** — not directly represented in OBML
-- **`ai_context`** — preserved losslessly via `customExtensions` (see Section 2.4)
-- **`custom_extensions`** — mapped to OBML `customExtensions`
+- **`primary_key`** — natively represented: OSI's dataset-level `primary_key` array maps to per-column `primaryKey: true` on OBML columns (`DataObjectColumn.primaryKey`), and back to the dataset array on export.
+- **`unique_keys`** — no native OBML equivalent; round-trips via an `OSI`-vendor `customExtension` (`obml_unique_keys`).
+- **Multi-dialect expressions** — on import the converter reads the first available SQL dialect in the order `ANSI_SQL`, `SNOWFLAKE`, `DATABRICKS`; non-SQL dialects (`MDX`, `TABLEAU`, `MAQL`) are not parsed. A metric with no SQL-parseable dialect, or an expression OBML cannot decompose, is preserved verbatim (`obml_unconverted_metrics`) with a `LOSSY:` warning rather than dropped. On export, OBML measures/metrics emit `ANSI_SQL`.
+- **`ai_context`** — preserved losslessly via `customExtensions` (see Section 2.4).
+- **`custom_extensions`** — mapped to OBML `customExtensions`.
 
 ## 3. Conversion Strategies
 

--- a/packages/osi-orionbelt/src/osi_orionbelt/converter.py
+++ b/packages/osi-orionbelt/src/osi_orionbelt/converter.py
@@ -29,6 +29,24 @@ _OSI_VERSION = "0.2.0.dev0"
 
 # Dialect / vendor enum extras new in v0.2.0.dev0
 _OSI_KNOWN_DIALECTS = ("ANSI_SQL", "SNOWFLAKE", "MDX", "TABLEAU", "DATABRICKS", "MAQL")
+# SQL dialects (of the OSI enum) whose aggregation expressions our regex-based
+# metric parser can read, in preference order. ANSI_SQL first; SNOWFLAKE and
+# DATABRICKS are SQL engines OrionBelt also targets, and their simple/expression
+# aggregations (``SUM(t.c)``, ``SUM(t.a * t.b)``) are syntactically identical to
+# ANSI. MDX / TABLEAU / MAQL are non-SQL languages and are never parsed as SQL.
+_SQL_PARSEABLE_DIALECTS = ("ANSI_SQL", "SNOWFLAKE", "DATABRICKS")
+
+# Matches a ``dataset.column`` reference inside a SQL expression, where each
+# side is a bare identifier or a quoted identifier (double quotes, backticks, or
+# brackets). The leading lookbehind prevents matching the tail of a longer path
+# (``a.b.c``) or a mid-token boundary; the bare form must start with a letter or
+# underscore so numeric literals (``1.5``) are never treated as references.
+_COLUMN_REF_RE = re.compile(
+    r'(?<![\w."`\]])'
+    r'(?P<ds>[A-Za-z_]\w*|"[^"]+"|`[^`]+`|\[[^\]]+\])'
+    r"\s*\.\s*"
+    r'(?P<col>[A-Za-z_]\w*|"[^"]+"|`[^`]+`|\[[^\]]+\])'
+)
 _OSI_KNOWN_VENDORS = (
     "COMMON",
     "ORIONBELT",
@@ -96,6 +114,10 @@ class OSItoOBML:
         self.default_database = default_database
         self.default_schema = default_schema
         self.warnings: list[str] = []
+        # OSI metrics that have no OBML representation (non-SQL dialect only,
+        # or an expression our parser cannot decompose). Preserved verbatim
+        # rather than dropped — see ``_preserve_unconverted_metric``.
+        self._unconverted_metrics: list[dict] = []
 
     def _normalize_legacy_v01(self) -> None:
         """Promote OSI v0.1.x payloads to the v0.2 shape, in place.
@@ -143,6 +165,12 @@ class OSItoOBML:
             )
 
     def convert(self) -> dict:
+        # Reset per-conversion accumulators so calling convert() twice on the
+        # same instance is idempotent (no duplicated warnings or preserved
+        # metrics). Both are populated as a side effect of conversion below.
+        self.warnings = []
+        self._unconverted_metrics = []
+
         # v0.1.x inputs need the legacy shim to promote pre-v0.2
         # custom_extensions into v0.2 first-class fields before we parse.
         self._normalize_legacy_v01()
@@ -205,6 +233,19 @@ class OSItoOBML:
             obml["measures"] = measures
         if metrics:
             obml["metrics"] = metrics
+
+        # Metrics that have no OBML representation are not dropped: stash the
+        # original OSI metric verbatim under the OSI vendor so the reverse
+        # (OBML -> OSI) direction re-emits them and a full OSI -> OBML -> OSI
+        # roundtrip stays lossless. They are not queryable in OBML; a LOSSY
+        # warning was already recorded per metric.
+        if self._unconverted_metrics:
+            obml.setdefault("customExtensions", []).append(
+                {
+                    "vendor": _VENDOR_OSI,
+                    "data": json.dumps({"obml_unconverted_metrics": self._unconverted_metrics}),
+                }
+            )
 
         # ── Restore model-level properties from custom_extensions ────
         for ext in model.get("custom_extensions", []):
@@ -632,6 +673,19 @@ class OSItoOBML:
         measures: dict[str, Any] = {}
         metrics: dict[str, Any] = {}
 
+        # Case-insensitive dataset/field index for resolving SQL identifiers
+        # back to their canonical OSI names (Snowflake/Databricks expressions
+        # commonly upper-case or quote them).
+        ds_lc = {name.lower(): name for name in ds_map}
+        fields_lc = {
+            name: {
+                f["name"].lower(): f["name"]
+                for f in ds.get("fields", []) or []
+                if isinstance(f, dict) and f.get("name")
+            }
+            for name, ds in ds_map.items()
+        }
+
         for m in osi_metrics:
             name = m["name"]
 
@@ -690,10 +744,29 @@ class OSItoOBML:
                 measures[name] = delegated
                 continue
 
-            expr_text = self._get_ansi_expression(m.get("expression", {}))
+            # Prefer ANSI_SQL, but also read SNOWFLAKE / DATABRICKS expressions
+            # (SQL engines OrionBelt targets) — their aggregations are
+            # syntactically ANSI-compatible. Non-SQL dialects (MDX/TABLEAU/MAQL)
+            # are not parsed as SQL.
+            expr_text, _expr_dialect = self._select_sql_expression(m.get("expression", {}))
             if not expr_text:
-                self.warnings.append(f"Metric '{name}' has no ANSI_SQL expression; skipped.")
+                self._preserve_unconverted_metric(
+                    m, "no SQL-parseable dialect (ANSI_SQL / SNOWFLAKE / DATABRICKS) expression"
+                )
                 continue
+
+            # Resolve `dataset.column` references to canonical OSI names
+            # (case-insensitive, quote-stripped) before parsing. Copying raw
+            # Snowflake/Databricks identifiers verbatim would yield OBML refs to
+            # non-existent dataObjects/columns; when a reference cannot be
+            # mapped the metric is preserved rather than emitted dangling.
+            resolved_expr = self._resolve_column_refs(expr_text, ds_lc, fields_lc)
+            if resolved_expr is None:
+                self._preserve_unconverted_metric(
+                    m, "expression references columns not found in the model"
+                )
+                continue
+            expr_text = resolved_expr
 
             # Try simple: AGG(dataset.column) or AGG(DISTINCT dataset.column)
             parsed = self._parse_simple_agg(expr_text)
@@ -760,7 +833,12 @@ class OSItoOBML:
                     metric_def["owner"] = obml_extras["obml_owner"]
                 metrics[name] = metric_def
             else:
-                self.warnings.append(f"Metric '{name}' has unparseable expression: {expr_text}")
+                # Expression matched none of simple-agg / expr-agg /
+                # complex-decompose. Preserve verbatim instead of dropping so
+                # the metric survives an OSI -> OBML -> OSI roundtrip.
+                self._preserve_unconverted_metric(
+                    m, f"expression not decomposable into OBML measures/metrics: {expr_text!r}"
+                )
 
         # Preserve third-party vendor extensions, carrying them into whichever
         # OBML entity (measure or metric) the OSI metric became.
@@ -934,16 +1012,87 @@ class OSItoOBML:
             return a["expression"] == b["expression"]
         return False
 
-    def _get_ansi_expression(self, expr_obj: dict) -> str:
-        """Extract ANSI_SQL expression text."""
-        if isinstance(expr_obj, dict):
-            dialects = expr_obj.get("dialects", [])
-            for d in dialects:
-                if d.get("dialect") == "ANSI_SQL":
-                    return d.get("expression", "")
-            if dialects:
-                return dialects[0].get("expression", "")
-        return ""
+    def _select_sql_expression(self, expr_obj: dict) -> tuple[str, str]:
+        """Pick a SQL-parseable expression from an OSI ``expression`` object.
+
+        Returns ``(expression, dialect)`` for the most preferred SQL dialect
+        present (ANSI_SQL > SNOWFLAKE > DATABRICKS), or ``("", "")`` when the
+        metric only carries non-SQL dialects (MDX / TABLEAU / MAQL) or no usable
+        expression. Catching SNOWFLAKE / DATABRICKS lets third-party models
+        whose authors omitted ANSI_SQL still convert, since their aggregation
+        syntax is ANSI-compatible.
+        """
+        if not isinstance(expr_obj, dict):
+            return "", ""
+        dialects = expr_obj.get("dialects", [])
+        by_name = {
+            d.get("dialect"): d.get("expression", "")
+            for d in dialects
+            if isinstance(d, dict) and d.get("expression")
+        }
+        for dialect in _SQL_PARSEABLE_DIALECTS:
+            expr = by_name.get(dialect)
+            if expr:
+                return expr, dialect
+        return "", ""
+
+    @staticmethod
+    def _unquote_identifier(ident: str) -> str:
+        """Strip SQL identifier quoting (double quotes, backticks, or brackets)."""
+        ident = ident.strip()
+        if len(ident) >= 2 and (
+            (ident[0] == '"' and ident[-1] == '"')
+            or (ident[0] == "`" and ident[-1] == "`")
+            or (ident[0] == "[" and ident[-1] == "]")
+        ):
+            return ident[1:-1]
+        return ident
+
+    def _resolve_column_refs(
+        self, expr: str, ds_lc: dict[str, str], fields_lc: dict[str, dict[str, str]]
+    ) -> str | None:
+        """Rewrite ``dataset.column`` references to canonical OSI names.
+
+        Identifiers are matched case-insensitively and with SQL quoting
+        stripped, so Snowflake/Databricks forms such as ``SUM(ORDERS.AMOUNT)``
+        or ``SUM("Orders"."amount")`` resolve to the real ``Orders.amount``.
+        Returns the rewritten expression, or ``None`` if any reference cannot be
+        mapped (the caller then preserves the metric verbatim rather than emit a
+        dangling reference that would fail query resolution).
+        """
+        unresolved = False
+
+        def repl(match: re.Match[str]) -> str:
+            nonlocal unresolved
+            ds_real = ds_lc.get(self._unquote_identifier(match.group("ds")).lower())
+            if ds_real is None:
+                unresolved = True
+                return match.group(0)
+            col_real = fields_lc.get(ds_real, {}).get(
+                self._unquote_identifier(match.group("col")).lower()
+            )
+            if col_real is None:
+                unresolved = True
+                return match.group(0)
+            return f"{ds_real}.{col_real}"
+
+        rewritten = _COLUMN_REF_RE.sub(repl, expr)
+        return None if unresolved else rewritten
+
+    def _preserve_unconverted_metric(self, osi_metric: dict, reason: str) -> None:
+        """Preserve an OSI metric that has no OBML representation.
+
+        OBML cannot express the metric, but dropping it silently would break
+        the README's roundtrip promise. Instead the original OSI metric is kept
+        verbatim (re-emitted on OBML -> OSI) and a loud LOSSY warning is raised:
+        the metric is preserved but NOT queryable through OBML.
+        """
+        self._unconverted_metrics.append(osi_metric)
+        self.warnings.append(
+            f"LOSSY: OSI metric '{osi_metric.get('name', '?')}' has no OBML representation "
+            f"({reason}); preserved verbatim for OSI -> OBML -> OSI roundtrip but it is "
+            f"NOT queryable in OBML."
+        )
 
     def _parse_simple_agg(self, expr: str) -> tuple | None:
         """
@@ -1007,10 +1156,16 @@ class OSItoOBML:
         return agg.lower(), inner
 
     def _sql_refs_to_obml(self, sql_expr: str) -> str:
-        """Convert dataset.column references in SQL to OBML {[dataset].[column]} syntax."""
-        import re
+        """Convert dataset.column references in SQL to OBML {[dataset].[column]} syntax.
 
-        return re.sub(r"(\w+)\.(\w+)", r"{[\1].[\2]}", sql_expr)
+        Uses the shared identifier matcher so decimal literals (``1.23``) are not
+        mistaken for references; only identifiers that start with a letter or
+        underscore are rewritten. By this point references are already canonical
+        (resolved upstream), so the bare-identifier branch is what fires.
+        """
+        return _COLUMN_REF_RE.sub(
+            lambda m: "{[" + m.group("ds") + "].[" + m.group("col") + "]}", sql_expr
+        )
 
     def _decompose_complex_metric(self, name: str, expr: str) -> tuple[str, dict]:
         """
@@ -1124,11 +1279,11 @@ class OBMLtoOSI:
         self.warnings: list[str] = []
 
     def convert(self) -> dict:
+        # Reset warnings so a second convert() call on the same instance does
+        # not duplicate them.
+        self.warnings = []
+
         osi: dict[str, Any] = {"version": _OSI_VERSION}
-        # Vendor names accumulate as we emit custom_extensions so we can
-        # populate the v0.2 top-level ``vendors`` informational array at the
-        # end of the conversion.
-        self._used_vendors: set[str] = {_VENDOR_OBML}
 
         data_objects = self.obml.get("dataObjects", {})
         obml_dimensions = self.obml.get("dimensions", {})
@@ -1146,6 +1301,12 @@ class OBMLtoOSI:
 
         # ── Metrics (OBML measures + metrics → OSI metrics) ────────
         osi_metrics = self._convert_measures_and_metrics(obml_measures, obml_metrics, data_objects)
+
+        # Re-emit OSI metrics that OBML could not represent and that the import
+        # path preserved verbatim (vendor OSI, ``obml_unconverted_metrics``).
+        # This closes the OSI -> OBML -> OSI roundtrip for non-SQL or
+        # non-decomposable metrics.
+        self._merge_restored_metrics(osi_metrics)
 
         # ── Build semantic model ────────────────────────────────────
         sem_model: dict[str, Any] = {"name": self.model_name}
@@ -1196,19 +1357,14 @@ class OBMLtoOSI:
 
         osi["semantic_model"] = [sem_model]
 
-        # v0.2 informational enums — only what's actually used in the doc.
-        # ANSI_SQL is always emitted (every OBML measure compiles via it).
-        osi["dialects"] = ["ANSI_SQL"]
-        vendors_emitted = sorted(self._used_vendors)
-        if vendors_emitted:
-            osi["vendors"] = vendors_emitted
-
+        # The published OSI core schema forbids root-level ``dialects`` /
+        # ``vendors`` (root is additionalProperties:false, only ``version`` +
+        # ``semantic_model``). Dialects live per-expression in
+        # ``expression.dialects[]`` and vendors per-entity in
+        # ``custom_extensions[].vendor_name`` — the schema-valid homes — so the
+        # document stays fully conformant without root advertisement arrays.
+        # See OSI PR #148 (and the single-document-dialect direction in #52).
         return osi
-
-    def _record_vendor(self, vendor_name: str) -> None:
-        """Record a vendor seen during emission; populates the top-level
-        ``vendors`` informational array. Safe to call repeatedly."""
-        self._used_vendors.add(vendor_name)
 
     def _emit_foreign_extensions(self, obml_exts: list[dict] | None, osi_exts: list[dict]) -> None:
         """Re-emit third-party OBML customExtensions as OSI custom_extensions.
@@ -1221,7 +1377,6 @@ class OBMLtoOSI:
             vendor = ext.get("vendor")
             if vendor and vendor not in _INTERNAL_VENDORS:
                 osi_exts.append({"vendor_name": vendor, "data": ext.get("data", "")})
-                self._record_vendor(vendor)
 
     def _convert_data_object(
         self, do_name: str, do_obj: dict, obml_dimensions: dict
@@ -1408,7 +1563,6 @@ class OBMLtoOSI:
                 continue
             if ext_label_data.get("obml_field_label"):
                 field["label"] = ext_label_data["obml_field_label"]
-                self._record_vendor(_VENDOR_OSI)
                 break
 
         # Restore ai_context from customExtensions (OSI vendor) if present
@@ -1552,6 +1706,48 @@ class OBMLtoOSI:
             codes.append(col.get("code", display.lower().replace(" ", "_")))
         return codes
 
+    def _restore_unconverted_metrics(self) -> list[dict]:
+        """Recover OSI metrics preserved verbatim during OSI -> OBML import.
+
+        The import path stashes metrics OBML can't represent under an OSI-vendor
+        model-level customExtension (``obml_unconverted_metrics``). Re-emit them
+        unchanged so a full OSI -> OBML -> OSI roundtrip keeps them.
+        """
+        restored: list[dict] = []
+        for ext in self.obml.get("customExtensions", []) or []:
+            if ext.get("vendor") not in _OSI_VENDOR_READ:
+                continue
+            try:
+                data = json.loads(ext.get("data", "{}"))
+            except (json.JSONDecodeError, TypeError):
+                continue
+            preserved = data.get("obml_unconverted_metrics")
+            if isinstance(preserved, list):
+                restored.extend(m for m in preserved if isinstance(m, dict))
+        return restored
+
+    def _merge_restored_metrics(self, osi_metrics: list[dict]) -> None:
+        """Append preserved (unconverted) OSI metrics to the converted ones.
+
+        Name-collision guard: if a queryable OBML measure/metric now owns a name
+        a stale preserved metric also uses, skip the preserved copy (the real
+        metric wins) so the OSI output has no duplicate metric names and passes
+        semantic validation. Each appended metric carries its own dialects
+        (``expression.dialects[]``) and vendors (``custom_extensions``)
+        verbatim, which are the schema-valid homes for that metadata.
+        """
+        existing = {m.get("name") for m in osi_metrics if isinstance(m, dict)}
+        for restored in self._restore_unconverted_metrics():
+            name = restored.get("name")
+            if name in existing:
+                self.warnings.append(
+                    f"Preserved OSI metric '{name}' dropped on export: a converted "
+                    f"OBML metric now uses that name."
+                )
+                continue
+            existing.add(name)
+            osi_metrics.append(restored)
+
     def _convert_measures_and_metrics(
         self, obml_measures: dict, obml_metrics: dict, data_objects: dict
     ) -> list:
@@ -1634,7 +1830,6 @@ class OBMLtoOSI:
             }
             if ai_ctx:
                 measure_metric["ai_context"] = ai_ctx
-            self._record_vendor("DATABRICKS")
             self._add_obml_measure_extras(
                 measure_metric, {**measure, "_extra_obml_aggregation": "measure"}
             )

--- a/packages/osi-orionbelt/src/osi_orionbelt/schemas/osi-schema.json
+++ b/packages/osi-orionbelt/src/osi_orionbelt/schemas/osi-schema.json
@@ -10,20 +10,6 @@
       "const": "0.2.0.dev0",
       "description": "OSI specification version"
     },
-    "dialects": {
-      "type": "array",
-      "description": "Supported expression language dialects (enumeration definition)",
-      "items": {
-        "$ref": "#/$defs/Dialect"
-      }
-    },
-    "vendors": {
-      "type": "array",
-      "description": "List of vendor names used in custom extensions within this model",
-      "items": {
-        "$ref": "#/$defs/Vendor"
-      }
-    },
     "semantic_model": {
       "type": "array",
       "description": "Collection of semantic model definitions",

--- a/packages/osi-orionbelt/tests/test_osi_converter_measure_overrides.py
+++ b/packages/osi-orionbelt/tests/test_osi_converter_measure_overrides.py
@@ -267,11 +267,6 @@ class TestMeasureAggregationRoundtrip:
         expr = metrics["Total Revenue"]["expression"]["dialects"][0]["expression"]
         assert expr == 'MEASURE("Total Revenue")'
 
-    def test_obml_to_osi_records_databricks_vendor(self):
-        obml = self._delegated_obml()
-        osi = conv.OBMLtoOSI(obml).convert()
-        assert "DATABRICKS" in osi.get("vendors", [])
-
     def test_obml_to_osi_stashes_aggregation_marker(self):
         obml = self._delegated_obml()
         osi = conv.OBMLtoOSI(obml).convert()

--- a/packages/osi-orionbelt/tests/test_osi_converter_vendors.py
+++ b/packages/osi-orionbelt/tests/test_osi_converter_vendors.py
@@ -42,7 +42,6 @@ class TestOwnVendorTags:
         osi = conv.OBMLtoOSI(obml).convert()
         ce = osi["semantic_model"][0]["custom_extensions"]
         assert all(e["vendor_name"] == "ORIONBELT" for e in ce)
-        assert "ORIONBELT" in osi["vendors"]
 
     def test_osi_to_obml_native_stash_uses_osi_vendor(self) -> None:
         osi = {
@@ -129,8 +128,6 @@ class TestForeignVendorRoundtrip:
         assert "DBT" in model_vendors
         assert "SALESFORCE" in ds_vendors
         assert "GOODDATA" in field_vendors
-        for v in ("DBT", "SALESFORCE", "GOODDATA", "ORIONBELT"):
-            assert v in osi["vendors"]
 
     def test_foreign_metric_roundtrip(self) -> None:
         osi_in = {
@@ -173,7 +170,6 @@ class TestForeignVendorRoundtrip:
         osi_out = conv.OBMLtoOSI(obml, "demo").convert()
         metric = osi_out["semantic_model"][0]["metrics"][0]
         assert any(e["vendor_name"] == "LOOKER" for e in metric["custom_extensions"])
-        assert "LOOKER" in osi_out["vendors"]
 
     def test_foreign_dimension_emitted_to_field(self) -> None:
         # OSI has no separate dimension entity, so an OBML dimension's foreign
@@ -203,7 +199,6 @@ class TestForeignVendorRoundtrip:
             f for f in osi["semantic_model"][0]["datasets"][0]["fields"] if f["name"] == "status"
         )
         assert any(e["vendor_name"] == "TABLEAU" for e in field["custom_extensions"])
-        assert "TABLEAU" in osi["vendors"]
 
 
 class TestLegacyBackCompat:

--- a/packages/osi-orionbelt/tests/test_osi_metric_no_silent_loss.py
+++ b/packages/osi-orionbelt/tests/test_osi_metric_no_silent_loss.py
@@ -1,0 +1,365 @@
+"""Third-party OSI metrics must never be silently lost on import.
+
+Regression coverage for the review on OSI PR #153: the converter only emits
+``ANSI_SQL`` on the OBML -> OSI path, so our own roundtrip corpus never exercised
+the import drop paths. A genuinely foreign OSI model (Snowflake/Databricks
+authored, or a non-SQL dialect) hit them and lost metrics with only a warning.
+
+Two guarantees are tested here:
+
+1. **Dialect catching** - a metric whose only expression is ``SNOWFLAKE`` or
+   ``DATABRICKS`` (SQL engines OrionBelt targets) is converted, not dropped.
+2. **No silent loss** - a metric with only a non-SQL dialect (``MDX``), or an
+   expression OBML can't decompose, is preserved verbatim (re-emitted on the way
+   back) and raises a loud ``LOSSY:`` warning.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import osi_orionbelt.converter as conv
+
+
+def _osi_model(metrics: list[dict[str, Any]]) -> dict[str, Any]:
+    """Minimal single-dataset OSI v0.2 model carrying the given metrics."""
+    return {
+        "version": "0.2.0.dev0",
+        "semantic_model": [
+            {
+                "name": "sales",
+                "datasets": [
+                    {
+                        "name": "Orders",
+                        "source": "ANALYTICS.PUBLIC.ORDERS",
+                        "fields": [
+                            {"name": "amount", "data_type": "number"},
+                            {"name": "id", "data_type": "integer"},
+                        ],
+                    }
+                ],
+                "metrics": metrics,
+            }
+        ],
+    }
+
+
+def _metric(name: str, dialect: str, expression: str, **extra: Any) -> dict[str, Any]:
+    m: dict[str, Any] = {
+        "name": name,
+        "expression": {"dialects": [{"dialect": dialect, "expression": expression}]},
+    }
+    m.update(extra)
+    return m
+
+
+class TestDialectCatching:
+    """SNOWFLAKE / DATABRICKS aggregations convert like ANSI_SQL."""
+
+    def test_snowflake_simple_agg_becomes_measure(self) -> None:
+        osi = _osi_model([_metric("Total Amount", "SNOWFLAKE", "SUM(Orders.amount)")])
+        converter = conv.OSItoOBML(osi)
+        obml = converter.convert()
+
+        assert "Total Amount" in obml.get("measures", {})
+        assert obml["measures"]["Total Amount"]["aggregation"] == "sum"
+        # Converted cleanly - no loss warning, nothing stashed.
+        assert not any(w.startswith("LOSSY:") for w in converter.warnings)
+        assert "customExtensions" not in obml or all(
+            "obml_unconverted_metrics" not in ext.get("data", "")
+            for ext in obml["customExtensions"]
+        )
+
+    def test_databricks_expression_agg_becomes_measure(self) -> None:
+        osi = _osi_model([_metric("Net", "DATABRICKS", "SUM(Orders.amount * Orders.amount)")])
+        converter = conv.OSItoOBML(osi)
+        obml = converter.convert()
+
+        assert "Net" in obml.get("measures", {})
+        assert not any(w.startswith("LOSSY:") for w in converter.warnings)
+
+    def test_snowflake_uppercased_identifiers_resolve_to_canonical(self) -> None:
+        # Snowflake commonly upper-cases identifiers. They must resolve back to
+        # the real OSI dataset/field names, not produce refs to ORDERS.AMOUNT.
+        osi = _osi_model([_metric("Total Amount", "SNOWFLAKE", "SUM(ORDERS.AMOUNT)")])
+        converter = conv.OSItoOBML(osi)
+        obml = converter.convert()
+
+        ref = obml["measures"]["Total Amount"]["columns"][0]
+        assert ref == {"dataObject": "Orders", "column": "amount"}
+        assert not any(w.startswith("LOSSY:") for w in converter.warnings)
+
+    def test_quoted_identifiers_resolve_to_canonical(self) -> None:
+        # Quoted forms must be unquoted and resolved, not fall through to an
+        # expression measure containing raw "Orders"."amount".
+        osi = _osi_model([_metric("Total Amount", "SNOWFLAKE", 'SUM("Orders"."amount")')])
+        converter = conv.OSItoOBML(osi)
+        obml = converter.convert()
+
+        measure = obml["measures"]["Total Amount"]
+        assert measure["columns"][0] == {"dataObject": "Orders", "column": "amount"}
+        assert "expression" not in measure  # resolved to a simple-agg measure
+        assert not any(w.startswith("LOSSY:") for w in converter.warnings)
+
+    def test_decimal_literals_not_rewritten_as_refs(self) -> None:
+        # A decimal literal inside an expression measure must stay literal, not
+        # become an OBML ref like {[1].[23]} (which fails validate_obml).
+        osi = _osi_model([_metric("Scaled", "ANSI_SQL", "SUM(Orders.amount * 1.23)")])
+        obml = conv.OSItoOBML(osi).convert()
+        measure = (obml.get("measures") or {}).get("Scaled") or (obml.get("metrics") or {})[
+            "Scaled"
+        ]
+        assert "1.23" in measure["expression"]
+        assert "{[1]" not in measure["expression"]
+        assert conv.validate_obml(obml).valid
+
+    def test_expression_agg_identifiers_resolved(self) -> None:
+        # Canonical refs inside an expression measure, from upper-cased input.
+        osi = _osi_model([_metric("Net", "SNOWFLAKE", "SUM(ORDERS.AMOUNT * ORDERS.ID)")])
+        obml = conv.OSItoOBML(osi).convert()
+        expr = obml["measures"]["Net"]["expression"]
+        assert "{[Orders].[amount]}" in expr and "{[Orders].[id]}" in expr
+        assert "ORDERS" not in expr
+
+    def test_unmappable_reference_is_preserved_not_dangling(self) -> None:
+        # A column that does not exist in the model must not become a dangling
+        # OBML reference; the metric is preserved verbatim with a LOSSY warning.
+        osi = _osi_model([_metric("Bogus", "SNOWFLAKE", "SUM(Orders.nonexistent)")])
+        converter = conv.OSItoOBML(osi)
+        obml = converter.convert()
+
+        assert "Bogus" not in obml.get("measures", {})
+        assert "Bogus" not in obml.get("metrics", {})
+        assert any(m["name"] == "Bogus" for m in _unconverted_stash(obml))
+        assert any(w.startswith("LOSSY:") and "Bogus" in w for w in converter.warnings)
+
+    def test_unknown_dataset_reference_is_preserved(self) -> None:
+        osi = _osi_model([_metric("Cross", "SNOWFLAKE", "SUM(Unknown.amount)")])
+        converter = conv.OSItoOBML(osi)
+        obml = converter.convert()
+        assert "Cross" not in obml.get("measures", {})
+        assert any(m["name"] == "Cross" for m in _unconverted_stash(obml))
+
+    def test_ansi_preferred_over_other_dialects(self) -> None:
+        osi = _osi_model(
+            [
+                {
+                    "name": "Total Amount",
+                    "expression": {
+                        "dialects": [
+                            {"dialect": "SNOWFLAKE", "expression": "SUM(Orders.amount)"},
+                            {"dialect": "ANSI_SQL", "expression": "SUM(Orders.id)"},
+                        ]
+                    },
+                }
+            ]
+        )
+        obml = conv.OSItoOBML(osi).convert()
+        # ANSI_SQL wins regardless of ordering -> column is `id`, not `amount`.
+        assert obml["measures"]["Total Amount"]["columns"][0]["column"] == "id"
+
+
+class TestNoSilentLoss:
+    """Non-convertible metrics are preserved + warned, never dropped."""
+
+    def test_non_sql_dialect_is_preserved_not_dropped(self) -> None:
+        osi = _osi_model([_metric("Mdx Thing", "MDX", "[Measures].[Amount]")])
+        converter = conv.OSItoOBML(osi)
+        obml = converter.convert()
+
+        # Not emitted as an OBML measure/metric...
+        assert "Mdx Thing" not in obml.get("measures", {})
+        assert "Mdx Thing" not in obml.get("metrics", {})
+        # ...but preserved verbatim under the OSI vendor...
+        stash = _unconverted_stash(obml)
+        assert any(m["name"] == "Mdx Thing" for m in stash)
+        # ...and loudly flagged.
+        assert any(w.startswith("LOSSY:") and "Mdx Thing" in w for w in converter.warnings)
+
+    def test_real_maql_metric_syntax_is_preserved(self) -> None:
+        # MAQL is an analytical query language, not SQL, with `{fact/...}` /
+        # `{metric/...}` object references. A MAQL-only metric must be preserved
+        # verbatim, not mis-parsed as SQL and dropped.
+        maql = "SELECT SUM({fact/store_sales.fact.store_sales.ss_net_profit})"
+        osi = _osi_model([_metric("Total Profit", "MAQL", maql)])
+        converter = conv.OSItoOBML(osi)
+        obml = converter.convert()
+
+        assert "Total Profit" not in obml.get("measures", {})
+        preserved = next((m for m in _unconverted_stash(obml) if m["name"] == "Total Profit"), None)
+        assert preserved is not None
+        # Verbatim: the MAQL expression survives untouched for the round trip.
+        assert preserved["expression"]["dialects"][0]["expression"] == maql
+        assert any(w.startswith("LOSSY:") and "Total Profit" in w for w in converter.warnings)
+
+    def test_undecomposable_sql_is_preserved_not_dropped(self) -> None:
+        # A non-aggregated expression: no AGG(...) to lift into a measure, so
+        # it decomposes into nothing and cannot become an OBML metric.
+        osi = _osi_model([_metric("Ratio", "ANSI_SQL", "Orders.amount / Orders.id")])
+        converter = conv.OSItoOBML(osi)
+        obml = converter.convert()
+
+        assert "Ratio" not in obml.get("measures", {})
+        assert "Ratio" not in obml.get("metrics", {})
+        assert any(m["name"] == "Ratio" for m in _unconverted_stash(obml))
+        assert any(w.startswith("LOSSY:") and "Ratio" in w for w in converter.warnings)
+
+    def test_roundtrip_restores_preserved_metric(self) -> None:
+        original = _metric("Mdx Thing", "MDX", "[Measures].[Amount]", description="from cube")
+        osi = _osi_model([original])
+
+        obml = conv.OSItoOBML(osi).convert()
+        osi_again = conv.OBMLtoOSI(obml, "sales").convert()
+
+        metrics = osi_again["semantic_model"][0].get("metrics", [])
+        restored = next((m for m in metrics if m["name"] == "Mdx Thing"), None)
+        assert restored is not None
+        # Verbatim: expression dialect + description survive the round trip.
+        assert restored["description"] == "from cube"
+        assert restored["expression"]["dialects"][0]["dialect"] == "MDX"
+
+    def test_mixed_model_keeps_convertible_and_preserves_rest(self) -> None:
+        osi = _osi_model(
+            [
+                _metric("Total Amount", "SNOWFLAKE", "SUM(Orders.amount)"),
+                _metric("Mdx Thing", "MDX", "[Measures].[Amount]"),
+            ]
+        )
+        converter = conv.OSItoOBML(osi)
+        obml = converter.convert()
+
+        assert "Total Amount" in obml["measures"]
+        assert any(m["name"] == "Mdx Thing" for m in _unconverted_stash(obml))
+        lossy = [w for w in converter.warnings if w.startswith("LOSSY:")]
+        assert len(lossy) == 1 and "Mdx Thing" in lossy[0]
+
+
+class TestRestoredMetricMetadata:
+    """A preserved metric's dialect/vendor survive on the metric itself, not in
+    a (non-conformant) root array. See OSI PR #148."""
+
+    def test_preserved_metric_keeps_dialect_and_vendor_on_the_metric(self) -> None:
+        # MDX metric carrying a GOODDATA custom extension. After OSI -> OBML ->
+        # OSI the metric round-trips with its dialect on expression.dialects[]
+        # and its vendor on custom_extensions - the schema-valid homes.
+        metric = _metric("Cube Metric", "MDX", "[Measures].[Amount]")
+        metric["custom_extensions"] = [{"vendor_name": "GOODDATA", "data": "{}"}]
+        osi = _osi_model([metric])
+
+        obml = conv.OSItoOBML(osi).convert()
+        osi_again = conv.OBMLtoOSI(obml, "sales").convert()
+
+        restored = next(
+            m for m in osi_again["semantic_model"][0]["metrics"] if m["name"] == "Cube Metric"
+        )
+        assert [d["dialect"] for d in restored["expression"]["dialects"]] == ["MDX"]
+        assert any(e["vendor_name"] == "GOODDATA" for e in restored["custom_extensions"])
+
+    def test_no_root_dialects_or_vendors_emitted(self) -> None:
+        # The output must stay schema-conformant: no root-level dialects/vendors,
+        # whether or not a preserved metric is present.
+        osi = _osi_model(
+            [
+                _metric("Total", "ANSI_SQL", "SUM(Orders.amount)"),
+                _metric("Cube Metric", "MDX", "[Measures].[Amount]"),
+            ]
+        )
+        obml = conv.OSItoOBML(osi).convert()
+        osi_again = conv.OBMLtoOSI(obml, "sales").convert()
+        assert "dialects" not in osi_again
+        assert "vendors" not in osi_again
+
+
+class TestStaleStashNameCollision:
+    """A queryable OBML metric wins over a stale preserved metric of same name."""
+
+    def test_collision_drops_preserved_copy_not_duplicate(self) -> None:
+        # Import an unconvertible metric named "Revenue"...
+        osi = _osi_model([_metric("Revenue", "MDX", "[Measures].[Rev]")])
+        obml = conv.OSItoOBML(osi).convert()
+        assert any(m["name"] == "Revenue" for m in _unconverted_stash(obml))
+
+        # ...then the user adds a real OBML measure with the same name.
+        obml["measures"] = {
+            "Revenue": {
+                "columns": [{"dataObject": "Orders", "column": "amount"}],
+                "resultType": "float",
+                "aggregation": "sum",
+            }
+        }
+
+        converter = conv.OBMLtoOSI(obml, "sales")
+        osi_again = converter.convert()
+
+        metrics = osi_again["semantic_model"][0].get("metrics", [])
+        revenue = [m for m in metrics if m["name"] == "Revenue"]
+        # Exactly one "Revenue" — no duplicate that would fail validation.
+        assert len(revenue) == 1
+        # The queryable (converted) one wins: it has a real SQL expression.
+        assert revenue[0]["expression"]["dialects"][0]["dialect"] == "ANSI_SQL"
+        # And the drop is reported.
+        assert any("Revenue" in w and "dropped on export" in w for w in converter.warnings)
+
+    def test_output_passes_osi_validation_after_collision(self) -> None:
+        pytest.importorskip("jsonschema")  # validate_osi needs it
+        osi = _osi_model([_metric("Revenue", "MDX", "[Measures].[Rev]")])
+        obml = conv.OSItoOBML(osi).convert()
+        obml["measures"] = {
+            "Revenue": {
+                "columns": [{"dataObject": "Orders", "column": "amount"}],
+                "resultType": "float",
+                "aggregation": "sum",
+            }
+        }
+        osi_again = conv.OBMLtoOSI(obml, "sales").convert()
+        result = conv.validate_osi(osi_again)
+        assert result.valid, result.errors
+
+
+class TestIdempotency:
+    """convert() may be called twice on one instance without duplication."""
+
+    def test_osi_to_obml_convert_is_idempotent(self) -> None:
+        osi = _osi_model(
+            [
+                _metric("Total Amount", "ANSI_SQL", "SUM(Orders.amount)"),
+                _metric("Mdx Thing", "MDX", "[Measures].[Amount]"),
+            ]
+        )
+        converter = conv.OSItoOBML(osi)
+        first = converter.convert()
+        first_warnings = list(converter.warnings)
+        second = converter.convert()
+
+        # Preserved-metric stash is not duplicated on the second pass.
+        assert len(_unconverted_stash(first)) == 1
+        assert len(_unconverted_stash(second)) == 1
+        # Warnings do not accumulate across calls.
+        assert converter.warnings == first_warnings
+
+    def test_obml_to_osi_convert_is_idempotent(self) -> None:
+        obml = conv.OSItoOBML(
+            _osi_model([_metric("Mdx Thing", "MDX", "[Measures].[Amount]")])
+        ).convert()
+        converter = conv.OBMLtoOSI(obml, "sales")
+        converter.convert()
+        warnings_after_first = list(converter.warnings)
+        osi_again = converter.convert()
+
+        metrics = osi_again["semantic_model"][0].get("metrics", [])
+        assert [m["name"] for m in metrics].count("Mdx Thing") == 1
+        assert converter.warnings == warnings_after_first
+
+
+def _unconverted_stash(obml: dict[str, Any]) -> list[dict[str, Any]]:
+    """Pull the preserved OSI metrics out of the OSI-vendor customExtension."""
+    import json
+
+    for ext in obml.get("customExtensions", []) or []:
+        if ext.get("vendor") in ("OSI", "OBSL"):
+            data = json.loads(ext.get("data", "{}"))
+            if "obml_unconverted_metrics" in data:
+                return data["obml_unconverted_metrics"]
+    return []

--- a/packages/osi-orionbelt/tests/test_osi_v02_compat.py
+++ b/packages/osi-orionbelt/tests/test_osi_v02_compat.py
@@ -39,6 +39,25 @@ def schema_validator() -> Any:
     return jsonschema.Draft202012Validator(schema)
 
 
+def _collect_vendor_names(osi: dict[str, Any]) -> set[str]:
+    """Every ``custom_extensions[].vendor_name`` anywhere in an OSI document."""
+    found: set[str] = set()
+
+    def walk(node: Any) -> None:
+        if isinstance(node, dict):
+            for ext in node.get("custom_extensions", []) or []:
+                if isinstance(ext, dict) and ext.get("vendor_name"):
+                    found.add(ext["vendor_name"])
+            for v in node.values():
+                walk(v)
+        elif isinstance(node, list):
+            for v in node:
+                walk(v)
+
+    walk(osi)
+    return found
+
+
 _OBML_WITH_PK_AND_LABEL: dict[str, Any] = {
     "version": 1.0,
     "dataObjects": {
@@ -140,17 +159,29 @@ class TestEmittedVersion:
         assert osi["version"] == conv._OSI_VERSION
         assert osi["version"].startswith("0.2")
 
-    def test_dialects_array_present(self) -> None:
+    def test_no_root_dialects_or_vendors(self) -> None:
+        # The published OSI core schema forbids root-level dialects/vendors
+        # (root is additionalProperties:false). See OSI PR #148.
         osi = conv.OBMLtoOSI(_OBML_WITH_PK_AND_LABEL).convert()
-        assert osi["dialects"] == ["ANSI_SQL"]
+        assert "dialects" not in osi
+        assert "vendors" not in osi
+        assert set(osi.keys()) <= {"version", "semantic_model"}
 
-    def test_vendors_array_present(self) -> None:
+    def test_dialect_tagged_per_expression(self) -> None:
+        # Dialects live on each expression, the schema-valid home.
         osi = conv.OBMLtoOSI(_OBML_WITH_PK_AND_LABEL).convert()
-        # ORIONBELT tags our roundtrip metadata; OSI tags the restored native
-        # field label. (The input fixture uses the legacy OBSL tag, exercising
-        # back-compat reads.)
-        assert "ORIONBELT" in osi["vendors"]
-        assert "OSI" in osi["vendors"]
+        for metric in osi["semantic_model"][0].get("metrics", []):
+            tags = [d["dialect"] for d in metric["expression"]["dialects"]]
+            assert "ANSI_SQL" in tags
+
+    def test_vendor_tagged_per_entity_not_root(self) -> None:
+        # ORIONBELT tags our roundtrip metadata in per-entity custom_extensions,
+        # not a root array. The OBML field label round-trips as a *native* OSI
+        # field label (no vendor tag needed).
+        osi = conv.OBMLtoOSI(_OBML_WITH_PK_AND_LABEL).convert()
+        assert "ORIONBELT" in _collect_vendor_names(osi)
+        fields = osi["semantic_model"][0]["datasets"][0]["fields"]
+        assert any(f.get("label") for f in fields), "expected a native OSI field label"
 
 
 # ---------------------------------------------------------------------------
@@ -325,6 +356,15 @@ class TestSchemaValidation:
         osi = conv.OBMLtoOSI(obml).convert()
         errors = list(schema_validator.iter_errors(osi))
         assert errors == [], [e.message for e in errors[:5]]
+
+    def test_schema_rejects_root_dialects_and_vendors(self, schema_validator: Any) -> None:
+        """Guard OSI PR #148: root-level dialects/vendors are non-conformant."""
+        osi = conv.OBMLtoOSI(_OBML_WITH_PK_AND_LABEL).convert()
+        osi["dialects"] = ["ANSI_SQL"]
+        osi["vendors"] = ["ORIONBELT"]
+        messages = [e.message for e in schema_validator.iter_errors(osi)]
+        assert any("dialects" in m for m in messages), messages
+        assert any("vendors" in m for m in messages), messages
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Re-do of the earlier OSI converter fix as a clean, OSI-only PR (the previous attempt was accidentally branched off `feature/acr-composability` and bundled ACR; that was rolled back).

Scope: `packages/osi-orionbelt` only - no ACR, no version bump.

- Dialect catching (ANSI_SQL / SNOWFLAKE / DATABRICKS); non-SQL dialects preserved.
- Identifier resolution (case-insensitive, quote-stripped) against the dataset/field map; unmappable refs and decimal literals handled safely.
- No silent metric loss: preserve-verbatim + `LOSSY:` warning; lossless OSI -> OBML -> OSI roundtrip.
- Schema conformance: no root-level dialects/vendors (aligns with OSI PR #148).
- Name-collision safety + idempotent `convert()`.

141 tests pass, ruff/format/mypy clean. Mirrors OSI PR #153.