### PR TITLE
Add automated docs deployment to ralforion.com

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,71 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'pyproject.toml'  # In case version changes
+      - '.github/workflows/deploy-docs.yml'
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout orionbelt-semantic-layer
+        uses: actions/checkout@v4
+        with:
+          path: docs-source
+
+      - name: Checkout ralforion.github.io
+        uses: actions/checkout@v4
+        with:
+          repository: ralforion/ralforion.github.io
+          token: ${{ secrets.DEPLOY_PAT || secrets.GITHUB_TOKEN }}
+          path: main-site
+
+      - name: Set up Python with uv
+        uses: drivendataorg/setup-python-uv-action@v1
+        with:
+          python-version: "3.11"
+      
+      - name: Build documentation
+        working-directory: docs-source
+        run: |
+          uv run mkdocs build -d ../main-site/public/orionbelt-semantic-layer
+      
+      - name: Get version info
+        id: version
+        working-directory: docs-source
+        run: |
+          echo "version=$(grep project_version mkdocs.yml | cut -d':' -f2 | xargs)" >> $GITHUB_OUTPUT
+          echo "commit=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "branch=$(git branch --show-current)" >> $GITHUB_OUTPUT
+
+      - name: Deploy to ralforion.github.io
+        working-directory: main-site
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          
+          if [[ `git status --porcelain public/orionbelt-semantic-layer` ]]; then
+            git add public/orionbelt-semantic-layer
+            git commit -m "Update OrionBelt docs to ${{ steps.version.outputs.version }}
+
+            Built from ralforion/orionbelt-semantic-layer@${{ steps.version.outputs.commit }}
+            Triggered by: ${{ github.event_name }}
+            Branch: ${{ steps.version.outputs.branch }}"
+            
+            git push
+            echo "✅ Documentation deployed to ralforion.com/orionbelt-semantic-layer/"
+            echo "Version: ${{ steps.version.outputs.version }}"
+          else
+            echo "📝 No documentation changes detected"
+          fi

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ralforion/ralforion.github.io
-          token: ${{ secrets.DEPLOY_PAT || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.DOCS_DEPLOY_TOKEN }}
           path: main-site
 
       - name: Set up Python with uv

--- a/deploy-docs.sh
+++ b/deploy-docs.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Deploy OrionBelt docs to ralforion.github.io
+
+set -e
+
+echo "📚 Building OrionBelt documentation..."
+uv run mkdocs build -d ../ralforion.github.io/public/orionbelt-semantic-layer
+
+echo "📦 Committing to ralforion.github.io..."
+cd ../ralforion.github.io
+git add public/orionbelt-semantic-layer
+git commit -m "Update OrionBelt docs from $(cd ../orionbelt-semantic-layer && git describe --tags --always)"
+git push
+
+echo "✅ Docs deployed! Will be live at https://ralforion.com/orionbelt-semantic-layer/ in ~1 minute"


### PR DESCRIPTION
## Summary

This PR adds a GitHub Action to automatically deploy documentation to ralforion.com/orionbelt-semantic-layer/ whenever docs are updated.

## Background

Previously, the orionbelt-semantic-layer repo was deploying to its own GitHub Pages, which was **shadowing** the main website's deployment. This caused the "stale docs" issue where updates wouldn't appear.

## Solution

- Disabled GitHub Pages on this repo (gh-pages branch deleted)
- Added GitHub Action that builds docs and pushes to ralforion.github.io
- Uses existing DOCS_DEPLOY_TOKEN secret for cross-repo access

## How it Works

1. **Triggers on:**
   - Push to main (when docs/** or mkdocs.yml changes)
   - GitHub Release creation
   - Manual workflow dispatch

2. **Process:**
   - Builds docs with mkdocs
   - Pushes to ralforion.github.io/public/orionbelt-semantic-layer/
   - Main site auto-deploys via its own GitHub Actions
   - Live at ralforion.com in ~1 minute

## Testing

After merge:
1. Make a small docs change
2. Push to main
3. Check Actions tab for workflow run
4. Verify update appears at https://ralforion.com/orionbelt-semantic-layer/

## Important

**Never run `mkdocs gh-deploy` in this repo** - it would recreate the competing site problem.