### PR TITLE
Harden pgwire float/numeric text params to the Postgres numeric grammar

### DIFF
--- a/src/orionbelt/pgwire/extended.py
+++ b/src/orionbelt/pgwire/extended.py
@@ -472,6 +472,11 @@ _OID_NUMERIC = 1700
 
 _INTEGER_TEXT_OIDS: frozenset[int] = frozenset({_OID_INT2, _OID_INT4, _OID_INT8})
 _INT_TEXT_RE = re.compile(r"[+-]?[0-9]+")
+# ASCII decimal/float literal (sign, digits, optional fraction, optional
+# exponent). Postgres numeric text input has no room for underscores or
+# unicode digits, which ``Decimal`` would otherwise accept and silently
+# normalize; match the DB grammar so those forms are rejected.
+_NUMERIC_TEXT_RE = re.compile(r"[+-]?(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)(?:[eE][+-]?[0-9]+)?")
 _NUMERIC_TEXT_OIDS: frozenset[int] = frozenset(
     {_OID_INT2, _OID_INT4, _OID_INT8, _OID_FLOAT4, _OID_FLOAT8, _OID_NUMERIC}
 )
@@ -498,6 +503,10 @@ def _canonical_numeric_text(text: str, oid: int) -> str:
             if not _INT_TEXT_RE.fullmatch(s):
                 raise ValueError("not a plain integer")
             return str(int(s))
+        # Float / numeric: enforce the ASCII decimal grammar before Decimal so
+        # underscores and unicode digits are rejected rather than normalized.
+        if not _NUMERIC_TEXT_RE.fullmatch(s):
+            raise ValueError("not a plain decimal/float")
         value = decimal.Decimal(s)
     except (ValueError, ArithmeticError) as exc:
         raise _BadParameterError(f"Invalid numeric text parameter for OID {oid}: {text!r}") from exc

--- a/tests/unit/test_pgwire_extended.py
+++ b/tests/unit/test_pgwire_extended.py
@@ -119,6 +119,20 @@ def test_substitute_numeric_text_canonicalizes() -> None:
     assert substitute_parameters("x $1", (b"  -7 ",), [0], param_oids=(23,)) == "x -7"
     assert substitute_parameters("x $1", (b"3.14",), [0], param_oids=(1700,)) == "x 3.14"
     assert substitute_parameters("x $1", (b"1e3",), [0], param_oids=(701,)) == "x 1E+3"
+    # Fractional edge forms Postgres accepts.
+    assert substitute_parameters("x $1", (b".5",), [0], param_oids=(1700,)) == "x 0.5"
+    assert substitute_parameters("x $1", (b"-2.5E-3",), [0], param_oids=(701,)) == "x -0.0025"
+
+
+def test_substitute_numeric_text_rejects_nonstandard_forms() -> None:
+    """Underscores / unicode digits / hex are rejected for float+numeric OIDs
+    (matching Postgres text grammar), not silently normalized by Decimal."""
+    from orionbelt.pgwire.extended import _BadParameterError
+
+    for oid in (700, 701, 1700):
+        for payload in (b"1_000", b"1__0", "１２".encode(), "٣".encode(), b"0x10"):
+            with pytest.raises(_BadParameterError):
+                substitute_parameters("x $1", (payload,), [0], param_oids=(oid,))
 
 
 def test_substitute_numeric_text_rejects_non_finite() -> None:


### PR DESCRIPTION
## Summary

Follow-up hardening to the extended-protocol parameter-injection fix (#174). **Not a security fix** - the rendered numeric literal was always safe ASCII - just a protocol-strictness gap.

Integer text params were already validated against a strict ASCII grammar, but the float/numeric path (`FLOAT4`/`FLOAT8`/`NUMERIC`) parsed with `Decimal` directly. `Decimal` accepts forms Postgres text input rejects and silently normalizes them:

- underscores: `1_000` -> `1000`, `1__0` -> `10`
- unicode digits: `１２` -> `12`, `٣` -> `3`

**Fix:** enforce an ASCII decimal/float grammar (`[+-]?(digits[.digits?] | .digits)([eE][+-]?digits)?`) before handing the string to `Decimal`, so those forms are rejected rather than normalized. Valid forms still parse and canonicalize (`.5` -> `0.5`, `5.` -> `5`, `1e3` -> `1E+3`, `-2.5E-3` -> `-0.0025`).

## Tests

Extends `test_pgwire_extended.py`: nonstandard forms (underscores / unicode digits / hex) are rejected for all three numeric OIDs; fractional edge forms still canonicalize. Full pgwire suite passes; `ruff` + `mypy` clean.