### PR TITLE
docs(demo): show full-circle diagram in Dremio README

### DIFF
--- a/demo/dremio/README.md
+++ b/demo/dremio/README.md
@@ -6,6 +6,8 @@ Postgres wire protocol as if it were an ordinary database; OrionBelt compiles
 the request into Dremio SQL and pushes it **back into Dremio** over Arrow
 Flight, executing against the very same Parquet datasets you can query raw.
 
+![OrionBelt + Dremio full circle](https://raw.githubusercontent.com/ralfbecher/orionbelt-semantic-layer/main/docs/assets/dremio-orionbelt-full-circle.png)
+
 ```
  Dremio SQL editor
     │  (1) one pgwire source  ──►  OrionBelt API


### PR DESCRIPTION
Adds the `dremio-orionbelt-full-circle.png` diagram to the top of `demo/dremio/README.md` (raw GitHub URL so it renders on GitHub). Image already lives in `docs/assets/`.