### PR TITLE
ci: coverage floors for engine + osi packages [Phase 7.1]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,38 @@ jobs:
         working-directory: packages/osi-orionbelt
         run: uv run pytest --tb=short -q
 
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --all-extras --all-groups
+
+      # Coverage floor for the core engine packages. Baselines were measured
+      # at compiler+parser+api 85% and osi-orionbelt 82%; the floors sit just
+      # below to catch accidental test loss without blocking refactors. Raise
+      # them as coverage improves.
+      - name: Coverage (compiler / parser / api)
+        run: >
+          uv run pytest -q
+          --cov=orionbelt.compiler --cov=orionbelt.parser --cov=orionbelt.api
+          --cov-report=term-missing --cov-fail-under=83
+
+      - name: Coverage (osi-orionbelt)
+        working-directory: packages/osi-orionbelt
+        run: >
+          uv run pytest -q
+          --cov=osi_orionbelt --cov-report=term-missing --cov-fail-under=80
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,6 +175,16 @@ markers = [
     "notebook: heavy end-to-end notebook execution (Colab quickstart); needs nbclient + ipykernel + duckdb; run with: pytest -m notebook",
 ]
 
+[tool.coverage.report]
+# Lines that should never count against coverage (defensive / type-only).
+exclude_also = [
+    "if TYPE_CHECKING:",
+    "raise NotImplementedError",
+    "@(abc\\.)?abstractmethod",
+    "if __name__ == .__main__.:",
+    "\\.\\.\\.",  # ellipsis bodies (Protocols / overloads)
+]
+
 [tool.mypy]
 python_version = "3.12"
 strict = true


### PR DESCRIPTION
## Summary

**Phase 7.1** (completes Phase 7): add a CI coverage gate for the core engine packages, with floors set just below the measured baseline so accidental test loss fails CI without blocking ordinary refactors.

| Scope | Measured | Floor (`--cov-fail-under`) |
| --- | ---: | ---: |
| `compiler` + `parser` + `api` | 84.86% | **83%** |
| `osi-orionbelt` | 82.11% | **80%** |

## Details

- New dedicated **`coverage`** job in `ci.yml` (the fast matrix `test` job is unchanged). Runs the suite once under `pytest-cov` and enforces the floors; the osi member is covered from its own directory.
- Coverage runs **only in CI**, not in local `pytest` `addopts`, so local runs stay fast.
- `[tool.coverage.report].exclude_also` ignores type-only / defensive lines (`if TYPE_CHECKING:`, `@abstractmethod`, ellipsis bodies, `__main__`).
- Raise the floors as coverage improves.

## Verification (locally, with the new config)

- compiler/parser/api: `Required test coverage of 83% reached. Total coverage: 84.86%` (exit 0)
- osi-orionbelt: `Required test coverage of 80% reached. Total coverage: 82.11%` (exit 0)
- `ci.yml` is valid YAML; full suite 2497 passed / 167 skipped

This is the last Phase 7 item. The whole architecture program is now complete except deferred Phase 6 (generated artifacts), which the plan gates on the OBML manifest surviving a real OBML change.