### PR TITLE
feat(obml): OBML contract manifest + drift gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,8 @@ OBML defines all types, enums, error codes, operators, and semantics for the pro
 
 Every new OBML field must also propagate to the OSI converter (`packages/osi-orionbelt`, custom_extensions roundtrip) and the ontology (`ontology/obsl.ttl` class + properties, `obsl.shacl.ttl` shapes). Never change any dependent without checking consistency with OBML and all other dependents.
 
+The field surface is captured in the hand-maintained manifest `schema/obml-contract.yml`; `tests/unit/test_obml_contract.py` fails if a Pydantic field is added/removed without updating it, and checks the manifest against the JSON schema and ontology. See `docs/getting-started/development.md` ("Changing the OBML model").
+
 Top-level YAML keys: `version`, `dataObjects`, `dimensions`, `measures`, `metrics`, `filters`.
 
 - **Column names are unique within each data object** — dimensions, measures, and metrics must be unique across the whole model

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ from orionbelt.compiler.pipeline import CompilationPipeline
 from orionbelt.models.query import QueryObject, QuerySelect
 
 model_yaml = """
-version: "1.0"
+version: 1.0
 dataObjects:
   Orders:
     code: ORDERS
@@ -348,7 +348,7 @@ Also works with Copilot, Cursor, and Windsurf. See the [MCP repo](https://github
 
 ```yaml
 # yaml-language-server: $schema=https://raw.githubusercontent.com/ralforion/orionbelt-semantic-layer/main/schema/obml-schema.json
-version: "1.0"
+version: 1.0
 dataObjects:
   Customers:
     code: CUSTOMERS

--- a/docs/getting-started/development.md
+++ b/docs/getting-started/development.md
@@ -69,6 +69,20 @@ field surface in one place: every enum and class, and per field its camelCase
 `alias`, whether it appears in the JSON schema (`json_schema`), its ontology
 property (`ontology_property`), and OSI round-trip behaviour (`osi_roundtrip`).
 
+### Schema validation at the API boundary
+
+The REST API validates raw model and query payloads against the published JSON
+Schemas *before* processing them: the session model-load endpoints validate
+`model_yaml` against `obml-schema.json`, and the query endpoints validate the
+query payload against `query-schema.json` (see `api/schema_guards.py`). A
+contract violation returns HTTP 422. This makes the JSON Schema a load-bearing
+gate that every real request exercises - so the published contract stays
+provably correct and external consumers can rely on the same rules the engine
+enforces. The schemas are camelCase-only; snake_case keys that Pydantic would
+otherwise coerce are rejected at the boundary.
+
+### Keeping the manifest honest
+
 `tests/unit/test_obml_contract.py` keeps the manifest in sync with the live
 Pydantic models, the JSON schema, and the ontology. **Adding or removing a
 field on the Pydantic models without updating the manifest fails this test** -

--- a/docs/getting-started/development.md
+++ b/docs/getting-started/development.md
@@ -71,11 +71,15 @@ property (`ontology_property`), and OSI round-trip behaviour (`osi_roundtrip`).
 
 ### Schema validation at the API boundary
 
-The REST API validates raw model and query payloads against the published JSON
-Schemas *before* processing them: the session model-load endpoints validate
-`model_yaml` against `obml-schema.json`, and the query endpoints validate the
-query payload against `query-schema.json` (see `api/schema_guards.py`). A
-contract violation returns HTTP 422. This makes the JSON Schema a load-bearing
+The API validates raw model and query payloads against the published JSON
+Schemas *before* processing them (see `api/schema_guards.py`). Coverage spans
+every OBML/QueryObject ingestion point: session and shortcut model-load and
+query endpoints, the oneshot batch (its inline `model_yaml` and each query),
+and the `MODEL_FILES` startup preload. Model documents validate against
+`obml-schema.json`, query payloads against `query-schema.json`. A contract
+violation returns HTTP 422 (or fails startup for `MODEL_FILES`). SQL-input
+surfaces (OBSQL / pgwire / Flight) are out of scope: they receive SQL, not
+OBML/QueryObject JSON, and build a trusted `QueryObject` internally. This makes the JSON Schema a load-bearing
 gate that every real request exercises - so the published contract stays
 provably correct and external consumers can rely on the same rules the engine
 enforces. The schemas are camelCase-only; snake_case keys that Pydantic would

--- a/docs/getting-started/development.md
+++ b/docs/getting-started/development.md
@@ -50,3 +50,38 @@ src/orionbelt/
   service/      Session manager, model store
   ui/           Gradio web interface
 ```
+
+## Changing the OBML model
+
+OBML is the single source of truth for the project. Every type, enum, and
+field is mirrored across several dependent artifacts that must move together:
+
+1. **Pydantic models** — `src/orionbelt/models/semantic.py` (and `models/query.py`, `models/errors.py`)
+2. **JSON schema** — `schema/obml-schema.json` (and `schema/query-schema.json`)
+3. **Ontology** — `ontology/obsl.ttl` (class + properties) and `obsl.shacl.ttl`
+4. **OSI converter** — `packages/osi-orionbelt` (custom_extensions round-trip)
+5. **MkDocs + REST API docs**, and **tests/fixtures**
+
+### The contract manifest
+
+`schema/obml-contract.yml` is a hand-maintained manifest that records the OBML
+field surface in one place: every enum and class, and per field its camelCase
+`alias`, whether it appears in the JSON schema (`json_schema`), its ontology
+property (`ontology_property`), and OSI round-trip behaviour (`osi_roundtrip`).
+
+`tests/unit/test_obml_contract.py` keeps the manifest in sync with the live
+Pydantic models, the JSON schema, and the ontology. **Adding or removing a
+field on the Pydantic models without updating the manifest fails this test** -
+that is the intended early-warning gate that you also need to touch the other
+dependents.
+
+When you change OBML:
+
+1. Update the Pydantic model in `models/semantic.py`.
+2. Add/update the field (or enum value) in `schema/obml-contract.yml`. Set
+   `json_schema` / `ontology_property` to match the schema and ontology you are
+   about to update. If a field should never be part of the contract, add it to
+   `MANIFEST_FIELD_EXCLUSIONS` in the test with a comment.
+3. Update the JSON schema, ontology, OSI converter, docs, and fixtures.
+4. Run `uv run pytest tests/unit/test_obml_contract.py` (plus the schema and OSI
+   drift tests) until green.

--- a/docs/guide/model-format.md
+++ b/docs/guide/model-format.md
@@ -759,7 +759,7 @@ measures:
 Override the built-in default for all numeric measures/metrics in the model:
 
 ```yaml
-version: "1.0"
+version: 1.0
 settings:
  defaultNumericDataType: "decimal(18, 4)"
 
@@ -874,7 +874,7 @@ OrionBelt supports timezone-aware serialization of temporal query results. When 
 ### Configuration
 
 ```yaml
-version: "1.0"
+version: 1.0
 settings:
  defaultTimezone: "Europe/Zagreb"
 ```
@@ -928,7 +928,7 @@ Zero microseconds are elided for cleaner output. UTC offsets (`+00:00`) use the 
 ### Example
 
 ```yaml
-version: "1.0"
+version: 1.0
 settings:
  defaultNumericDataType: "decimal(18, 2)"
  defaultTimezone: "Europe/Zagreb"

--- a/examples/movies.obml.yml
+++ b/examples/movies.obml.yml
@@ -12,7 +12,7 @@
 #   - "Director" + "Producer"
 #       + "Movies Cnt"             → fanout via both junctions, resolved by GROUP BY
 
-version: "1.0"
+version: 1.0
 
 dataObjects:
   # ── Fact table ─────────────────────────────────────────────────────

--- a/packages/osi-orionbelt/src/osi_orionbelt/schemas/obml-schema.json
+++ b/packages/osi-orionbelt/src/osi_orionbelt/schemas/obml-schema.json
@@ -108,13 +108,9 @@
               "type": "string",
               "description": "IANA TZ name; only used when anchor is set. Default UTC"
             },
-            "max_staleness": {
-              "type": "string",
-              "description": "Required for mode=heartbeat. Max time between heartbeats before stale"
-            },
             "maxStaleness": {
               "type": "string",
-              "description": "camelCase alias for max_staleness"
+              "description": "Required for mode=heartbeat. Max time between heartbeats before stale"
             }
           },
           "required": [
@@ -1179,16 +1175,9 @@
             "type": "string",
             "description": "One- or two-sentence explanation of what this example shows"
           },
-          "intent_tags": {
-            "type": "array",
-            "description": "Free-form tags used by the /examples?intent= filter",
-            "items": {
-              "type": "string"
-            }
-          },
           "intentTags": {
             "type": "array",
-            "description": "camelCase alias for intent_tags",
+            "description": "Free-form tags used by the /examples?intent= filter",
             "items": {
               "type": "string"
             }

--- a/schema/obml-contract.yml
+++ b/schema/obml-contract.yml
@@ -1,0 +1,1069 @@
+# OBML contract manifest — single source of truth for the OBML field surface.
+#
+# AUTO-CHECKED, HAND-MAINTAINED. Adding/removing an OBML field on the Pydantic
+# models in src/orionbelt/models/semantic.py without updating this file fails
+# tests/unit/test_obml_contract.py. See docs/getting-started/development.md.
+#
+# Per field:
+#   alias            - camelCase YAML/JSON alias (Pydantic Field alias)
+#   type             - short Python type summary (informational)
+#   json_schema      - true if the alias appears in schema/obml-schema.json
+#   ontology_property- obsl.ttl property local-name, or null if not directly mapped
+#   osi_roundtrip    - advisory; whether the OSI converter round-trips the field
+
+enums:
+  AggregationType:
+    python: orionbelt.models.semantic.AggregationType
+    values: ['sum', 'count', 'count_distinct', 'avg', 'min', 'max', 'any_value', 'median', 'mode', 'listagg', 'stddev', 'stddev_pop', 'variance', 'var_pop', 'corr', 'covar_pop', 'covar_samp', 'regr_slope', 'regr_intercept', 'measure']
+  Cardinality:
+    python: orionbelt.models.semantic.Cardinality
+    values: ['many-to-one', 'one-to-one', 'many-to-many']
+  CumulativeAggType:
+    python: orionbelt.models.semantic.CumulativeAggType
+    values: ['sum', 'avg', 'min', 'max', 'count']
+  DataType:
+    python: orionbelt.models.semantic.DataType
+    values: ['string', 'json', 'int', 'float', 'date', 'time', 'time_tz', 'timestamp', 'timestamp_tz', 'boolean']
+  FilterContextMode:
+    python: orionbelt.models.semantic.FilterContextMode
+    values: ['RELATIVE', 'FIXED']
+  FilterLogic:
+    python: orionbelt.models.semantic.FilterLogic
+    values: ['and', 'or']
+  GrainMode:
+    python: orionbelt.models.semantic.GrainMode
+    values: ['RELATIVE', 'FIXED']
+  GrainToDate:
+    python: orionbelt.models.semantic.GrainToDate
+    values: ['year', 'quarter', 'month', 'week']
+  JoinType:
+    python: orionbelt.models.semantic.JoinType
+    values: ['left', 'inner', 'right', 'full']
+  MetricType:
+    python: orionbelt.models.semantic.MetricType
+    values: ['derived', 'cumulative', 'period_over_period', 'window']
+  NumClass:
+    python: orionbelt.models.semantic.NumClass
+    values: ['categorical', 'additive', 'non-additive']
+  PeriodOverPeriodComparison:
+    python: orionbelt.models.semantic.PeriodOverPeriodComparison
+    values: ['ratio', 'difference', 'previousValue', 'percentChange']
+  TimeGrain:
+    python: orionbelt.models.semantic.TimeGrain
+    values: ['year', 'quarter', 'month', 'week', 'day', 'hour', 'minute', 'second']
+  WindowFunctionKind:
+    python: orionbelt.models.semantic.WindowFunctionKind
+    values: ['rank', 'dense_rank', 'row_number', 'ntile', 'lag', 'lead', 'first_value', 'last_value']
+
+classes:
+  CustomExtension:
+    python: orionbelt.models.semantic.CustomExtension
+    json_schema_def: customExtension
+    ontology_class: CustomExtension
+    fields:
+      vendor:
+        alias: vendor
+        type: "str"
+        json_schema: true
+        ontology_property: vendor
+        osi_roundtrip: true
+      data:
+        alias: data
+        type: "str"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+  DataColumnRef:
+    python: orionbelt.models.semantic.DataColumnRef
+    json_schema_def: queryColumn
+    ontology_class: null
+    fields:
+      view:
+        alias: dataObject
+        type: "str | None"
+        json_schema: true
+        ontology_property: dataObject
+        osi_roundtrip: true
+      column:
+        alias: column
+        type: "str | None"
+        json_schema: true
+        ontology_property: column
+        osi_roundtrip: true
+  DataObject:
+    python: orionbelt.models.semantic.DataObject
+    json_schema_def: dataObject
+    ontology_class: DataObject
+    fields:
+      label:
+        alias: label
+        type: "str"
+        json_schema: false
+        ontology_property: null
+        osi_roundtrip: false
+      code:
+        alias: code
+        type: "str"
+        json_schema: true
+        ontology_property: code
+        osi_roundtrip: true
+      database:
+        alias: database
+        type: "str"
+        json_schema: true
+        ontology_property: database
+        osi_roundtrip: true
+      schema_name:
+        alias: schema
+        type: "str"
+        json_schema: true
+        ontology_property: schema
+        osi_roundtrip: true
+      columns:
+        alias: columns
+        type: "dict[str, DataObjectColumn]"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      joins:
+        alias: joins
+        type: "list[DataObjectJoin]"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      description:
+        alias: description
+        type: "str | None"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      comment:
+        alias: comment
+        type: "str | None"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      owner:
+        alias: owner
+        type: "str | None"
+        json_schema: true
+        ontology_property: owner
+        osi_roundtrip: true
+      synonyms:
+        alias: synonyms
+        type: "list[str]"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      custom_extensions:
+        alias: customExtensions
+        type: "list[CustomExtension]"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      refresh:
+        alias: refresh
+        type: "RefreshPolicy | None"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+  DataObjectColumn:
+    python: orionbelt.models.semantic.DataObjectColumn
+    json_schema_def: column
+    ontology_class: Column
+    fields:
+      label:
+        alias: label
+        type: "str"
+        json_schema: false
+        ontology_property: null
+        osi_roundtrip: false
+      code:
+        alias: code
+        type: "str"
+        json_schema: true
+        ontology_property: code
+        osi_roundtrip: true
+      abstract_type:
+        alias: abstractType
+        type: "DataType"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      sql_type:
+        alias: sqlType
+        type: "str | None"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      sql_precision:
+        alias: sqlPrecision
+        type: "int | None"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      sql_scale:
+        alias: sqlScale
+        type: "int | None"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      num_class:
+        alias: numClass
+        type: "NumClass | None"
+        json_schema: true
+        ontology_property: numClass
+        osi_roundtrip: true
+      primary_key:
+        alias: primaryKey
+        type: "bool"
+        json_schema: true
+        ontology_property: primaryKey
+        osi_roundtrip: true
+      description:
+        alias: description
+        type: "str | None"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      comment:
+        alias: comment
+        type: "str | None"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      owner:
+        alias: owner
+        type: "str | None"
+        json_schema: true
+        ontology_property: owner
+        osi_roundtrip: true
+      expression:
+        alias: expression
+        type: "str | None"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      synonyms:
+        alias: synonyms
+        type: "list[str]"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      custom_extensions:
+        alias: customExtensions
+        type: "list[CustomExtension]"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+  DataObjectJoin:
+    python: orionbelt.models.semantic.DataObjectJoin
+    json_schema_def: join
+    ontology_class: Join
+    fields:
+      join_type:
+        alias: joinType
+        type: "Cardinality"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      join_to:
+        alias: joinTo
+        type: "str"
+        json_schema: true
+        ontology_property: joinTo
+        osi_roundtrip: true
+      columns_from:
+        alias: columnsFrom
+        type: "list[str]"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      columns_to:
+        alias: columnsTo
+        type: "list[str]"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      secondary:
+        alias: secondary
+        type: "bool"
+        json_schema: true
+        ontology_property: secondary
+        osi_roundtrip: true
+      path_name:
+        alias: pathName
+        type: "str | None"
+        json_schema: true
+        ontology_property: pathName
+        osi_roundtrip: true
+  Dimension:
+    python: orionbelt.models.semantic.Dimension
+    json_schema_def: dimension
+    ontology_class: Dimension
+    fields:
+      label:
+        alias: label
+        type: "str"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      view:
+        alias: dataObject
+        type: "str"
+        json_schema: true
+        ontology_property: dataObject
+        osi_roundtrip: true
+      column:
+        alias: column
+        type: "str"
+        json_schema: true
+        ontology_property: column
+        osi_roundtrip: true
+      result_type:
+        alias: resultType
+        type: "DataType"
+        json_schema: true
+        ontology_property: resultType
+        osi_roundtrip: true
+      time_grain:
+        alias: timeGrain
+        type: "TimeGrain | None"
+        json_schema: true
+        ontology_property: timeGrain
+        osi_roundtrip: true
+      description:
+        alias: description
+        type: "str | None"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      format:
+        alias: format
+        type: "str | None"
+        json_schema: true
+        ontology_property: format
+        osi_roundtrip: true
+      via:
+        alias: via
+        type: "str | None"
+        json_schema: true
+        ontology_property: via
+        osi_roundtrip: true
+      owner:
+        alias: owner
+        type: "str | None"
+        json_schema: true
+        ontology_property: owner
+        osi_roundtrip: true
+      synonyms:
+        alias: synonyms
+        type: "list[str]"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      custom_extensions:
+        alias: customExtensions
+        type: "list[CustomExtension]"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+  FilterContext:
+    python: orionbelt.models.semantic.FilterContext
+    json_schema_def: filterContext
+    ontology_class: null
+    fields:
+      mode:
+        alias: mode
+        type: "FilterContextMode"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      exclude:
+        alias: exclude
+        type: "list[str]"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      include:
+        alias: include
+        type: "list[FilterContextFilter]"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      keep_only:
+        alias: keepOnly
+        type: "list[str]"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+  FilterContextFilter:
+    python: orionbelt.models.semantic.FilterContextFilter
+    json_schema_def: filterContextFilter
+    ontology_class: null
+    fields:
+      field:
+        alias: field
+        type: "str"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      op:
+        alias: op
+        type: "str"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      value:
+        alias: value
+        type: "object"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+  FilterValue:
+    python: orionbelt.models.semantic.FilterValue
+    json_schema_def: parameterValue
+    ontology_class: null
+    fields:
+      data_type:
+        alias: dataType
+        type: "DataType"
+        json_schema: true
+        ontology_property: dataType
+        osi_roundtrip: true
+      is_null:
+        alias: isNull
+        type: "bool | None"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      value_string:
+        alias: valueString
+        type: "str | None"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      value_int:
+        alias: valueInt
+        type: "int | None"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      value_float:
+        alias: valueFloat
+        type: "float | None"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      value_date:
+        alias: valueDate
+        type: "str | None"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      value_boolean:
+        alias: valueBoolean
+        type: "bool | None"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+  GrainOverride:
+    python: orionbelt.models.semantic.GrainOverride
+    json_schema_def: grainOverride
+    ontology_class: null
+    fields:
+      mode:
+        alias: mode
+        type: "GrainMode"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      exclude:
+        alias: exclude
+        type: "list[str]"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      include:
+        alias: include
+        type: "list[str]"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      keep_only:
+        alias: keepOnly
+        type: "list[str]"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+  Measure:
+    python: orionbelt.models.semantic.Measure
+    json_schema_def: measure
+    ontology_class: Measure
+    fields:
+      label:
+        alias: label
+        type: "str"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      columns:
+        alias: columns
+        type: "list[DataColumnRef]"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      result_type:
+        alias: resultType
+        type: "DataType"
+        json_schema: true
+        ontology_property: resultType
+        osi_roundtrip: true
+      aggregation:
+        alias: aggregation
+        type: "AggregationType"
+        json_schema: true
+        ontology_property: aggregation
+        osi_roundtrip: true
+      expression:
+        alias: expression
+        type: "str | None"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      distinct:
+        alias: distinct
+        type: "bool"
+        json_schema: true
+        ontology_property: distinct
+        osi_roundtrip: true
+      total:
+        alias: total
+        type: "bool"
+        json_schema: true
+        ontology_property: total
+        osi_roundtrip: true
+      grain:
+        alias: grain
+        type: "GrainOverride | None"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      filter_context:
+        alias: filterContext
+        type: "FilterContext | None"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      filters:
+        alias: filters
+        type: "list[MeasureFilter | MeasureFilterGroup]"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      data_type:
+        alias: dataType
+        type: "str | None"
+        json_schema: true
+        ontology_property: dataType
+        osi_roundtrip: true
+      description:
+        alias: description
+        type: "str | None"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      format:
+        alias: format
+        type: "str | None"
+        json_schema: true
+        ontology_property: format
+        osi_roundtrip: true
+      allow_fan_out:
+        alias: allowFanOut
+        type: "bool"
+        json_schema: true
+        ontology_property: allowFanOut
+        osi_roundtrip: true
+      delimiter:
+        alias: delimiter
+        type: "str | None"
+        json_schema: true
+        ontology_property: delimiter
+        osi_roundtrip: true
+      within_group:
+        alias: withinGroup
+        type: "WithinGroup | None"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      owner:
+        alias: owner
+        type: "str | None"
+        json_schema: true
+        ontology_property: owner
+        osi_roundtrip: true
+      synonyms:
+        alias: synonyms
+        type: "list[str]"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      custom_extensions:
+        alias: customExtensions
+        type: "list[CustomExtension]"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+  MeasureFilter:
+    python: orionbelt.models.semantic.MeasureFilter
+    json_schema_def: filter
+    ontology_class: null
+    fields:
+      column:
+        alias: column
+        type: "DataColumnRef | None"
+        json_schema: true
+        ontology_property: column
+        osi_roundtrip: true
+      operator:
+        alias: operator
+        type: "str"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      values:
+        alias: values
+        type: "list[FilterValue]"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+  MeasureFilterGroup:
+    python: orionbelt.models.semantic.MeasureFilterGroup
+    json_schema_def: filterGroup
+    ontology_class: null
+    fields:
+      logic:
+        alias: logic
+        type: "FilterLogic"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      filters:
+        alias: filters
+        type: "list[MeasureFilter | MeasureFilterGroup]"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      negated:
+        alias: negated
+        type: "bool"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+  Metric:
+    python: orionbelt.models.semantic.Metric
+    json_schema_def: metric
+    ontology_class: Metric
+    fields:
+      label:
+        alias: label
+        type: "str"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      type:
+        alias: type
+        type: "MetricType"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      expression:
+        alias: expression
+        type: "str | None"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      measure:
+        alias: measure
+        type: "str | None"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      time_dimension:
+        alias: timeDimension
+        type: "str | None"
+        json_schema: true
+        ontology_property: timeDimension
+        osi_roundtrip: true
+      cumulative_type:
+        alias: cumulativeType
+        type: "CumulativeAggType"
+        json_schema: true
+        ontology_property: cumulativeType
+        osi_roundtrip: true
+      window:
+        alias: window
+        type: "int | None"
+        json_schema: true
+        ontology_property: window
+        osi_roundtrip: true
+      grain_to_date:
+        alias: grainToDate
+        type: "GrainToDate | None"
+        json_schema: true
+        ontology_property: grainToDate
+        osi_roundtrip: true
+      partition_by:
+        alias: partitionBy
+        type: "list[str]"
+        json_schema: true
+        ontology_property: partitionBy
+        osi_roundtrip: true
+      period_over_period:
+        alias: periodOverPeriod
+        type: "PeriodOverPeriod | None"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      window_function:
+        alias: windowFunction
+        type: "WindowFunctionKind | None"
+        json_schema: true
+        ontology_property: windowFunction
+        osi_roundtrip: true
+      offset:
+        alias: offset
+        type: "int | None"
+        json_schema: true
+        ontology_property: offset
+        osi_roundtrip: true
+      buckets:
+        alias: buckets
+        type: "int | None"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      order_direction:
+        alias: orderDirection
+        type: "str"
+        json_schema: true
+        ontology_property: orderDirection
+        osi_roundtrip: true
+      default_value:
+        alias: defaultValue
+        type: "str | int | float | bool | None"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      data_type:
+        alias: dataType
+        type: "str | None"
+        json_schema: true
+        ontology_property: dataType
+        osi_roundtrip: true
+      description:
+        alias: description
+        type: "str | None"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      format:
+        alias: format
+        type: "str | None"
+        json_schema: true
+        ontology_property: format
+        osi_roundtrip: true
+      owner:
+        alias: owner
+        type: "str | None"
+        json_schema: true
+        ontology_property: owner
+        osi_roundtrip: true
+      synonyms:
+        alias: synonyms
+        type: "list[str]"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      custom_extensions:
+        alias: customExtensions
+        type: "list[CustomExtension]"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+  ModelExample:
+    python: orionbelt.models.semantic.ModelExample
+    json_schema_pointer: properties/examples/items
+    ontology_class: ModelExample
+    fields:
+      name:
+        alias: name
+        type: "str"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      description:
+        alias: description
+        type: "str"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      intent_tags:
+        alias: intentTags
+        type: "list[str]"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      query:
+        alias: query
+        type: "dict[str, object]"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+  ModelFilter:
+    python: orionbelt.models.semantic.ModelFilter
+    json_schema_pointer: properties/filters/items
+    ontology_class: null
+    fields:
+      data_object:
+        alias: dataObject
+        type: "str"
+        json_schema: true
+        ontology_property: dataObject
+        osi_roundtrip: true
+      column:
+        alias: column
+        type: "str"
+        json_schema: true
+        ontology_property: column
+        osi_roundtrip: true
+      operator:
+        alias: operator
+        type: "str"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      value:
+        alias: value
+        type: "str | int | float | bool | None"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      values:
+        alias: values
+        type: "list[str | int | float | bool]"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+  ModelSettings:
+    python: orionbelt.models.semantic.ModelSettings
+    json_schema_pointer: properties/settings
+    ontology_class: null
+    fields:
+      default_numeric_data_type:
+        alias: defaultNumericDataType
+        type: "str | None"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      default_timezone:
+        alias: defaultTimezone
+        type: "str | None"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      override_database_timezone:
+        alias: overrideDatabaseTimezone
+        type: "bool"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      default_dialect:
+        alias: defaultDialect
+        type: "str | None"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      default_locale:
+        alias: defaultLocale
+        type: "str | None"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+  PeriodOverPeriod:
+    python: orionbelt.models.semantic.PeriodOverPeriod
+    json_schema_def: periodOverPeriod
+    ontology_class: null
+    fields:
+      time_dimension:
+        alias: timeDimension
+        type: "str"
+        json_schema: true
+        ontology_property: timeDimension
+        osi_roundtrip: true
+      grain:
+        alias: grain
+        type: "TimeGrain"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      offset:
+        alias: offset
+        type: "int"
+        json_schema: true
+        ontology_property: offset
+        osi_roundtrip: true
+      offset_grain:
+        alias: offsetGrain
+        type: "TimeGrain"
+        json_schema: true
+        ontology_property: offsetGrain
+        osi_roundtrip: true
+      comparison:
+        alias: comparison
+        type: "PeriodOverPeriodComparison"
+        json_schema: true
+        ontology_property: comparison
+        osi_roundtrip: true
+  RefreshPolicy:
+    python: orionbelt.models.semantic.RefreshPolicy
+    json_schema_pointer: definitions/dataObject/properties/refresh
+    ontology_class: RefreshPolicy
+    fields:
+      mode:
+        alias: mode
+        type: "str"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      interval:
+        alias: interval
+        type: "str | None"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      anchor:
+        alias: anchor
+        type: "str | None"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      timezone:
+        alias: timezone
+        type: "str | None"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      max_staleness:
+        alias: maxStaleness
+        type: "str | None"
+        json_schema: true
+        ontology_property: maxStaleness
+        osi_roundtrip: true
+  SemanticModel:
+    python: orionbelt.models.semantic.SemanticModel
+    json_schema_root: true
+    ontology_class: SemanticModel
+    fields:
+      version:
+        alias: version
+        type: "float"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      name:
+        alias: name
+        type: "str | None"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      description:
+        alias: description
+        type: "str | None"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      settings:
+        alias: settings
+        type: "ModelSettings | None"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      data_objects:
+        alias: dataObjects
+        type: "dict[str, DataObject]"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      dimensions:
+        alias: dimensions
+        type: "dict[str, Dimension]"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      measures:
+        alias: measures
+        type: "dict[str, Measure]"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      metrics:
+        alias: metrics
+        type: "dict[str, Metric]"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      filters:
+        alias: filters
+        type: "list[ModelFilter]"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      examples:
+        alias: examples
+        type: "list[ModelExample]"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+      extends_sources:
+        alias: extends_sources
+        type: "list[str]"
+        json_schema: false
+        ontology_property: null
+        osi_roundtrip: false
+      inherits_source:
+        alias: inherits_source
+        type: "str | None"
+        json_schema: false
+        ontology_property: null
+        osi_roundtrip: false
+      owner:
+        alias: owner
+        type: "str | None"
+        json_schema: true
+        ontology_property: owner
+        osi_roundtrip: true
+      custom_extensions:
+        alias: customExtensions
+        type: "list[CustomExtension]"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true
+  WithinGroup:
+    python: orionbelt.models.semantic.WithinGroup
+    json_schema_pointer: definitions/measure/properties/withinGroup
+    ontology_class: WithinGroup
+    fields:
+      column:
+        alias: column
+        type: "DataColumnRef"
+        json_schema: true
+        ontology_property: column
+        osi_roundtrip: true
+      order:
+        alias: order
+        type: "str"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: true

--- a/schema/obml-schema.json
+++ b/schema/obml-schema.json
@@ -108,13 +108,9 @@
               "type": "string",
               "description": "IANA TZ name; only used when anchor is set. Default UTC"
             },
-            "max_staleness": {
-              "type": "string",
-              "description": "Required for mode=heartbeat. Max time between heartbeats before stale"
-            },
             "maxStaleness": {
               "type": "string",
-              "description": "camelCase alias for max_staleness"
+              "description": "Required for mode=heartbeat. Max time between heartbeats before stale"
             }
           },
           "required": [
@@ -1179,16 +1175,9 @@
             "type": "string",
             "description": "One- or two-sentence explanation of what this example shows"
           },
-          "intent_tags": {
-            "type": "array",
-            "description": "Free-form tags used by the /examples?intent= filter",
-            "items": {
-              "type": "string"
-            }
-          },
           "intentTags": {
             "type": "array",
-            "description": "camelCase alias for intent_tags",
+            "description": "Free-form tags used by the /examples?intent= filter",
             "items": {
               "type": "string"
             }

--- a/src/orionbelt/api/app.py
+++ b/src/orionbelt/api/app.py
@@ -51,6 +51,7 @@ from orionbelt.api.routers import (
 from orionbelt.api.routers import settings as settings_router
 from orionbelt.api.schemas import HealthResponse
 from orionbelt.cache.factory import build_cache
+from orionbelt.parser.schema_validation import validate_obml_yaml
 from orionbelt.service.session_manager import SessionManager
 from orionbelt.settings import Settings
 
@@ -235,7 +236,19 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     query_execute_enabled = settings.query_execute or settings.flight_enabled
 
     # Each MODEL_FILES entry goes into its own protected named session.
+    # Validate against the published JSON Schema first so an operator's
+    # model file is held to the same camelCase contract as REST uploads;
+    # fail fast on a violation rather than silently coercing it.
     for name, yaml_str in named_preloads:
+        schema_errors = validate_obml_yaml(yaml_str)
+        if schema_errors:
+            detail = "; ".join(
+                f"[{e.code}] {e.message}" + (f" (at {e.path})" if e.path else "")
+                for e in schema_errors
+            )
+            raise RuntimeError(
+                f"MODEL_FILES model '{name}' failed JSON Schema validation: {detail}"
+            )
         store = mgr.get_or_create_named(name)
         store.load_model(yaml_str)
         logger.info("Loaded model '%s' into protected session", name)

--- a/src/orionbelt/api/app.py
+++ b/src/orionbelt/api/app.py
@@ -51,7 +51,6 @@ from orionbelt.api.routers import (
 from orionbelt.api.routers import settings as settings_router
 from orionbelt.api.schemas import HealthResponse
 from orionbelt.cache.factory import build_cache
-from orionbelt.parser.schema_validation import validate_obml_yaml
 from orionbelt.service.session_manager import SessionManager
 from orionbelt.settings import Settings
 
@@ -236,19 +235,10 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     query_execute_enabled = settings.query_execute or settings.flight_enabled
 
     # Each MODEL_FILES entry goes into its own protected named session.
-    # Validate against the published JSON Schema first so an operator's
-    # model file is held to the same camelCase contract as REST uploads;
-    # fail fast on a violation rather than silently coercing it.
+    # JSON Schema validation already happened in ``_read_and_validate_model_file``
+    # (via ``store.validate``, which is schema-aware), so an invalid file has
+    # already failed startup by this point.
     for name, yaml_str in named_preloads:
-        schema_errors = validate_obml_yaml(yaml_str)
-        if schema_errors:
-            detail = "; ".join(
-                f"[{e.code}] {e.message}" + (f" (at {e.path})" if e.path else "")
-                for e in schema_errors
-            )
-            raise RuntimeError(
-                f"MODEL_FILES model '{name}' failed JSON Schema validation: {detail}"
-            )
         store = mgr.get_or_create_named(name)
         store.load_model(yaml_str)
         logger.info("Loaded model '%s' into protected session", name)

--- a/src/orionbelt/api/routers/oneshot.py
+++ b/src/orionbelt/api/routers/oneshot.py
@@ -27,6 +27,7 @@ from orionbelt.api.routers.sessions import (
     _build_explain_response,
     _resolve_dialect,
 )
+from orionbelt.api.schema_guards import validate_oneshot_body
 from orionbelt.api.schemas import (
     OneshotBatchQueryError,
     OneshotBatchQueryItem,
@@ -428,7 +429,11 @@ async def _run_query(
         )
 
 
-@router.post("/batch", response_model=OneshotBatchResponse)
+@router.post(
+    "/batch",
+    response_model=OneshotBatchResponse,
+    dependencies=[Depends(validate_oneshot_body)],
+)
 async def oneshot_batch(
     body: OneshotBatchRequest,
     mgr: SessionManager = Depends(get_session_manager),  # noqa: B008

--- a/src/orionbelt/api/routers/reference.py
+++ b/src/orionbelt/api/routers/reference.py
@@ -9,8 +9,6 @@ scraping Swagger UI.
 from __future__ import annotations
 
 import json
-from importlib.resources import files as resource_files
-from pathlib import Path
 from typing import Any
 
 from fastapi import APIRouter, HTTPException
@@ -19,6 +17,7 @@ from pydantic import BaseModel, Field
 
 from orionbelt.obml_reference import OBML_REFERENCE
 from orionbelt.obsql_reference import OBSQL_REFERENCE
+from orionbelt.parser.schema_validation import read_schema_text
 
 # Prefix on the constructor keeps the root index route ("") at /v1/reference with
 # no trailing slash (FastAPI 0.137+ rejects empty paths via include_router prefix).
@@ -116,31 +115,6 @@ _SCHEMA_FILES: dict[str, str] = {
 }
 
 
-def _read_schema_text(filename: str) -> str | None:
-    """Return the contents of a JSON Schema file, or ``None`` if not found.
-
-    The schema files are shipped inside the wheel as package data under
-    ``orionbelt/schema/`` (see ``force-include`` in ``pyproject.toml``), so
-    they resolve via :mod:`importlib.resources` for PyPI and Docker installs.
-    Editable / source checkouts have no packaged copy, so fall back to the
-    repo-root ``schema/`` directory.
-
-    Module path: src/orionbelt/api/routers/reference.py
-    parents[0..4]: routers / api / orionbelt / src / repo_root
-    """
-    try:
-        resource = resource_files("orionbelt") / "schema" / filename
-        if resource.is_file():
-            return resource.read_text(encoding="utf-8")
-    except (FileNotFoundError, ModuleNotFoundError):
-        pass
-
-    src_path = Path(__file__).resolve().parents[4] / "schema" / filename
-    if src_path.is_file():
-        return src_path.read_text(encoding="utf-8")
-    return None
-
-
 def _load_schema(name: str) -> dict[str, Any]:
     """Read a JSON Schema file by reference name.
 
