### PR TITLE
test(arch): RawSQL containment guard + documented sites [Phase 7.5]

### DIFF
--- a/src/orionbelt/compiler/pop_wrap.py
+++ b/src/orionbelt/compiler/pop_wrap.py
@@ -148,6 +148,8 @@ def wrap_with_pop(
     date_range_sql = _build_date_range_sql(
         resolved, model, dialect, qualify_table, grain, time_dim_name
     )
+    # RawSQL: dialect-specific date aggregation/casts the SQL AST does not model.
+    # Covered by the PoP drift snapshots. See tests/architecture/test_rawsql_guard.py.
     date_range_cte = CTE(name="date_range", query=RawSQL(sql=date_range_sql))
 
     # --- CTE 2: date_spine ---
@@ -160,6 +162,8 @@ def wrap_with_pop(
         offset=offset,
         offset_grain=offset_grain,
     )
+    # RawSQL: per-dialect date-spine generator (recursive CTE / generate_series /
+    # sequence) — not expressible as a typed Select. Covered by PoP drift snapshots.
     date_spine_cte = CTE(name="date_spine", query=RawSQL(sql=spine_sql))
 
     # --- CTE 3: pop_base ---
@@ -168,10 +172,14 @@ def wrap_with_pop(
     pop_base_sql = _build_pop_base_sql(
         ast, resolved, model, dialect, qualify_table, grain, time_obj_name, time_source_col
     )
+    # RawSQL: restructured join tree anchored on the date spine with dialect date
+    # arithmetic; not the planner's Select shape. Covered by PoP drift snapshots.
     pop_base_cte = CTE(name="pop_base", query=RawSQL(sql=pop_base_sql))
 
     # --- CTE 4: pop_compare ---
     pop_compare_sql = _build_pop_compare_sql(resolved, dialect, pop_measures)
+    # RawSQL: dynamic self-joins (one per distinct PoP offset) with inline date
+    # arithmetic; not a fixed typed Select. Covered by PoP drift snapshots.
     pop_compare_cte = CTE(name="pop_compare", query=RawSQL(sql=pop_compare_sql))
 
     # --- Final SELECT from pop_compare ---

--- a/src/orionbelt/dialect/mysql.py
+++ b/src/orionbelt/dialect/mysql.py
@@ -178,6 +178,9 @@ class MySQLDialect(Dialect):
             from orionbelt.ast.nodes import RawSQL
 
             col_sql = self.compile_expr(column)
+            # RawSQL: MySQL quarter truncation via nested DATE_ADD/MAKEDATE/QUARTER
+            # date arithmetic — no single typed FunctionCall expresses it. Covered
+            # by dialect drift snapshots. See tests/architecture/test_rawsql_guard.py.
             return RawSQL(
                 sql=(
                     f"DATE_ADD(MAKEDATE(YEAR({col_sql}), 1), "

--- a/tests/architecture/test_rawsql_guard.py
+++ b/tests/architecture/test_rawsql_guard.py
@@ -1,0 +1,61 @@
+"""RawSQL containment gate (Phase 7.5).
+
+``RawSQL`` is the dialect escape hatch: a SQL string spliced into the AST
+where the typed nodes can't express a fragment (dialect-specific date-spine
+generators, period-over-period self-joins, MySQL quarter arithmetic). The
+goal is not to ban it but to keep it **narrow and visible** — every site is
+enumerated here, carries an inline reason comment at its call site, and is
+covered by drift snapshots. A new ``RawSQL`` construction anywhere fails
+this test until it is added to the approved inventory.
+
+Counting by module (not line) keeps the gate robust to unrelated edits.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+
+from tests.architecture.inventory import build_inventory
+
+# Approved production ``RawSQL`` construction sites: path -> max count.
+# Each corresponding call site carries a ``# RawSQL: <reason>`` comment.
+# Lower these as fragments become expressible with typed AST nodes; raising a
+# count (or adding a path) is a deliberate, reviewed escape-hatch decision.
+APPROVED_RAWSQL: dict[str, int] = {
+    # Period-over-period CTEs: date_range, date_spine, pop_base, pop_compare —
+    # dialect-specific date-spine SQL the typed AST does not model.
+    "src/orionbelt/compiler/pop_wrap.py": 4,
+    # MySQL quarter truncation (nested DATE_ADD/MAKEDATE/QUARTER).
+    "src/orionbelt/dialect/mysql.py": 1,
+}
+
+
+def test_rawsql_sites_are_approved() -> None:
+    inv = build_inventory()
+    counts = Counter(site.path for site in inv.raw_sql_sites)
+
+    unexpected_files = sorted(set(counts) - set(APPROVED_RAWSQL))
+    assert not unexpected_files, (
+        "New RawSQL construction in unapproved file(s): "
+        f"{unexpected_files}. RawSQL is the dialect escape hatch — add a "
+        "`# RawSQL: <reason>` comment at the call site and an entry in "
+        "APPROVED_RAWSQL, or use a typed AST node instead."
+    )
+
+    grown = {
+        path: (n, APPROVED_RAWSQL[path]) for path, n in counts.items() if n > APPROVED_RAWSQL[path]
+    }
+    assert not grown, (
+        "RawSQL use grew beyond the approved baseline (path: actual vs approved): "
+        f"{grown}. Justify and raise APPROVED_RAWSQL, or avoid the new RawSQL."
+    )
+
+
+def test_rawsql_total_does_not_grow() -> None:
+    inv = build_inventory()
+    total = len(inv.raw_sql_sites)
+    baseline = sum(APPROVED_RAWSQL.values())
+    assert total <= baseline, (
+        f"Total RawSQL construction sites grew to {total} (baseline {baseline}). "
+        "RawSQL count must stay stable or decrease."
+    )


### PR DESCRIPTION
## Summary

**Phase 7.5**: keep the `RawSQL` dialect escape hatch *narrow and visible* (the plan's goal — not to ban it).

- **`tests/architecture/test_rawsql_guard.py`** enumerates the approved `RawSQL` construction sites by module and fails when a new one appears, a per-file count grows, or the total grows. Count-based, so robust to line shifts.
- **Inline `# RawSQL: <reason>` comments** added at each of the 5 call sites explaining why the fragment can't be a typed AST node and noting drift-snapshot coverage.

Approved inventory (unchanged from baseline):

| Site | Count | Why raw |
| --- | ---: | --- |
| `compiler/pop_wrap.py` | 4 | period-over-period CTEs: `date_range`, `date_spine`, `pop_base`, `pop_compare` — dialect-specific date-spine SQL + dynamic self-joins |
| `dialect/mysql.py` | 1 | MySQL quarter truncation (nested `DATE_ADD`/`MAKEDATE`/`QUARTER`) |

## On the "typed PoP builders"

The plan suggests typed builders "where the dialect API already has enough primitives." I assessed all five sites and **did not** convert them: the remaining fragments encode per-dialect date-spine generators (recursive CTEs / `generate_series` / sequences), dynamic multi-offset self-joins, and MySQL-specific date arithmetic — none expressible as a fixed typed `Select`/`FunctionCall`, and a rewrite couldn't stay byte-identical across the 8 dialects (the acceptance criterion: "PoP snapshots remain stable"). So the safe, plan-aligned deliverable is containment + documentation. The guard ensures the count only goes **down** from here as the AST gains primitives.

## Verification

- `src` changes are **comment-only** — PoP and dialect drift snapshots unchanged.
- `uv run pytest` → 2497 passed, 167 skipped (no `*.yaml` snapshot changes)
- ruff / format / mypy clean

Phase 7 remaining: **7.1** (coverage CI gate — needs your OK to touch `.github/workflows`).