### PR TITLE
Add GitHub Actions workflow for automated docs deployment

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,37 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/deploy-docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          
+      - name: Build and deploy docs
+        env:
+          GITHUB_TOKEN: ${{ secrets.DOCS_DEPLOY_TOKEN }}
+        run: |
+          ./scripts/deploy-docs.sh


### PR DESCRIPTION
Adds automated docs deployment workflow that triggers on:
- Push to main branch (when docs/ or mkdocs.yml change)  
- Manual workflow dispatch

Uses the DOCS_DEPLOY_TOKEN secret to authenticate with GitHub when pushing to gh-pages branch.