### PR TITLE
test(arch): dependency-direction + broad-except growth guards [Phase 7.3/7.4]

### DIFF
--- a/tests/architecture/inventory.py
+++ b/tests/architecture/inventory.py
@@ -128,13 +128,24 @@ def _internal(name: str) -> bool:
     return name == PACKAGE or name.startswith(PACKAGE + ".")
 
 
-def _import_targets(node: ast.Import | ast.ImportFrom, current: str, known: set[str]) -> list[str]:
+def _import_targets(
+    node: ast.Import | ast.ImportFrom,
+    current: str,
+    known: set[str],
+    *,
+    is_package: bool = False,
+) -> list[str]:
     """Internal modules a single import statement depends on, resolved.
 
     A ``from pkg import sub`` where ``pkg.sub`` is a known module is treated
     as a dependency on the **submodule** (``pkg.sub``), not on ``pkg``'s
     ``__init__``. Resolving it to the package would manufacture spurious
     cycles for the standard "package re-exports its submodules" pattern.
+
+    ``is_package`` is True when ``current`` is a package ``__init__`` (whose
+    dotted name *is* the package). Relative imports anchor differently there:
+    ``from . import x`` resolves within the package itself, whereas for a
+    regular module it resolves within the parent package.
     """
     resolved: list[str] = []
 