@@ -154,7 +128,7 @@ def _load_schema(name: str) -> dict[str, Any]:
             status_code=404,
             detail=(f"Unknown schema '{name}'. Available: {', '.join(sorted(_SCHEMA_FILES))}"),
         )
-    text = _read_schema_text(filename)
+    text = read_schema_text(filename)
     if text is None:
         raise HTTPException(
             status_code=500,

--- a/src/orionbelt/api/routers/sessions.py
+++ b/src/orionbelt/api/routers/sessions.py
@@ -31,6 +31,7 @@ from orionbelt.api.query_cache import (
     build_type_map,
     execute_query_with_cache,
 )
+from orionbelt.api.schema_guards import validate_model_body, validate_query_body
 from orionbelt.api.schemas import (
     ColumnMetadata,
     ConvertResponse,
@@ -169,7 +170,12 @@ def _session_response(info: SessionInfo) -> SessionResponse:
 # -- session CRUD ------------------------------------------------------------
 
 
-@router.post("", response_model=SessionResponse, status_code=201)
+@router.post(
+    "",
+    response_model=SessionResponse,
+    status_code=201,
+    dependencies=[Depends(validate_model_body)],
+)
 async def create_session(
     body: SessionCreateRequest | None = None,
     mgr: SessionManager = Depends(get_session_manager),  # noqa: B008
@@ -256,6 +262,7 @@ async def close_session(
     "/{session_id}/models",
     response_model=ModelLoadResponse,
     status_code=201,
+    dependencies=[Depends(validate_model_body)],
 )
 async def load_model(
     session_id: str,
@@ -499,7 +506,11 @@ async def validate_model(
     )
 
 
-@router.post("/{session_id}/query/sql", response_model=QueryCompileResponse)
+@router.post(
+    "/{session_id}/query/sql",
+    response_model=QueryCompileResponse,
+    dependencies=[Depends(validate_query_body)],
+)
 async def compile_query(
     session_id: str,
     body: SessionQueryRequest,
@@ -720,7 +731,11 @@ def _build_execute_response(
     )
 
 
-@router.post("/{session_id}/query/plan", response_model=QueryPlanResponse)
+@router.post(
+    "/{session_id}/query/plan",
+    response_model=QueryPlanResponse,
+    dependencies=[Depends(validate_query_body)],
+)
 async def plan_query(
     session_id: str,
     body: QueryPlanRequest,
@@ -873,7 +888,11 @@ def _join_path_steps(result: Any) -> list[JoinPathStep]:
     return steps
 
 
-@router.post("/{session_id}/query/execute", response_model=QueryExecuteResponse)
+@router.post(
+    "/{session_id}/query/execute",
+    response_model=QueryExecuteResponse,
+    dependencies=[Depends(validate_query_body)],
+)
 async def execute_query(
     session_id: str,
     body: SessionQueryExecuteRequest,

--- a/src/orionbelt/api/routers/shortcuts.py
+++ b/src/orionbelt/api/routers/shortcuts.py
@@ -24,6 +24,7 @@ from orionbelt.api.routers.model_api import (
     _build_schema,
     _build_search_response,
 )
+from orionbelt.api.schema_guards import validate_query_body
 from orionbelt.api.schemas import (
     ComposablesResponse,
     DiagramResponse,
@@ -309,7 +310,12 @@ async def shortcut_join_graph(
     return _build_join_graph(model)
 
 
-@router.post("/composables", response_model=ComposablesResponse, tags=["model-discovery"])
+@router.post(
+    "/composables",
+    response_model=ComposablesResponse,
+    tags=["model-discovery"],
+    dependencies=[Depends(validate_query_body)],
+)
 async def shortcut_composables_for_query(
     query: QueryObject,
     mgr: SessionManager = Depends(get_session_manager),  # noqa: B008
@@ -408,7 +414,12 @@ class ShortcutQueryRequest(QueryObject):
     pass
 
 
-@router.post("/query/sql", response_model=QueryCompileResponse, tags=["query"])
+@router.post(
+    "/query/sql",
+    response_model=QueryCompileResponse,
+    tags=["query"],
+    dependencies=[Depends(validate_query_body)],
+)
 async def shortcut_compile_query(
     body: ShortcutQueryRequest,
     dialect: str | None = None,
@@ -514,7 +525,12 @@ class ShortcutQueryExecuteRequest(QueryObject):
     pass
 
 
-@router.post("/query/execute", response_model=QueryExecuteResponse, tags=["query"])
+@router.post(
+    "/query/execute",
+    response_model=QueryExecuteResponse,
+    tags=["query"],
+    dependencies=[Depends(validate_query_body)],
+)
 async def shortcut_execute_query(
     body: ShortcutQueryExecuteRequest,
     dialect: str | None = None,
@@ -690,7 +706,12 @@ async def shortcut_execute_semantic_ql(
     )
 
 
-@router.post("/query/plan", response_model=QueryPlanResponse, tags=["query"])
+@router.post(
+    "/query/plan",
+    response_model=QueryPlanResponse,
+    tags=["query"],
+    dependencies=[Depends(validate_query_body)],
+)
 async def shortcut_plan_query(
     body: QueryPlanRequest,
     mgr: SessionManager = Depends(get_session_manager),  # noqa: B008

--- a/src/orionbelt/api/schema_guards.py
+++ b/src/orionbelt/api/schema_guards.py
@@ -71,3 +71,32 @@ async def validate_model_body(request: Request) -> None:
         errors = validate_obml_yaml(text)
         if errors:
             _raise_422(errors)
+
+
+def _prefix_path(error: SemanticError, prefix: str) -> SemanticError:
+    path = prefix if error.path in (None, "(root)") else f"{prefix}.{error.path}"
+    return error.model_copy(update={"path": path})
+
+
+async def validate_oneshot_body(request: Request) -> None:
+    """Validate a oneshot-batch body: its ``model_yaml`` and every query.
+
+    The batch carries an optional inline ``model_yaml`` and a ``queries``
+    list of ``{"query": {...}}`` items; each is validated against its schema
+    with the offending location reported in ``path``.
+    """
+    raw = await _json_body(request)
+    if not isinstance(raw, dict):
+        return
+    errors: list[SemanticError] = []
+    text = raw.get("model_yaml")
+    if isinstance(text, str) and text.strip():
+        errors.extend(validate_obml_yaml(text))
+    queries = raw.get("queries")
+    if isinstance(queries, list):
+        for index, item in enumerate(queries):
+            if isinstance(item, dict) and isinstance(item.get("query"), dict):
+                for error in validate_query_document(item["query"]):
+                    errors.append(_prefix_path(error, f"queries[{index}].query"))
+    if errors:
+        _raise_422(errors)

--- a/src/orionbelt/api/schema_guards.py
+++ b/src/orionbelt/api/schema_guards.py
@@ -1,0 +1,73 @@
+"""Request-body JSON Schema guards for the REST ingestion boundary.
+
+These FastAPI dependencies validate incoming model and query payloads
+against the published JSON Schemas (``schema/obml-schema.json`` /
+``query-schema.json``) *before* they are processed. Validating here, at the
+external boundary, makes the schema the contract every real request is held
+to — so the schema stays provably correct and external consumers rely on
+the same rules the engine enforces — without imposing JSON-Schema strictness
+on the internal, coercion-tolerant model/query construction paths.
+
+A violation returns HTTP 422 with the structured schema errors, alongside
+the Pydantic validation FastAPI already performs.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import HTTPException, Request
+
+from orionbelt.models.errors import SemanticError
+from orionbelt.parser.schema_validation import validate_obml_yaml, validate_query_document
+
+
+async def _json_body(request: Request) -> Any:
+    """Parsed JSON body, or ``None`` if absent/unparseable.
+
+    A malformed body is left to FastAPI's own request parsing to reject.
+    """
+    try:
+        return await request.json()
+    except ValueError:
+        return None
+
+
+def _raise_422(errors: list[SemanticError]) -> None:
+    raise HTTPException(
+        status_code=422,
+        detail={
+            "message": "Request failed JSON Schema validation.",
+            "errors": [{"code": e.code, "message": e.message, "path": e.path} for e in errors],
+        },
+    )
+
+
+async def validate_query_body(request: Request) -> None:
+    """Validate the query payload of a request against ``query-schema.json``.
+
+    Handles both wrapped bodies (``{"query": {...}, ...}``) and bare
+    ``QueryObject`` bodies (identified by a top-level ``select``).
+    """
+    raw = await _json_body(request)
+    if not isinstance(raw, dict):
+        return
+    candidate = raw.get("query")
+    if not isinstance(candidate, dict):
+        candidate = raw if "select" in raw else None
+    if isinstance(candidate, dict):
+        errors = validate_query_document(candidate)
+        if errors:
+            _raise_422(errors)
+
+
+async def validate_model_body(request: Request) -> None:
+    """Validate a request's ``model_yaml`` against ``obml-schema.json``."""
+    raw = await _json_body(request)
+    if not isinstance(raw, dict):
+        return
+    text = raw.get("model_yaml")
+    if isinstance(text, str) and text.strip():
+        errors = validate_obml_yaml(text)
+        if errors:
+            _raise_422(errors)

--- a/src/orionbelt/api/schema_guards.py
+++ b/src/orionbelt/api/schema_guards.py
@@ -14,12 +14,17 @@ the Pydantic validation FastAPI already performs.
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 from fastapi import HTTPException, Request
 
 from orionbelt.models.errors import SemanticError
-from orionbelt.parser.schema_validation import validate_obml_yaml, validate_query_document
+from orionbelt.parser.schema_validation import (
+    validate_obml_document,
+    validate_obml_yaml,
+    validate_query_document,
+)
 
 
 async def _json_body(request: Request) -> Any:
@@ -61,16 +66,37 @@ async def validate_query_body(request: Request) -> None:
             _raise_422(errors)
 
 
+def _model_json_errors(model_json: object) -> list[SemanticError]:
+    """Schema errors for a ``model_json`` payload (dict or JSON string)."""
+    document = model_json
+    if isinstance(document, str):
+        try:
+            document = json.loads(document)
+        except ValueError:
+            return []  # malformed JSON — let the loader report it precisely
+    if not isinstance(document, dict):
+        return []
+    public = {k: v for k, v in document.items() if not str(k).startswith("_")}
+    return validate_obml_document(public)
+
+
 async def validate_model_body(request: Request) -> None:
-    """Validate a request's ``model_yaml`` against ``obml-schema.json``."""
+    """Validate a request's ``model_yaml`` / ``model_json`` against the schema.
+
+    Both forms reach the same load path, so both must be gated: ``model_json``
+    may be a JSON object or an auto-parsed JSON string.
+    """
     raw = await _json_body(request)
     if not isinstance(raw, dict):
         return
+    errors: list[SemanticError] = []
     text = raw.get("model_yaml")
     if isinstance(text, str) and text.strip():
-        errors = validate_obml_yaml(text)
-        if errors:
-            _raise_422(errors)
+        errors.extend(validate_obml_yaml(text))
+    if raw.get("model_json") is not None:
+        errors.extend(_model_json_errors(raw.get("model_json")))
+    if errors:
+        _raise_422(errors)
 
 
 def _prefix_path(error: SemanticError, prefix: str) -> SemanticError:

--- a/src/orionbelt/parser/schema_validation.py
+++ b/src/orionbelt/parser/schema_validation.py
@@ -1,0 +1,129 @@
+"""JSON Schema validation for OBML models and query payloads.
+
+The JSON Schemas in ``schema/`` are the published, language-agnostic
+contract for OBML model documents and ``QueryObject`` payloads. Validating
+raw input against them *first* — before Pydantic parsing — makes the schema
+a load-bearing gate rather than a published-but-unused artifact: every real
+document exercises it, so the schema is continuously proven correct, and
+external consumers can rely on the same contract the engine enforces.
+
+This is the single place that loads and runs those schemas. The schema
+files ship inside the wheel as package data under ``orionbelt/schema/``
+(see ``force-include`` in ``pyproject.toml``); source checkouts fall back
+to the repo-root ``schema/`` directory.
+"""
+
+from __future__ import annotations
+
+import json
+from functools import cache
+from importlib.resources import files as resource_files
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+import yaml
+
+from orionbelt.models.errors import SemanticError
+
+SCHEMA_VALIDATION_CODE = "SCHEMA_VALIDATION"
+
+_SCHEMA_FILES: dict[str, str] = {
+    "obml": "obml-schema.json",
+    "query": "query-schema.json",
+}
+
+
+def read_schema_text(filename: str) -> str | None:
+    """Return the contents of a JSON Schema file, or ``None`` if not found.
+
+    Resolves via :mod:`importlib.resources` for installed wheels, falling
+    back to the repo-root ``schema/`` directory for editable/source
+    checkouts (``parents[3]`` from ``src/orionbelt/parser/``).
+    """
+    try:
+        resource = resource_files("orionbelt") / "schema" / filename
+        if resource.is_file():
+            return resource.read_text(encoding="utf-8")
+    except (FileNotFoundError, ModuleNotFoundError):
+        pass
+
+    src_path = Path(__file__).resolve().parents[3] / "schema" / filename
+    if src_path.is_file():
+        return src_path.read_text(encoding="utf-8")
+    return None
+
+
+@cache
+def _validator(name: str) -> Any:
+    """Build (and cache) the JSON Schema validator for ``name``.
+
+    Returns ``None`` when the schema file is absent from the deployment, so
+    validation degrades to a no-op rather than blocking model loading.
+    """
+    text = read_schema_text(_SCHEMA_FILES[name])
+    if text is None:
+        return None
+    schema = json.loads(text)
+    validator_cls = jsonschema.validators.validator_for(schema)
+    validator_cls.check_schema(schema)
+    return validator_cls(schema)
+
+
+def _format_path(error: jsonschema.ValidationError) -> str:
+    parts = [str(p) for p in error.absolute_path]
+    return ".".join(parts) if parts else "(root)"
+
+
+def _validate(name: str, document: object) -> list[SemanticError]:
+    validator = _validator(name)
+    if validator is None:  # pragma: no cover - only if schema is unpackaged
+        return []
+    errors = sorted(validator.iter_errors(document), key=lambda e: list(e.absolute_path))
+    return [
+        SemanticError(
+            code=SCHEMA_VALIDATION_CODE,
+            message=error.message,
+            path=_format_path(error),
+            severity="error",
+        )
+        for error in errors
+    ]
+
+
+def validate_obml_document(document: object) -> list[SemanticError]:
+    """Validate a raw OBML model document against ``obml-schema.json``."""
+    return _validate("obml", document)
+
+
+def validate_query_document(document: object) -> list[SemanticError]:
+    """Validate a raw ``QueryObject`` payload against ``query-schema.json``."""
+    return _validate("query", document)
+
+
+def _json_native(obj: object) -> object:
+    """Coerce a YAML-parsed structure to JSON-native types.
+
+    ruamel/PyYAML parse ISO dates and timestamps into Python ``date`` /
+    ``datetime`` objects, which JSON Schema cannot validate. A JSON
+    round-trip (``default=str``) renders them as strings, matching how the
+    same document is transmitted as JSON.
+    """
+    return json.loads(json.dumps(obj, default=str))
+
+
+def validate_obml_yaml(text: str) -> list[SemanticError]:
+    """Validate an OBML model YAML string against ``obml-schema.json``.
+
+    Returns no schema errors when the text is not parseable YAML or not a
+    mapping; the normal loader reports those with precise source positions.
+    Merger-injected private keys (``_extends_sources`` etc.) are stripped.
+    """
+    try:
+        document = yaml.safe_load(text)
+    except yaml.YAMLError:
+        return []
+    if not isinstance(document, dict):
+        return []
+    public = {k: v for k, v in document.items() if not str(k).startswith("_")}
+    return validate_obml_document(_json_native(public))

--- a/src/orionbelt/parser/schema_validation.py
+++ b/src/orionbelt/parser/schema_validation.py
@@ -22,7 +22,6 @@ from pathlib import Path
 from typing import Any
 
 import jsonschema
-import yaml
 
 from orionbelt.models.errors import SemanticError
 
@@ -75,11 +74,24 @@ def _format_path(error: jsonschema.ValidationError) -> str:
     return ".".join(parts) if parts else "(root)"
 
 
+def _json_native(obj: object) -> object:
+    """Coerce a parsed structure to JSON-native types.
+
+    ruamel/PyYAML parse ISO dates and timestamps into Python ``date`` /
+    ``datetime`` objects (and ruamel uses ``CommentedMap`` etc.), which JSON
+    Schema cannot validate directly. A JSON round-trip (``default=str``)
+    renders them as the strings JSON Schema expects, matching how the same
+    document is transmitted as JSON.
+    """
+    return json.loads(json.dumps(obj, default=str))
+
+
 def _validate(name: str, document: object) -> list[SemanticError]:
     validator = _validator(name)
     if validator is None:  # pragma: no cover - only if schema is unpackaged
         return []
-    errors = sorted(validator.iter_errors(document), key=lambda e: list(e.absolute_path))
+    native = _json_native(document)
+    errors = sorted(validator.iter_errors(native), key=lambda e: list(e.absolute_path))
     return [
         SemanticError(
             code=SCHEMA_VALIDATION_CODE,
@@ -101,29 +113,25 @@ def validate_query_document(document: object) -> list[SemanticError]:
     return _validate("query", document)
 
 
-def _json_native(obj: object) -> object:
-    """Coerce a YAML-parsed structure to JSON-native types.
-
-    ruamel/PyYAML parse ISO dates and timestamps into Python ``date`` /
-    ``datetime`` objects, which JSON Schema cannot validate. A JSON
-    round-trip (``default=str``) renders them as strings, matching how the
-    same document is transmitted as JSON.
-    """
-    return json.loads(json.dumps(obj, default=str))
-
-
 def validate_obml_yaml(text: str) -> list[SemanticError]:
     """Validate an OBML model YAML string against ``obml-schema.json``.
 
-    Returns no schema errors when the text is not parseable YAML or not a
-    mapping; the normal loader reports those with precise source positions.
+    Parses through the safety-checked :class:`TrackedLoader` (not plain
+    ``yaml.safe_load``) so a malicious document — billion-laughs aliases,
+    oversized input — never expands here on the untrusted ingestion path.
+    Returns no schema errors when the text is unsafe, unparseable, or not a
+    mapping; the normal loader then reports those with precise positions.
     Merger-injected private keys (``_extends_sources`` etc.) are stripped.
     """
+    # Local import avoids a module-load cycle (loader is lower-level).
+    from orionbelt.parser.loader import TrackedLoader
+
     try:
-        document = yaml.safe_load(text)
-    except yaml.YAMLError:
+        document, _source_map = TrackedLoader().load_string(text)
+    except Exception:
+        # Unsafe or unparseable input — defer the precise error to the loader.
         return []
     if not isinstance(document, dict):
         return []
     public = {k: v for k, v in document.items() if not str(k).startswith("_")}
-    return validate_obml_document(_json_native(public))
+    return validate_obml_document(public)

--- a/src/orionbelt/service/model_store.py
+++ b/src/orionbelt/service/model_store.py
@@ -22,6 +22,7 @@ from orionbelt.obsl.sparql import SPARQLResult, execute_sparql
 from orionbelt.parser.loader import TrackedLoader, YAMLSafetyError
 from orionbelt.parser.merger import ExtendsMerger, MergeError
 from orionbelt.parser.resolver import ReferenceResolver
+from orionbelt.parser.schema_validation import validate_obml_document
 from orionbelt.parser.validator import SemanticValidator
 
 # ---------------------------------------------------------------------------
@@ -789,18 +790,40 @@ class ModelStore:
         extends_yaml: list[str] | None = None,
         inherits_model_id: str | None = None,
     ) -> ValidationSummary:
-        """Validate a model without storing it.  Accepts YAML string or raw dict."""
-        _model, _raw, errors, warnings = self._parse_and_validate(
+        """Validate a model without storing it.  Accepts YAML string or raw dict.
+
+        Reports JSON Schema violations alongside semantic errors so that the
+        ``/validate`` endpoints match what the schema-guarded load/query
+        endpoints enforce — a model that fails the schema is reported invalid
+        here rather than being silently coerced.
+        """
+        _model, raw, errors, warnings = self._parse_and_validate(
             yaml_str,
             raw_dict=raw_dict,
             extends_yaml=extends_yaml,
             inherits_model_id=inherits_model_id,
         )
+        # Schema-validate the already-safely-parsed dict (``_parse_and_validate``
+        # loads via the safety-checked TrackedLoader). Skip when the YAML never
+        # parsed safely — the fatal parse/safety error is already reported and
+        # there is no document to validate.
+        fatal = {"YAML_SAFETY_ERROR", "YAML_PARSE_ERROR"}
+        if not any(e.code in fatal for e in errors):
+            errors = self._schema_errors(raw) + errors
         return ValidationSummary(
             valid=len(errors) == 0,
             errors=errors,
             warnings=warnings,
         )
+
+    @staticmethod
+    def _schema_errors(raw: dict[str, object]) -> list[ErrorInfo]:
+        """JSON Schema errors for a parsed model document, as ``ErrorInfo``."""
+        public = {k: v for k, v in raw.items() if not str(k).startswith("_")}
+        return [
+            ErrorInfo(code=e.code, message=e.message, path=e.path, severity=e.severity)
+            for e in validate_obml_document(public)
+        ]
 
     # -- OBSL graph ---------------------------------------------------------
 

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -432,7 +432,7 @@ class TestSessionModelFlow:
             },
             "measures": {
                 "Total Revenue": {
-                    "aggregation": "SUM",
+                    "aggregation": "sum",
                     "resultType": "float",
                     "columns": [{"dataObject": "Orders", "column": "Amount"}],
                 }
@@ -466,7 +466,7 @@ class TestSessionModelFlow:
                 },
                 "measures": {
                     "Revenue": {
-                        "aggregation": "SUM",
+                        "aggregation": "sum",
                         "resultType": "float",
                         "columns": [{"dataObject": "Orders", "column": "Amount"}],
                     }

--- a/tests/integration/test_cache_endpoints.py
+++ b/tests/integration/test_cache_endpoints.py
@@ -209,7 +209,7 @@ _MODEL_WITH_EXAMPLES = (
 examples:
   - name: revenue_by_country
     description: Total completed-order revenue by customer country.
-    intent_tags: [revenue, geography]
+    intentTags: [revenue, geography]
     query:
       select:
         dimensions: [Customer Country]

--- a/tests/integration/test_model_api.py
+++ b/tests/integration/test_model_api.py
@@ -150,7 +150,7 @@ class TestMeasures:
            the model held it the response never carried it.
         """
         annotated = """\
-version: "1.0"
+version: 1.0
 dataObjects:
   Orders:
     code: orders
@@ -361,7 +361,7 @@ _MODEL_WITH_EXAMPLES = (
 examples:
   - name: revenue_by_country
     description: Total completed-order revenue by customer country.
-    intent_tags: [revenue, geography]
+    intentTags: [revenue, geography]
     query:
       select:
         dimensions: [Customer Country]
@@ -369,7 +369,7 @@ examples:
 
   - name: order_count_by_country
     description: Number of orders per customer country.
-    intent_tags: [orders, geography]
+    intentTags: [orders, geography]
     query:
       select:
         dimensions: [Customer Country]

--- a/tests/integration/test_schema_validation_api.py
+++ b/tests/integration/test_schema_validation_api.py
@@ -106,6 +106,44 @@ async def test_query_unknown_key_rejected(client: AsyncClient) -> None:
     assert resp.json()["detail"]["errors"][0]["code"] == "SCHEMA_VALIDATION"
 
 
+async def test_shortcut_query_unknown_key_rejected(client: AsyncClient) -> None:
+    sid = await _new_session(client)
+    await client.post(f"/v1/sessions/{sid}/models", json={"model_yaml": _VALID_MODEL})
+    # Bare QueryObject body (top-level shortcut, auto-resolves the model).
+    resp = await client.post(
+        "/v1/query/sql",
+        json={"select": {"measures": ["Revenue"]}, "bogus": 1},
+    )
+    assert resp.status_code == 422
+    assert resp.json()["detail"]["errors"][0]["code"] == "SCHEMA_VALIDATION"
+
+
+async def test_oneshot_batch_query_validated(client: AsyncClient) -> None:
+    resp = await client.post(
+        "/v1/oneshot/batch",
+        json={
+            "model_yaml": _VALID_MODEL,
+            "queries": [{"query": {"select": {"measures": ["Revenue"]}, "bogus": 1}}],
+        },
+    )
+    assert resp.status_code == 422
+    errors = resp.json()["detail"]["errors"]
+    assert errors[0]["code"] == "SCHEMA_VALIDATION"
+    assert errors[0]["path"].startswith("queries[0].query")
+
+
+async def test_oneshot_batch_model_yaml_validated(client: AsyncClient) -> None:
+    resp = await client.post(
+        "/v1/oneshot/batch",
+        json={
+            "model_yaml": _VALID_MODEL.replace("abstractType:", "abstract_type:"),
+            "queries": [{"query": {"select": {"measures": ["Revenue"]}}}],
+        },
+    )
+    assert resp.status_code == 422
+    assert resp.json()["detail"]["errors"][0]["code"] == "SCHEMA_VALIDATION"
+
+
 async def test_model_files_preload_validates_at_startup(tmp_path) -> None:
     """A MODEL_FILES entry that violates the schema fails app startup.
 

--- a/tests/integration/test_schema_validation_api.py
+++ b/tests/integration/test_schema_validation_api.py
@@ -1,0 +1,106 @@
+"""JSON Schema validation at the REST ingestion boundary.
+
+The model-load and query endpoints validate raw request payloads against
+the published JSON Schemas (``obml-schema.json`` / ``query-schema.json``)
+before processing, returning 422 on a contract violation. This locks that
+behaviour: canonical camelCase payloads pass; snake_case / unknown-key
+payloads that Pydantic would otherwise coerce or accept are rejected.
+"""
+
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from orionbelt.api.app import create_app
+from orionbelt.api.deps import init_session_manager, reset_session_manager
+from orionbelt.service.session_manager import SessionManager
+from orionbelt.settings import Settings
+
+_VALID_MODEL = """\
+version: 1.0
+dataObjects:
+  Orders:
+    code: orders
+    database: db
+    schema: public
+    columns:
+      Amount:
+        code: amount
+        abstractType: float
+measures:
+  Revenue:
+    columns: [{dataObject: Orders, column: Amount}]
+    resultType: float
+    aggregation: sum
+"""
+
+
+@pytest.fixture
+def app():
+    settings = Settings(session_ttl_seconds=3600, session_cleanup_interval=9999)
+    application = create_app(settings=settings)
+    mgr = SessionManager(
+        ttl_seconds=settings.session_ttl_seconds,
+        cleanup_interval=settings.session_cleanup_interval,
+    )
+    init_session_manager(mgr)
+    yield application
+    reset_session_manager()
+
+
+@pytest.fixture
+async def client(app) -> AsyncClient:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+async def _new_session(client: AsyncClient) -> str:
+    resp = await client.post("/v1/sessions")
+    return str(resp.json()["session_id"])
+
+
+async def test_valid_model_loads(client: AsyncClient) -> None:
+    sid = await _new_session(client)
+    resp = await client.post(f"/v1/sessions/{sid}/models", json={"model_yaml": _VALID_MODEL})
+    assert resp.status_code == 201, resp.text
+
+
+async def test_unknown_top_level_key_rejected(client: AsyncClient) -> None:
+    sid = await _new_session(client)
+    bad = _VALID_MODEL + "dataObjekts: {}\n"
+    resp = await client.post(f"/v1/sessions/{sid}/models", json={"model_yaml": bad})
+    assert resp.status_code == 422
+    assert resp.json()["detail"]["errors"][0]["code"] == "SCHEMA_VALIDATION"
+
+
+async def test_snake_case_field_rejected(client: AsyncClient) -> None:
+    sid = await _new_session(client)
+    # ``abstract_type`` is the snake_case form of the camelCase contract key.
+    bad = _VALID_MODEL.replace("abstractType:", "abstract_type:")
+    resp = await client.post(f"/v1/sessions/{sid}/models", json={"model_yaml": bad})
+    assert resp.status_code == 422
+
+
+async def test_valid_query_compiles(client: AsyncClient) -> None:
+    sid = await _new_session(client)
+    load = await client.post(f"/v1/sessions/{sid}/models", json={"model_yaml": _VALID_MODEL})
+    mid = load.json()["model_id"]
+    resp = await client.post(
+        f"/v1/sessions/{sid}/query/sql",
+        json={"model_id": mid, "query": {"select": {"measures": ["Revenue"]}}},
+    )
+    assert resp.status_code == 200, resp.text
+
+
+async def test_query_unknown_key_rejected(client: AsyncClient) -> None:
+    sid = await _new_session(client)
+    load = await client.post(f"/v1/sessions/{sid}/models", json={"model_yaml": _VALID_MODEL})
+    mid = load.json()["model_id"]
+    resp = await client.post(
+        f"/v1/sessions/{sid}/query/sql",
+        json={"model_id": mid, "query": {"select": {"measures": ["Revenue"]}, "bogus": 1}},
+    )
+    assert resp.status_code == 422
+    assert resp.json()["detail"]["errors"][0]["code"] == "SCHEMA_VALIDATION"

--- a/tests/integration/test_schema_validation_api.py
+++ b/tests/integration/test_schema_validation_api.py
@@ -9,6 +9,8 @@ payloads that Pydantic would otherwise coerce or accept are rejected.
 
 from __future__ import annotations
 
+import json
+
 import pytest
 from httpx import ASGITransport, AsyncClient
 
@@ -81,6 +83,58 @@ async def test_snake_case_field_rejected(client: AsyncClient) -> None:
     bad = _VALID_MODEL.replace("abstractType:", "abstract_type:")
     resp = await client.post(f"/v1/sessions/{sid}/models", json={"model_yaml": bad})
     assert resp.status_code == 422
+
+
+_VALID_MODEL_JSON: dict = {
+    "version": 1.0,
+    "dataObjects": {
+        "Orders": {
+            "code": "orders",
+            "database": "db",
+            "schema": "public",
+            "columns": {"Amount": {"code": "amount", "abstractType": "float"}},
+        }
+    },
+    "measures": {
+        "Revenue": {
+            "columns": [{"dataObject": "Orders", "column": "Amount"}],
+            "resultType": "float",
+            "aggregation": "sum",
+        }
+    },
+}
+
+
+def _invalid_model_json() -> dict:
+    bad = json.loads(json.dumps(_VALID_MODEL_JSON))
+    col = bad["dataObjects"]["Orders"]["columns"]["Amount"]
+    col["abstract_type"] = col.pop("abstractType")  # snake_case violates the schema
+    return bad
+
+
+async def test_model_json_snake_case_rejected(client: AsyncClient) -> None:
+    sid = await _new_session(client)
+    resp = await client.post(
+        f"/v1/sessions/{sid}/models", json={"model_json": _invalid_model_json()}
+    )
+    assert resp.status_code == 422
+    assert resp.json()["detail"]["errors"][0]["code"] == "SCHEMA_VALIDATION"
+
+
+async def test_model_json_string_form_rejected(client: AsyncClient) -> None:
+    sid = await _new_session(client)
+    resp = await client.post(
+        f"/v1/sessions/{sid}/models",
+        json={"model_json": json.dumps(_invalid_model_json())},
+    )
+    assert resp.status_code == 422
+    assert resp.json()["detail"]["errors"][0]["code"] == "SCHEMA_VALIDATION"
+
+
+async def test_model_json_valid_loads(client: AsyncClient) -> None:
+    sid = await _new_session(client)
+    resp = await client.post(f"/v1/sessions/{sid}/models", json={"model_json": _VALID_MODEL_JSON})
+    assert resp.status_code == 201, resp.text
 
 
 async def test_valid_query_compiles(client: AsyncClient) -> None:

--- a/tests/integration/test_schema_validation_api.py
+++ b/tests/integration/test_schema_validation_api.py
@@ -144,6 +144,29 @@ async def test_oneshot_batch_model_yaml_validated(client: AsyncClient) -> None:
     assert resp.json()["detail"]["errors"][0]["code"] == "SCHEMA_VALIDATION"
 
 
+async def test_validate_endpoint_reports_schema_errors(client: AsyncClient) -> None:
+    """The /validate endpoint reports schema violations (not a 422).
+
+    This keeps the UI's Validate button consistent with the schema-guarded
+    load/run path: a snake_case model is reported invalid rather than being
+    silently coerced and called valid.
+    """
+    sid = await _new_session(client)
+    bad = _VALID_MODEL.replace("abstractType:", "abstract_type:")
+    resp = await client.post(f"/v1/sessions/{sid}/validate", json={"model_yaml": bad})
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["valid"] is False
+    assert any(e["code"] == "SCHEMA_VALIDATION" for e in body["errors"])
+
+
+async def test_validate_endpoint_accepts_valid_model(client: AsyncClient) -> None:
+    sid = await _new_session(client)
+    resp = await client.post(f"/v1/sessions/{sid}/validate", json={"model_yaml": _VALID_MODEL})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["valid"] is True
+
+
 async def test_model_files_preload_validates_at_startup(tmp_path) -> None:
     """A MODEL_FILES entry that violates the schema fails app startup.
 
@@ -159,7 +182,9 @@ async def test_model_files_preload_validates_at_startup(tmp_path) -> None:
     )
     app = create_app(settings=settings)
     try:
-        with pytest.raises(RuntimeError, match="JSON Schema"):
+        # The preload validates each file via ``store.validate`` (schema-aware)
+        # and fails startup with a clear message on a contract violation.
+        with pytest.raises(ValueError, match="model file validation failed"):
             async with app.router.lifespan_context(app):
                 pass
     finally:

--- a/tests/integration/test_schema_validation_api.py
+++ b/tests/integration/test_schema_validation_api.py
@@ -104,3 +104,42 @@ async def test_query_unknown_key_rejected(client: AsyncClient) -> None:
     )
     assert resp.status_code == 422
     assert resp.json()["detail"]["errors"][0]["code"] == "SCHEMA_VALIDATION"
+
+
+async def test_model_files_preload_validates_at_startup(tmp_path) -> None:
+    """A MODEL_FILES entry that violates the schema fails app startup.
+
+    The preload runs in the FastAPI lifespan, so the failure surfaces when
+    the lifespan context is entered (i.e. at real server startup).
+    """
+    bad = tmp_path / "bad.yaml"
+    bad.write_text(_VALID_MODEL.replace("abstractType:", "abstract_type:"), encoding="utf-8")
+    settings = Settings(
+        model_files=str(bad),
+        session_ttl_seconds=3600,
+        session_cleanup_interval=9999,
+    )
+    app = create_app(settings=settings)
+    try:
+        with pytest.raises(RuntimeError, match="JSON Schema"):
+            async with app.router.lifespan_context(app):
+                pass
+    finally:
+        reset_session_manager()
+
+
+async def test_model_files_preload_accepts_valid_model(tmp_path) -> None:
+    """A canonical (camelCase) MODEL_FILES entry preloads cleanly."""
+    good = tmp_path / "good.yaml"
+    good.write_text(_VALID_MODEL, encoding="utf-8")
+    settings = Settings(
+        model_files=str(good),
+        session_ttl_seconds=3600,
+        session_cleanup_interval=9999,
+    )
+    app = create_app(settings=settings)
+    try:
+        async with app.router.lifespan_context(app):
+            pass
+    finally:
+        reset_session_manager()

--- a/tests/unit/test_obml_contract.py
+++ b/tests/unit/test_obml_contract.py
@@ -43,13 +43,10 @@ ONTOLOGY_PATH = REPO_ROOT / "ontology" / "obsl.ttl"
 MANIFEST_FIELD_EXCLUSIONS: dict[str, set[str]] = {}
 
 # JSON-schema properties that intentionally have no matching manifest field
-# alias, because the schema accepts a second spelling for one field. These
-# are compatibility aliases, not new fields, so they are exempt from the
-# reverse (schema -> manifest) coverage check.
+# alias. The schema is camelCase-only; the only remaining exceptions are the
+# two top-level merge keys, which the parser consumes (they map to the
+# private extends_sources / inherits_source model fields).
 SCHEMA_ONLY_PROPERTIES: dict[str, set[str]] = {
-    "ModelExample": {"intent_tags"},  # snake_case alias of intentTags
-    "RefreshPolicy": {"max_staleness"},  # snake_case alias of maxStaleness
-    # SemanticModel.extends_sources / inherits_source load from these keys.
     "SemanticModel": {"extends", "inherits"},
 }
 

--- a/tests/unit/test_obml_contract.py
+++ b/tests/unit/test_obml_contract.py
@@ -1,0 +1,258 @@
+"""OBML contract drift gate (Phase 2).
+
+``schema/obml-contract.yml`` is the single, hand-maintained manifest of the
+OBML field surface. These tests keep it honest against the three artifacts
+it summarizes:
+
+* **Pydantic models** (``orionbelt.models.semantic``) — every modeled OBML
+  field and enum must appear in the manifest (or an explicit exclusion),
+  and the manifest must not list fields that no longer exist.
+* **JSON schema** (``schema/obml-schema.json``) — every field the manifest
+  marks ``json_schema: true`` must resolve to a property in the schema.
+* **Ontology** (``ontology/obsl.ttl``) — every ``ontology_property`` /
+  ``ontology_class`` the manifest declares must exist in the ontology.
+
+Adding an OBML field on the Pydantic models without updating the manifest
+fails ``test_every_pydantic_field_is_in_manifest``. The pre-existing schema
+and OSI drift tests remain the authority on those artifacts' internal
+integrity; this gate only checks the manifest's cross-references.
+"""
+
+from __future__ import annotations
+
+import enum
+import json
+import re
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+import yaml
+from pydantic import BaseModel
+
+import orionbelt.models.semantic as semantic
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MANIFEST_PATH = REPO_ROOT / "schema" / "obml-contract.yml"
+SCHEMA_PATH = REPO_ROOT / "schema" / "obml-schema.json"
+ONTOLOGY_PATH = REPO_ROOT / "ontology" / "obsl.ttl"
+
+# Pydantic fields intentionally absent from the manifest, keyed by class
+# name. Empty today; every field is currently modeled. Add entries here
+# (with a comment) if a field should never be part of the OBML contract.
+MANIFEST_FIELD_EXCLUSIONS: dict[str, set[str]] = {}
+
+# JSON-schema properties that intentionally have no matching manifest field
+# alias, because the schema accepts a second spelling for one field. These
+# are compatibility aliases, not new fields, so they are exempt from the
+# reverse (schema -> manifest) coverage check.
+SCHEMA_ONLY_PROPERTIES: dict[str, set[str]] = {
+    "ModelExample": {"intent_tags"},  # snake_case alias of intentTags
+    "RefreshPolicy": {"max_staleness"},  # snake_case alias of maxStaleness
+    # SemanticModel.extends_sources / inherits_source load from these keys.
+    "SemanticModel": {"extends", "inherits"},
+}
+
+
+# ─────────────────────────── fixtures / loaders ────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def manifest() -> dict[str, Any]:
+    return cast(dict[str, Any], yaml.safe_load(MANIFEST_PATH.read_text(encoding="utf-8")))
+
+
+@pytest.fixture(scope="module")
+def schema() -> dict[str, Any]:
+    return cast(dict[str, Any], json.loads(SCHEMA_PATH.read_text(encoding="utf-8")))
+
+
+def _obml_model_classes() -> dict[str, type[BaseModel]]:
+    return {
+        name: obj
+        for name, obj in vars(semantic).items()
+        if isinstance(obj, type)
+        and issubclass(obj, BaseModel)
+        and obj.__module__ == semantic.__name__
+    }
+
+
+def _obml_enums() -> dict[str, type[enum.Enum]]:
+    return {
+        name: obj
+        for name, obj in vars(semantic).items()
+        if isinstance(obj, type)
+        and issubclass(obj, enum.Enum)
+        and obj.__module__ == semantic.__name__
+    }
+
+
+def _schema_property_names(schema: dict[str, Any], node: Any) -> set[str]:
+    """Resolve the property aliases reachable from a schema node.
+
+    Follows ``$ref`` into ``definitions`` and merges ``allOf`` / ``anyOf`` /
+    ``oneOf`` branches, matching how the schema composes object shapes.
+    """
+    defs = schema["definitions"]
+    out: set[str] = set()
+    if not isinstance(node, dict):
+        return out
+    if "$ref" in node:
+        return _schema_property_names(schema, defs[node["$ref"].split("/")[-1]])
+    out |= set((node.get("properties") or {}).keys())
+    for key in ("allOf", "anyOf", "oneOf"):
+        for sub in node.get(key, []):
+            out |= _schema_property_names(schema, sub)
+    return out
+
+
+def _resolve_pointer(schema: dict[str, Any], pointer: str) -> Any:
+    node: Any = schema
+    for key in pointer.split("/"):
+        node = node[key]
+    return node
+
+
+def _schema_props_for_class(schema: dict[str, Any], entry: dict[str, Any]) -> set[str] | None:
+    """Property aliases the schema exposes for a manifest class entry."""
+    if entry.get("json_schema_root"):
+        return set((schema.get("properties") or {}).keys())
+    if "json_schema_def" in entry:
+        return _schema_property_names(schema, schema["definitions"][entry["json_schema_def"]])
+    if "json_schema_pointer" in entry:
+        node = _resolve_pointer(schema, entry["json_schema_pointer"])
+        return _schema_property_names(schema, node)
+    return None
+
+
+def _ontology_text() -> str:
+    return ONTOLOGY_PATH.read_text(encoding="utf-8")
+
+
+def _ontology_names(kind: str) -> set[str]:
+    """Local names declared in the ontology for the given OWL ``kind``."""
+    pattern = re.compile(rf"obsl:([A-Za-z_]+)\s+a\s+owl:{kind}\b")
+    return set(pattern.findall(_ontology_text()))
+
+
+def _ontology_property_names() -> set[str]:
+    return _ontology_names("DatatypeProperty") | _ontology_names("ObjectProperty")
+
+
+# ─────────────────────────── 2.2 Pydantic ↔ manifest ───────────────────────
+
+
+def test_every_obml_class_is_in_manifest(manifest: dict[str, Any]) -> None:
+    classes = manifest["classes"]
+    for name in _obml_model_classes():
+        assert name in classes, f"OBML class {name!r} missing from {MANIFEST_PATH.name}"
+
+
+def test_manifest_has_no_unknown_classes(manifest: dict[str, Any]) -> None:
+    known = set(_obml_model_classes())
+    for name in manifest["classes"]:
+        assert name in known, f"manifest lists class {name!r} that no longer exists"
+
+
+def test_every_pydantic_field_is_in_manifest(manifest: dict[str, Any]) -> None:
+    classes = manifest["classes"]
+    for name, model in _obml_model_classes().items():
+        listed = set(classes[name].get("fields") or {})
+        excluded = MANIFEST_FIELD_EXCLUSIONS.get(name, set())
+        for field_name in model.model_fields:
+            assert field_name in listed or field_name in excluded, (
+                f"{name}.{field_name} is not in the manifest. Add it to "
+                f"schema/obml-contract.yml (or MANIFEST_FIELD_EXCLUSIONS)."
+            )
+
+
+def test_manifest_has_no_stale_fields(manifest: dict[str, Any]) -> None:
+    classes = manifest["classes"]
+    for name, model in _obml_model_classes().items():
+        listed = set(classes[name].get("fields") or {})
+        for field_name in listed:
+            assert field_name in model.model_fields, (
+                f"manifest lists {name}.{field_name} which no longer exists on the model"
+            )
+
+
+def test_manifest_field_aliases_match_models(manifest: dict[str, Any]) -> None:
+    classes = manifest["classes"]
+    for name, model in _obml_model_classes().items():
+        fields = classes[name].get("fields") or {}
+        for field_name, meta in fields.items():
+            expected = model.model_fields[field_name].alias or field_name
+            assert meta["alias"] == expected, (
+                f"{name}.{field_name}: manifest alias {meta['alias']!r} != model alias {expected!r}"
+            )
+
+
+def test_every_enum_is_in_manifest(manifest: dict[str, Any]) -> None:
+    enums = manifest["enums"]
+    declared = _obml_enums()
+    assert set(enums) == set(declared), (
+        f"manifest enums {sorted(enums)} != model enums {sorted(declared)}"
+    )
+    for name, enum_cls in declared.items():
+        assert enums[name]["values"] == [e.value for e in enum_cls], (
+            f"enum {name} values drifted from the model"
+        )
+
+
+# ─────────────────────────── 2.3 manifest ↔ JSON schema ────────────────────
+
+
+def test_json_schema_fields_exist_in_schema(
+    manifest: dict[str, Any], schema: dict[str, Any]
+) -> None:
+    for name, entry in manifest["classes"].items():
+        props = _schema_props_for_class(schema, entry)
+        if props is None:
+            continue
+        for field_name, meta in (entry.get("fields") or {}).items():
+            if meta.get("json_schema"):
+                assert meta["alias"] in props, (
+                    f"{name}.{field_name} is marked json_schema: true but alias "
+                    f"{meta['alias']!r} is not in the schema definition"
+                )
+
+
+def test_schema_properties_are_covered_by_manifest(
+    manifest: dict[str, Any], schema: dict[str, Any]
+) -> None:
+    """Every schema property of a mapped class is a manifest field alias.
+
+    Catches a property added to the JSON schema without a matching manifest
+    entry (the other drift direction).
+    """
+    for name, entry in manifest["classes"].items():
+        props = _schema_props_for_class(schema, entry)
+        if props is None:
+            continue
+        manifest_aliases = {meta["alias"] for meta in (entry.get("fields") or {}).values()}
+        missing = props - manifest_aliases - SCHEMA_ONLY_PROPERTIES.get(name, set())
+        assert not missing, f"{name}: schema properties not in manifest: {sorted(missing)}"
+
+
+# ─────────────────────────── 2.4 manifest ↔ ontology ───────────────────────
+
+
+def test_declared_ontology_properties_exist(manifest: dict[str, Any]) -> None:
+    available = _ontology_property_names()
+    for name, entry in manifest["classes"].items():
+        for field_name, meta in (entry.get("fields") or {}).items():
+            prop = meta.get("ontology_property")
+            if prop:
+                assert prop in available, (
+                    f"{name}.{field_name}: ontology_property {prop!r} is not declared in obsl.ttl"
+                )
+
+
+def test_declared_ontology_classes_exist(manifest: dict[str, Any]) -> None:
+    available = _ontology_names("Class")
+    for name, entry in manifest["classes"].items():
+        ont_class = entry.get("ontology_class")
+        if ont_class:
+            assert ont_class in available, (
+                f"{name}: ontology_class {ont_class!r} is not declared in obsl.ttl"
+            )

--- a/tests/unit/test_reference_schema_loader.py
+++ b/tests/unit/test_reference_schema_loader.py
@@ -13,18 +13,19 @@ import json
 import pytest
 
 from orionbelt.api.routers import reference
+from orionbelt.parser.schema_validation import read_schema_text
 
 
 @pytest.mark.parametrize("filename", ["obml-schema.json", "query-schema.json"])
 def test_read_schema_text_resolves_each_file(filename: str) -> None:
-    text = reference._read_schema_text(filename)
+    text = read_schema_text(filename)
     assert text is not None, f"{filename} should resolve in any install layout"
     parsed = json.loads(text)
     assert parsed.get("$schema") or parsed.get("type")
 
 
 def test_read_schema_text_unknown_file_returns_none() -> None:
-    assert reference._read_schema_text("does-not-exist.json") is None
+    assert read_schema_text("does-not-exist.json") is None
 
 
 @pytest.mark.parametrize("name", ["obml", "query"])


### PR DESCRIPTION
## Summary

Implements **Phase 2** of the architecture improvement program: a single canonical manifest for the OBML field surface, used as a drift source (generation is deferred to Phase 6).

`schema/obml-contract.yml` records, in one hand-maintained file:
- every **enum** (14) with its values,
- every **class** (21) and per field: the camelCase `alias`, a short `type`, `json_schema` exposure, `ontology_property`, and an advisory `osi_roundtrip` flag.

151 fields covered.

## Drift gate

`tests/unit/test_obml_contract.py` (10 tests) keeps the manifest honest against the three artifacts it summarizes:

| Direction | Check |
| --- | --- |
| Pydantic -> manifest | every modeled field/enum is in the manifest (or `MANIFEST_FIELD_EXCLUSIONS`); aliases match the model |
| manifest -> Pydantic | no stale fields/classes |
| manifest -> JSON schema | every `json_schema: true` field resolves to a schema property |
| JSON schema -> manifest | every mapped schema property is covered (minus documented compat aliases) |
| manifest -> ontology | declared `ontology_property` / `ontology_class` names exist in `obsl.ttl` |

**Adding or removing an OBML field on the Pydantic models without updating the manifest now fails CI** - the intended early-warning that the other dependents (schema, ontology, OSI, docs) also need attention.

## Notes

- The reverse schema check immediately surfaced three intentional snake_case/compat aliases the schema accepts (`intent_tags`, `max_staleness`, `extends`/`inherits`); these are documented in a `SCHEMA_ONLY_PROPERTIES` allowlist rather than silently ignored.
- No generated files: per the plan, Phase 2 is a drift manifest first. The existing schema and OSI drift tests are unchanged and remain the authority on those artifacts' internal integrity.
- Update flow documented in `docs/getting-started/development.md` ("Changing the OBML model"), with a pointer from `AGENTS.md`.

## Verification

- `uv run ruff check src/ tests/` clean
- `uv run ruff format --check src/ tests/` clean
- `uv run mypy src/` clean
- `uv run pytest` : 2464 passed, 167 skipped

Builds on Phases 0 (#141) and 1 (#142), both merged. Unblocks Phase 6 (generated artifacts).