### PR TITLE
fix(api,ui): disallow crawler indexing via robots.txt

### DIFF
--- a/src/orionbelt/api/app.py
+++ b/src/orionbelt/api/app.py
@@ -628,7 +628,11 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
     @app.get("/robots.txt", include_in_schema=False)
     async def robots_txt() -> Response:
-        return Response("User-agent: *\nAllow: /\n", media_type="text/plain")
+        # This host serves the REST API and the interactive Gradio UI (under
+        # /ui) - there is nothing here meant for search indexing (the docs site
+        # lives on a separate host). Disallow all crawling so compliant bots
+        # (Googlebot/GoogleOther/bingbot) stop probing app/internal paths.
+        return Response("User-agent: *\nDisallow: /\n", media_type="text/plain")
 
     # Mount Gradio UI at /ui when the 'ui' extra is installed
     try:

--- a/src/orionbelt/ui/app.py
+++ b/src/orionbelt/ui/app.py
@@ -3435,7 +3435,7 @@ def create_ui() -> None:
         # favicon ourselves and inject a <link> tag into the head.
         import gradio as gr
         from fastapi import FastAPI
-        from fastapi.responses import FileResponse
+        from fastapi.responses import FileResponse, PlainTextResponse
 
         favicon_url = f"{root_path.rstrip('/')}/favicon.png"
         head_html = f'<link rel="icon" type="image/png" href="{favicon_url}">'
@@ -3446,6 +3446,13 @@ def create_ui() -> None:
         @app.get(favicon_url, include_in_schema=False)
         async def _favicon() -> FileResponse:
             return FileResponse(favicon_file, media_type="image/png")
+
+        @app.get("/robots.txt", include_in_schema=False)
+        async def _robots() -> PlainTextResponse:
+            # The UI is an interactive app, not indexable content. When this
+            # service is fronted on its own host (rather than under /ui on the
+            # API host), serve a disallow-all so crawlers skip it.
+            return PlainTextResponse("User-agent: *\nDisallow: /\n")
 
         app = gr.mount_gradio_app(app, demo, path=root_path)
         uvicorn.run(


### PR DESCRIPTION
## Why

The public demo host (`orionbelt.ralforion.com`) serves the REST API at the root and the interactive Gradio UI under `/ui`. None of it is meant for search indexing - the docs site lives on a separate host (`ralforion.com/orionbelt-semantic-layer/`). Yet the host-root `robots.txt` returned `Allow: /`, so compliant crawlers (Googlebot/GoogleOther/bingbot) were probing app and Gradio-internal paths (e.g. `GoogleOther GET /_highlight_pickers_3` -> 404), generating load-balancer log noise.

## What

- **API** (`api/app.py`): host-root `/robots.txt` now returns `User-agent: *` / `Disallow: /`. This is the only robots.txt crawlers read for the host (the UI is mounted under `/ui`), so it governs crawling of the whole host including the UI.
- **UI** (`ui/app.py`): added a matching disallow-all `/robots.txt` to the standalone FastAPI wrapper, so the UI also self-serves a sane robots.txt when fronted on its own host (other deployment topologies).

## Notes

- Affects crawlers only - no change to real users or app/API behaviour. Fully reversible.
- Cloud Armor already blocks the malicious scanner traffic (wp-config, .git, .php, OWASP rules); this PR only addresses benign crawler indexing noise.
- `ruff check`, `ruff format`, `mypy` clean; `tests/integration/test_api_auth.py` (incl. `test_robots_exempt`) passes.