@@ -152,11 +163,14 @@ def _import_targets(node: ast.Import | ast.ImportFrom, current: str, known: set[
 
     # ast.ImportFrom
     if node.level:
-        # Relative import: resolve against the current module's package.
-        base_parts = current.split(".")
-        # Drop ``level`` trailing components: ``from . import x`` (level 1)
-        # targets a sibling of the current module.
-        base_parts = base_parts[: len(base_parts) - node.level]
+        # Anchor package: a package __init__'s own dotted name; otherwise the
+        # current module's parent package.
+        anchor = current if is_package else current.rpartition(".")[0]
+        anchor_parts = anchor.split(".") if anchor else []
+        # ``from . import x`` (level 1) targets the anchor package itself, so
+        # drop (level - 1) trailing components from the anchor.
+        keep = len(anchor_parts) - (node.level - 1)
+        base_parts = anchor_parts[:keep] if keep > 0 else []
         prefix = ".".join(base_parts)
         module = f"{prefix}.{node.module}" if node.module else prefix
     else:
@@ -219,13 +233,19 @@ def _iter_import_time_imports(body: list[ast.stmt]) -> list[ast.Import | ast.Imp
     return found
 
 
-def _collect_import_edges(tree: ast.Module, current: str, known: set[str]) -> set[str]:
+def _collect_import_edges(
+    tree: ast.Module, current: str, known: set[str], *, is_package: bool = False
+) -> set[str]:
     edges: set[str] = set()
     for node in _iter_import_time_imports(tree.body):
-        for resolved in _import_targets(node, current, known):
+        for resolved in _import_targets(node, current, known, is_package=is_package):
             if resolved != current:
                 edges.add(resolved)
     return edges
+
+
+def _is_package_init(path: Path) -> bool:
+    return path.name == "__init__.py"
 
 
 _BROAD_NAMES = frozenset({"Exception", "BaseException"})
@@ -274,7 +294,7 @@ def import_edges() -> set[tuple[str, str]]:
         tree = _safe_parse(path)
         if tree is None:
             continue
-        for target in _collect_import_edges(tree, module, known):
+        for target in _collect_import_edges(tree, module, known, is_package=_is_package_init(path)):
             edges.add((module, target))
     return edges
 
@@ -302,7 +322,7 @@ def build_inventory(*, top_n: int = 15) -> Inventory:
         if tree is None:
             continue
 
-        for target in _collect_import_edges(tree, module, known):
+        for target in _collect_import_edges(tree, module, known, is_package=_is_package_init(path)):
             graph.add_edge(module, target)
 
         for node in ast.walk(tree):

--- a/tests/architecture/inventory.py
+++ b/tests/architecture/inventory.py
@@ -258,6 +258,27 @@ def _is_raw_sql_call(node: ast.Call) -> bool:
     return False
 
 
+def import_edges() -> set[tuple[str, str]]:
+    """Internal import-time module dependency edges, ``(source, target)``.
+
+    Same edge model the cycle detector uses: only imports that execute at
+    import time (no deferred function-local or ``TYPE_CHECKING`` imports),
+    resolved to known internal modules. Used by the dependency-direction
+    architecture test.
+    """
+    files = _iter_source_files()
+    known = {_module_name(p) for p in files}
+    edges: set[tuple[str, str]] = set()
+    for path in files:
+        module = _module_name(path)
+        tree = _safe_parse(path)
+        if tree is None:
+            continue
+        for target in _collect_import_edges(tree, module, known):
+            edges.add((module, target))
+    return edges
+
+
 def build_inventory(*, top_n: int = 15) -> Inventory:
     """Compute the architecture inventory from the source tree."""
     files = _iter_source_files()

--- a/tests/architecture/test_broad_except_guard.py
+++ b/tests/architecture/test_broad_except_guard.py
@@ -1,0 +1,37 @@
+"""Broad-except growth guard (Phase 7.4).
+
+Boundary modules (HTTP, wire protocols, caches, DB drivers, the YAML
+parser) legitimately catch broadly; the core compiler/dialect/model layers
+should not. This gate fails if broad ``except Exception`` / bare ``except``
+sites *outside* the approved boundary modules grow beyond the current
+baseline, forcing a deliberate choice: narrow the exception, move the code
+to a boundary module, or raise the baseline with a justification.
+
+Counting (not line numbers) keeps the guard robust to unrelated edits that
+shift line positions. ``inventory.BOUNDARY_PREFIXES`` defines which modules
+are exempt.
+"""
+
+from __future__ import annotations
+
+from tests.architecture.inventory import build_inventory
+
+# Current core (non-boundary) broad-except sites. As of this baseline they
+# live in the compiler resolution layer:
+#   compiler/resolution.py:88            (noqa: BLE001 — preserve prior behaviour)
+#   compiler/metric_resolution.py x2     (expression-resolution fallbacks)
+# Lower this number as the exceptions are narrowed; raise it only with a
+# documented reason in the PR.
+BASELINE_CORE_BROAD_EXCEPT = 3
+
+
+def test_core_broad_except_does_not_grow() -> None:
+    inv = build_inventory()
+    sites = inv.core_broad_except_sites
+    listing = "\n".join(f"  {s.path}:{s.line}" for s in sites)
+    assert len(sites) <= BASELINE_CORE_BROAD_EXCEPT, (
+        f"Broad `except` outside boundary modules grew to {len(sites)} "
+        f"(baseline {BASELINE_CORE_BROAD_EXCEPT}). Narrow the exception, move it to a "
+        f"boundary module, or raise BASELINE_CORE_BROAD_EXCEPT with a reason.\n"
+        f"Current core sites:\n{listing}"
+    )

--- a/tests/architecture/test_dependencies.py
+++ b/tests/architecture/test_dependencies.py
@@ -1,0 +1,53 @@
+"""Architecture dependency-direction gate (Phase 7.3).
+
+Enforces the layering of ``src/orionbelt``: a lower layer must not import a
+higher one. The rules below encode the *forbidden* directions and are
+derived from the current (clean) import graph — every rule holds today, so
+a new edge that inverts a layer (e.g. ``compiler`` importing ``api``, or
+``models`` importing ``compiler``) fails this test.
+
+Edges are import-time only (deferred function-local / ``TYPE_CHECKING``
+imports are excluded), matching the cycle detector. Cheap enough for every
+PR.
+"""
+
+from __future__ import annotations
+
+from tests.architecture.inventory import import_edges
+
+# For each subpackage, the set of subpackages it must NOT import. The layering
+# (low -> high): ast/models -> dialect -> compiler -> {cache,obsl,parser} ->
+# service -> api -> pgwire; ui is a thin client over service. ``auth`` and
+# ``settings`` are leaf config consumed widely and are not constrained here.
+# Everything above the data layer; the two leaf layers (ast, models) may not
+# import any of these (nor each other).
+_ABOVE_DATA = {"dialect", "compiler", "parser", "cache", "obsl", "service", "api", "pgwire", "ui"}
+
+FORBIDDEN: dict[str, set[str]] = {
+    "ast": _ABOVE_DATA | {"models"},
+    "models": _ABOVE_DATA | {"ast"},
+    "dialect": {"compiler", "parser", "cache", "obsl", "service", "api", "pgwire", "ui"},
+    "compiler": {"parser", "cache", "obsl", "service", "api", "pgwire", "ui"},
+    "parser": {"dialect", "compiler", "cache", "obsl", "service", "api", "pgwire", "ui"},
+    "cache": {"dialect", "compiler", "parser", "obsl", "service", "api", "pgwire", "ui"},
+    "obsl": {"dialect", "compiler", "parser", "cache", "service", "api", "pgwire", "ui"},
+    "service": {"api", "pgwire", "ui"},
+    "api": {"pgwire", "ui"},
+    "ui": {"pgwire"},
+}
+
+
+def _subpackage(module: str) -> str:
+    parts = module.split(".")
+    return parts[1] if len(parts) > 1 else module
+
+
+def test_no_forbidden_layer_imports() -> None:
+    violations: list[str] = []
+    for source, target in import_edges():
+        src, dst = _subpackage(source), _subpackage(target)
+        if src == dst:
+            continue
+        if dst in FORBIDDEN.get(src, set()):
+            violations.append(f"{source} -> {target}  ({src} must not import {dst})")
+    assert not violations, "Forbidden import directions found:\n" + "\n".join(sorted(violations))

--- a/tests/architecture/test_dependencies.py
+++ b/tests/architecture/test_dependencies.py
@@ -13,7 +13,9 @@ PR.
 
 from __future__ import annotations
 
-from tests.architecture.inventory import import_edges
+import ast
+
+from tests.architecture.inventory import _collect_import_edges, import_edges
 
 # For each subpackage, the set of subpackages it must NOT import. The layering
 # (low -> high): ast/models -> dialect -> compiler -> {cache,obsl,parser} ->
@@ -51,3 +53,27 @@ def test_no_forbidden_layer_imports() -> None:
         if dst in FORBIDDEN.get(src, set()):
             violations.append(f"{source} -> {target}  ({src} must not import {dst})")
     assert not violations, "Forbidden import directions found:\n" + "\n".join(sorted(violations))
+
+
+def test_relative_import_from_package_init_is_resolved() -> None:
+    """Regression: a relative import in a package ``__init__`` must produce an edge.
+
+    ``from .. import compiler`` inside ``orionbelt/models/__init__.py`` targets
+    ``orionbelt.compiler`` — it must not be silently dropped (which would let a
+    forbidden models -> compiler edge bypass the layering gate).
+    """
+    known = {"orionbelt.models", "orionbelt.compiler"}
+    tree = ast.parse("from .. import compiler\n")
+    edges = _collect_import_edges(tree, "orionbelt.models", known, is_package=True)
+    assert "orionbelt.compiler" in edges
+
+    # The same statement in a regular module ``orionbelt.models.semantic``
+    # anchors at the parent, so ``..`` reaches ``orionbelt`` -> still compiler.
+    edges_mod = _collect_import_edges(tree, "orionbelt.models.semantic", known, is_package=False)
+    assert "orionbelt.compiler" in edges_mod
+
+    # ``from . import x`` in the package targets the package itself, not a sibling.
+    known2 = {"orionbelt.models", "orionbelt.models.helpers"}
+    tree2 = ast.parse("from . import helpers\n")
+    edges2 = _collect_import_edges(tree2, "orionbelt.models", known2, is_package=True)
+    assert "orionbelt.models.helpers" in edges2


### PR DESCRIPTION
## Summary

Starts **Phase 7** (quality gates) by promoting two Phase 0 inventory measurements into enforced architecture tests. No production code changes — only `tests/architecture/`.

## New gates

**`test_dependencies.py` (7.3) — dependency-direction guard.** Encodes the `src/orionbelt` layering as a `FORBIDDEN` map and fails on any import that inverts a layer:

```
ast / models  ->  dialect  ->  compiler  ->  {cache, obsl, parser}  ->  service  ->  api  ->  pgwire
                                                                                   ui  ->  service
```

e.g. `compiler` importing `api`, or `models` importing `compiler`, would fail. Every rule holds on the current graph. Uses import-time edges only (deferred / `TYPE_CHECKING` imports excluded), matching the cycle detector.

**`test_broad_except_guard.py` (7.4) — broad-except growth guard.** Fails if broad `except Exception` / bare `except` sites *outside* the approved boundary modules grow beyond the baseline (currently **3**, all in the compiler resolution layer). Count-based, so it's robust to unrelated line-shifting edits; boundary modules (HTTP, wire, caches, DB drivers, YAML parser) stay exempt.

`inventory.py` gains a reusable `import_edges()` accessor (shared with the cycle detector).

## Verification

- `uv run pytest tests/architecture/` → 15 passed
- `uv run ruff check` / `ruff format --check` / `mypy` on `tests/architecture/` → clean

## Phase 7 remaining
- 7.1 coverage reporting + thresholds (CI config)
- 7.2 compiler invariant / metamorphic tests
- 7.5 RawSQL inventory + typed PoP builders

(Phase 6 — generated artifacts — is intentionally deferred per the plan until the OBML manifest has survived a real OBML change.)