### PR TITLE
refactor(flight): decompose server.py (1730 to 557 lines) [Phase 5.5]

### DIFF
--- a/drivers/ob-flight-extension/src/ob_flight/server.py
+++ b/drivers/ob-flight-extension/src/ob_flight/server.py
@@ -11,17 +11,7 @@ from typing import Any
 import pyarrow as pa
 import pyarrow.flight as flight
 
-from ob_driver_core.detection import is_obml, parse_obml  # type: ignore[import-untyped]
-
-from ob_flight.catalog import (
-    VIRTUAL_TABLES,
-    build_dimensions_data,
-    build_measures_data,
-    build_metrics_data,
-    model_to_flight_infos,
-    model_virtual_table_name,
-)
-from ob_flight.converters import rows_to_batch, schema_from_description
+from ob_flight import server_catalog, server_execution, server_routing
 from ob_flight.db_router import connect as db_connect
 from ob_flight.flight_sql import (
     ACTION_CLOSE_PREPARED_STATEMENT,
@@ -39,45 +29,29 @@ from ob_flight.flight_sql import (
     CMD_GET_XDBC_TYPE_INFO,
     CMD_PREPARED_STATEMENT_QUERY,
     CMD_STATEMENT_QUERY,
-    build_catalogs_table,
-    build_columns_table,
-    build_db_schemas_table,
     SQL_INFO_SCHEMA,
-    build_empty_imported_keys_table,
-    build_empty_keys_table,
     build_prepared_statement_result,
-    build_sql_info_table,
-    build_table_types_table,
-    build_tables_table,
     is_flight_sql_command,
     parse_any,
     parse_create_prepared_statement,
     parse_prepared_statement_handle,
     parse_statement_query,
 )
+from ob_flight.server_routing import (
+    _ROUTING_MIDDLEWARE_KEY,
+    _SessionRoutingFactory,
+    _SessionRoutingMiddleware,
+)
 
 logger = logging.getLogger("ob_flight.server")
 
-
-def _arrow_to_obsl_type_hint(arrow_type: pa.DataType) -> str:
-    """Map an Arrow DataType to the OBSL ``ColumnMetadata.type`` vocabulary
-    (``string`` / ``number`` / ``datetime`` / ``binary``). Used when Flight
-    writes to the shared result cache so REST readers decode column types
-    correctly instead of falling back to ``string``.
-    """
-    if pa.types.is_integer(arrow_type) or pa.types.is_floating(arrow_type):
-        return "number"
-    if pa.types.is_decimal(arrow_type):
-        return "number"
-    if (
-        pa.types.is_date(arrow_type)
-        or pa.types.is_timestamp(arrow_type)
-        or pa.types.is_time(arrow_type)
-    ):
-        return "datetime"
-    if pa.types.is_binary(arrow_type) or pa.types.is_large_binary(arrow_type):
-        return "binary"
-    return "string"
+__all__ = [
+    "OBFlightServer",
+    "_SessionRoutingFactory",
+    "_SessionRoutingMiddleware",
+    "_ROUTING_MIDDLEWARE_KEY",
+    "db_connect",
+]
 
 
 # Flight SQL catalog command type URLs that return metadata (no DB execution)
@@ -95,98 +69,13 @@ _CATALOG_COMMANDS = {
     CMD_GET_COLUMNS,
 }
 
-
-# Query modes for the Flight SQL surface. See PLAN_flight_natural_sql.md §3.2.
-# OBSL is a semantic layer, not a JDBC proxy — there are no escape hatches.
-_MODE_SEMANTIC = "semantic"
-"""OBSQL query against the model's virtual table — compiled through the pipeline."""
-_MODE_CATALOG = "catalog"
-"""SHOW / DESCRIBE / information_schema / pg_catalog / canned probes — answered
-from the model, never touches the warehouse."""
-_MODE_REJECTED = "rejected"
-"""Anything else — raw SQL against unknown targets, data-object labels, etc.
-Rejects with RAW_SQL_REJECTED."""
-
-
-# Catalog FROM-target prefixes / system-function tokens — anything matching is
-# routed to a model-backed catalog handler instead of the warehouse.
-_CATALOG_SCHEMAS = ("information_schema.", "pg_catalog.")
-_LABEL_VIEW_NAMES = ("dimensions", "measures", "metrics")
-"""Label views — `SELECT "X" FROM dimensions` routes to semantic mode."""
-
-_METADATA_VIEW_NAMES = ("_dimensions_metadata", "_measures_metadata", "_metrics_metadata")
-"""Metadata views — `SELECT * FROM _dimensions_metadata` returns introspection rows."""
+# Catalog query modes — re-exported from server_execution for back-compat.
+_MODE_SEMANTIC = server_execution._MODE_SEMANTIC
+_MODE_CATALOG = server_execution._MODE_CATALOG
+_MODE_REJECTED = server_execution._MODE_REJECTED
 
 # Back-compat name retained while callers transition.
-_CATALOG_VIRTUAL_TABLES = _METADATA_VIEW_NAMES
-_CATALOG_STATEMENT_KINDS = {
-    "Show",  # SHOW TABLES, SHOW COLUMNS, SHOW DATABASES (some dialects)
-    "Describe",  # DESCRIBE / DESC
-    "Use",  # USE <database>
-    "Set",  # SET <var> = <value>
-    "Command",  # sqlglot's fallback for dialect-unknown commands like SHOW
-}
-_CATALOG_SCALAR_PROBES = {
-    "version",
-    "current_database",
-    "current_schema",
-    "current_user",
-    "current_role",
-    "session_user",
-    "user",
-}
-
-
-class _SessionRoutingMiddleware(flight.ServerMiddleware):  # type: ignore[misc]
-    """Per-call middleware that captures the incoming session/model selector.
-
-    BI tools (DBeaver, Tableau, Power BI) and JDBC clients pass the model
-    name via the gRPC ``database`` header — set by
-    ``Connection.setCatalog()`` on the Arrow Flight SQL JDBC driver, or
-    by URL path ``/database`` on direct gRPC clients. ``x-obsl-model`` is
-    accepted as an alias for clients that can't set the catalog header.
-
-    See ``design/PLAN_flight_natural_sql.md`` multi-model addressing.
-    """
-
-    def __init__(self, selected_model: str | None) -> None:
-        self.selected_model: str | None = selected_model
-
-    def call_completed(self, exception: BaseException | None) -> None:
-        pass
-
-
-class _SessionRoutingFactory(flight.ServerMiddlewareFactory):  # type: ignore[misc]
-    """Reads the connection's catalog / model selector from incoming gRPC
-    metadata and produces a :class:`_SessionRoutingMiddleware` per call.
-
-    Resolution order for the selector:
-      1. ``database`` (standard JDBC catalog header)
-      2. ``x-obsl-model`` (OBSL-specific alias)
-      3. ``catalog`` (some clients send this instead of ``database``)
-      4. None — caller's request enters with no explicit selector and the
-         auto-resolve / __default__ paths in ``_get_model`` apply.
-    """
-
-    _SELECTOR_KEYS = ("database", "x-obsl-model", "catalog")
-
-    def start_call(
-        self, info: flight.CallInfo, headers: dict[str, list[str]]
-    ) -> _SessionRoutingMiddleware:
-        selected: str | None = None
-        # Headers come in lowercased per gRPC convention; values are lists.
-        for key in self._SELECTOR_KEYS:
-            values = headers.get(key) or headers.get(key.lower())
-            if values:
-                raw = values[0]
-                if raw:
-                    selected = raw.strip().lower() or None
-                    break
-        return _SessionRoutingMiddleware(selected)
-
-
-# Key used to register / look up the routing middleware.
-_ROUTING_MIDDLEWARE_KEY = "obsl_routing"
+_CATALOG_VIRTUAL_TABLES = server_execution._METADATA_VIEW_NAMES
 
 
 class OBFlightServer(flight.FlightServerBase):  # type: ignore[misc]
@@ -262,526 +151,58 @@ class OBFlightServer(flight.FlightServerBase):  # type: ignore[misc]
             return None
         return payload
 
+    # ------------------------------------------------------------------
+    # Session / model routing — delegates to ``server_routing``.
+    # ------------------------------------------------------------------
     @staticmethod
     def _selector_from_context(
         context: flight.ServerCallContext | None,
     ) -> str | None:
-        """Read the per-call routing selector from the middleware.
-
-        Returns the (already-lowercased) model name set by the client's
-        ``database`` / ``x-obsl-model`` / ``catalog`` gRPC header, or
-        ``None`` if no selector was sent or the middleware isn't installed
-        (e.g. in unit tests that bypass the real gRPC machinery).
-        """
-        if context is None:
-            return None
-        try:
-            mw = context.get_middleware(_ROUTING_MIDDLEWARE_KEY)
-        except Exception:
-            return None
-        if mw is None:
-            return None
-        return getattr(mw, "selected_model", None)
+        return server_routing.selector_from_context(context)
 
     def _list_available_model_names(self) -> list[str]:
-        """List protected (admin-loaded) session ids in addressing order.
-
-        Used by ``_get_model``'s error path and by the catalog endpoint.
-        The session id IS the model name in multi-model mode; legacy
-        single-model mode contributes ``__default__`` (not really an
-        addressable name — see the auto-resolve branch).
-        """
-        if self._session_manager is None:
-            return []
-        try:
-            ids: list[str] = self._session_manager.list_protected_session_ids()
-            return ids
-        except Exception:
-            return []
+        return server_routing.list_available_model_names(self)
 
     def _resolve_model_by_name(
         self,
         stashed_name: str,
         context: flight.ServerCallContext | None,
     ) -> Any:
-        """Resolve a model by a stashed selector first, falling back to the
-        current call's context. Used by ``do_get`` for ticket round-trips.
-        """
-        if stashed_name:
-            try:
-                store = self._session_manager.get_store(stashed_name)
-                model, _ = self._stamp_model(store, stashed_name)
-                return model
-            except Exception:
-                pass
-        model, _ = self._get_model(context)
-        return model
+        return server_routing.resolve_model_by_name(self, stashed_name, context)
 
     def _get_model(self, context: flight.ServerCallContext | None = None) -> tuple[Any, str]:
-        """Resolve the model targeted by the current call.
-
-        Returns ``(model, dialect)``. Resolution order:
-
-        1. **Explicit selector** from the gRPC ``database`` /
-           ``x-obsl-model`` / ``catalog`` header → that named session.
-        2. **Legacy `__default__`** session (single-model mode via
-           ``MODEL_FILE``).
-        3. **Auto-resolve**: if exactly one admin-loaded session exists,
-           use it without requiring a selector.
-        4. **Rich error** listing the available model names and how to
-           select one.
-
-        Stamps ``_ob_model_id`` on the returned model so downstream
-        catalog code can produce a stable virtual-table name.
-        """
-        if self._session_manager is None:
-            raise flight.FlightUnavailableError("No session manager configured")
-
-        selector = self._selector_from_context(context)
-
-        # 1. Explicit selector
-        if selector:
-            try:
-                store = self._session_manager.get_store(selector)
-            except Exception:
-                available = self._list_available_model_names()
-                raise flight.FlightUnavailableError(
-                    self._format_unknown_model_error(selector, available)
-                ) from None
-            return self._stamp_model(store, selector)
-
-        # 2. Legacy __default__ session (single-model mode)
-        try:
-            default_store = self._session_manager.get_store("__default__")
-            return self._stamp_model(default_store, "__default__")
-        except Exception:
-            pass
-
-        # 3. Auto-resolve when exactly one admin-loaded model exists
-        protected = self._list_available_model_names()
-        if len(protected) == 1:
-            store = self._session_manager.get_store(protected[0])
-            return self._stamp_model(store, protected[0])
-
-        # 4. Ambiguous or empty → rich error
-        if not protected:
-            raise flight.FlightUnavailableError(
-                "[NO_MODEL_AVAILABLE] No models are loaded on this server. "
-                "Either set MODEL_FILES=<path,...> (or legacy MODEL_FILE) "
-                "before starting the server, or load models dynamically "
-                "via POST /v1/sessions + POST /v1/sessions/{id}/models."
-            )
-        raise flight.FlightUnavailableError(self._format_ambiguous_model_error(protected))
+        return server_routing.get_model(self, context)
 
     def _stamp_model(self, store: Any, session_id: str) -> tuple[Any, str]:
-        """Pull the (single) model out of a store and stamp the session
-        id onto it as the virtual-table name. Returns ``(model, dialect)``.
-
-        Per-model dialect resolution: prefer the OBML model's
-        ``settings.defaultDialect`` if set; otherwise fall back to the
-        server's process-wide ``_default_dialect`` (from ``DB_VENDOR``).
-        """
-        models = store.list_models()
-        if not models:
-            raise flight.FlightUnavailableError(
-                f"Session '{session_id}' exists but has no models loaded."
-            )
-        model_id = models[0].model_id
-        model = store.get_model(model_id)
-        try:
-            # In multi-model mode the session_id IS the model name —
-            # use it as the virtual-table name. In legacy mode session_id
-            # is __default__ and we fall back to internal model_id.
-            virtual_name = session_id if not session_id.startswith("_") else model_id
-            model.__dict__["_ob_model_id"] = virtual_name
-        except Exception:
-            pass
-
-        # Per-model dialect override via OBML settings.defaultDialect
-        model_dialect: str | None = None
-        settings = getattr(model, "settings", None)
-        if settings is not None:
-            model_dialect = getattr(settings, "default_dialect", None)
-        return model, model_dialect or self._default_dialect
+        return server_routing.stamp_model(self, store, session_id)
 
     @staticmethod
     def _format_unknown_model_error(selector: str, available: list[str]) -> str:
-        if not available:
-            return (
-                f"[UNKNOWN_MODEL] Model '{selector}' is not loaded and no "
-                "models are available on this server. Either set "
-                "MODEL_FILES=<path,...> at startup or load a model "
-                "dynamically via REST."
-            )
-        return (
-            f"[UNKNOWN_MODEL] Model '{selector}' is not loaded on this server. "
-            f"Available models: {', '.join(sorted(available))}. "
-            "Set the connection's `database` (or `catalog`) field to one "
-            "of these names. In DBeaver: Connection → Database field. "
-            "Pyarrow: client.do_get(...) with a FlightCallOptions header "
-            "(b'database', b'<name>')."
-        )
+        return server_routing.format_unknown_model_error(selector, available)
 
     @staticmethod
     def _format_ambiguous_model_error(available: list[str]) -> str:
-        return (
-            "[NO_MODEL_SELECTED] Multiple models are loaded and no selector "
-            "was sent on this connection. Pick one by setting the "
-            "connection's `database` field (or `x-obsl-model` header). "
-            f"Available models: {', '.join(sorted(available))}.\n"
-            "\n"
-            "  DBeaver:    Connection → Database field = <name>\n"
-            "  Tableau:    Same field on the Arrow Flight JDBC connector\n"
-            "  pyarrow:    options = flight.FlightCallOptions(\n"
-            "                  headers=[(b'database', b'<name>')])\n"
-            "  REST:       Use /v1/sessions/<name>/query/semantic-ql\n"
-            "\n"
-            "Discover available models via GET /v1/models."
-        )
+        return server_routing.format_ambiguous_model_error(available)
 
+    # ------------------------------------------------------------------
+    # SQL classification / preparation / execution — delegates to
+    # ``server_execution``.
+    # ------------------------------------------------------------------
     def _rewrite_table_names(self, sql: str, model: Any) -> str:
-        """Rewrite compiled SQL for execution on the actual database.
-
-        Two rewrites:
-        1. Quoted label → physical code (DBeaver sends "Sales", DB has sales)
-        2. Strip OBML schema prefix — the connection's search_path handles
-           schema resolution, so PUBLIC.sales → sales avoids mismatches
-           between the OBML model's schema field and the actual DB schema.
-        """
-        if not hasattr(model, "data_objects") or not model.data_objects:
-            return sql
-        for obj_name, obj in model.data_objects.items():
-            label = getattr(obj, "label", obj_name) or obj_name
-            code = getattr(obj, "code", None)
-            if not code:
-                continue
-            # Replace quoted "Label" → code (DBeaver-generated SQL)
-            if label != code:
-                sql = sql.replace(f'"{label}"', code)
-            # Strip schema/database prefix — connection context handles resolution
-            # 3-part: ANALYTICS.PUBLIC.sales → sales (BigQuery, Snowflake, Databricks)
-            # 2-part: PUBLIC.sales → sales (Postgres, MySQL, ClickHouse, DuckDB)
-            database = getattr(obj, "database", None)
-            schema_name = getattr(obj, "schema_name", None)
-            if database and schema_name:
-                sql = sql.replace(f"{database}.{schema_name}.{code}", code)
-            if schema_name:
-                sql = sql.replace(f"{schema_name}.{code}", code)
-        return sql
+        return server_execution.rewrite_table_names(self, sql, model)
 
     def _classify_sql(self, sql: str, model: Any) -> str:
-        """Classify a SQL query into one of three handling modes.
-
-        Returns one of:
-
-        * ``_MODE_SEMANTIC`` — OBSQL query against the model's virtual table.
-        * ``_MODE_CATALOG`` — discovery query (``SHOW``, ``DESCRIBE``,
-          ``information_schema.*``, ``pg_catalog.*``, canned probes like
-          ``SELECT version()``). Routed to model-backed responses;
-          **never reaches the warehouse**.
-        * ``_MODE_REJECTED`` — anything else (raw SQL against unknown
-          targets, FROM-<data-object-label>, multi-statement, parse
-          failures). The caller raises ``RAW_SQL_REJECTED``.
-
-        OBSL is a semantic layer, not a JDBC proxy — there are no escape
-        hatches. See ``design/PLAN_flight_natural_sql.md`` §3.2.
-        """
-        # Strip the bare trailing ``WITH ROLLUP``/``WITH CUBE`` before parsing
-        # — sqlglot requires a GROUP BY in front of those modifiers, but the
-        # OBSQL surface lets callers write them as a trailing flag.
-        from orionbelt.compiler.sql_translator import _strip_trailing_grouping
-
-        cleaned, _ = _strip_trailing_grouping(sql)
-
-        # SHOW / DESCRIBE / USE / SET — short-circuit before sqlglot. sqlglot
-        # logs a "unsupported syntax. Falling back to ... Command" warning on
-        # each of these in its default dialect, which spams the log on every
-        # BI-tool catalog probe.
-        cleaned_upper = cleaned.strip().upper()
-        if cleaned_upper.startswith(("SHOW ", "DESCRIBE ", "DESC ", "USE ", "SET ")):
-            return _MODE_CATALOG
-
-        try:
-            import sqlglot
-            import sqlglot.expressions as exp
-
-            ast = sqlglot.parse_one(cleaned)
-        except Exception:
-            return _MODE_REJECTED
-
-        # SHOW / DESCRIBE / USE / SET — top-level non-Select catalog statements
-        if type(ast).__name__ in _CATALOG_STATEMENT_KINDS:
-            return _MODE_CATALOG
-
-        if not isinstance(ast, exp.Select):
-            # INSERT, UPDATE, DELETE, DROP, CREATE, ALTER, TRUNCATE, MERGE,
-            # multi-statement, Union, etc. all reject as raw — write ops
-            # surface a more specific error in _prepare_sql.
-            return _MODE_REJECTED
-
-        # SELECT with no FROM:
-        # * canned-probe functions (version, current_schema, …) → CATALOG
-        # * literal-only (SELECT 1) → CATALOG (connectivity probe)
-        # * column identifiers that all match the model's dims / measures /
-        #   metrics → SEMANTIC. "No FROM" is shorthand for "FROM <model>"
-        #   on a single-model connection, so requiring the FROM is a tax.
-        #   Any identifier that doesn't match falls through to REJECTED
-        #   so users get RAW_SQL_REJECTED rather than UNKNOWN_SELECT_ITEM.
-        from_node = ast.args.get("from")
-        if from_node is None:
-            known_labels = {label.lower() for label in model.dimensions}
-            known_labels |= {label.lower() for label in model.measures}
-            known_labels |= {label.lower() for label in model.metrics}
-
-            saw_canned_probe = False
-            saw_literal_only = True
-            identifier_count = 0
-            unmatched_identifier = False
-            for proj in ast.expressions:
-                inner = proj.this if isinstance(proj, exp.Alias) else proj
-                if isinstance(inner, exp.Anonymous | exp.Func):
-                    fname = (getattr(inner, "name", "") or "").lower()
-                    # sqlglot's typed function nodes (CurrentSchema,
-                    # CurrentUser, …) carry an empty ``.name`` — fall
-                    # back to the class name so canned-probe detection
-                    # still fires for ``SELECT current_schema()``.
-                    if not fname:
-                        fname = type(inner).__name__.lower()
-                    if fname in _CATALOG_SCALAR_PROBES:
-                        saw_canned_probe = True
-                    saw_literal_only = False
-                elif isinstance(inner, exp.Literal):
-                    pass  # keep saw_literal_only True
-                elif isinstance(inner, exp.Column):
-                    col_name = (getattr(inner, "name", "") or "").lower()
-                    # Bare ``SESSION_USER`` / ``CURRENT_USER`` etc. parse
-                    # as Columns. They're system info, not model
-                    # references — treat them as canned probes so the
-                    # whole SELECT routes to catalog.
-                    if col_name in _CATALOG_SCALAR_PROBES:
-                        saw_canned_probe = True
-                        saw_literal_only = False
-                        continue
-                    identifier_count += 1
-                    saw_literal_only = False
-                    if col_name not in known_labels:
-                        unmatched_identifier = True
-                else:
-                    saw_literal_only = False
-            if identifier_count > 0 and not unmatched_identifier:
-                return _MODE_SEMANTIC
-            if saw_canned_probe or saw_literal_only:
-                return _MODE_CATALOG
-            return _MODE_REJECTED
-
-        # FROM something — examine the target
-        table_node = getattr(from_node, "this", None)
-        if table_node is None and getattr(from_node, "expressions", None):
-            table_node = from_node.expressions[0]
-        if table_node is None:
-            return _MODE_REJECTED
-
-        # Pull the qualified name (`pg_catalog.pg_class` etc.) and the
-        # bare identifier separately.
-        full_sql = table_node.sql().lower()
-        bare = getattr(table_node, "name", None) or table_node.sql()
-        bare = str(bare).strip('"').strip("`").strip("'").lower()
-
-        # Catalog schemas
-        for prefix in _CATALOG_SCHEMAS:
-            if prefix in full_sql:
-                return _MODE_CATALOG
-        # Metadata views — return introspection rows (name / data_object / …).
-        if bare in _METADATA_VIEW_NAMES:
-            return _MODE_CATALOG
-
-        # Schema-qualified metadata / label view. Three shapes the BI
-        # tools fire after picking a table from the schema tree:
-        #
-        #   FROM <model>.dimensions                       (2-part, pgjdbc/DBeaver pushdown)
-        #   FROM "orionbelt"."<model>"."dimensions"       (3-part, Tableau pushdown)
-        #   FROM <model>.model / FROM <model>.measures    (2-part, generic)
-        #
-        # All three are "metadata for THIS model" → route to the
-        # catalog where ``SELECT *`` is honoured. Bare label-view
-        # references (``FROM dimensions``) keep the OBSQL
-        # category-filtered virtual-table semantics so existing
-        # surface behaviour is preserved.
-        #
-        # Compare the schema qualifier against BOTH the
-        # ``_ob_model_id`` (stamped session name = pg_namespace
-        # nspname BI tools see in the tree) AND the OBML
-        # ``name:`` field — they can differ when the OBML doesn't
-        # declare ``name:`` explicitly and falls back to a filename
-        # stem, in which case ``model.name`` is empty and only the
-        # stamp is reliable.
-        schema = (
-            (getattr(table_node, "db", None) or table_node.text("db") or "")
-            .strip('"')
-            .strip("`")
-            .strip("'")
-            .lower()
-        )
-        stamped_name = (getattr(model, "_ob_model_id", "") or "").lower()
-        obml_name = (getattr(model, "name", "") or "").lower()
-        model_schemas = {n for n in (stamped_name, obml_name) if n}
-        if (
-            schema
-            and schema in model_schemas
-            and bare in (_LABEL_VIEW_NAMES + _METADATA_VIEW_NAMES + ("model",))
-        ):
-            return _MODE_CATALOG
-
-        # Semantic — the model's virtual table, OR a per-category label view
-        # (_dimensions/_measures/_metrics). Label views are aliases for the
-        # model VT restricted to one category, so `SELECT "X" FROM _dimensions`
-        # compiles through the standard semantic pipeline.
-        vt = model_virtual_table_name(model).lower()
-        if bare == vt or bare in _LABEL_VIEW_NAMES:
-            return _MODE_SEMANTIC
-
-        # Anything else (including FROM-<data-object-label>) rejects.
-        return _MODE_REJECTED
+        return server_execution.classify_sql(self, sql, model)
 
     def _semantic_result_schema(self, query: Any, model: Any) -> pa.Schema:
-        """Build the result Arrow schema for a semantic query without DB I/O.
-
-        Reads ``result_type`` from each selected dimension / measure / metric.
-        See ``design/PLAN_flight_natural_sql.md`` §3.4 "Schema probe".
-        """
-        from ob_flight.catalog import _obml_type_to_arrow
-
-        fields: list[pa.Field] = []
-        dims = getattr(query.select, "dimensions", [])
-        measures = getattr(query.select, "measures", [])
-        for name in dims:
-            label = name if isinstance(name, str) else getattr(name, "alias", None)
-            if label is None:
-                continue
-            dim = model.dimensions.get(label)
-            rt = getattr(getattr(dim, "result_type", None), "value", None) or "string"
-            fields.append(pa.field(label, _obml_type_to_arrow(rt)))
-        for label in measures:
-            meas = model.measures.get(label)
-            met = model.metrics.get(label) if meas is None else None
-            if meas is not None:
-                rt = getattr(getattr(meas, "result_type", None), "value", None) or "float"
-                fields.append(pa.field(label, _obml_type_to_arrow(rt)))
-            elif met is not None:
-                fields.append(pa.field(label, pa.float64()))
-            else:
-                fields.append(pa.field(label, pa.float64()))
-        if query.grouping is not None:
-            # GROUPING() flag columns — int64, one per dimension. See
-            # PLAN_with_rollup.md §"Output: GROUPING() flag columns".
-            for name in dims:
-                label = name if isinstance(name, str) else getattr(name, "alias", None)
-                if label is None:
-                    continue
-                fields.append(pa.field(f"_g_{label}", pa.int64()))
-        return pa.schema(fields)
+        return server_execution.semantic_result_schema(self, query, model)
 
     def _prepare_sql(
         self,
         sql: str,
         context: flight.ServerCallContext | None = None,
     ) -> tuple[str, str, Any, pa.Schema | None, str, dict[str, Any] | None]:
-        """Resolve model, classify SQL, translate / compile / route.
-
-        Returns ``(final_sql_or_token, dialect, model, schema_hint, mode,
-        cache_meta)``. ``cache_meta`` is a dict with ``key``, ``ttl``,
-        ``session_id``, ``model_id``, ``physical_tables`` when the semantic
-        query is cacheable; ``None`` otherwise (catalog mode, no cache
-        backend, OBML, or oversize-skip).
-
-        * ``mode == _MODE_SEMANTIC`` — ``final_sql_or_token`` is compiled
-          warehouse SQL; ``schema_hint`` is the result schema computed
-          from the model. Caller executes against the warehouse.
-        * ``mode == _MODE_CATALOG`` — ``final_sql_or_token`` is the
-          original SQL; the caller routes to ``_handle_catalog_sql``
-          which returns model-backed metadata. ``schema_hint`` is None.
-        * Anything else raises before returning.
-
-        ``context`` carries the per-call gRPC metadata used to select the
-        target model (``database`` / ``x-obsl-model`` headers).
-
-        Hard rules (v2.4.0+, no env flags):
-
-        * **Raw SQL pass-through is never allowed.** OBSL is a semantic
-          layer, not a JDBC proxy. Unrecognised FROM targets reject
-          with ``RAW_SQL_REJECTED``.
-        * **Write operations (DDL / DML / TCL) are never allowed.** Only
-          ``SELECT`` reaches the warehouse. Reject with
-          ``WRITE_OPERATION_REJECTED``.
-        * **Catalog discovery is always allowed**, never touches the
-          warehouse — answered from the model.
-        """
-        from orionbelt.compiler.pipeline import CompilationPipeline
-        from orionbelt.compiler.sql_translator import (
-            SQLTranslationError,
-            translate_sql_to_query,
-        )
-
-        model, dialect = self._get_model(context)
-
-        # Write-op early reject — covers DDL/DML/TCL across all paths.
-        # OBML YAML detection happens after this so YAML-wrapped writes
-        # also can't sneak through (OBML has no write syntax, but it's
-        # cheap defence-in-depth).
-        self._reject_write_operation(sql)
-
-        # OBML YAML wrapped as a SQL string — power-user path
-        if is_obml(sql):
-            obml = parse_obml(sql)
-            logger.info("OBML request:\n%s", sql)
-            compiled = self._compile_obml(obml, model, dialect)
-            sql = self._rewrite_table_names(compiled.sql, model)
-            logger.info("Compiled SQL:\n%s", sql)
-            # OBML compiles to deterministic SQL like OBSQL; share the cache.
-            cache_meta = self._build_cache_meta(
-                compiled_sql=sql,
-                dialect=dialect,
-                context=context,
-                physical_tables=list(getattr(compiled, "physical_tables", [])),
-            )
-            return sql, dialect, model, None, _MODE_SEMANTIC, cache_meta
-
-        mode = self._classify_sql(sql, model)
-
-        if mode == _MODE_SEMANTIC:
-            logger.info("OBSQL request:\n%s", sql)
-            try:
-                query = translate_sql_to_query(sql, model)
-            except SQLTranslationError as exc:
-                detail = "; ".join(f"[{e.code}] {e.message}" for e in exc.errors)
-                raise flight.FlightServerError(
-                    f"OrionBelt Semantic QL translation failed: {detail}"
-                ) from None
-            compiled = CompilationPipeline().compile(query, model, dialect)
-            sql = self._rewrite_table_names(compiled.sql, model)
-            logger.info("Compiled SQL:\n%s", sql)
-            schema_hint = self._semantic_result_schema(query, model)
-            cache_meta = self._build_cache_meta(
-                compiled_sql=sql,
-                dialect=dialect,
-                context=context,
-                physical_tables=list(getattr(compiled, "physical_tables", [])),
-            )
-            return sql, dialect, model, schema_hint, _MODE_SEMANTIC, cache_meta
-
-        if mode == _MODE_CATALOG:
-            # Don't compile or rewrite — the caller routes the original SQL
-            # to a model-backed catalog handler. Schema is computed there.
-            return sql, dialect, model, None, _MODE_CATALOG, None
-
-        # _MODE_REJECTED — no escape hatch.
-        raise flight.FlightServerError(
-            "[RAW_SQL_REJECTED] Raw SQL pass-through is not supported. "
-            "OBSL accepts: (1) OBSQL queries against the model's virtual "
-            "table, (2) compiled QueryObjects via the REST API, and "
-            "(3) catalog discovery (SHOW / DESCRIBE / information_schema / "
-            "pg_catalog). Arbitrary warehouse SQL is rejected by design."
-        )
+        return server_execution.prepare_sql(self, sql, context)
 
     def _build_cache_meta(
         self,
@@ -791,364 +212,69 @@ class OBFlightServer(flight.FlightServerBase):  # type: ignore[misc]
         context: flight.ServerCallContext | None,
         physical_tables: list[str],
     ) -> dict[str, Any] | None:
-        """Compute cache key + TTL for a semantic Flight query.
-
-        Returns ``None`` when the cache backend is disabled or the TTL
-        resolver decides the query isn't cacheable (no refresh contracts
-        + ``no_cache`` unknown policy). The caller drops the cache_meta
-        and runs the warehouse query directly.
-        """
-        if self._cache is None or self._cache_config is None:
-            return None
-        backend = getattr(self._cache, "backend_name", "noop")
-        if backend == "noop":
-            return None
-
-        # Non-deterministic SQL (RAND, NOW, CURRENT_DATE, TABLESAMPLE, ...)
-        # must bypass the cache — the SQL hash is the cache key, so caching
-        # would freeze one stale clock/random slice forever.
-        from orionbelt.cache import is_nondeterministic_sql
-
-        nondet, name = is_nondeterministic_sql(compiled_sql)
-        if nondet:
-            logger.info("cache skipped: non-deterministic SQL (%s)", name)
-            return None
-
-        # Resolve session_id from the selector header. Falls back to the
-        # __default__ slot for legacy single-model deployments — matches
-        # how the REST endpoints derive session_id for the cache key.
-        selector = self._selector_from_context(context) or ""
-        if not selector:
-            # Use the protected list (auto-resolve) — single-entry path.
-            protected = self._list_available_model_names()
-            selector = protected[0] if len(protected) == 1 else "__default__"
-
-        try:
-            store = self._session_manager.get_store(selector)
-            models = store.list_models()
-            if not models:
-                return None
-            model_id = models[0].model_id
-        except Exception:
-            return None
-
-        from orionbelt.cache import build_cache_key, compute_effective_ttl
-
-        # v2 keys hash on the compiled SQL string — the canonical, dialect-
-        # rendered form actually sent to the warehouse.
-        cache_key = build_cache_key(
-            session_id=selector,
-            model_id=model_id,
+        return server_execution.build_cache_meta(
+            self,
+            compiled_sql=compiled_sql,
             dialect=dialect,
-            sql=compiled_sql,
-        )
-
-        # Resolve TTL from refresh contracts + heartbeats — same logic
-        # the REST endpoint uses.
-        try:
-            contracts = store.refresh_contracts(model_id)
-        except Exception:
-            contracts = {}
-        heartbeats: dict[str, Any] = {}
-        snapshot = getattr(self._cache, "heartbeats_snapshot", None)
-        if callable(snapshot):
-            try:
-                heartbeats = snapshot()
-            except Exception:
-                heartbeats = {}
-        ttl_outcome = compute_effective_ttl(
+            context=context,
             physical_tables=physical_tables,
-            contracts=contracts,
-            heartbeats=heartbeats,
-            min_ttl_seconds=self._cache_config.min_ttl_seconds,
-            max_ttl_seconds=self._cache_config.max_ttl_seconds,
-            unknown_policy=self._cache_config.unknown_policy,
-            unknown_default_ttl_seconds=self._cache_config.unknown_default_ttl_seconds,
         )
-        if ttl_outcome.ttl is None:
-            return None
-        return {
-            "key": cache_key,
-            "ttl": int(ttl_outcome.ttl.seconds),
-            "session_id": selector,
-            "model_id": model_id,
-            "physical_tables": physical_tables,
-            "dialect": dialect,
-            "sql": compiled_sql,
-        }
 
     @staticmethod
     def _reject_write_operation(sql: str) -> None:
-        """Reject DDL / DML / TCL statements at the door.
+        server_execution.reject_write_operation(sql)
 
-        Parses the SQL with sqlglot and rejects anything whose top-level
-        node is a write operation. ``SELECT`` and ``WITH ... SELECT`` CTEs
-        pass; the catalog-specific ``SHOW`` / ``DESCRIBE`` / ``USE`` /
-        ``SET`` statements also pass (handled by catalog mode). Anything
-        else raises ``WRITE_OPERATION_REJECTED``.
+    def _compile_obml(self, obml: dict[str, Any], model: Any, dialect: str) -> Any:
+        return server_execution.compile_obml(self, obml, model, dialect)
 
-        Defence-in-depth — the translator already rejects non-SELECT for
-        semantic mode, but this guard ensures write ops can't reach the
-        warehouse via *any* path.
-        """
-        # Short-circuit catalog-discovery statements before sqlglot — those
-        # are explicitly allowed and parsing them logs a noisy "unsupported
-        # syntax. Falling back to Command" warning in sqlglot's default
-        # dialect, which would fire on every BI-tool catalog probe.
-        upper = sql.strip().upper()
-        if upper.startswith(("SHOW ", "DESCRIBE ", "DESC ", "USE ", "SET ")):
-            return
+    def _execute_sql(
+        self,
+        sql: str,
+        dialect: str,
+        cache_meta: dict[str, Any] | None = None,
+    ) -> flight.RecordBatchStream:
+        return server_execution.execute_sql(self, sql, dialect, cache_meta)
 
-        try:
-            import sqlglot
-            import sqlglot.expressions as exp
+    def _cache_get_table(self, key: str) -> pa.Table | None:
+        return server_execution.cache_get_table(self, key)
 
-            ast = sqlglot.parse_one(sql)
-        except Exception:
-            # Parse failure isn't a write op per se — let downstream
-            # classification surface the right error.
-            return
-        if isinstance(ast, exp.Select):
-            return
-        if type(ast).__name__ in _CATALOG_STATEMENT_KINDS:
-            return
-        # Insert, Update, Delete, Drop, Create, Alter, Truncate, Merge,
-        # Commit, Rollback, Grant, Revoke, etc. — all reject.
-        kind = type(ast).__name__.upper()
-        if kind in {"UNION"}:  # set ops surface as raw
-            return
-        raise flight.FlightServerError(
-            f"[WRITE_OPERATION_REJECTED] {kind} statements are not allowed. "
-            "OBSL is read-only — only SELECT queries (and catalog discovery) "
-            "reach the warehouse."
-        )
+    def _cache_put_table(self, table: pa.Table, cache_meta: dict[str, Any]) -> None:
+        server_execution.cache_put_table(self, table, cache_meta)
 
+    # ------------------------------------------------------------------
+    # Catalog / metadata — delegates to ``server_catalog``.
+    # ------------------------------------------------------------------
     def _handle_catalog_sql(self, sql: str, model: Any) -> pa.Table:
-        """Answer a catalog/discovery SQL query from the model — no warehouse hop.
-
-        Returns a :class:`pa.Table` so callers can wrap it in a
-        ``RecordBatchStream`` once. Covers the common BI-tool / JDBC
-        introspection probes:
-
-        * ``SHOW TABLES`` → list of virtual tables (the model + metadata views)
-        * ``SHOW COLUMNS FROM <model>`` / ``DESCRIBE <model>`` → dim+measure+metric
-        * ``SELECT … FROM information_schema.tables`` → same as SHOW TABLES
-        * ``SELECT … FROM information_schema.columns`` → flat column list
-        * ``SELECT … FROM pg_catalog.*`` → mapped to the same model-backed responses
-        * Canned scalar probes: ``SELECT 1``, ``SELECT version()``, ``current_schema()``
-
-        Unrecognised catalog queries return an empty result set rather
-        than failing — Postgres / MySQL clients probe a long tail of
-        system tables, and breaking on every unknown probe blocks tool
-        discovery. Empty results are the right default — clients adapt.
-        """
-        import sqlglot
-        import sqlglot.expressions as exp
-
-        # Fast-path SHOW / DESCRIBE / USE / SET by raw text — sqlglot logs a
-        # "unsupported syntax. Falling back to ... Command" warning on each
-        # of these in its default dialect, which spams the log on every
-        # BI-tool catalog probe. The dispatch below is the same as the
-        # Command branch, so skipping sqlglot here is a pure log-noise win.
-        raw_upper = sql.strip().upper()
-        if raw_upper.startswith(("SHOW ", "DESCRIBE ", "DESC ")):
-            if raw_upper.startswith(("DESCRIBE ", "DESC ")) or "COLUMN" in raw_upper:
-                return self._catalog_columns_table(model)
-            return self._catalog_tables_table(model)
-        if raw_upper.startswith(("USE ", "SET ")):
-            return self._catalog_empty_table()
-
-        try:
-            ast = sqlglot.parse_one(sql)
-        except Exception:
-            return self._catalog_empty_table()
-
-        kind = type(ast).__name__
-
-        # SHOW TABLES / SHOW COLUMNS / DESCRIBE / etc.
-        # sqlglot parses bare SHOW/DESCRIBE statements as ``Command`` when
-        # the dialect doesn't have an explicit Show node; inspect the raw
-        # text in that case.
-        if kind in {"Show", "Describe", "Command"}:
-            raw_text = sql.strip().upper()
-            this = ast.args.get("this")
-            target_arg = (str(this).upper() if this is not None else "") or (
-                getattr(ast, "name", "") or ""
-            ).upper()
-            if (
-                "COLUMN" in target_arg
-                or kind == "Describe"
-                or raw_text.startswith("DESC")
-                or "SHOW COLUMN" in raw_text
-            ):
-                return self._catalog_columns_table(model)
-            # Default: list tables
-            return self._catalog_tables_table(model)
-
-        # USE / SET — accept silently (Postgres clients send these on connect)
-        if kind in {"Use", "Set"}:
-            return self._catalog_empty_table()
-
-        # SELECT against pg_catalog / information_schema or scalar probes
-        if isinstance(ast, exp.Select):
-            from_node = ast.args.get("from")
-            if from_node is None:
-                # Scalar probe: SELECT 1, SELECT version(), SELECT current_schema()
-                return self._catalog_scalar_probe_table(ast)
-            target_sql = ""
-            table_node = getattr(from_node, "this", None) or (
-                from_node.expressions[0] if from_node.expressions else None
-            )
-            if table_node is not None:
-                target_sql = table_node.sql().lower()
-            bare = ""
-            if table_node is not None:
-                bare_raw = getattr(table_node, "name", None) or table_node.sql()
-                bare = str(bare_raw).strip('"').strip("`").strip("'").lower()
-            if "information_schema.tables" in target_sql or "pg_catalog.pg_class" in target_sql:
-                return self._catalog_tables_table(model)
-            if (
-                "information_schema.columns" in target_sql
-                or "pg_catalog.pg_attribute" in target_sql
-            ):
-                return self._catalog_columns_table(model)
-            if bare == "_dimensions_metadata" or bare == "dimensions":
-                return build_dimensions_data(model)
-            if bare == "_measures_metadata" or bare == "measures":
-                return build_measures_data(model)
-            if bare == "_metrics_metadata" or bare == "metrics":
-                return build_metrics_data(model)
-            if bare == "model":
-                # ``SELECT * FROM <model>.model`` — column-shape probe
-                # from a BI tool clicking the model table. Same payload
-                # as the canonical ``information_schema.columns`` view
-                # (one row per dim/measure/metric).
-                return self._catalog_columns_table(model)
-
-        # Unknown catalog probe — empty result. Tool moves on.
-        return self._catalog_empty_table()
+        return server_catalog.handle_catalog_sql(self, sql, model)
 
     @staticmethod
     def _catalog_tables_table(model: Any) -> pa.Table:
-        """One row per queryable virtual table (model + metadata views).
-
-        Drops the spec-mandated ``table_schema`` binary column for the
-        text-mode ``SHOW TABLES`` / ``information_schema.tables`` path —
-        the IPC bytes are unreadable in a CLI / pandas display. The
-        protobuf ``CommandGetTables`` handler (``_build_tables_from_model``)
-        keeps the full table for JDBC clients that decode the binary.
-        """
-        from ob_flight.flight_sql import build_tables_table
-
-        table = build_tables_table(model)
-        if "table_schema" in table.column_names:
-            table = table.drop_columns(["table_schema"])
-        return table
+        return server_catalog.catalog_tables_table(model)
 
     @staticmethod
     def _catalog_columns_table(model: Any) -> pa.Table:
-        """One row per dim/measure/metric of the model's virtual table."""
-        from ob_flight.flight_sql import build_columns_table
-
-        return build_columns_table(model)
+        return server_catalog.catalog_columns_table(model)
 
     @staticmethod
     def _catalog_empty_table() -> pa.Table:
-        """Empty single-column response — used for unknown catalog probes."""
-        schema = pa.schema([pa.field("result", pa.utf8())])
-        return pa.table({"result": pa.array([], type=pa.utf8())}, schema=schema)
+        return server_catalog.catalog_empty_table()
 
     def _catalog_scalar_probe_table(self, ast: Any) -> pa.Table:
-        """Answer common scalar probes — SELECT 1, version(), current_schema()."""
-        import sqlglot.expressions as exp
-
-        values: list[str] = []
-        names: list[str] = []
-        for i, proj in enumerate(ast.expressions):
-            alias_name: str | None = None
-            inner = proj
-            if isinstance(proj, exp.Alias):
-                alias_name = proj.alias_or_name
-                inner = proj.this
-            if isinstance(inner, exp.Literal):
-                values.append(str(inner.this))
-                names.append(alias_name or f"col_{i + 1}")
-                continue
-            fname = (getattr(inner, "name", "") or "").lower()
-            if fname in {"version"}:
-                values.append("OrionBelt Semantic Layer (OBSL)")
-            elif fname in {"current_database"}:
-                values.append("orionbelt")
-            elif fname in {"current_schema"}:
-                values.append("model")
-            elif fname in {"current_user", "current_role", "session_user", "user"}:
-                values.append("obsl")
-            else:
-                values.append("")
-            names.append(alias_name or fname or f"col_{i + 1}")
-        if not values:
-            return self._catalog_empty_table()
-        schema = pa.schema([pa.field(n, pa.utf8()) for n in names])
-        return pa.table({n: [v] for n, v in zip(names, values, strict=True)}, schema=schema)
+        return server_catalog.catalog_scalar_probe_table(ast)
 
     @staticmethod
     def _detect_virtual_table(sql: str) -> str | None:
-        """Detect a metadata-view reference (``_dimensions_metadata``, etc.).
-
-        Word-boundary matching avoids false positives on names like
-        ``sales_measures_metadata`` or ``total_metrics``.
-        """
-        import re
-
-        sql_lower = sql.lower()
-        # Check longest names first so ``_dimensions_metadata`` wins over
-        # ``_dimensions`` when both would match the regex.
-        for vt in sorted(VIRTUAL_TABLES, key=len, reverse=True):
-            if re.search(rf"\b{re.escape(vt)}\b", sql_lower):
-                return vt
-        return None
+        return server_catalog.detect_virtual_table(sql)
 
     def _query_virtual_table(
         self,
         vt_name: str,
         context: flight.ServerCallContext | None = None,
     ) -> flight.RecordBatchStream:
-        """Return data for a metadata view (``_dimensions_metadata`` etc.)."""
-        model, _ = self._get_model(context)
-        if vt_name == "_dimensions_metadata":
-            table = build_dimensions_data(model)
-        elif vt_name == "_measures_metadata":
-            table = build_measures_data(model)
-        elif vt_name == "_metrics_metadata":
-            table = build_metrics_data(model)
-        else:
-            raise flight.FlightServerError(f"Unknown virtual table: {vt_name}")
-        return flight.RecordBatchStream(table)
+        return server_catalog.query_virtual_table(self, vt_name, context)
 
     def _probe_schema(self, sql: str, dialect: str) -> pa.Schema:
-        """Probe the database to determine the result schema for a query.
-
-        Executes the query, peeks at a small batch for accurate type inference
-        (UNION ALL queries may have NULL-padded columns in early rows).
-        Falls back to a generic schema on error.
-        """
-        vt = self._detect_virtual_table(sql)
-        if vt is not None:
-            return VIRTUAL_TABLES[vt]
-
-        conn = db_connect(dialect)
-        try:
-            cursor = conn.cursor()
-            cursor.execute(sql)
-            if cursor.description is None:
-                return pa.schema([pa.field("status", pa.utf8())])
-            rows = cursor.fetchmany(64)
-            return schema_from_description(cursor.description, sample_rows=rows)
-        except Exception as exc:
-            logger.debug("Schema probe failed: %s", exc)
-            return pa.schema([pa.field("result", pa.utf8())])
-        finally:
-            conn.close()
+        return server_catalog.probe_schema(self, sql, dialect)
 
     def _resolve_model_for_catalog(
         self,
@@ -1156,46 +282,9 @@ class OBFlightServer(flight.FlightServerBase):  # type: ignore[misc]
         context: flight.ServerCallContext | None,
         db_schema_filter: str | None = None,
     ) -> Any:
-        """Resolve the model for a metadata request.
-
-        v2.5.0 catalog layout exposes a single ``orionbelt`` catalog with
-        one schema per loaded model and a literal ``model`` table inside
-        each schema. Model resolution therefore moves to the
-        ``db_schema_filter_pattern`` (protobuf field 2): when a BI client
-        expands ``orionbelt.<model_name>`` in the schema tree, that
-        ``<model_name>`` arrives as the schema filter on the subsequent
-        GetTables / GetColumns call.
-
-        ``catalog_filter`` is honoured for legacy callers that still
-        pre-v2.5 emit ``catalog=<model>`` (the pre-flip layout exposed
-        models as catalogs) — it falls through as the second priority
-        so the obsql CLI ``--model`` flag and existing integration
-        tests keep working.
-
-        Unknown selector → ``None`` (empty metadata, no fallback) so
-        BI clients don't accidentally browse the wrong model.
-        """
-        # db_schema_filter is the v2.5.0 selector — preferred.
-        if db_schema_filter and self._session_manager is not None:
-            try:
-                store = self._session_manager.get_store(db_schema_filter)
-                model, _ = self._stamp_model(store, db_schema_filter)
-                return model
-            except Exception:
-                return None
-        # catalog_filter is the legacy pre-flip selector — fall back.
-        if catalog_filter and self._session_manager is not None:
-            try:
-                store = self._session_manager.get_store(catalog_filter)
-                model, _ = self._stamp_model(store, catalog_filter)
-                return model
-            except Exception:
-                return None
-        try:
-            model, _ = self._get_model(context)
-            return model
-        except Exception:
-            return None
+        return server_catalog.resolve_model_for_catalog(
+            self, catalog_filter, context, db_schema_filter
+        )
 
     def _build_tables_from_model(
         self,
@@ -1205,21 +294,13 @@ class OBFlightServer(flight.FlightServerBase):  # type: ignore[misc]
         catalog_filter: str | None = None,
         db_schema_filter: str | None = None,
     ) -> pa.Table:
-        """Build the CommandGetTables response.
-
-        Lists the ``model`` virtual table + ``dimensions`` /
-        ``measures`` / ``metrics`` views and their ``_*_metadata``
-        siblings. Data objects are intentionally hidden — they're not
-        queryable through the semantic layer. ``table_filter``, when
-        set, scopes the response to a single table name (DBeaver sends
-        one filter request per expanded tree node). v2.5.0 layout uses
-        ``db_schema_filter`` (protobuf field 2) for model selection;
-        ``catalog_filter`` is honoured as a legacy fallback.
-        """
-        model = self._resolve_model_for_catalog(
-            catalog_filter, context, db_schema_filter=db_schema_filter
+        return server_catalog.build_tables_from_model(
+            self,
+            context,
+            table_filter=table_filter,
+            catalog_filter=catalog_filter,
+            db_schema_filter=db_schema_filter,
         )
-        return build_tables_table(model, table_filter=table_filter)
 
     def _build_columns_from_model(
         self,
@@ -1229,34 +310,25 @@ class OBFlightServer(flight.FlightServerBase):  # type: ignore[misc]
         catalog_filter: str | None = None,
         db_schema_filter: str | None = None,
     ) -> pa.Table:
-        """Build the CommandGetColumns response.
-
-        Returns dim / measure / metric columns of the ``model`` virtual
-        table plus the introspection columns of each metadata view.
-        ``table_filter`` scopes the response to one table — without
-        it, DBeaver displays the unfiltered union under every view
-        (the cross-pollution bug v2.4.0 had until this commit).
-        ``db_schema_filter`` selects the model in v2.5.0;
-        ``catalog_filter`` is honoured as a legacy fallback.
-        """
-        model = self._resolve_model_for_catalog(
-            catalog_filter, context, db_schema_filter=db_schema_filter
+        return server_catalog.build_columns_from_model(
+            self,
+            context,
+            table_filter=table_filter,
+            catalog_filter=catalog_filter,
+            db_schema_filter=db_schema_filter,
         )
-        return build_columns_table(model, table_filter=table_filter)
 
-    def _compile_obml(self, obml: dict[str, Any], model: Any, dialect: str) -> Any:
-        """Compile OBML to SQL using the OrionBelt pipeline directly.
+    def _handle_catalog_command(
+        self,
+        type_url: str,
+        cmd_value: bytes = b"",
+        context: flight.ServerCallContext | None = None,
+    ) -> flight.RecordBatchStream:
+        return server_catalog.handle_catalog_command(self, type_url, cmd_value, context)
 
-        Returns the full ``CompilationResult`` so callers can access
-        ``sql`` plus ``physical_tables`` (needed for the freshness-
-        driven cache TTL resolution).
-        """
-        from orionbelt.compiler.pipeline import CompilationPipeline
-        from orionbelt.models.query import QueryObject
-
-        query = QueryObject.model_validate(obml)
-        return CompilationPipeline().compile(query, model, dialect)
-
+    # ------------------------------------------------------------------
+    # Flight protocol overrides — stay on the server class.
+    # ------------------------------------------------------------------
     def get_flight_info(
         self, context: flight.ServerCallContext, descriptor: flight.FlightDescriptor
     ) -> flight.FlightInfo:
@@ -1405,253 +477,6 @@ class OBFlightServer(flight.FlightServerBase):  # type: ignore[misc]
         )
         return self._execute_sql(sql, dialect, cache_meta=cache_meta)
 
-    def _handle_catalog_command(
-        self,
-        type_url: str,
-        cmd_value: bytes = b"",
-        context: flight.ServerCallContext | None = None,
-    ) -> flight.RecordBatchStream:
-        """Handle Flight SQL catalog metadata commands.
-
-        Multi-model aware: ``CommandGetCatalogs`` returns the list of
-        loaded model names so BI tools see them in the catalog dropdown.
-        ``CommandGetTables`` / ``CommandGetColumns`` apply the
-        ``table_name_filter_pattern`` from the protobuf body — JDBC
-        clients (DBeaver) send one filter request per expanded node and
-        expect the response scoped to that node's table name.
-        """
-        from ob_flight.flight_sql import (
-            parse_catalog_filter,
-            parse_db_schema_filter,
-            parse_table_filter,
-        )
-
-        table_filter = parse_table_filter(cmd_value) if cmd_value else None
-        catalog_filter = parse_catalog_filter(cmd_value) if cmd_value else None
-        db_schema_filter = parse_db_schema_filter(cmd_value) if cmd_value else None
-
-        if type_url == CMD_GET_CATALOGS:
-            # v2.5.0 layout: single ``orionbelt`` catalog. The
-            # ``Database`` dropdown in DBeaver/Tableau/Power BI shows
-            # one entry; the per-model selector is the schema dropdown.
-            table = build_catalogs_table(self._list_available_model_names())
-        elif type_url == CMD_GET_DB_SCHEMAS:
-            # One row per loaded model — DBeaver renders these under
-            # ``orionbelt`` in the schema tree.
-            table = build_db_schemas_table(self._list_available_model_names())
-        elif type_url == CMD_GET_TABLES:
-            table = self._build_tables_from_model(
-                context,
-                table_filter=table_filter,
-                catalog_filter=catalog_filter,
-                db_schema_filter=db_schema_filter,
-            )
-        elif type_url == CMD_GET_COLUMNS:
-            table = self._build_columns_from_model(
-                context,
-                table_filter=table_filter,
-                catalog_filter=catalog_filter,
-                db_schema_filter=db_schema_filter,
-            )
-        elif type_url == CMD_GET_TABLE_TYPES:
-            table = build_table_types_table()
-        elif type_url in (CMD_GET_PRIMARY_KEYS, CMD_GET_EXPORTED_KEYS, CMD_GET_CROSS_REFERENCE):
-            table = build_empty_keys_table()
-        elif type_url == CMD_GET_IMPORTED_KEYS:
-            table = build_empty_imported_keys_table()
-        elif type_url == CMD_GET_SQL_INFO:
-            # Populate the standard SqlInfo entries so JDBC clients display
-            # the server name (otherwise DBeaver shows "Server: ?").
-            from orionbelt import __version__ as _obsl_version
-
-            table = build_sql_info_table(_obsl_version)
-        elif type_url == CMD_GET_XDBC_TYPE_INFO:
-            # XDBC type info is request-shaped; an empty result is acceptable
-            # for BI tools that fall back to driver-side type metadata.
-            table = pa.table({"info": pa.array([], type=pa.utf8())})
-        else:
-            raise flight.FlightServerError(f"Unsupported catalog command: {type_url}")
-
-        logger.debug("Catalog response for %s: %d rows", type_url.rsplit(".", 1)[-1], len(table))
-        return flight.RecordBatchStream(table)
-
-    def _execute_sql(
-        self,
-        sql: str,
-        dialect: str,
-        cache_meta: dict[str, Any] | None = None,
-    ) -> flight.RecordBatchStream:
-        """Execute SQL on the vendor database and stream results.
-
-        Note: table name rewriting is already handled by ``_prepare_sql``
-        during the ``get_flight_info`` phase — no need to rewrite here.
-
-        When ``cache_meta`` is set (semantic mode + cache backend
-        enabled), the function consults the freshness-driven result
-        cache first: on hit it decodes the cached Arrow payload and
-        returns it directly; on miss it executes against the warehouse
-        and writes the resulting ``pa.Table`` back to the cache under
-        the TTL resolved at prepare time. See PLAN_freshness_driven_cache.
-        """
-        # Virtual metadata tables — served from model, no DB needed
-        vt = self._detect_virtual_table(sql)
-        if vt is not None:
-            return self._query_virtual_table(vt)
-
-        # Cache lookup — only when the prepare step gave us a key + ttl.
-        if cache_meta is not None and self._cache is not None:
-            cached_table = self._cache_get_table(cache_meta["key"])
-            if cached_table is not None:
-                logger.info(
-                    "Flight cache HIT: key=%s rows=%d", cache_meta["key"], cached_table.num_rows
-                )
-                return flight.RecordBatchStream(cached_table)
-
-        conn = db_connect(dialect)
-        try:
-            cursor = conn.cursor()
-            cursor.execute(sql)
-
-            if cursor.description is None:
-                schema = pa.schema([pa.field("status", pa.utf8())])
-                batch = rows_to_batch([("OK",)], schema)
-                table = pa.Table.from_batches([batch])
-                return flight.RecordBatchStream(table)
-
-            # Fetch first batch and scan rows for Arrow type inference
-            # (UNION ALL queries may have NULL-padded columns in early rows)
-            first_rows = cursor.fetchmany(self._batch_size)
-            schema = schema_from_description(cursor.description, sample_rows=first_rows)
-
-            batches: list[pa.RecordBatch] = []
-            if first_rows:
-                batches.append(rows_to_batch(first_rows, schema))
-            while True:
-                rows = cursor.fetchmany(self._batch_size)
-                if not rows:
-                    break
-                batches.append(rows_to_batch(rows, schema))
-
-            if not batches:
-                batches = [rows_to_batch([], schema)]
-
-            table = pa.Table.from_batches(batches)
-
-            # Cache populate — write back after a successful warehouse run.
-            if cache_meta is not None and self._cache is not None:
-                self._cache_put_table(table, cache_meta)
-
-            return flight.RecordBatchStream(table)
-        finally:
-            conn.close()
-
-    def _cache_get_table(self, key: str) -> pa.Table | None:
-        """Look up a Flight cache entry. Returns the decoded ``pa.Table`` or None.
-
-        The cache stores parquet-encoded payloads using the same
-        ``parquet_codec`` envelope REST uses, so a Flight reader can
-        consume a REST writer's entry and vice versa. We use plain
-        ``pq.read_table`` because Flight only needs the columnar data;
-        the envelope metadata (sql, dialect, explain, …) is harmless
-        to read and re-serve.
-        """
-        import asyncio
-
-        try:
-            loop = asyncio.new_event_loop()
-            try:
-                result = loop.run_until_complete(self._cache.get(key))
-            finally:
-                loop.close()
-        except Exception:
-            logger.debug("cache.get failed for key=%s", key, exc_info=True)
-            return None
-        if result is None or not getattr(result, "payload", None):
-            return None
-        try:
-            import io
-
-            import pyarrow.parquet as pq
-
-            return pq.read_table(io.BytesIO(result.payload))
-        except Exception:
-            logger.debug("cache decode failed for key=%s", key, exc_info=True)
-            return None
-
-    def _cache_put_table(self, table: pa.Table, cache_meta: dict[str, Any]) -> None:
-        """Serialize a ``pa.Table`` to the shared parquet_codec envelope and
-        store under ``cache_meta``.
-
-        REST and Flight share the cache namespace — both must encode the
-        same envelope so the other side can decode ``sql``, ``dialect``,
-        ``columns``, etc. without falling back to defaults. Errors are
-        swallowed; cache writes must never break query execution.
-        """
-        import asyncio
-
-        from orionbelt.cache import parquet_codec
-
-        rows = table.to_pylist()
-        list_of_lists: list[list[Any]] = [
-            [row.get(name) for name in table.column_names] for row in rows
-        ]
-        # REST's ColumnMetadata uses ``type`` (Pydantic field name) with the
-        # vocabulary ``string`` / ``number`` / ``datetime`` / ``binary`` —
-        # match it so a Flight-written cache entry decoded by REST yields
-        # the right column types instead of falling back to ``string``.
-        columns_meta = [
-            {"name": field.name, "type": _arrow_to_obsl_type_hint(field.type)}
-            for field in table.schema
-        ]
-
-        try:
-            payload = parquet_codec.encode(
-                columns=columns_meta,
-                rows=list_of_lists,
-                sql=cache_meta.get("sql", ""),
-                dialect=cache_meta.get("dialect", ""),
-                explain=None,
-                warnings=[],
-                sql_valid=True,
-                execution_time_ms=0.0,
-                timezone=None,
-                resolved={},
-                physical_tables=cache_meta.get("physical_tables", []),
-            )
-        except Exception:
-            logger.debug("cache encode failed", exc_info=True)
-            return
-
-        from orionbelt.cache import query_hash as _query_hash
-
-        try:
-            loop = asyncio.new_event_loop()
-            try:
-                loop.run_until_complete(
-                    self._cache.set(
-                        cache_meta["key"],
-                        payload,
-                        ttl_seconds=cache_meta["ttl"],
-                        physical_tables=cache_meta["physical_tables"],
-                        session_id=cache_meta["session_id"],
-                        model_id=cache_meta["model_id"],
-                        query_hash=_query_hash(sql=cache_meta["sql"]),
-                        dialect=cache_meta["dialect"],
-                        row_count=table.num_rows,
-                    )
-                )
-            finally:
-                loop.close()
-            logger.info(
-                "Flight cache STORE: key=%s ttl=%ds rows=%d size=%dB",
-                cache_meta["key"],
-                cache_meta["ttl"],
-                table.num_rows,
-                len(payload),
-            )
-        except Exception:
-            logger.debug("cache.set failed", exc_info=True)
-
     def do_action(self, context: flight.ServerCallContext, action: flight.Action) -> Any:
         """Handle Flight SQL actions (CreatePreparedStatement, ClosePreparedStatement)."""
         action_type = action.type
@@ -1722,6 +547,8 @@ class OBFlightServer(flight.FlightServerBase):  # type: ignore[misc]
 
     def list_flights(self, context: flight.ServerCallContext, _criteria: bytes) -> Any:
         """List the semantic virtual table + metadata views."""
+        from ob_flight.catalog import model_to_flight_infos
+
         try:
             model, _ = self._get_model(context)
         except Exception:

--- a/drivers/ob-flight-extension/src/ob_flight/server_catalog.py
+++ b/drivers/ob-flight-extension/src/ob_flight/server_catalog.py
@@ -1,0 +1,446 @@
+"""Catalog / metadata helpers for :class:`~ob_flight.server.OBFlightServer`.
+
+Extracted from ``server.py`` (Phase 5.5) as a pure code move. The helper
+functions take the ``OBFlightServer`` instance as their first argument
+(``server``) so the class can delegate to them as one-liners. The
+``@staticmethod`` helpers that don't use the instance are plain module
+functions here.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+import pyarrow as pa
+import pyarrow.flight as flight
+
+from ob_flight.catalog import (
+    VIRTUAL_TABLES,
+    build_dimensions_data,
+    build_measures_data,
+    build_metrics_data,
+)
+from ob_flight.converters import schema_from_description
+from ob_flight.flight_sql import (
+    CMD_GET_CATALOGS,
+    CMD_GET_COLUMNS,
+    CMD_GET_CROSS_REFERENCE,
+    CMD_GET_DB_SCHEMAS,
+    CMD_GET_EXPORTED_KEYS,
+    CMD_GET_IMPORTED_KEYS,
+    CMD_GET_PRIMARY_KEYS,
+    CMD_GET_SQL_INFO,
+    CMD_GET_TABLE_TYPES,
+    CMD_GET_TABLES,
+    CMD_GET_XDBC_TYPE_INFO,
+    build_catalogs_table,
+    build_columns_table,
+    build_db_schemas_table,
+    build_empty_imported_keys_table,
+    build_empty_keys_table,
+    build_sql_info_table,
+    build_table_types_table,
+    build_tables_table,
+)
+
+if TYPE_CHECKING:
+    from ob_flight.server import OBFlightServer
+
+logger = logging.getLogger("ob_flight.server")
+
+
+def handle_catalog_sql(server: OBFlightServer, sql: str, model: Any) -> pa.Table:
+    """Answer a catalog/discovery SQL query from the model — no warehouse hop.
+
+    Returns a :class:`pa.Table` so callers can wrap it in a
+    ``RecordBatchStream`` once. Covers the common BI-tool / JDBC
+    introspection probes:
+
+    * ``SHOW TABLES`` → list of virtual tables (the model + metadata views)
+    * ``SHOW COLUMNS FROM <model>`` / ``DESCRIBE <model>`` → dim+measure+metric
+    * ``SELECT … FROM information_schema.tables`` → same as SHOW TABLES
+    * ``SELECT … FROM information_schema.columns`` → flat column list
+    * ``SELECT … FROM pg_catalog.*`` → mapped to the same model-backed responses
+    * Canned scalar probes: ``SELECT 1``, ``SELECT version()``, ``current_schema()``
+
+    Unrecognised catalog queries return an empty result set rather
+    than failing — Postgres / MySQL clients probe a long tail of
+    system tables, and breaking on every unknown probe blocks tool
+    discovery. Empty results are the right default — clients adapt.
+    """
+    import sqlglot
+    import sqlglot.expressions as exp
+
+    # Fast-path SHOW / DESCRIBE / USE / SET by raw text — sqlglot logs a
+    # "unsupported syntax. Falling back to ... Command" warning on each
+    # of these in its default dialect, which spams the log on every
+    # BI-tool catalog probe. The dispatch below is the same as the
+    # Command branch, so skipping sqlglot here is a pure log-noise win.
+    raw_upper = sql.strip().upper()
+    if raw_upper.startswith(("SHOW ", "DESCRIBE ", "DESC ")):
+        if raw_upper.startswith(("DESCRIBE ", "DESC ")) or "COLUMN" in raw_upper:
+            return catalog_columns_table(model)
+        return catalog_tables_table(model)
+    if raw_upper.startswith(("USE ", "SET ")):
+        return catalog_empty_table()
+
+    try:
+        ast = sqlglot.parse_one(sql)
+    except Exception:
+        return catalog_empty_table()
+
+    kind = type(ast).__name__
+
+    # SHOW TABLES / SHOW COLUMNS / DESCRIBE / etc.
+    # sqlglot parses bare SHOW/DESCRIBE statements as ``Command`` when
+    # the dialect doesn't have an explicit Show node; inspect the raw
+    # text in that case.
+    if kind in {"Show", "Describe", "Command"}:
+        raw_text = sql.strip().upper()
+        this = ast.args.get("this")
+        target_arg = (str(this).upper() if this is not None else "") or (
+            getattr(ast, "name", "") or ""
+        ).upper()
+        if (
+            "COLUMN" in target_arg
+            or kind == "Describe"
+            or raw_text.startswith("DESC")
+            or "SHOW COLUMN" in raw_text
+        ):
+            return catalog_columns_table(model)
+        # Default: list tables
+        return catalog_tables_table(model)
+
+    # USE / SET — accept silently (Postgres clients send these on connect)
+    if kind in {"Use", "Set"}:
+        return catalog_empty_table()
+
+    # SELECT against pg_catalog / information_schema or scalar probes
+    if isinstance(ast, exp.Select):
+        from_node = ast.args.get("from")
+        if from_node is None:
+            # Scalar probe: SELECT 1, SELECT version(), SELECT current_schema()
+            return catalog_scalar_probe_table(ast)
+        target_sql = ""
+        table_node = getattr(from_node, "this", None) or (
+            from_node.expressions[0] if from_node.expressions else None
+        )
+        if table_node is not None:
+            target_sql = table_node.sql().lower()
+        bare = ""
+        if table_node is not None:
+            bare_raw = getattr(table_node, "name", None) or table_node.sql()
+            bare = str(bare_raw).strip('"').strip("`").strip("'").lower()
+        if "information_schema.tables" in target_sql or "pg_catalog.pg_class" in target_sql:
+            return catalog_tables_table(model)
+        if "information_schema.columns" in target_sql or "pg_catalog.pg_attribute" in target_sql:
+            return catalog_columns_table(model)
+        if bare == "_dimensions_metadata" or bare == "dimensions":
+            return build_dimensions_data(model)
+        if bare == "_measures_metadata" or bare == "measures":
+            return build_measures_data(model)
+        if bare == "_metrics_metadata" or bare == "metrics":
+            return build_metrics_data(model)
+        if bare == "model":
+            # ``SELECT * FROM <model>.model`` — column-shape probe
+            # from a BI tool clicking the model table. Same payload
+            # as the canonical ``information_schema.columns`` view
+            # (one row per dim/measure/metric).
+            return catalog_columns_table(model)
+
+    # Unknown catalog probe — empty result. Tool moves on.
+    return catalog_empty_table()
+
+
+def catalog_tables_table(model: Any) -> pa.Table:
+    """One row per queryable virtual table (model + metadata views).
+
+    Drops the spec-mandated ``table_schema`` binary column for the
+    text-mode ``SHOW TABLES`` / ``information_schema.tables`` path —
+    the IPC bytes are unreadable in a CLI / pandas display. The
+    protobuf ``CommandGetTables`` handler (``_build_tables_from_model``)
+    keeps the full table for JDBC clients that decode the binary.
+    """
+    table = build_tables_table(model)
+    if "table_schema" in table.column_names:
+        table = table.drop_columns(["table_schema"])
+    return table
+
+
+def catalog_columns_table(model: Any) -> pa.Table:
+    """One row per dim/measure/metric of the model's virtual table."""
+    return build_columns_table(model)
+
+
+def catalog_empty_table() -> pa.Table:
+    """Empty single-column response — used for unknown catalog probes."""
+    schema = pa.schema([pa.field("result", pa.utf8())])
+    return pa.table({"result": pa.array([], type=pa.utf8())}, schema=schema)
+
+
+def catalog_scalar_probe_table(ast: Any) -> pa.Table:
+    """Answer common scalar probes — SELECT 1, version(), current_schema()."""
+    import sqlglot.expressions as exp
+
+    values: list[str] = []
+    names: list[str] = []
+    for i, proj in enumerate(ast.expressions):
+        alias_name: str | None = None
+        inner = proj
+        if isinstance(proj, exp.Alias):
+            alias_name = proj.alias_or_name
+            inner = proj.this
+        if isinstance(inner, exp.Literal):
+            values.append(str(inner.this))
+            names.append(alias_name or f"col_{i + 1}")
+            continue
+        fname = (getattr(inner, "name", "") or "").lower()
+        if fname in {"version"}:
+            values.append("OrionBelt Semantic Layer (OBSL)")
+        elif fname in {"current_database"}:
+            values.append("orionbelt")
+        elif fname in {"current_schema"}:
+            values.append("model")
+        elif fname in {"current_user", "current_role", "session_user", "user"}:
+            values.append("obsl")
+        else:
+            values.append("")
+        names.append(alias_name or fname or f"col_{i + 1}")
+    if not values:
+        return catalog_empty_table()
+    schema = pa.schema([pa.field(n, pa.utf8()) for n in names])
+    return pa.table({n: [v] for n, v in zip(names, values, strict=True)}, schema=schema)
+
+
+def detect_virtual_table(sql: str) -> str | None:
+    """Detect a metadata-view reference (``_dimensions_metadata``, etc.).
+
+    Word-boundary matching avoids false positives on names like
+    ``sales_measures_metadata`` or ``total_metrics``.
+    """
+    import re
+
+    sql_lower = sql.lower()
+    # Check longest names first so ``_dimensions_metadata`` wins over
+    # ``_dimensions`` when both would match the regex.
+    for vt in sorted(VIRTUAL_TABLES, key=len, reverse=True):
+        if re.search(rf"\b{re.escape(vt)}\b", sql_lower):
+            return vt
+    return None
+
+
+def query_virtual_table(
+    server: OBFlightServer,
+    vt_name: str,
+    context: flight.ServerCallContext | None = None,
+) -> flight.RecordBatchStream:
+    """Return data for a metadata view (``_dimensions_metadata`` etc.)."""
+    model, _ = server._get_model(context)
+    if vt_name == "_dimensions_metadata":
+        table = build_dimensions_data(model)
+    elif vt_name == "_measures_metadata":
+        table = build_measures_data(model)
+    elif vt_name == "_metrics_metadata":
+        table = build_metrics_data(model)
+    else:
+        raise flight.FlightServerError(f"Unknown virtual table: {vt_name}")
+    return flight.RecordBatchStream(table)
+
+
+def probe_schema(server: OBFlightServer, sql: str, dialect: str) -> pa.Schema:
+    """Probe the database to determine the result schema for a query.
+
+    Executes the query, peeks at a small batch for accurate type inference
+    (UNION ALL queries may have NULL-padded columns in early rows).
+    Falls back to a generic schema on error.
+    """
+    vt = server._detect_virtual_table(sql)
+    if vt is not None:
+        return VIRTUAL_TABLES[vt]
+
+    # Resolve ``db_connect`` through the ``ob_flight.server`` module so tests
+    # that patch ``ob_flight.server.db_connect`` take effect.
+    from ob_flight.server import db_connect
+
+    conn = db_connect(dialect)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(sql)
+        if cursor.description is None:
+            return pa.schema([pa.field("status", pa.utf8())])
+        rows = cursor.fetchmany(64)
+        return schema_from_description(cursor.description, sample_rows=rows)
+    except Exception as exc:
+        logger.debug("Schema probe failed: %s", exc)
+        return pa.schema([pa.field("result", pa.utf8())])
+    finally:
+        conn.close()
+
+
+def resolve_model_for_catalog(
+    server: OBFlightServer,
+    catalog_filter: str | None,
+    context: flight.ServerCallContext | None,
+    db_schema_filter: str | None = None,
+) -> Any:
+    """Resolve the model for a metadata request.
+
+    v2.5.0 catalog layout exposes a single ``orionbelt`` catalog with
+    one schema per loaded model and a literal ``model`` table inside
+    each schema. Model resolution therefore moves to the
+    ``db_schema_filter_pattern`` (protobuf field 2): when a BI client
+    expands ``orionbelt.<model_name>`` in the schema tree, that
+    ``<model_name>`` arrives as the schema filter on the subsequent
+    GetTables / GetColumns call.
+
+    ``catalog_filter`` is honoured for legacy callers that still
+    pre-v2.5 emit ``catalog=<model>`` (the pre-flip layout exposed
+    models as catalogs) — it falls through as the second priority
+    so the obsql CLI ``--model`` flag and existing integration
+    tests keep working.
+
+    Unknown selector → ``None`` (empty metadata, no fallback) so
+    BI clients don't accidentally browse the wrong model.
+    """
+    # db_schema_filter is the v2.5.0 selector — preferred.
+    if db_schema_filter and server._session_manager is not None:
+        try:
+            store = server._session_manager.get_store(db_schema_filter)
+            model, _ = server._stamp_model(store, db_schema_filter)
+            return model
+        except Exception:
+            return None
+    # catalog_filter is the legacy pre-flip selector — fall back.
+    if catalog_filter and server._session_manager is not None:
+        try:
+            store = server._session_manager.get_store(catalog_filter)
+            model, _ = server._stamp_model(store, catalog_filter)
+            return model
+        except Exception:
+            return None
+    try:
+        model, _ = server._get_model(context)
+        return model
+    except Exception:
+        return None
+
+
+def build_tables_from_model(
+    server: OBFlightServer,
+    context: flight.ServerCallContext | None = None,
+    *,
+    table_filter: str | None = None,
+    catalog_filter: str | None = None,
+    db_schema_filter: str | None = None,
+) -> pa.Table:
+    """Build the CommandGetTables response.
+
+    Lists the ``model`` virtual table + ``dimensions`` /
+    ``measures`` / ``metrics`` views and their ``_*_metadata``
+    siblings. Data objects are intentionally hidden — they're not
+    queryable through the semantic layer. ``table_filter``, when
+    set, scopes the response to a single table name (DBeaver sends
+    one filter request per expanded tree node). v2.5.0 layout uses
+    ``db_schema_filter`` (protobuf field 2) for model selection;
+    ``catalog_filter`` is honoured as a legacy fallback.
+    """
+    model = resolve_model_for_catalog(
+        server, catalog_filter, context, db_schema_filter=db_schema_filter
+    )
+    return build_tables_table(model, table_filter=table_filter)
+
+
+def build_columns_from_model(
+    server: OBFlightServer,
+    context: flight.ServerCallContext | None = None,
+    *,
+    table_filter: str | None = None,
+    catalog_filter: str | None = None,
+    db_schema_filter: str | None = None,
+) -> pa.Table:
+    """Build the CommandGetColumns response.
+
+    Returns dim / measure / metric columns of the ``model`` virtual
+    table plus the introspection columns of each metadata view.
+    ``table_filter`` scopes the response to one table — without
+    it, DBeaver displays the unfiltered union under every view
+    (the cross-pollution bug v2.4.0 had until this commit).
+    ``db_schema_filter`` selects the model in v2.5.0;
+    ``catalog_filter`` is honoured as a legacy fallback.
+    """
+    model = resolve_model_for_catalog(
+        server, catalog_filter, context, db_schema_filter=db_schema_filter
+    )
+    return build_columns_table(model, table_filter=table_filter)
+
+
+def handle_catalog_command(
+    server: OBFlightServer,
+    type_url: str,
+    cmd_value: bytes = b"",
+    context: flight.ServerCallContext | None = None,
+) -> flight.RecordBatchStream:
+    """Handle Flight SQL catalog metadata commands.
+
+    Multi-model aware: ``CommandGetCatalogs`` returns the list of
+    loaded model names so BI tools see them in the catalog dropdown.
+    ``CommandGetTables`` / ``CommandGetColumns`` apply the
+    ``table_name_filter_pattern`` from the protobuf body — JDBC
+    clients (DBeaver) send one filter request per expanded node and
+    expect the response scoped to that node's table name.
+    """
+    from ob_flight.flight_sql import (
+        parse_catalog_filter,
+        parse_db_schema_filter,
+        parse_table_filter,
+    )
+
+    table_filter = parse_table_filter(cmd_value) if cmd_value else None
+    catalog_filter = parse_catalog_filter(cmd_value) if cmd_value else None
+    db_schema_filter = parse_db_schema_filter(cmd_value) if cmd_value else None
+
+    if type_url == CMD_GET_CATALOGS:
+        # v2.5.0 layout: single ``orionbelt`` catalog. The
+        # ``Database`` dropdown in DBeaver/Tableau/Power BI shows
+        # one entry; the per-model selector is the schema dropdown.
+        table = build_catalogs_table(server._list_available_model_names())
+    elif type_url == CMD_GET_DB_SCHEMAS:
+        # One row per loaded model — DBeaver renders these under
+        # ``orionbelt`` in the schema tree.
+        table = build_db_schemas_table(server._list_available_model_names())
+    elif type_url == CMD_GET_TABLES:
+        table = server._build_tables_from_model(
+            context,
+            table_filter=table_filter,
+            catalog_filter=catalog_filter,
+            db_schema_filter=db_schema_filter,
+        )
+    elif type_url == CMD_GET_COLUMNS:
+        table = server._build_columns_from_model(
+            context,
+            table_filter=table_filter,
+            catalog_filter=catalog_filter,
+            db_schema_filter=db_schema_filter,
+        )
+    elif type_url == CMD_GET_TABLE_TYPES:
+        table = build_table_types_table()
+    elif type_url in (CMD_GET_PRIMARY_KEYS, CMD_GET_EXPORTED_KEYS, CMD_GET_CROSS_REFERENCE):
+        table = build_empty_keys_table()
+    elif type_url == CMD_GET_IMPORTED_KEYS:
+        table = build_empty_imported_keys_table()
+    elif type_url == CMD_GET_SQL_INFO:
+        # Populate the standard SqlInfo entries so JDBC clients display
+        # the server name (otherwise DBeaver shows "Server: ?").
+        from orionbelt import __version__ as _obsl_version
+
+        table = build_sql_info_table(_obsl_version)
+    elif type_url == CMD_GET_XDBC_TYPE_INFO:
+        # XDBC type info is request-shaped; an empty result is acceptable
+        # for BI tools that fall back to driver-side type metadata.
+        table = pa.table({"info": pa.array([], type=pa.utf8())})
+    else:
+        raise flight.FlightServerError(f"Unsupported catalog command: {type_url}")
+
+    logger.debug("Catalog response for %s: %d rows", type_url.rsplit(".", 1)[-1], len(table))
+    return flight.RecordBatchStream(table)

--- a/drivers/ob-flight-extension/src/ob_flight/server_execution.py
+++ b/drivers/ob-flight-extension/src/ob_flight/server_execution.py
@@ -1,0 +1,772 @@
+"""SQL classification / preparation / execution helpers for
+:class:`~ob_flight.server.OBFlightServer`.
+
+Extracted from ``server.py`` (Phase 5.5) as a pure code move. The helper
+functions take the ``OBFlightServer`` instance as their first argument
+(``server``) so the class can delegate to them as one-liners.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+import pyarrow as pa
+import pyarrow.flight as flight
+
+from ob_driver_core.detection import is_obml, parse_obml  # type: ignore[import-untyped]
+
+from ob_flight.converters import rows_to_batch, schema_from_description
+
+if TYPE_CHECKING:
+    from ob_flight.server import OBFlightServer
+
+logger = logging.getLogger("ob_flight.server")
+
+
+def _arrow_to_obsl_type_hint(arrow_type: pa.DataType) -> str:
+    """Map an Arrow DataType to the OBSL ``ColumnMetadata.type`` vocabulary
+    (``string`` / ``number`` / ``datetime`` / ``binary``). Used when Flight
+    writes to the shared result cache so REST readers decode column types
+    correctly instead of falling back to ``string``.
+    """
+    if pa.types.is_integer(arrow_type) or pa.types.is_floating(arrow_type):
+        return "number"
+    if pa.types.is_decimal(arrow_type):
+        return "number"
+    if (
+        pa.types.is_date(arrow_type)
+        or pa.types.is_timestamp(arrow_type)
+        or pa.types.is_time(arrow_type)
+    ):
+        return "datetime"
+    if pa.types.is_binary(arrow_type) or pa.types.is_large_binary(arrow_type):
+        return "binary"
+    return "string"
+
+
+# Query modes for the Flight SQL surface. See PLAN_flight_natural_sql.md §3.2.
+# OBSL is a semantic layer, not a JDBC proxy — there are no escape hatches.
+_MODE_SEMANTIC = "semantic"
+"""OBSQL query against the model's virtual table — compiled through the pipeline."""
+_MODE_CATALOG = "catalog"
+"""SHOW / DESCRIBE / information_schema / pg_catalog / canned probes — answered
+from the model, never touches the warehouse."""
+_MODE_REJECTED = "rejected"
+"""Anything else — raw SQL against unknown targets, data-object labels, etc.
+Rejects with RAW_SQL_REJECTED."""
+
+
+# Catalog FROM-target prefixes / system-function tokens — anything matching is
+# routed to a model-backed catalog handler instead of the warehouse.
+_CATALOG_SCHEMAS = ("information_schema.", "pg_catalog.")
+_LABEL_VIEW_NAMES = ("dimensions", "measures", "metrics")
+"""Label views — `SELECT "X" FROM dimensions` routes to semantic mode."""
+
+_METADATA_VIEW_NAMES = ("_dimensions_metadata", "_measures_metadata", "_metrics_metadata")
+"""Metadata views — `SELECT * FROM _dimensions_metadata` returns introspection rows."""
+
+_CATALOG_STATEMENT_KINDS = {
+    "Show",  # SHOW TABLES, SHOW COLUMNS, SHOW DATABASES (some dialects)
+    "Describe",  # DESCRIBE / DESC
+    "Use",  # USE <database>
+    "Set",  # SET <var> = <value>
+    "Command",  # sqlglot's fallback for dialect-unknown commands like SHOW
+}
+_CATALOG_SCALAR_PROBES = {
+    "version",
+    "current_database",
+    "current_schema",
+    "current_user",
+    "current_role",
+    "session_user",
+    "user",
+}
+
+
+def rewrite_table_names(server: OBFlightServer, sql: str, model: Any) -> str:
+    """Rewrite compiled SQL for execution on the actual database.
+
+    Two rewrites:
+    1. Quoted label → physical code (DBeaver sends "Sales", DB has sales)
+    2. Strip OBML schema prefix — the connection's search_path handles
+       schema resolution, so PUBLIC.sales → sales avoids mismatches
+       between the OBML model's schema field and the actual DB schema.
+    """
+    if not hasattr(model, "data_objects") or not model.data_objects:
+        return sql
+    for obj_name, obj in model.data_objects.items():
+        label = getattr(obj, "label", obj_name) or obj_name
+        code = getattr(obj, "code", None)
+        if not code:
+            continue
+        # Replace quoted "Label" → code (DBeaver-generated SQL)
+        if label != code:
+            sql = sql.replace(f'"{label}"', code)
+        # Strip schema/database prefix — connection context handles resolution
+        # 3-part: ANALYTICS.PUBLIC.sales → sales (BigQuery, Snowflake, Databricks)
+        # 2-part: PUBLIC.sales → sales (Postgres, MySQL, ClickHouse, DuckDB)
+        database = getattr(obj, "database", None)
+        schema_name = getattr(obj, "schema_name", None)
+        if database and schema_name:
+            sql = sql.replace(f"{database}.{schema_name}.{code}", code)
+        if schema_name:
+            sql = sql.replace(f"{schema_name}.{code}", code)
+    return sql
+
+
+def classify_sql(server: OBFlightServer, sql: str, model: Any) -> str:
+    """Classify a SQL query into one of three handling modes.
+
+    Returns one of:
+
+    * ``_MODE_SEMANTIC`` — OBSQL query against the model's virtual table.
+    * ``_MODE_CATALOG`` — discovery query (``SHOW``, ``DESCRIBE``,
+      ``information_schema.*``, ``pg_catalog.*``, canned probes like
+      ``SELECT version()``). Routed to model-backed responses;
+      **never reaches the warehouse**.
+    * ``_MODE_REJECTED`` — anything else (raw SQL against unknown
+      targets, FROM-<data-object-label>, multi-statement, parse
+      failures). The caller raises ``RAW_SQL_REJECTED``.
+
+    OBSL is a semantic layer, not a JDBC proxy — there are no escape
+    hatches. See ``design/PLAN_flight_natural_sql.md`` §3.2.
+    """
+    # Strip the bare trailing ``WITH ROLLUP``/``WITH CUBE`` before parsing
+    # — sqlglot requires a GROUP BY in front of those modifiers, but the
+    # OBSQL surface lets callers write them as a trailing flag.
+    from orionbelt.compiler.sql_translator import _strip_trailing_grouping
+
+    cleaned, _ = _strip_trailing_grouping(sql)
+
+    # SHOW / DESCRIBE / USE / SET — short-circuit before sqlglot. sqlglot
+    # logs a "unsupported syntax. Falling back to ... Command" warning on
+    # each of these in its default dialect, which spams the log on every
+    # BI-tool catalog probe.
+    cleaned_upper = cleaned.strip().upper()
+    if cleaned_upper.startswith(("SHOW ", "DESCRIBE ", "DESC ", "USE ", "SET ")):
+        return _MODE_CATALOG
+
+    try:
+        import sqlglot
+        import sqlglot.expressions as exp
+
+        ast = sqlglot.parse_one(cleaned)
+    except Exception:
+        return _MODE_REJECTED
+
+    # SHOW / DESCRIBE / USE / SET — top-level non-Select catalog statements
+    if type(ast).__name__ in _CATALOG_STATEMENT_KINDS:
+        return _MODE_CATALOG
+
+    if not isinstance(ast, exp.Select):
+        # INSERT, UPDATE, DELETE, DROP, CREATE, ALTER, TRUNCATE, MERGE,
+        # multi-statement, Union, etc. all reject as raw — write ops
+        # surface a more specific error in _prepare_sql.
+        return _MODE_REJECTED
+
+    # SELECT with no FROM:
+    # * canned-probe functions (version, current_schema, …) → CATALOG
+    # * literal-only (SELECT 1) → CATALOG (connectivity probe)
+    # * column identifiers that all match the model's dims / measures /
+    #   metrics → SEMANTIC. "No FROM" is shorthand for "FROM <model>"
+    #   on a single-model connection, so requiring the FROM is a tax.
+    #   Any identifier that doesn't match falls through to REJECTED
+    #   so users get RAW_SQL_REJECTED rather than UNKNOWN_SELECT_ITEM.
+    from_node = ast.args.get("from")
+    if from_node is None:
+        known_labels = {label.lower() for label in model.dimensions}
+        known_labels |= {label.lower() for label in model.measures}
+        known_labels |= {label.lower() for label in model.metrics}
+
+        saw_canned_probe = False
+        saw_literal_only = True
+        identifier_count = 0
+        unmatched_identifier = False
+        for proj in ast.expressions:
+            inner = proj.this if isinstance(proj, exp.Alias) else proj
+            if isinstance(inner, exp.Anonymous | exp.Func):
+                fname = (getattr(inner, "name", "") or "").lower()
+                # sqlglot's typed function nodes (CurrentSchema,
+                # CurrentUser, …) carry an empty ``.name`` — fall
+                # back to the class name so canned-probe detection
+                # still fires for ``SELECT current_schema()``.
+                if not fname:
+                    fname = type(inner).__name__.lower()
+                if fname in _CATALOG_SCALAR_PROBES:
+                    saw_canned_probe = True
+                saw_literal_only = False
+            elif isinstance(inner, exp.Literal):
+                pass  # keep saw_literal_only True
+            elif isinstance(inner, exp.Column):
+                col_name = (getattr(inner, "name", "") or "").lower()
+                # Bare ``SESSION_USER`` / ``CURRENT_USER`` etc. parse
+                # as Columns. They're system info, not model
+                # references — treat them as canned probes so the
+                # whole SELECT routes to catalog.
+                if col_name in _CATALOG_SCALAR_PROBES:
+                    saw_canned_probe = True
+                    saw_literal_only = False
+                    continue
+                identifier_count += 1
+                saw_literal_only = False
+                if col_name not in known_labels:
+                    unmatched_identifier = True
+            else:
+                saw_literal_only = False
+        if identifier_count > 0 and not unmatched_identifier:
+            return _MODE_SEMANTIC
+        if saw_canned_probe or saw_literal_only:
+            return _MODE_CATALOG
+        return _MODE_REJECTED
+
+    # FROM something — examine the target
+    table_node = getattr(from_node, "this", None)
+    if table_node is None and getattr(from_node, "expressions", None):
+        table_node = from_node.expressions[0]
+    if table_node is None:
+        return _MODE_REJECTED
+
+    # Pull the qualified name (`pg_catalog.pg_class` etc.) and the
+    # bare identifier separately.
+    full_sql = table_node.sql().lower()
+    bare = getattr(table_node, "name", None) or table_node.sql()
+    bare = str(bare).strip('"').strip("`").strip("'").lower()
+
+    # Catalog schemas
+    for prefix in _CATALOG_SCHEMAS:
+        if prefix in full_sql:
+            return _MODE_CATALOG
+    # Metadata views — return introspection rows (name / data_object / …).
+    if bare in _METADATA_VIEW_NAMES:
+        return _MODE_CATALOG
+
+    # Schema-qualified metadata / label view. Three shapes the BI
+    # tools fire after picking a table from the schema tree:
+    #
+    #   FROM <model>.dimensions                       (2-part, pgjdbc/DBeaver pushdown)
+    #   FROM "orionbelt"."<model>"."dimensions"       (3-part, Tableau pushdown)
+    #   FROM <model>.model / FROM <model>.measures    (2-part, generic)
+    #
+    # All three are "metadata for THIS model" → route to the
+    # catalog where ``SELECT *`` is honoured. Bare label-view
+    # references (``FROM dimensions``) keep the OBSQL
+    # category-filtered virtual-table semantics so existing
+    # surface behaviour is preserved.
+    #
+    # Compare the schema qualifier against BOTH the
+    # ``_ob_model_id`` (stamped session name = pg_namespace
+    # nspname BI tools see in the tree) AND the OBML
+    # ``name:`` field — they can differ when the OBML doesn't
+    # declare ``name:`` explicitly and falls back to a filename
+    # stem, in which case ``model.name`` is empty and only the
+    # stamp is reliable.
+    schema = (
+        (getattr(table_node, "db", None) or table_node.text("db") or "")
+        .strip('"')
+        .strip("`")
+        .strip("'")
+        .lower()
+    )
+    stamped_name = (getattr(model, "_ob_model_id", "") or "").lower()
+    obml_name = (getattr(model, "name", "") or "").lower()
+    model_schemas = {n for n in (stamped_name, obml_name) if n}
+    if (
+        schema
+        and schema in model_schemas
+        and bare in (_LABEL_VIEW_NAMES + _METADATA_VIEW_NAMES + ("model",))
+    ):
+        return _MODE_CATALOG
+
+    # Semantic — the model's virtual table, OR a per-category label view
+    # (_dimensions/_measures/_metrics). Label views are aliases for the
+    # model VT restricted to one category, so `SELECT "X" FROM _dimensions`
+    # compiles through the standard semantic pipeline.
+    from ob_flight.catalog import model_virtual_table_name
+
+    vt = model_virtual_table_name(model).lower()
+    if bare == vt or bare in _LABEL_VIEW_NAMES:
+        return _MODE_SEMANTIC
+
+    # Anything else (including FROM-<data-object-label>) rejects.
+    return _MODE_REJECTED
+
+
+def semantic_result_schema(server: OBFlightServer, query: Any, model: Any) -> pa.Schema:
+    """Build the result Arrow schema for a semantic query without DB I/O.
+
+    Reads ``result_type`` from each selected dimension / measure / metric.
+    See ``design/PLAN_flight_natural_sql.md`` §3.4 "Schema probe".
+    """
+    from ob_flight.catalog import _obml_type_to_arrow
+
+    fields: list[pa.Field] = []
+    dims = getattr(query.select, "dimensions", [])
+    measures = getattr(query.select, "measures", [])
+    for name in dims:
+        label = name if isinstance(name, str) else getattr(name, "alias", None)
+        if label is None:
+            continue
+        dim = model.dimensions.get(label)
+        rt = getattr(getattr(dim, "result_type", None), "value", None) or "string"
+        fields.append(pa.field(label, _obml_type_to_arrow(rt)))
+    for label in measures:
+        meas = model.measures.get(label)
+        met = model.metrics.get(label) if meas is None else None
+        if meas is not None:
+            rt = getattr(getattr(meas, "result_type", None), "value", None) or "float"
+            fields.append(pa.field(label, _obml_type_to_arrow(rt)))
+        elif met is not None:
+            fields.append(pa.field(label, pa.float64()))
+        else:
+            fields.append(pa.field(label, pa.float64()))
+    if query.grouping is not None:
+        # GROUPING() flag columns — int64, one per dimension. See
+        # PLAN_with_rollup.md §"Output: GROUPING() flag columns".
+        for name in dims:
+            label = name if isinstance(name, str) else getattr(name, "alias", None)
+            if label is None:
+                continue
+            fields.append(pa.field(f"_g_{label}", pa.int64()))
+    return pa.schema(fields)
+
+
+def prepare_sql(
+    server: OBFlightServer,
+    sql: str,
+    context: flight.ServerCallContext | None = None,
+) -> tuple[str, str, Any, pa.Schema | None, str, dict[str, Any] | None]:
+    """Resolve model, classify SQL, translate / compile / route.
+
+    Returns ``(final_sql_or_token, dialect, model, schema_hint, mode,
+    cache_meta)``. ``cache_meta`` is a dict with ``key``, ``ttl``,
+    ``session_id``, ``model_id``, ``physical_tables`` when the semantic
+    query is cacheable; ``None`` otherwise (catalog mode, no cache
+    backend, OBML, or oversize-skip).
+
+    * ``mode == _MODE_SEMANTIC`` — ``final_sql_or_token`` is compiled
+      warehouse SQL; ``schema_hint`` is the result schema computed
+      from the model. Caller executes against the warehouse.
+    * ``mode == _MODE_CATALOG`` — ``final_sql_or_token`` is the
+      original SQL; the caller routes to ``_handle_catalog_sql``
+      which returns model-backed metadata. ``schema_hint`` is None.
+    * Anything else raises before returning.
+
+    ``context`` carries the per-call gRPC metadata used to select the
+    target model (``database`` / ``x-obsl-model`` headers).
+
+    Hard rules (v2.4.0+, no env flags):
+
+    * **Raw SQL pass-through is never allowed.** OBSL is a semantic
+      layer, not a JDBC proxy. Unrecognised FROM targets reject
+      with ``RAW_SQL_REJECTED``.
+    * **Write operations (DDL / DML / TCL) are never allowed.** Only
+      ``SELECT`` reaches the warehouse. Reject with
+      ``WRITE_OPERATION_REJECTED``.
+    * **Catalog discovery is always allowed**, never touches the
+      warehouse — answered from the model.
+    """
+    from orionbelt.compiler.pipeline import CompilationPipeline
+    from orionbelt.compiler.sql_translator import (
+        SQLTranslationError,
+        translate_sql_to_query,
+    )
+
+    model, dialect = server._get_model(context)
+
+    # Write-op early reject — covers DDL/DML/TCL across all paths.
+    # OBML YAML detection happens after this so YAML-wrapped writes
+    # also can't sneak through (OBML has no write syntax, but it's
+    # cheap defence-in-depth).
+    server._reject_write_operation(sql)
+
+    # OBML YAML wrapped as a SQL string — power-user path
+    if is_obml(sql):
+        obml = parse_obml(sql)
+        logger.info("OBML request:\n%s", sql)
+        compiled = server._compile_obml(obml, model, dialect)
+        sql = server._rewrite_table_names(compiled.sql, model)
+        logger.info("Compiled SQL:\n%s", sql)
+        # OBML compiles to deterministic SQL like OBSQL; share the cache.
+        cache_meta = server._build_cache_meta(
+            compiled_sql=sql,
+            dialect=dialect,
+            context=context,
+            physical_tables=list(getattr(compiled, "physical_tables", [])),
+        )
+        return sql, dialect, model, None, _MODE_SEMANTIC, cache_meta
+
+    mode = server._classify_sql(sql, model)
+
+    if mode == _MODE_SEMANTIC:
+        logger.info("OBSQL request:\n%s", sql)
+        try:
+            query = translate_sql_to_query(sql, model)
+        except SQLTranslationError as exc:
+            detail = "; ".join(f"[{e.code}] {e.message}" for e in exc.errors)
+            raise flight.FlightServerError(
+                f"OrionBelt Semantic QL translation failed: {detail}"
+            ) from None
+        compiled = CompilationPipeline().compile(query, model, dialect)
+        sql = server._rewrite_table_names(compiled.sql, model)
+        logger.info("Compiled SQL:\n%s", sql)
+        schema_hint = server._semantic_result_schema(query, model)
+        cache_meta = server._build_cache_meta(
+            compiled_sql=sql,
+            dialect=dialect,
+            context=context,
+            physical_tables=list(getattr(compiled, "physical_tables", [])),
+        )
+        return sql, dialect, model, schema_hint, _MODE_SEMANTIC, cache_meta
+
+    if mode == _MODE_CATALOG:
+        # Don't compile or rewrite — the caller routes the original SQL
+        # to a model-backed catalog handler. Schema is computed there.
+        return sql, dialect, model, None, _MODE_CATALOG, None
+
+    # _MODE_REJECTED — no escape hatch.
+    raise flight.FlightServerError(
+        "[RAW_SQL_REJECTED] Raw SQL pass-through is not supported. "
+        "OBSL accepts: (1) OBSQL queries against the model's virtual "
+        "table, (2) compiled QueryObjects via the REST API, and "
+        "(3) catalog discovery (SHOW / DESCRIBE / information_schema / "
+        "pg_catalog). Arbitrary warehouse SQL is rejected by design."
+    )
+
+
+def build_cache_meta(
+    server: OBFlightServer,
+    *,
+    compiled_sql: str,
+    dialect: str,
+    context: flight.ServerCallContext | None,
+    physical_tables: list[str],
+) -> dict[str, Any] | None:
+    """Compute cache key + TTL for a semantic Flight query.
+
+    Returns ``None`` when the cache backend is disabled or the TTL
+    resolver decides the query isn't cacheable (no refresh contracts
+    + ``no_cache`` unknown policy). The caller drops the cache_meta
+    and runs the warehouse query directly.
+    """
+    if server._cache is None or server._cache_config is None:
+        return None
+    backend = getattr(server._cache, "backend_name", "noop")
+    if backend == "noop":
+        return None
+
+    # Non-deterministic SQL (RAND, NOW, CURRENT_DATE, TABLESAMPLE, ...)
+    # must bypass the cache — the SQL hash is the cache key, so caching
+    # would freeze one stale clock/random slice forever.
+    from orionbelt.cache import is_nondeterministic_sql
+
+    nondet, name = is_nondeterministic_sql(compiled_sql)
+    if nondet:
+        logger.info("cache skipped: non-deterministic SQL (%s)", name)
+        return None
+
+    # Resolve session_id from the selector header. Falls back to the
+    # __default__ slot for legacy single-model deployments — matches
+    # how the REST endpoints derive session_id for the cache key.
+    selector = server._selector_from_context(context) or ""
+    if not selector:
+        # Use the protected list (auto-resolve) — single-entry path.
+        protected = server._list_available_model_names()
+        selector = protected[0] if len(protected) == 1 else "__default__"
+
+    try:
+        store = server._session_manager.get_store(selector)
+        models = store.list_models()
+        if not models:
+            return None
+        model_id = models[0].model_id
+    except Exception:
+        return None
+
+    from orionbelt.cache import build_cache_key, compute_effective_ttl
+
+    # v2 keys hash on the compiled SQL string — the canonical, dialect-
+    # rendered form actually sent to the warehouse.
+    cache_key = build_cache_key(
+        session_id=selector,
+        model_id=model_id,
+        dialect=dialect,
+        sql=compiled_sql,
+    )
+
+    # Resolve TTL from refresh contracts + heartbeats — same logic
+    # the REST endpoint uses.
+    try:
+        contracts = store.refresh_contracts(model_id)
+    except Exception:
+        contracts = {}
+    heartbeats: dict[str, Any] = {}
+    snapshot = getattr(server._cache, "heartbeats_snapshot", None)
+    if callable(snapshot):
+        try:
+            heartbeats = snapshot()
+        except Exception:
+            heartbeats = {}
+    ttl_outcome = compute_effective_ttl(
+        physical_tables=physical_tables,
+        contracts=contracts,
+        heartbeats=heartbeats,
+        min_ttl_seconds=server._cache_config.min_ttl_seconds,
+        max_ttl_seconds=server._cache_config.max_ttl_seconds,
+        unknown_policy=server._cache_config.unknown_policy,
+        unknown_default_ttl_seconds=server._cache_config.unknown_default_ttl_seconds,
+    )
+    if ttl_outcome.ttl is None:
+        return None
+    return {
+        "key": cache_key,
+        "ttl": int(ttl_outcome.ttl.seconds),
+        "session_id": selector,
+        "model_id": model_id,
+        "physical_tables": physical_tables,
+        "dialect": dialect,
+        "sql": compiled_sql,
+    }
+
+
+def reject_write_operation(sql: str) -> None:
+    """Reject DDL / DML / TCL statements at the door.
+
+    Parses the SQL with sqlglot and rejects anything whose top-level
+    node is a write operation. ``SELECT`` and ``WITH ... SELECT`` CTEs
+    pass; the catalog-specific ``SHOW`` / ``DESCRIBE`` / ``USE`` /
+    ``SET`` statements also pass (handled by catalog mode). Anything
+    else raises ``WRITE_OPERATION_REJECTED``.
+
+    Defence-in-depth — the translator already rejects non-SELECT for
+    semantic mode, but this guard ensures write ops can't reach the
+    warehouse via *any* path.
+    """
+    # Short-circuit catalog-discovery statements before sqlglot — those
+    # are explicitly allowed and parsing them logs a noisy "unsupported
+    # syntax. Falling back to Command" warning in sqlglot's default
+    # dialect, which would fire on every BI-tool catalog probe.
+    upper = sql.strip().upper()
+    if upper.startswith(("SHOW ", "DESCRIBE ", "DESC ", "USE ", "SET ")):
+        return
+
+    try:
+        import sqlglot
+        import sqlglot.expressions as exp
+
+        ast = sqlglot.parse_one(sql)
+    except Exception:
+        # Parse failure isn't a write op per se — let downstream
+        # classification surface the right error.
+        return
+    if isinstance(ast, exp.Select):
+        return
+    if type(ast).__name__ in _CATALOG_STATEMENT_KINDS:
+        return
+    # Insert, Update, Delete, Drop, Create, Alter, Truncate, Merge,
+    # Commit, Rollback, Grant, Revoke, etc. — all reject.
+    kind = type(ast).__name__.upper()
+    if kind in {"UNION"}:  # set ops surface as raw
+        return
+    raise flight.FlightServerError(
+        f"[WRITE_OPERATION_REJECTED] {kind} statements are not allowed. "
+        "OBSL is read-only — only SELECT queries (and catalog discovery) "
+        "reach the warehouse."
+    )
+
+
+def compile_obml(server: OBFlightServer, obml: dict[str, Any], model: Any, dialect: str) -> Any:
+    """Compile OBML to SQL using the OrionBelt pipeline directly.
+
+    Returns the full ``CompilationResult`` so callers can access
+    ``sql`` plus ``physical_tables`` (needed for the freshness-
+    driven cache TTL resolution).
+    """
+    from orionbelt.compiler.pipeline import CompilationPipeline
+    from orionbelt.models.query import QueryObject
+
+    query = QueryObject.model_validate(obml)
+    return CompilationPipeline().compile(query, model, dialect)
+
+
+def execute_sql(
+    server: OBFlightServer,
+    sql: str,
+    dialect: str,
+    cache_meta: dict[str, Any] | None = None,
+) -> flight.RecordBatchStream:
+    """Execute SQL on the vendor database and stream results.
+
+    Note: table name rewriting is already handled by ``_prepare_sql``
+    during the ``get_flight_info`` phase — no need to rewrite here.
+
+    When ``cache_meta`` is set (semantic mode + cache backend
+    enabled), the function consults the freshness-driven result
+    cache first: on hit it decodes the cached Arrow payload and
+    returns it directly; on miss it executes against the warehouse
+    and writes the resulting ``pa.Table`` back to the cache under
+    the TTL resolved at prepare time. See PLAN_freshness_driven_cache.
+    """
+    # Virtual metadata tables — served from model, no DB needed
+    vt = server._detect_virtual_table(sql)
+    if vt is not None:
+        return server._query_virtual_table(vt)
+
+    # Cache lookup — only when the prepare step gave us a key + ttl.
+    if cache_meta is not None and server._cache is not None:
+        cached_table = server._cache_get_table(cache_meta["key"])
+        if cached_table is not None:
+            logger.info(
+                "Flight cache HIT: key=%s rows=%d", cache_meta["key"], cached_table.num_rows
+            )
+            return flight.RecordBatchStream(cached_table)
+
+    # Resolve ``db_connect`` through the ``ob_flight.server`` module so tests
+    # that patch ``ob_flight.server.db_connect`` take effect.
+    from ob_flight.server import db_connect
+
+    conn = db_connect(dialect)
+    try:
+        cursor = conn.cursor()
+        cursor.execute(sql)
+
+        if cursor.description is None:
+            schema = pa.schema([pa.field("status", pa.utf8())])
+            batch = rows_to_batch([("OK",)], schema)
+            table = pa.Table.from_batches([batch])
+            return flight.RecordBatchStream(table)
+
+        # Fetch first batch and scan rows for Arrow type inference
+        # (UNION ALL queries may have NULL-padded columns in early rows)
+        first_rows = cursor.fetchmany(server._batch_size)
+        schema = schema_from_description(cursor.description, sample_rows=first_rows)
+
+        batches: list[pa.RecordBatch] = []
+        if first_rows:
+            batches.append(rows_to_batch(first_rows, schema))
+        while True:
+            rows = cursor.fetchmany(server._batch_size)
+            if not rows:
+                break
+            batches.append(rows_to_batch(rows, schema))
+
+        if not batches:
+            batches = [rows_to_batch([], schema)]
+
+        table = pa.Table.from_batches(batches)
+
+        # Cache populate — write back after a successful warehouse run.
+        if cache_meta is not None and server._cache is not None:
+            server._cache_put_table(table, cache_meta)
+
+        return flight.RecordBatchStream(table)
+    finally:
+        conn.close()
+
+
+def cache_get_table(server: OBFlightServer, key: str) -> pa.Table | None:
+    """Look up a Flight cache entry. Returns the decoded ``pa.Table`` or None.
+
+    The cache stores parquet-encoded payloads using the same
+    ``parquet_codec`` envelope REST uses, so a Flight reader can
+    consume a REST writer's entry and vice versa. We use plain
+    ``pq.read_table`` because Flight only needs the columnar data;
+    the envelope metadata (sql, dialect, explain, …) is harmless
+    to read and re-serve.
+    """
+    import asyncio
+
+    try:
+        loop = asyncio.new_event_loop()
+        try:
+            result = loop.run_until_complete(server._cache.get(key))
+        finally:
+            loop.close()
+    except Exception:
+        logger.debug("cache.get failed for key=%s", key, exc_info=True)
+        return None
+    if result is None or not getattr(result, "payload", None):
+        return None
+    try:
+        import io
+
+        import pyarrow.parquet as pq
+
+        return pq.read_table(io.BytesIO(result.payload))
+    except Exception:
+        logger.debug("cache decode failed for key=%s", key, exc_info=True)
+        return None
+
+
+def cache_put_table(server: OBFlightServer, table: pa.Table, cache_meta: dict[str, Any]) -> None:
+    """Serialize a ``pa.Table`` to the shared parquet_codec envelope and
+    store under ``cache_meta``.
+
+    REST and Flight share the cache namespace — both must encode the
+    same envelope so the other side can decode ``sql``, ``dialect``,
+    ``columns``, etc. without falling back to defaults. Errors are
+    swallowed; cache writes must never break query execution.
+    """
+    import asyncio
+
+    from orionbelt.cache import parquet_codec
+
+    rows = table.to_pylist()
+    list_of_lists: list[list[Any]] = [
+        [row.get(name) for name in table.column_names] for row in rows
+    ]
+    # REST's ColumnMetadata uses ``type`` (Pydantic field name) with the
+    # vocabulary ``string`` / ``number`` / ``datetime`` / ``binary`` —
+    # match it so a Flight-written cache entry decoded by REST yields
+    # the right column types instead of falling back to ``string``.
+    columns_meta = [
+        {"name": field.name, "type": _arrow_to_obsl_type_hint(field.type)} for field in table.schema
+    ]
+
+    try:
+        payload = parquet_codec.encode(
+            columns=columns_meta,
+            rows=list_of_lists,
+            sql=cache_meta.get("sql", ""),
+            dialect=cache_meta.get("dialect", ""),
+            explain=None,
+            warnings=[],
+            sql_valid=True,
+            execution_time_ms=0.0,
+            timezone=None,
+            resolved={},
+            physical_tables=cache_meta.get("physical_tables", []),
+        )
+    except Exception:
+        logger.debug("cache encode failed", exc_info=True)
+        return
+
+    from orionbelt.cache import query_hash as _query_hash
+
+    try:
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(
+                server._cache.set(
+                    cache_meta["key"],
+                    payload,
+                    ttl_seconds=cache_meta["ttl"],
+                    physical_tables=cache_meta["physical_tables"],
+                    session_id=cache_meta["session_id"],
+                    model_id=cache_meta["model_id"],
+                    query_hash=_query_hash(sql=cache_meta["sql"]),
+                    dialect=cache_meta["dialect"],
+                    row_count=table.num_rows,
+                )
+            )
+        finally:
+            loop.close()
+        logger.info(
+            "Flight cache STORE: key=%s ttl=%ds rows=%d size=%dB",
+            cache_meta["key"],
+            cache_meta["ttl"],
+            table.num_rows,
+            len(payload),
+        )
+    except Exception:
+        logger.debug("cache.set failed", exc_info=True)

--- a/drivers/ob-flight-extension/src/ob_flight/server_routing.py
+++ b/drivers/ob-flight-extension/src/ob_flight/server_routing.py
@@ -1,0 +1,250 @@
+"""Session / model routing helpers for :class:`~ob_flight.server.OBFlightServer`.
+
+Extracted from ``server.py`` (Phase 5.5) as a pure code move. The helper
+functions take the ``OBFlightServer`` instance as their first argument
+(``server``) so the class can delegate to them as one-liners.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pyarrow.flight as flight
+
+if TYPE_CHECKING:
+    from ob_flight.server import OBFlightServer
+
+
+class _SessionRoutingMiddleware(flight.ServerMiddleware):  # type: ignore[misc]
+    """Per-call middleware that captures the incoming session/model selector.
+
+    BI tools (DBeaver, Tableau, Power BI) and JDBC clients pass the model
+    name via the gRPC ``database`` header — set by
+    ``Connection.setCatalog()`` on the Arrow Flight SQL JDBC driver, or
+    by URL path ``/database`` on direct gRPC clients. ``x-obsl-model`` is
+    accepted as an alias for clients that can't set the catalog header.
+
+    See ``design/PLAN_flight_natural_sql.md`` multi-model addressing.
+    """
+
+    def __init__(self, selected_model: str | None) -> None:
+        self.selected_model: str | None = selected_model
+
+    def call_completed(self, exception: BaseException | None) -> None:
+        pass
+
+
+class _SessionRoutingFactory(flight.ServerMiddlewareFactory):  # type: ignore[misc]
+    """Reads the connection's catalog / model selector from incoming gRPC
+    metadata and produces a :class:`_SessionRoutingMiddleware` per call.
+
+    Resolution order for the selector:
+      1. ``database`` (standard JDBC catalog header)
+      2. ``x-obsl-model`` (OBSL-specific alias)
+      3. ``catalog`` (some clients send this instead of ``database``)
+      4. None — caller's request enters with no explicit selector and the
+         auto-resolve / __default__ paths in ``_get_model`` apply.
+    """
+
+    _SELECTOR_KEYS = ("database", "x-obsl-model", "catalog")
+
+    def start_call(
+        self, info: flight.CallInfo, headers: dict[str, list[str]]
+    ) -> _SessionRoutingMiddleware:
+        selected: str | None = None
+        # Headers come in lowercased per gRPC convention; values are lists.
+        for key in self._SELECTOR_KEYS:
+            values = headers.get(key) or headers.get(key.lower())
+            if values:
+                raw = values[0]
+                if raw:
+                    selected = raw.strip().lower() or None
+                    break
+        return _SessionRoutingMiddleware(selected)
+
+
+# Key used to register / look up the routing middleware.
+_ROUTING_MIDDLEWARE_KEY = "obsl_routing"
+
+
+def selector_from_context(
+    context: flight.ServerCallContext | None,
+) -> str | None:
+    """Read the per-call routing selector from the middleware.
+
+    Returns the (already-lowercased) model name set by the client's
+    ``database`` / ``x-obsl-model`` / ``catalog`` gRPC header, or
+    ``None`` if no selector was sent or the middleware isn't installed
+    (e.g. in unit tests that bypass the real gRPC machinery).
+    """
+    if context is None:
+        return None
+    try:
+        mw = context.get_middleware(_ROUTING_MIDDLEWARE_KEY)
+    except Exception:
+        return None
+    if mw is None:
+        return None
+    return getattr(mw, "selected_model", None)
+
+
+def list_available_model_names(server: OBFlightServer) -> list[str]:
+    """List protected (admin-loaded) session ids in addressing order.
+
+    Used by ``_get_model``'s error path and by the catalog endpoint.
+    The session id IS the model name in multi-model mode; legacy
+    single-model mode contributes ``__default__`` (not really an
+    addressable name — see the auto-resolve branch).
+    """
+    if server._session_manager is None:
+        return []
+    try:
+        ids: list[str] = server._session_manager.list_protected_session_ids()
+        return ids
+    except Exception:
+        return []
+
+
+def resolve_model_by_name(
+    server: OBFlightServer,
+    stashed_name: str,
+    context: flight.ServerCallContext | None,
+) -> Any:
+    """Resolve a model by a stashed selector first, falling back to the
+    current call's context. Used by ``do_get`` for ticket round-trips.
+    """
+    if stashed_name:
+        try:
+            store = server._session_manager.get_store(stashed_name)
+            model, _ = server._stamp_model(store, stashed_name)
+            return model
+        except Exception:
+            pass
+    model, _ = server._get_model(context)
+    return model
+
+
+def get_model(
+    server: OBFlightServer, context: flight.ServerCallContext | None = None
+) -> tuple[Any, str]:
+    """Resolve the model targeted by the current call.
+
+    Returns ``(model, dialect)``. Resolution order:
+
+    1. **Explicit selector** from the gRPC ``database`` /
+       ``x-obsl-model`` / ``catalog`` header → that named session.
+    2. **Legacy `__default__`** session (single-model mode via
+       ``MODEL_FILE``).
+    3. **Auto-resolve**: if exactly one admin-loaded session exists,
+       use it without requiring a selector.
+    4. **Rich error** listing the available model names and how to
+       select one.
+
+    Stamps ``_ob_model_id`` on the returned model so downstream
+    catalog code can produce a stable virtual-table name.
+    """
+    if server._session_manager is None:
+        raise flight.FlightUnavailableError("No session manager configured")
+
+    selector = selector_from_context(context)
+
+    # 1. Explicit selector
+    if selector:
+        try:
+            store = server._session_manager.get_store(selector)
+        except Exception:
+            available = list_available_model_names(server)
+            raise flight.FlightUnavailableError(
+                format_unknown_model_error(selector, available)
+            ) from None
+        return server._stamp_model(store, selector)
+
+    # 2. Legacy __default__ session (single-model mode)
+    try:
+        default_store = server._session_manager.get_store("__default__")
+        return server._stamp_model(default_store, "__default__")
+    except Exception:
+        pass
+
+    # 3. Auto-resolve when exactly one admin-loaded model exists
+    protected = list_available_model_names(server)
+    if len(protected) == 1:
+        store = server._session_manager.get_store(protected[0])
+        return server._stamp_model(store, protected[0])
+
+    # 4. Ambiguous or empty → rich error
+    if not protected:
+        raise flight.FlightUnavailableError(
+            "[NO_MODEL_AVAILABLE] No models are loaded on this server. "
+            "Either set MODEL_FILES=<path,...> (or legacy MODEL_FILE) "
+            "before starting the server, or load models dynamically "
+            "via POST /v1/sessions + POST /v1/sessions/{id}/models."
+        )
+    raise flight.FlightUnavailableError(format_ambiguous_model_error(protected))
+
+
+def stamp_model(server: OBFlightServer, store: Any, session_id: str) -> tuple[Any, str]:
+    """Pull the (single) model out of a store and stamp the session
+    id onto it as the virtual-table name. Returns ``(model, dialect)``.
+
+    Per-model dialect resolution: prefer the OBML model's
+    ``settings.defaultDialect`` if set; otherwise fall back to the
+    server's process-wide ``_default_dialect`` (from ``DB_VENDOR``).
+    """
+    models = store.list_models()
+    if not models:
+        raise flight.FlightUnavailableError(
+            f"Session '{session_id}' exists but has no models loaded."
+        )
+    model_id = models[0].model_id
+    model = store.get_model(model_id)
+    try:
+        # In multi-model mode the session_id IS the model name —
+        # use it as the virtual-table name. In legacy mode session_id
+        # is __default__ and we fall back to internal model_id.
+        virtual_name = session_id if not session_id.startswith("_") else model_id
+        model.__dict__["_ob_model_id"] = virtual_name
+    except Exception:
+        pass
+
+    # Per-model dialect override via OBML settings.defaultDialect
+    model_dialect: str | None = None
+    settings = getattr(model, "settings", None)
+    if settings is not None:
+        model_dialect = getattr(settings, "default_dialect", None)
+    return model, model_dialect or server._default_dialect
+
+
+def format_unknown_model_error(selector: str, available: list[str]) -> str:
+    if not available:
+        return (
+            f"[UNKNOWN_MODEL] Model '{selector}' is not loaded and no "
+            "models are available on this server. Either set "
+            "MODEL_FILES=<path,...> at startup or load a model "
+            "dynamically via REST."
+        )
+    return (
+        f"[UNKNOWN_MODEL] Model '{selector}' is not loaded on this server. "
+        f"Available models: {', '.join(sorted(available))}. "
+        "Set the connection's `database` (or `catalog`) field to one "
+        "of these names. In DBeaver: Connection → Database field. "
+        "Pyarrow: client.do_get(...) with a FlightCallOptions header "
+        "(b'database', b'<name>')."
+    )
+
+
+def format_ambiguous_model_error(available: list[str]) -> str:
+    return (
+        "[NO_MODEL_SELECTED] Multiple models are loaded and no selector "
+        "was sent on this connection. Pick one by setting the "
+        "connection's `database` field (or `x-obsl-model` header). "
+        f"Available models: {', '.join(sorted(available))}.\n"
+        "\n"
+        "  DBeaver:    Connection → Database field = <name>\n"
+        "  Tableau:    Same field on the Arrow Flight JDBC connector\n"
+        "  pyarrow:    options = flight.FlightCallOptions(\n"
+        "                  headers=[(b'database', b'<name>')])\n"
+        "  REST:       Use /v1/sessions/<name>/query/semantic-ql\n"
+        "\n"
+        "Discover available models via GET /v1/models."
+    )


### PR DESCRIPTION
## Summary

**Phase 5.5** (final Phase 5 decomposition): split the `OBFlightServer` gravity-well in `drivers/ob-flight-extension/src/ob_flight/server.py` (1730 lines) into a facade plus three sibling modules. Pure code movement; zero behavior change. `OBFlightServer` keeps the Arrow Flight overrides (`get_flight_info`, `do_get`, `do_action`, `list_flights`), `__init__`, and the pending-ticket helpers; every extracted helper is a one-line delegator.

`server.py`: **1730 → 557 lines.**

## New modules (under `ob_flight/`)

| Module | Lines | Contents |
| --- | ---: | --- |
| `server_routing.py` | 250 | session/model routing: `_SessionRouting*` middleware, selector/model resolution, error formatters |
| `server_catalog.py` | 446 | catalog/metadata: catalog tables/columns, virtual-table detection, schema probing, model→catalog builders |
| `server_execution.py` | 772 | SQL classify / rewrite / prepare / execute, cache get/put, arrow type hints, mode constants |

## Compat & cycles

- New modules type-hint the server via `TYPE_CHECKING` string annotation and never import `ob_flight.server` -> no cycle. `server.py` imports the three modules.
- `server.py` re-exports the routing classes, the `_MODE_*` constants, and `db_connect` (tests patch `ob_flight.server.db_connect`; execution helpers resolve it via a deferred import).
- `from ob_flight.server import OBFlightServer` (used by `__init__`, `startup`, tests) unchanged.

## Verification

- Driver suite: `uv run pytest drivers/ob-flight-extension/tests` → **150 passed**
- Driver `ruff check` + `ruff format --check` clean; `mypy drivers/ob-flight-extension/src` clean (11 files)
- Main repo unaffected (it doesn't import `ob_flight`): `pytest` → 2487 passed, 167 skipped
- `git status` shows only the 4 driver `.py` files

This completes **Phase 5** — all five gravity wells decomposed (resolution.py #146, cfl.py #147, ui/app.py #148, OSI converter #149, and this).