### PR TITLE
docs: stable explicit anchor for statistical-aggregates section

### DIFF
--- a/docs/comparison/dbt.md
+++ b/docs/comparison/dbt.md
@@ -204,7 +204,7 @@ OBSL `Measure.aggregation` ships 9 statistical functions that dbt SL doesn't exp
 | `covar_pop`, `covar_samp` | `COVAR_POP(x, y)`, `COVAR_SAMP(x, y)` | 2 |
 | `regr_slope`, `regr_intercept` | `REGR_SLOPE(y, x)`, `REGR_INTERCEPT(y, x)` | 2 |
 
-OBSL validates column arity at model-load time and gates dialect support at compile time (MySQL rejects correlation/covariance/regression; BigQuery + ClickHouse reject linear regression — all with a hard `UnsupportedAggregationError`, no silent fallback). See [Trend Analysis](../guide/trend-analysis.md#3-statistical-aggregates-on-measure) for the full coverage matrix.
+OBSL validates column arity at model-load time and gates dialect support at compile time (MySQL rejects correlation/covariance/regression; BigQuery + ClickHouse reject linear regression — all with a hard `UnsupportedAggregationError`, no silent fallback). See [Trend Analysis](../guide/trend-analysis.md#statistical-aggregates-on-measure) for the full coverage matrix.
 
 ---
 

--- a/docs/guide/model-format.md
+++ b/docs/guide/model-format.md
@@ -410,7 +410,7 @@ measures:
 
 #### Statistical aggregates
 
-Single-column aggregates take exactly one entry in `columns`; two-column aggregates take exactly two (arity is enforced at model-load time, error code `INVALID_AGGREGATION_INPUTS`). Dialect coverage varies — MySQL has no correlation / covariance / regression; BigQuery and ClickHouse lack the linear-regression family. Unsupported combinations raise `UNSUPPORTED_AGGREGATION_FOR_DIALECT` at compile time. See [Trend Analysis](trend-analysis.md#3-statistical-aggregates-on-measure) for the full coverage matrix and a worked example.
+Single-column aggregates take exactly one entry in `columns`; two-column aggregates take exactly two (arity is enforced at model-load time, error code `INVALID_AGGREGATION_INPUTS`). Dialect coverage varies — MySQL has no correlation / covariance / regression; BigQuery and ClickHouse lack the linear-regression family. Unsupported combinations raise `UNSUPPORTED_AGGREGATION_FOR_DIALECT` at compile time. See [Trend Analysis](trend-analysis.md#statistical-aggregates-on-measure) for the full coverage matrix and a worked example.
 
 | Type | SQL | Arity |
 |------|-----|:---:|

--- a/docs/guide/trend-analysis.md
+++ b/docs/guide/trend-analysis.md
@@ -129,7 +129,7 @@ No new compiler logic — `DERIVED` already composes any metric by name.
 | `lag` / `lead` require `offset >= 1` and `timeDimension:` | `INVALID_LAG_LEAD` |
 | `ntile` requires `buckets >= 2` | `INVALID_NTILE_BUCKETS` |
 
-## 3. Statistical aggregates on Measure
+## 3. Statistical aggregates on Measure { #statistical-aggregates-on-measure }
 
 Nine new values for `Measure.aggregation`: four single-column and five
 two-column. No new metric type.


### PR DESCRIPTION
## Problem

The trend-analysis heading `## 3. Statistical aggregates on Measure` slugifies to `3-statistical-aggregates-on-measure` (MkDocs folds the leading "3." into the id). Cross-page links were therefore coupled to the heading text: any renumber or reword would silently break the anchor again.

## Fix (durable)

- Give the heading an explicit `attr_list` id so the slug no longer depends on the visible text:
  `## 3. Statistical aggregates on Measure { #statistical-aggregates-on-measure }`
- Point the two linking pages (`guide/model-format.md`, `comparison/dbt.md`) at the stable slug `#statistical-aggregates-on-measure`.
- `attr_list` was already enabled in `mkdocs.yml`.

## Verification

- `mkdocs build --strict` passes clean.
- `id="statistical-aggregates-on-measure"` present in built `site/guide/trend-analysis/index.html`.
- Zero leftover `#3-statistical-aggregates-on-measure` links in `site/`.
- All linking pages resolve to the stable slug.

Docs-only; no source/code changes.