### PR TITLE
fix(ui): horizontally scroll wide query result tables

### DIFF
--- a/src/orionbelt/ui/app.py
+++ b/src/orionbelt/ui/app.py
@@ -430,6 +430,11 @@ _CSS = """\
 .ob-cb-met label span::before { content: '● '; color: #9C27B0; }
 .ob-cb-joins label span::before { content: '◆ '; color: #9E9E9E; }
 
+/* ── Results table: scroll wide tables horizontally instead of overflowing
+   (Gradio's .table-wrap defaults to overflow-x:visible, so the extra columns
+   spilled off and got clipped by the container on small screens). ── */
+.result-table .table-wrap { overflow-x: auto !important; }
+
 /* ── Responsive: narrower viewports ── */
 @media (max-width: 900px) {
   .settings-row { flex-wrap: wrap !important; }


### PR DESCRIPTION
Gradio's dataframe `.table-wrap` defaults to `overflow-x: visible`, so wide result tables spilled past the viewport (and got clipped by the mobile container's `overflow-x: hidden`). Set `.result-table .table-wrap { overflow-x: auto }` so extra columns scroll horizontally on all screen sizes.

Verified the wrapper is the constraining box (clientWidth 326 < scrollWidth 1732 for a 12-column table) via headless Chromium DOM inspection. `ruff`/`mypy` clean.