### PR TITLE
Fix GA feedback tracking with template override

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,8 +10,6 @@ dev_addr: 127.0.0.1:8080
 extra:
   obml_version: "1.0"
   project_version: "2.17.1"
-  javascript:
-    - javascripts/gtag-fix.js
   analytics:
     provider: google
     property: G-X19K4GX3EX

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -5,3 +5,9 @@
     Part of <strong>ralforion.com</strong> &nbsp;·&nbsp; back to home →
   </a>
 {% endblock %}
+
+{% block extrahead %}
+  {{ super() }}
+  <!-- Custom Google Analytics fixes for feedback tracking -->
+  <script src="{{ 'javascripts/gtag-fix.js' | url }}"></script>
+{% endblock %}


### PR DESCRIPTION
The previous attempt to add gtag-fix.js didn't work because extra.javascript isn't supported by MkDocs Material. This PR uses template override to properly include the script.