### PR TITLE
refactor(api): explicit AppRuntime with per-request isolation (Phase 4)

### DIFF
--- a/src/orionbelt/api/app.py
+++ b/src/orionbelt/api/app.py
@@ -330,7 +330,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     if len(named_preloads) == 1:
         preload_model_yaml = named_preloads[0][1]
 
-    init_session_manager(
+    app.state.runtime = init_session_manager(
         mgr,
         disable_session_list=settings.disable_session_list,
         admin_curated=is_admin_curated,

--- a/src/orionbelt/api/app.py
+++ b/src/orionbelt/api/app.py
@@ -9,6 +9,7 @@ import shutil
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from pathlib import Path
+from typing import Any
 
 import uvicorn
 from fastapi import APIRouter, Depends, FastAPI, Request
@@ -19,9 +20,12 @@ from fastapi.responses import JSONResponse, Response
 from orionbelt import __version__
 from orionbelt.api.auth import require_auth
 from orionbelt.api.deps import (
+    AppRuntime,
     CacheRuntimeConfig,
     OneshotBatchConfig,
+    bind_request_runtime,
     init_session_manager,
+    reset_request_runtime,
     reset_session_manager,
 )
 from orionbelt.api.logging_config import configure_logging
@@ -587,6 +591,23 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         trusted_proxy_count=settings.trusted_proxy_count,
     )
     app.add_middleware(RequestIdMiddleware)
+
+    @app.middleware("http")
+    async def _bind_runtime(request: Request, call_next: Any) -> Any:
+        """Bind this app's runtime for the request so deps providers read it.
+
+        Makes the no-argument providers request-scoped: with multiple app
+        instances in one process, each request reads its own app's runtime
+        instead of the shared process-level fallback.
+        """
+        runtime = getattr(request.app.state, "runtime", None)
+        if not isinstance(runtime, AppRuntime):
+            return await call_next(request)
+        token = bind_request_runtime(runtime)
+        try:
+            return await call_next(request)
+        finally:
+            reset_request_runtime(token)
 
     # Versioned API routes under /v1. The auth dependency is applied at the
     # router level so every /v1/* endpoint is protected when AUTH_MODE != none;

--- a/src/orionbelt/api/deps.py
+++ b/src/orionbelt/api/deps.py
@@ -1,21 +1,23 @@
 """Dependency injection for FastAPI.
 
 Runtime state is consolidated into a single :class:`AppRuntime` object
-rather than a scatter of module globals. ``create_app`` builds one and
-attaches it to ``app.state.runtime`` (so each app instance owns its own
-runtime object), while a module-level ``_runtime`` remains as the
-compatibility source the no-argument provider functions read from — direct
-callers across the routers keep working unchanged during the migration.
+rather than a scatter of module globals. ``create_app`` builds one per app
+and attaches it to ``app.state.runtime``; a middleware binds that runtime
+into a :class:`~contextvars.ContextVar` for the duration of each request.
 
 The provider functions (``get_session_manager`` etc.) keep their existing
-signatures so call sites are untouched; they now read fields off the single
-runtime object. Migrating the providers to read ``request.app.state.runtime``
-(for full per-request isolation) and removing ``reset_session_manager`` is a
-later cleanup step.
+signatures so call sites are untouched, and read fields off the *active*
+runtime: the request-bound one when serving a request, otherwise the
+process-level ``_runtime`` (used at startup / MODEL_FILES preload / direct
+tests). This gives real per-request isolation — two live app instances in
+one process each serve their own config — without threading ``request``
+through dozens of call sites. ``reset_session_manager`` remains a test
+compatibility helper that resets the process runtime.
 """
 
 from __future__ import annotations
 
+from contextvars import ContextVar, Token
 from dataclasses import dataclass, field
 
 from fastapi import Request
@@ -71,13 +73,39 @@ class AppRuntime:
     cache_config: CacheRuntimeConfig = field(default_factory=CacheRuntimeConfig)
 
 
-# Module-level compatibility runtime. Starts at defaults so providers called
-# before/without initialisation return the same values the old globals did.
+# Module-level compatibility runtime. Used outside a request (startup,
+# MODEL_FILES preload, direct tests) and as the fallback when no per-request
+# runtime is bound. Starts at defaults so providers called before/without
+# initialisation return the same values the old globals did.
 _runtime: AppRuntime = AppRuntime()
+
+# Per-request runtime, bound by ``bind_request_runtime`` from the app's
+# ``state.runtime`` at the start of each request (see the middleware in
+# ``app.py``). This is what makes providers request-scoped: with two live app
+# instances in one process, each request reads its own app's runtime instead
+# of a shared module global. ContextVars are isolated per async task.
+_request_runtime: ContextVar[AppRuntime | None] = ContextVar(
+    "orionbelt_request_runtime", default=None
+)
+
+
+def _active_runtime() -> AppRuntime:
+    """Runtime the providers should read: the request's, else the process one."""
+    return _request_runtime.get() or _runtime
+
+
+def bind_request_runtime(runtime: AppRuntime) -> Token[AppRuntime | None]:
+    """Bind ``runtime`` for the current request scope; returns a reset token."""
+    return _request_runtime.set(runtime)
+
+
+def reset_request_runtime(token: Token[AppRuntime | None]) -> None:
+    """Undo a :func:`bind_request_runtime` binding."""
+    _request_runtime.reset(token)
 
 
 def current_runtime() -> AppRuntime:
-    """Return the current process-level runtime (compat accessor)."""
+    """Return the process-level runtime (compat accessor; ignores request scope)."""
     return _runtime
 
 
@@ -147,14 +175,15 @@ def init_session_manager(
 
 def get_session_manager() -> SessionManager:
     """FastAPI ``Depends`` provider for SessionManager."""
-    if _runtime.session_manager is None:
+    manager = _active_runtime().session_manager
+    if manager is None:
         raise RuntimeError("SessionManager not initialised — call init_session_manager() first")
-    return _runtime.session_manager
+    return manager
 
 
 def is_session_list_disabled() -> bool:
     """Return True when the GET /sessions endpoint is suppressed."""
-    return _runtime.disable_session_list
+    return _active_runtime().disable_session_list
 
 
 def get_preload_model_yaml() -> str | None:
@@ -165,7 +194,7 @@ def get_preload_model_yaml() -> str | None:
     editor. Multi-model deployments return ``None``; clients use
     ``GET /v1/models`` for discovery instead.
     """
-    return _runtime.preload_model_yaml
+    return _active_runtime().preload_model_yaml
 
 
 def is_single_model_mode() -> bool:
@@ -176,12 +205,12 @@ def is_single_model_mode() -> bool:
     "any admin-curated preload is active", which gates POST/DELETE on
     ``/v1/sessions/{id}/models`` (returns 403) and several shortcut routes.
     """
-    return _runtime.admin_curated
+    return _active_runtime().admin_curated
 
 
 def get_flight_info() -> dict[str, object] | None:
     """Return Flight SQL settings dict, or None if Flight is not enabled."""
-    return _runtime.flight_info
+    return _active_runtime().flight_info
 
 
 def update_flight_state(
@@ -196,37 +225,37 @@ def update_flight_state(
 
 def is_query_execute_enabled() -> bool:
     """Return True when POST /query/execute is available."""
-    return _runtime.query_execute_enabled
+    return _active_runtime().query_execute_enabled
 
 
 def get_db_vendor() -> str:
     """Return the configured default database vendor."""
-    return _runtime.db_vendor
+    return _active_runtime().db_vendor
 
 
 def get_query_default_limit() -> int:
     """Return the default row limit for query execution."""
-    return _runtime.query_default_limit
+    return _active_runtime().query_default_limit
 
 
 def get_default_locale() -> str:
     """Return the configured default locale for value formatting."""
-    return _runtime.default_locale
+    return _active_runtime().default_locale
 
 
 def get_oneshot_batch_config() -> OneshotBatchConfig:
     """Return the configured one-shot batch limits."""
-    return _runtime.oneshot_batch_config
+    return _active_runtime().oneshot_batch_config
 
 
 def get_cache() -> Cache:
     """FastAPI ``Depends`` provider for the result cache."""
-    return _runtime.cache
+    return _active_runtime().cache
 
 
 def get_cache_config() -> CacheRuntimeConfig:
     """Return the cache runtime config (TTL bounds, heartbeat token, etc.)."""
-    return _runtime.cache_config
+    return _active_runtime().cache_config
 
 
 def reset_session_manager() -> None:

--- a/src/orionbelt/api/deps.py
+++ b/src/orionbelt/api/deps.py
@@ -1,8 +1,24 @@
-"""Dependency injection for FastAPI — SessionManager singleton."""
+"""Dependency injection for FastAPI.
+
+Runtime state is consolidated into a single :class:`AppRuntime` object
+rather than a scatter of module globals. ``create_app`` builds one and
+attaches it to ``app.state.runtime`` (so each app instance owns its own
+runtime object), while a module-level ``_runtime`` remains as the
+compatibility source the no-argument provider functions read from — direct
+callers across the routers keep working unchanged during the migration.
+
+The provider functions (``get_session_manager`` etc.) keep their existing
+signatures so call sites are untouched; they now read fields off the single
+runtime object. Migrating the providers to read ``request.app.state.runtime``
+(for full per-request isolation) and removing ``reset_session_manager`` is a
+later cleanup step.
+"""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+
+from fastapi import Request
 
 from orionbelt.auth import init_auth, reset_auth
 from orionbelt.cache.noop import NoopCache
@@ -20,19 +36,6 @@ class OneshotBatchConfig:
     batch_timeout_ms: int = 120000
 
 
-_session_manager: SessionManager | None = None
-_disable_session_list: bool = False
-_single_model_mode: bool = False
-_preload_model_yaml: str | None = None
-_flight_info: dict[str, object] | None = None
-_query_execute_enabled: bool = False
-_db_vendor: str = "duckdb"
-_query_default_limit: int = 1000
-_default_locale: str = ""
-_oneshot_batch_config: OneshotBatchConfig = OneshotBatchConfig()
-_cache: Cache = NoopCache()
-
-
 @dataclass(frozen=True)
 class CacheRuntimeConfig:
     """Cache-related settings made available to request handlers."""
@@ -45,7 +48,43 @@ class CacheRuntimeConfig:
     heartbeat_auth_token: str | None = None
 
 
-_cache_config: CacheRuntimeConfig = CacheRuntimeConfig()
+@dataclass
+class AppRuntime:
+    """Explicit runtime state for one API app instance.
+
+    Replaces the former collection of ``deps`` module globals. Mutable so
+    late-binding updates (e.g. Flight auto-detection at startup) can refresh
+    individual fields via :func:`update_flight_state`.
+    """
+
+    session_manager: SessionManager | None = None
+    disable_session_list: bool = False
+    admin_curated: bool = False
+    preload_model_yaml: str | None = None
+    flight_info: dict[str, object] | None = None
+    query_execute_enabled: bool = False
+    db_vendor: str = "duckdb"
+    query_default_limit: int = 1000
+    default_locale: str = ""
+    oneshot_batch_config: OneshotBatchConfig = field(default_factory=OneshotBatchConfig)
+    cache: Cache = field(default_factory=NoopCache)
+    cache_config: CacheRuntimeConfig = field(default_factory=CacheRuntimeConfig)
+
+
+# Module-level compatibility runtime. Starts at defaults so providers called
+# before/without initialisation return the same values the old globals did.
+_runtime: AppRuntime = AppRuntime()
+
+
+def current_runtime() -> AppRuntime:
+    """Return the current process-level runtime (compat accessor)."""
+    return _runtime
+
+
+def get_runtime(request: Request) -> AppRuntime:
+    """Return the runtime owned by the request's app (``app.state.runtime``)."""
+    runtime = getattr(request.app.state, "runtime", None)
+    return runtime if isinstance(runtime, AppRuntime) else _runtime
 
 
 def init_session_manager(
@@ -66,70 +105,67 @@ def init_session_manager(
     api_keys: str = "",
     api_key_header: str = "X-API-Key",
     auth_enabled: bool = False,
-) -> None:
-    """Set the global SessionManager (called at app startup).
+) -> AppRuntime:
+    """Build the process runtime and initialise the auth subsystem.
+
+    Returns the constructed :class:`AppRuntime` so ``create_app`` can attach
+    it to ``app.state.runtime``.
 
     ``preload_model_yaml`` is the original YAML of the single protected
-    MODEL_FILES model — passed in only when admin-curated mode loaded
-    exactly one file. The string is surfaced via ``/v1/settings.model_yaml``
-    so UI clients can render the read-only model editor, and re-used by
-    ``POST /v1/sessions`` to seed each new user session with the protected
-    model (since session-scoped model upload is blocked with 403 in
-    admin-curated mode).
+    MODEL_FILES model — passed in only when admin-curated mode loaded exactly
+    one file. It is surfaced via ``/v1/settings.model_yaml`` so UI clients can
+    render the read-only model editor, and re-used by ``POST /v1/sessions`` to
+    seed each new user session with the protected model.
     """
-    global _session_manager, _disable_session_list  # noqa: PLW0603
-    global _single_model_mode, _preload_model_yaml, _flight_info  # noqa: PLW0603
-    global _query_execute_enabled, _db_vendor, _query_default_limit  # noqa: PLW0603
-    global _default_locale, _oneshot_batch_config  # noqa: PLW0603
-    global _cache, _cache_config  # noqa: PLW0603
-    _session_manager = manager
-    _disable_session_list = disable_session_list
-    _single_model_mode = admin_curated
-    _preload_model_yaml = preload_model_yaml
-    _flight_info = flight_info
-    _query_execute_enabled = query_execute_enabled
-    _db_vendor = db_vendor
-    _query_default_limit = query_default_limit
-    _default_locale = default_locale
-    if oneshot_batch_config is not None:
-        _oneshot_batch_config = oneshot_batch_config
-    if cache is not None:
-        _cache = cache
-    if cache_config is not None:
-        _cache_config = cache_config
+    global _runtime  # noqa: PLW0603 — single process-level runtime handle
+    _runtime = AppRuntime(
+        session_manager=manager,
+        disable_session_list=disable_session_list,
+        admin_curated=admin_curated,
+        preload_model_yaml=preload_model_yaml,
+        flight_info=flight_info,
+        query_execute_enabled=query_execute_enabled,
+        db_vendor=db_vendor,
+        query_default_limit=query_default_limit,
+        default_locale=default_locale,
+        oneshot_batch_config=oneshot_batch_config or OneshotBatchConfig(),
+        cache=cache if cache is not None else NoopCache(),
+        cache_config=cache_config or CacheRuntimeConfig(),
+    )
     # Initialise the shared auth subsystem here (not only in the ASGI
-    # lifespan) so test fixtures that call init_session_manager() directly
-    # get a consistent, validated auth config. Raises AuthConfigError on
-    # bad config — fail loudly at startup.
+    # lifespan) so test fixtures that call init_session_manager() directly get
+    # a consistent, validated auth config. Raises AuthConfigError on bad
+    # config — fail loudly at startup.
     init_auth(
         auth_mode=auth_mode,
         api_keys=api_keys,
         header_name=api_key_header,
         auth_enabled=auth_enabled,
     )
+    return _runtime
 
 
 def get_session_manager() -> SessionManager:
     """FastAPI ``Depends`` provider for SessionManager."""
-    if _session_manager is None:
+    if _runtime.session_manager is None:
         raise RuntimeError("SessionManager not initialised — call init_session_manager() first")
-    return _session_manager
+    return _runtime.session_manager
 
 
 def is_session_list_disabled() -> bool:
     """Return True when the GET /sessions endpoint is suppressed."""
-    return _disable_session_list
+    return _runtime.disable_session_list
 
 
 def get_preload_model_yaml() -> str | None:
     """Return the YAML of the single MODEL_FILES protected model, if any.
 
     Populated at startup only when MODEL_FILES has exactly one entry — the
-    single-model-mode UX expects exactly one model to render in the
-    read-only editor. Multi-model deployments return ``None``; clients use
+    single-model-mode UX expects exactly one model to render in the read-only
+    editor. Multi-model deployments return ``None``; clients use
     ``GET /v1/models`` for discovery instead.
     """
-    return _preload_model_yaml
+    return _runtime.preload_model_yaml
 
 
 def is_single_model_mode() -> bool:
@@ -140,12 +176,12 @@ def is_single_model_mode() -> bool:
     "any admin-curated preload is active", which gates POST/DELETE on
     ``/v1/sessions/{id}/models`` (returns 403) and several shortcut routes.
     """
-    return _single_model_mode
+    return _runtime.admin_curated
 
 
 def get_flight_info() -> dict[str, object] | None:
     """Return Flight SQL settings dict, or None if Flight is not enabled."""
-    return _flight_info
+    return _runtime.flight_info
 
 
 def update_flight_state(
@@ -154,63 +190,47 @@ def update_flight_state(
     query_execute_enabled: bool,
 ) -> None:
     """Refresh cached Flight state after auto-detection at startup."""
-    global _flight_info, _query_execute_enabled  # noqa: PLW0603
-    _flight_info = flight_info
-    _query_execute_enabled = query_execute_enabled
+    _runtime.flight_info = flight_info
+    _runtime.query_execute_enabled = query_execute_enabled
 
 
 def is_query_execute_enabled() -> bool:
     """Return True when POST /query/execute is available."""
-    return _query_execute_enabled
+    return _runtime.query_execute_enabled
 
 
 def get_db_vendor() -> str:
     """Return the configured default database vendor."""
-    return _db_vendor
+    return _runtime.db_vendor
 
 
 def get_query_default_limit() -> int:
     """Return the default row limit for query execution."""
-    return _query_default_limit
+    return _runtime.query_default_limit
 
 
 def get_default_locale() -> str:
     """Return the configured default locale for value formatting."""
-    return _default_locale
+    return _runtime.default_locale
 
 
 def get_oneshot_batch_config() -> OneshotBatchConfig:
     """Return the configured one-shot batch limits."""
-    return _oneshot_batch_config
+    return _runtime.oneshot_batch_config
 
 
 def get_cache() -> Cache:
     """FastAPI ``Depends`` provider for the result cache."""
-    return _cache
+    return _runtime.cache
 
 
 def get_cache_config() -> CacheRuntimeConfig:
     """Return the cache runtime config (TTL bounds, heartbeat token, etc.)."""
-    return _cache_config
+    return _runtime.cache_config
 
 
 def reset_session_manager() -> None:
-    """Clear the global SessionManager (for tests)."""
-    global _session_manager, _disable_session_list  # noqa: PLW0603
-    global _single_model_mode, _preload_model_yaml, _flight_info  # noqa: PLW0603
-    global _query_execute_enabled, _db_vendor, _query_default_limit  # noqa: PLW0603
-    global _default_locale, _oneshot_batch_config  # noqa: PLW0603
-    global _cache, _cache_config  # noqa: PLW0603
-    _session_manager = None
-    _disable_session_list = False
-    _single_model_mode = False
-    _preload_model_yaml = None
-    _flight_info = None
-    _query_execute_enabled = False
-    _db_vendor = "duckdb"
-    _query_default_limit = 1000
-    _default_locale = ""
-    _oneshot_batch_config = OneshotBatchConfig()
-    _cache = NoopCache()
-    _cache_config = CacheRuntimeConfig()
+    """Reset the process runtime to defaults (compatibility helper for tests)."""
+    global _runtime  # noqa: PLW0603 — single process-level runtime handle
+    _runtime = AppRuntime()
     reset_auth()

--- a/tests/integration/test_app_runtime.py
+++ b/tests/integration/test_app_runtime.py
@@ -1,0 +1,59 @@
+"""AppRuntime ownership (Phase 4).
+
+``create_app`` consolidates per-app runtime state into a single
+:class:`AppRuntime` attached to ``app.state.runtime``. These tests confirm
+each app instance owns its own runtime object carrying its own config —
+the foundation for embedding/instantiating apps without sharing a tangle
+of module globals.
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from orionbelt.api.app import create_app
+from orionbelt.api.deps import AppRuntime, reset_session_manager
+from orionbelt.settings import Settings
+
+
+def _app(db_vendor: str) -> FastAPI:
+    settings = Settings(
+        db_vendor=db_vendor,
+        # No network surfaces — we only test runtime ownership, and two apps
+        # would otherwise collide on the Flight / pgwire ports.
+        flight_enabled=False,
+        pgwire_enabled=False,
+        session_ttl_seconds=3600,
+        session_cleanup_interval=9999,
+    )
+    return create_app(settings=settings)
+
+
+async def test_app_owns_its_runtime() -> None:
+    app = _app("postgres")
+    try:
+        async with app.router.lifespan_context(app):
+            runtime = app.state.runtime
+            assert isinstance(runtime, AppRuntime)
+            assert runtime.db_vendor == "postgres"
+            assert runtime.session_manager is not None
+    finally:
+        reset_session_manager()
+
+
+async def test_two_apps_have_distinct_runtimes() -> None:
+    app1 = _app("postgres")
+    app2 = _app("mysql")
+    try:
+        async with (
+            app1.router.lifespan_context(app1),
+            app2.router.lifespan_context(app2),
+        ):
+            r1 = app1.state.runtime
+            r2 = app2.state.runtime
+            # Each app captured its own runtime object and config.
+            assert r1 is not r2
+            assert r1.db_vendor == "postgres"
+            assert r2.db_vendor == "mysql"
+    finally:
+        reset_session_manager()

--- a/tests/integration/test_app_runtime.py
+++ b/tests/integration/test_app_runtime.py
@@ -10,6 +10,7 @@ of module globals.
 from __future__ import annotations
 
 from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
 
 from orionbelt.api.app import create_app
 from orionbelt.api.deps import AppRuntime, reset_session_manager
@@ -55,5 +56,30 @@ async def test_two_apps_have_distinct_runtimes() -> None:
             assert r1 is not r2
             assert r1.db_vendor == "postgres"
             assert r2.db_vendor == "mysql"
+    finally:
+        reset_session_manager()
+
+
+async def test_requests_read_their_own_app_runtime() -> None:
+    """Regression: with two live apps, each request reads its OWN app's config.
+
+    Before the per-request runtime binding, the second app's lifespan
+    overwrote the shared module global and app1's /v1/settings reported
+    app2's db_vendor.
+    """
+    app1 = _app("postgres")
+    app2 = _app("mysql")
+    try:
+        async with (
+            app1.router.lifespan_context(app1),
+            app2.router.lifespan_context(app2),
+            AsyncClient(transport=ASGITransport(app=app1), base_url="http://t1") as c1,
+            AsyncClient(transport=ASGITransport(app=app2), base_url="http://t2") as c2,
+        ):
+            # /v1/settings.dialect.env reflects the app's db_vendor.
+            s1 = (await c1.get("/v1/settings")).json()
+            s2 = (await c2.get("/v1/settings")).json()
+            assert s1["dialect"]["env"] == "postgres", s1
+            assert s2["dialect"]["env"] == "mysql", s2
     finally:
         reset_session_manager()


### PR DESCRIPTION
## Summary

Implements **Phase 4** (explicit app runtime): replace the scatter of module globals in `api/deps.py` with a single `AppRuntime` object that each app owns via `app.state.runtime`, and make the dependency providers **request-scoped** so multiple app instances in one process don't share state. No endpoint or behavior change.

## What changed

- **`AppRuntime` dataclass** consolidates the 11 former `deps` globals (`session_manager`, `cache`, `cache_config`, `query_execute_enabled`, `db_vendor`, `query_default_limit`, `default_locale`, `oneshot_batch_config`, `preload_model_yaml`, `flight_info`, `admin_curated`, `disable_session_list`).
- **`create_app` owns one runtime per app**: `app.state.runtime = init_session_manager(...)`.
- **Per-request scoping (the real fix):** a middleware binds `request.app.state.runtime` into a `ContextVar` for the duration of each request. The no-argument providers (`get_session_manager`, `get_db_vendor`, …) read the *active* runtime — the request-bound one when serving a request, else the process-level fallback (startup / MODEL_FILES preload / direct tests). This delivers true per-request isolation **without** threading `request` through ~40 direct call sites, and provider signatures stay unchanged.
- **`reset_session_manager()`** is now a thin test compatibility helper.

## Why ContextVar (review fix)

A first cut stored a per-app runtime on `app.state` but left the providers reading the module global — so with two live apps the second lifespan overwrote the global and app1's requests served app2's config (reproducible via `/v1/settings`). Binding the runtime per request via a `ContextVar` (isolated per async task) fixes that at the read path, for both `Depends`-injected and directly-called providers, with zero call-site churn.

## Tests

`tests/integration/test_app_runtime.py`:
- each app owns a distinct `AppRuntime` with its own config;
- **regression:** two live apps each serve their own `db_vendor` through real `/v1/settings` requests (the exact scenario the review flagged).

## Verification

- `uv run ruff check src/ tests/` clean
- `uv run ruff format --check src/ tests/` clean
- `uv run mypy src/` clean (124 files)
- `uv run pytest` : 2485 passed, 167 skipped

Builds on Phases 0–3 (merged).