### PR TITLE
Fix Google Analytics feedback tracking in docs

### DIFF
--- a/docs/javascripts/gtag-fix.js
+++ b/docs/javascripts/gtag-fix.js
@@ -1,0 +1,67 @@
+// Fix for Google Analytics feedback tracking
+// MkDocs Material doesn't properly define gtag, so we define it here
+
+// Initialize gtag function if not already defined
+if (typeof window.gtag === 'undefined') {
+  window.dataLayer = window.dataLayer || [];
+  window.gtag = function(){
+    dataLayer.push(arguments);
+  }
+  
+  // Initialize with current time
+  gtag('js', new Date());
+  
+  // Configure GA4 property
+  gtag('config', 'G-X19K4GX3EX', {
+    'anonymize_ip': true,
+    'cookie_flags': 'SameSite=None;Secure'
+  });
+  
+  console.log('Google Analytics initialized with gtag function');
+}
+
+// Enhanced feedback tracking
+document.addEventListener('DOMContentLoaded', function() {
+  // Wait for MkDocs to set up the feedback form
+  setTimeout(function() {
+    const feedbackForm = document.querySelector('.md-feedback');
+    if (feedbackForm) {
+      const buttons = feedbackForm.querySelectorAll('button[data-md-value]');
+      
+      buttons.forEach(button => {
+        button.addEventListener('click', function(e) {
+          const value = this.getAttribute('data-md-value');
+          const page = window.location.pathname;
+          
+          // Send event to GA4
+          if (typeof gtag !== 'undefined') {
+            gtag('event', 'page_feedback', {
+              'event_category': 'engagement',
+              'event_label': page,
+              'value': parseInt(value),
+              'page_path': page,
+              'feedback_value': value === '1' ? 'helpful' : 'not_helpful'
+            });
+            
+            console.log('Feedback sent to GA4:', {
+              page: page,
+              value: value === '1' ? 'helpful' : 'not_helpful'
+            });
+          }
+        });
+      });
+      
+      console.log('Feedback tracking enhanced');
+    }
+  }, 1000);
+});
+
+// Also track page views properly
+document.addEventListener('DOMContentLoaded', function() {
+  if (typeof gtag !== 'undefined') {
+    gtag('event', 'page_view', {
+      page_path: window.location.pathname,
+      page_title: document.title
+    });
+  }
+});

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,8 @@ dev_addr: 127.0.0.1:8080
 extra:
   obml_version: "1.0"
   project_version: "2.17.1"
+  javascript:
+    - javascripts/gtag-fix.js
   analytics:
     provider: google
     property: G-X19K4GX3EX


### PR DESCRIPTION
## Problem
The feedback widget (\"Was this page helpful?\") in the documentation wasn't sending events to Google Analytics. Investigation revealed:
- MkDocs Material creates a local function `e()` instead of the global `gtag()` function
- This causes feedback clicks to fail silently
- No feedback data was being collected in GA4

## Solution
Added custom JavaScript (`docs/javascripts/gtag-fix.js`) that:
1. Properly initializes the global `gtag` function
2. Enhances feedback tracking with detailed event parameters
3. Sends events as `page_feedback` with `helpful`/`not_helpful` values
4. Includes page path and other useful metadata

## Changes
- Created `docs/javascripts/gtag-fix.js` with gtag initialization and enhanced tracking
- Added JavaScript file to `mkdocs.yml` extra configuration
- Feedback events now properly sent to GA4 property (G-X19K4GX3EX)

## Testing
After deployment, feedback events will appear in GA4 under:
- **Realtime → Events** (immediate)
- **Reports → Engagement → Events** (after processing)

Look for `page_feedback` events with parameters:
- `feedback_value`: "helpful" or "not_helpful"
- `page_path`: The documentation page path
- `value`: 1 (helpful) or 0 (not helpful)