### PR TITLE
Fix pgwire SQL injection in extended-protocol parameter substitution

### DIFF
--- a/src/orionbelt/pgwire/extended.py
+++ b/src/orionbelt/pgwire/extended.py
@@ -31,6 +31,7 @@ the trade space we revisit in Step 7:
 
 from __future__ import annotations
 
+import decimal
 import logging
 import re
 import struct
@@ -439,7 +440,11 @@ def substitute_parameters(
         except UnicodeDecodeError as exc:
             raise _BadParameterError(f"Text-format parameter is not valid UTF-8: {exc}") from None
         if oid in _NUMERIC_TEXT_OIDS:
-            rendered.append(text)
+            # Never splice client bytes into SQL raw: strictly parse the text
+            # per its declared numeric OID and re-render a canonical literal.
+            # A value like ``0 AND "x" = 'y'`` fails the parse and is rejected
+            # instead of becoming active SQL.
+            rendered.append(_canonical_numeric_text(text, oid))
         elif oid in _BOOL_TEXT_OIDS:
             rendered.append("TRUE" if text.lower() in {"t", "true", "1", "y", "yes"} else "FALSE")
         else:
@@ -463,10 +468,44 @@ _OID_VARCHAR = 1043
 _OID_NAME = 19
 _OID_BPCHAR = 1042
 
+_OID_NUMERIC = 1700
+
+_INTEGER_TEXT_OIDS: frozenset[int] = frozenset({_OID_INT2, _OID_INT4, _OID_INT8})
+_INT_TEXT_RE = re.compile(r"[+-]?[0-9]+")
 _NUMERIC_TEXT_OIDS: frozenset[int] = frozenset(
-    {_OID_INT2, _OID_INT4, _OID_INT8, _OID_FLOAT4, _OID_FLOAT8, 1700}
+    {_OID_INT2, _OID_INT4, _OID_INT8, _OID_FLOAT4, _OID_FLOAT8, _OID_NUMERIC}
 )
 _BOOL_TEXT_OIDS: frozenset[int] = frozenset({_OID_BOOL})
+
+
+def _canonical_numeric_text(text: str, oid: int) -> str:
+    """Parse a text-format numeric parameter and re-render it canonically.
+
+    Security boundary for the extended-protocol Bind path: a numeric-typed
+    parameter's *text* is attacker-controlled, so it must never reach the SQL
+    string unvalidated. We parse it strictly per the declared OID and emit the
+    canonical string form of the parsed number — which contains only
+    ``[-+0-9.eE]`` and can carry no SQL syntax. Anything that is not a plain
+    number (``0 AND 1=1``, ``1); DROP TABLE t; --``, ``NaN``, ``Infinity``) is
+    rejected with :class:`_BadParameterError`.
+    """
+    s = text.strip()
+    try:
+        if oid in _INTEGER_TEXT_OIDS:
+            # Strict ASCII integer grammar (Python int() also accepts
+            # underscores / unicode digits — harmless to render but not what
+            # Postgres accepts, so reject for predictability).
+            if not _INT_TEXT_RE.fullmatch(s):
+                raise ValueError("not a plain integer")
+            return str(int(s))
+        value = decimal.Decimal(s)
+    except (ValueError, ArithmeticError) as exc:
+        raise _BadParameterError(f"Invalid numeric text parameter for OID {oid}: {text!r}") from exc
+    if not value.is_finite():
+        raise _BadParameterError(
+            f"Non-finite numeric text parameter not allowed for OID {oid}: {text!r}"
+        )
+    return str(value)
 
 
 def _decode_binary_param(raw: bytes, oid: int) -> str:
@@ -516,59 +555,108 @@ def _decode_binary_param(raw: bytes, oid: int) -> str:
     )
 
 
-def _replace_placeholders(sql: str, rendered: list[str]) -> str:
-    """Replace ``$N`` placeholders with their rendered literal.
+# Opener for a dollar-quoted string: ``$$`` or ``$tag$`` where ``tag`` is a
+# SQL identifier (letter/underscore start). A digit-led ``$1`` is NOT a valid
+# dollar-quote tag, so it stays unambiguously a bind placeholder.
+_DOLLAR_QUOTE_OPEN = re.compile(r"\$(?:[A-Za-z_][A-Za-z0-9_]*)?\$")
 
-    Implements a tiny hand-rolled scan so we don't trample on dollar-
-    quoted strings (``$tag$ … $tag$``) or numbers occurring inside
-    string literals.
+
+def _replace_placeholders(sql: str, rendered: list[str]) -> str:
+    """Replace ``$N`` bind placeholders with their rendered literal.
+
+    A small SQL-aware scanner substitutes ``$N`` **only** in default context.
+    It skips over string literals (``'…''…'``), quoted identifiers (``"…""…"``),
+    line comments (``-- … <newline>``), block comments (``/* … */``, nested),
+    and dollar-quoted strings (``$tag$ … $tag$``). Without this a ``$N`` inside
+    a comment or dollar-quote would be substituted, letting a text parameter
+    that contains a newline, ``*/``, or ``$$`` break out of that context and
+    inject SQL. Only bare ``$digits`` in default context is a placeholder.
     """
 
     out: list[str] = []
     i = 0
     n = len(sql)
-    in_single = False
-    in_double = False
     while i < n:
         ch = sql[i]
-        if in_single:
-            out.append(ch)
-            if ch == "'":
-                # Doubled single quote stays inside the literal.
-                if i + 1 < n and sql[i + 1] == "'":
-                    out.append("'")
-                    i += 2
-                    continue
-                in_single = False
-            i += 1
+
+        # Line comment: -- … up to and including the newline (or EOL).
+        if ch == "-" and i + 1 < n and sql[i + 1] == "-":
+            nl = sql.find("\n", i + 2)
+            end = n if nl == -1 else nl + 1
+            out.append(sql[i:end])
+            i = end
             continue
-        if in_double:
-            out.append(ch)
-            if ch == '"':
-                in_double = False
-            i += 1
-            continue
-        if ch == "'":
-            out.append(ch)
-            in_single = True
-            i += 1
-            continue
-        if ch == '"':
-            out.append(ch)
-            in_double = True
-            i += 1
-            continue
-        if ch == "$" and i + 1 < n and sql[i + 1].isdigit():
-            # Read the placeholder index.
-            j = i + 1
-            while j < n and sql[j].isdigit():
-                j += 1
-            idx = int(sql[i + 1 : j]) - 1
-            if idx < 0 or idx >= len(rendered):
-                raise _BadParameterError(f"Placeholder ${idx + 1} has no bound value")
-            out.append(rendered[idx])
+
+        # Block comment: /* … */, nesting per Postgres.
+        if ch == "/" and i + 1 < n and sql[i + 1] == "*":
+            depth = 1
+            j = i + 2
+            while j < n and depth > 0:
+                if sql[j] == "/" and j + 1 < n and sql[j + 1] == "*":
+                    depth += 1
+                    j += 2
+                elif sql[j] == "*" and j + 1 < n and sql[j + 1] == "/":
+                    depth -= 1
+                    j += 2
+                else:
+                    j += 1
+            out.append(sql[i:j])
             i = j
             continue
+
+        # Single-quoted string literal ('' escapes an embedded quote).
+        if ch == "'":
+            j = i + 1
+            while j < n:
+                if sql[j] == "'":
+                    if j + 1 < n and sql[j + 1] == "'":
+                        j += 2
+                        continue
+                    j += 1
+                    break
+                j += 1
+            out.append(sql[i:j])
+            i = j
+            continue
+
+        # Double-quoted identifier ("" escapes an embedded quote).
+        if ch == '"':
+            j = i + 1
+            while j < n:
+                if sql[j] == '"':
+                    if j + 1 < n and sql[j + 1] == '"':
+                        j += 2
+                        continue
+                    j += 1
+                    break
+                j += 1
+            out.append(sql[i:j])
+            i = j
+            continue
+
+        if ch == "$":
+            # Dollar-quoted string: copy verbatim through the matching close
+            # tag (never substitute inside it).
+            m = _DOLLAR_QUOTE_OPEN.match(sql, i)
+            if m:
+                tag = m.group(0)
+                close = sql.find(tag, m.end())
+                end = n if close == -1 else close + len(tag)
+                out.append(sql[i:end])
+                i = end
+                continue
+            # Bind placeholder $N (digits only; disjoint from dollar-quote tags).
+            if i + 1 < n and sql[i + 1].isdigit():
+                j = i + 1
+                while j < n and sql[j].isdigit():
+                    j += 1
+                idx = int(sql[i + 1 : j]) - 1
+                if idx < 0 or idx >= len(rendered):
+                    raise _BadParameterError(f"Placeholder ${idx + 1} has no bound value")
+                out.append(rendered[idx])
+                i = j
+                continue
+
         out.append(ch)
         i += 1
     return "".join(out)

--- a/tests/unit/test_pgwire_extended.py
+++ b/tests/unit/test_pgwire_extended.py
@@ -101,6 +101,57 @@ def test_substitute_skips_inside_double_quotes() -> None:
     assert sql == 'SELECT "$1" AS "$1", \'val\''
 
 
+def test_substitute_numeric_text_rejects_injection() -> None:
+    """A numeric-typed text param that carries SQL syntax is rejected, not spliced."""
+    from orionbelt.pgwire.extended import _BadParameterError
+
+    with pytest.raises(_BadParameterError):
+        substitute_parameters(
+            'SELECT * FROM m WHERE "Total Revenue" > $1',
+            (b"0 AND \"Customer Country\" = 'US'",),
+            [0],
+            param_oids=(23,),  # INT4
+        )
+
+
+def test_substitute_numeric_text_canonicalizes() -> None:
+    """Valid numeric text params render as canonical numeric literals."""
+    assert substitute_parameters("x $1", (b"  -7 ",), [0], param_oids=(23,)) == "x -7"
+    assert substitute_parameters("x $1", (b"3.14",), [0], param_oids=(1700,)) == "x 3.14"
+    assert substitute_parameters("x $1", (b"1e3",), [0], param_oids=(701,)) == "x 1E+3"
+
+
+def test_substitute_numeric_text_rejects_non_finite() -> None:
+    from orionbelt.pgwire.extended import _BadParameterError
+
+    for payload in (b"NaN", b"Infinity", b"-Infinity"):
+        with pytest.raises(_BadParameterError):
+            substitute_parameters("x $1", (payload,), [0], param_oids=(1700,))
+
+
+def test_substitute_skips_inside_line_comment() -> None:
+    sql = substitute_parameters("SELECT 1 -- $1\nWHERE x = $1", (b"v",), [0])
+    assert sql == "SELECT 1 -- $1\nWHERE x = 'v'"
+
+
+def test_substitute_skips_inside_block_comment() -> None:
+    sql = substitute_parameters("SELECT /* $1 nested /* $1 */ */ $1", (b"v",), [0])
+    assert sql == "SELECT /* $1 nested /* $1 */ */ 'v'"
+
+
+def test_substitute_skips_inside_dollar_quote() -> None:
+    assert substitute_parameters("SELECT $$ $1 $$, $1", (b"v",), [0]) == "SELECT $$ $1 $$, 'v'"
+    assert (
+        substitute_parameters("SELECT $tag$ $1 $tag$, $1", (b"v",), [0])
+        == "SELECT $tag$ $1 $tag$, 'v'"
+    )
+
+
+def test_substitute_dollar_digit_is_placeholder_not_tag() -> None:
+    """``$1`` is a placeholder even next to a stray ``$`` (digit-led tags are invalid)."""
+    assert substitute_parameters("SELECT $1$", (b"v",), [0]) == "SELECT 'v'$"
+
+
 def test_substitute_rejects_binary_format_for_unknown_oid() -> None:
     """Unknown binary OID still errors — we only decode a small allow-list."""
     from orionbelt.pgwire.extended import _BinaryParameterError


### PR DESCRIPTION
## Summary

Two SQL injection vulnerabilities in the pgwire extended-protocol Bind path (`src/orionbelt/pgwire/extended.py`), where parameter values are inlined into the SQL string before running the router pipeline. Both are fixed with regression tests. No functional change to legitimate BI-tool traffic.

## High: numeric text parameters spliced raw

`substitute_parameters` appended the decoded text of a numeric-typed parameter directly into the SQL. A client binding a numeric placeholder (e.g. INT4) to `0 AND "Customer Country" = 'US'` produced active SQL:

```
WHERE "Total Revenue" > 0 AND "Customer Country" = 'US'
```

**Fix:** numeric text params are strictly parsed per their declared OID (integers via an ASCII-only grammar, float/numeric via `Decimal`, non-finite rejected) and re-rendered as canonical numeric literals. The output contains only `[-+0-9.eE]` and can carry no SQL syntax; anything that is not a plain number is rejected with a bind error.

## Medium: substitution inside comments and dollar-quoted strings

The placeholder scanner tracked only single/double quotes, so a `$N` inside a line comment, block comment, or dollar-quoted string was still substituted. A text parameter containing a newline, `*/`, or `$$` could break out of that context.

**Fix:** `_replace_placeholders` is now a SQL-aware scanner that skips line comments (`-- ...`), nested block comments (`/* ... */`), single-quoted strings, double-quoted identifiers (with `""` escaping), and dollar-quoted strings (`$tag$ ... $tag$`), substituting `$N` only in default context. A digit-led `$1` stays an unambiguous placeholder since dollar-quote tags cannot start with a digit.

## Tests

New cases in `tests/unit/test_pgwire_extended.py`: numeric injection rejected, valid numerics canonicalized, non-finite rejected, and no substitution inside line/block comments or dollar-quotes. Full suite passes; `ruff` + `mypy` clean.

## Not in scope

The reviewer also noted a non-injection hardening opportunity in the measure-expression tokenizer (`compiler/expr_parser.py` silently skips unknown characters). No confirmed vulnerability there; left out of this focused security fix to avoid touching the expression parser without cause.