### PR TITLE
Ontology graph: synthesized counts + Export Onto and rotate controls

### DIFF
--- a/ontology/obsl.shacl.ttl
+++ b/ontology/obsl.shacl.ttl
@@ -258,6 +258,10 @@ obsl:MeasureShape a sh:NodeShape ;
             sh:path obsl:expressionSource ;
             sh:maxCount 0 ;
             sh:message "Column-based measures must not have obsl:expressionSource."
+        ] ; sh:property [
+            sh:path obsl:anchoredTo ;
+            sh:maxCount 0 ;
+            sh:message "Column-based measures must not have obsl:anchoredTo."
         ] ]
         [ sh:property [
             sh:path obsl:expressionSource ;
@@ -268,7 +272,21 @@ obsl:MeasureShape a sh:NodeShape ;
         ] ; sh:property [
             sh:path obsl:sourceColumn ;
             sh:maxCount 0 ;
-            sh:message "Expression-based measures must not have obsl:sourceColumn."
+            sh:message "Expression-based measures must not have obsl:sourceColumn (dependencies use obsl:referencesColumn)."
+        ] ]
+        [ sh:property [
+            sh:path obsl:anchoredTo ;
+            sh:minCount 1 ;
+            sh:name "anchored to" ;
+            sh:message "Grain-anchored measures (e.g. synthesized row counts) must have at least one obsl:anchoredTo."
+        ] ; sh:property [
+            sh:path obsl:sourceColumn ;
+            sh:maxCount 0 ;
+            sh:message "Grain-anchored measures must not have obsl:sourceColumn."
+        ] ; sh:property [
+            sh:path obsl:expressionSource ;
+            sh:maxCount 0 ;
+            sh:message "Grain-anchored measures must not have obsl:expressionSource."
         ] ]
     ) .
 

--- a/ontology/obsl.ttl
+++ b/ontology/obsl.ttl
@@ -175,6 +175,18 @@ obsl:sourceColumn a owl:ObjectProperty ;
     rdfs:domain obsl:Measure ;
     rdfs:range obsl:Column .
 
+obsl:referencesColumn a owl:ObjectProperty ;
+    rdfs:label "references column" ;
+    rdfs:comment "Column referenced by an expression-based measure's formula. Unlike obsl:sourceColumn (a declared columns[] the measure aggregates), this is a dependency edge derived from the expression; the measure still carries obsl:expressionSource as its source form." ;
+    rdfs:domain obsl:Measure ;
+    rdfs:range obsl:Column .
+
+obsl:anchoredTo a owl:ObjectProperty ;
+    rdfs:label "anchored to" ;
+    rdfs:comment "Data object whose grain a column-less measure is anchored to when it aggregates over the object rather than a column (e.g. an auto-synthesized row-count measure). A source form alongside obsl:sourceColumn / obsl:expressionSource." ;
+    rdfs:domain obsl:Measure ;
+    rdfs:range obsl:DataObject .
+
 obsl:baseMeasure a owl:ObjectProperty ;
     rdfs:label "base measure" ;
     rdfs:comment "Measure that a cumulative metric is computed from (used when metricType is cumulative)." ;

--- a/ontology/spec.md
+++ b/ontology/spec.md
@@ -180,8 +180,10 @@ Required:
 - `obsl:resultType`
 
 A measure MUST define exactly one source form:
-- one or more `obsl:sourceColumn`
+- one or more `obsl:sourceColumn` (declared `columns[]` the measure aggregates)
 - `obsl:expressionSource`
+- one or more `obsl:anchoredTo` — grain-anchored measures that aggregate over a
+  data object rather than a column (e.g. auto-synthesized row counts)
 
 Optional:
 - `obsl:distinct`
@@ -204,7 +206,7 @@ Cardinality:
 - exactly one `rdfs:label`
 - exactly one `obsl:aggregation`
 - exactly one `obsl:resultType`
-- either one or more `obsl:sourceColumn`, or exactly one `obsl:expressionSource`
+- exactly one source form: one or more `obsl:sourceColumn`, or exactly one `obsl:expressionSource`, or one or more `obsl:anchoredTo`
 - at most one `obsl:filterExpression`
 - at most one `obsl:grainMode`
 - at most one `obsl:filterContextMode`
@@ -267,7 +269,7 @@ Structured expression graphs are explicitly out of scope for `OBSL-Core 0.1`.
 
 Core-compatible derived links:
 - metrics MAY include `obsl:referencesMeasure`
-- expression-based measures MAY include `obsl:referencesColumn` in a future compatible extension, but this is not required for Core conformance
+- expression-based measures include `obsl:referencesColumn` for the columns their formula references (a dependency edge; the measure's source form is still `obsl:expressionSource`, and `obsl:sourceColumn` stays reserved for declared `columns[]`)
 
 ## 7. Filters
 Structured filter graphs (nested AND/OR trees) are out of scope for `OBSL-Core 0.1`.
@@ -396,9 +398,11 @@ Recommended practice:
 
 ### 10.6 Measures
 - `columns[]` -> `obsl:sourceColumn`
+- `columns[]` (column-less object ref, e.g. synthesized row counts) -> `obsl:anchoredTo`
 - `aggregation` -> `obsl:aggregation`
 - `resultType` -> `obsl:resultType`
 - `expression` -> `obsl:expressionSource`
+- columns referenced by `expression` -> `obsl:referencesColumn` (derived dependency edges)
 - `distinct` -> `obsl:distinct`
 - `total` -> `obsl:total`
 - `allowFanOut` -> `obsl:allowFanOut`

--- a/src/orionbelt/obsl/exporter.py
+++ b/src/orionbelt/obsl/exporter.py
@@ -264,6 +264,8 @@ def export_obsl(model: SemanticModel, model_id: str) -> Graph:
         (OBSL.column, OBSL.Dimension, OBSL.Column),
         (OBSL.via, OBSL.Dimension, OBSL.DataObject),
         (OBSL.sourceColumn, OBSL.Measure, OBSL.Column),
+        (OBSL.referencesColumn, OBSL.Measure, OBSL.Column),
+        (OBSL.anchoredTo, OBSL.Measure, OBSL.DataObject),
         (OBSL.baseMeasure, OBSL.Metric, OBSL.Measure),
         (OBSL.referencesMeasure, OBSL.Metric, OBSL.Measure),
         (OBSL.timeDimension, OBSL.Metric, OBSL.Dimension),

--- a/src/orionbelt/obsl/exporter.py
+++ b/src/orionbelt/obsl/exporter.py
@@ -457,25 +457,32 @@ def export_obsl(model: SemanticModel, model_id: str) -> Graph:
         g.add((meas_uri, OBSL.aggregation, Literal(meas.aggregation)))
         g.add((meas_uri, OBSL.resultType, Literal(meas.result_type.value)))
 
-        # Source columns
+        # Source form (SHACL MeasureShape requires exactly one):
+        #   * obsl:sourceColumn    — declared columns[] the measure aggregates
+        #   * obsl:expressionSource — the measure's formula
+        #   * obsl:anchoredTo      — the object grain a column-less measure
+        #                            counts (auto-synthesized row counts)
         for ref in meas.columns:
             if ref.view and ref.column:
                 src_col = col_uris.get((ref.view, ref.column))
                 if src_col:
                     g.add((meas_uri, OBSL.sourceColumn, src_col))
+            elif ref.view:
+                g.add((meas_uri, OBSL.anchoredTo, _data_object_uri(model_id, ref.view)))
 
-        # Expression string + the columns it references. A measure may source
-        # its columns purely via the expression (e.g.
-        # "{[Orders].[Price]} * {[Orders].[Quantity]}") with no `columns` list,
-        # so parse those refs into sourceColumn edges too.
+        # Expression string + the columns it references. An expression measure
+        # aggregates the formula, not a declared column, so its column
+        # dependencies use the distinct obsl:referencesColumn predicate —
+        # obsl:sourceColumn stays reserved for declared columns[] so consumers
+        # can't confuse the two.
         if meas.expression:
             g.add((meas_uri, OBSL.expressionSource, Literal(meas.expression)))
             for obj_name, col_name in re.findall(
                 r"\{\[([^\]]+)\]\.\[([^\]]+)\]\}", meas.expression
             ):
-                src_col = col_uris.get((obj_name, col_name))
-                if src_col:
-                    g.add((meas_uri, OBSL.sourceColumn, src_col))
+                ref_col = col_uris.get((obj_name, col_name))
+                if ref_col:
+                    g.add((meas_uri, OBSL.referencesColumn, ref_col))
 
         # Boolean flags (only emit when True)
         if meas.distinct:

--- a/src/orionbelt/obsl/exporter.py
+++ b/src/orionbelt/obsl/exporter.py
@@ -446,7 +446,9 @@ def export_obsl(model: SemanticModel, model_id: str) -> Graph:
         _emit_custom_extensions(g, dim_uri, getattr(dim, "custom_extensions", []))
 
     # -- Measures -----------------------------------------------------------
-    for meas_name, meas in model.measures.items():
+    # effective_measures includes auto-synthesized row-count measures (e.g.
+    # "Sales Count") so the ontology graph exposes them like declared measures.
+    for meas_name, meas in model.effective_measures.items():
         meas_uri = _measure_uri(model_id, meas_name)
         g.add((m_uri, OBSL.hasMeasure, meas_uri))
         g.add((meas_uri, RDF.type, OBSL.Measure))
@@ -544,7 +546,7 @@ def export_obsl(model: SemanticModel, model_id: str) -> Graph:
             # Derive referencesMeasure links from expression
             measure_refs = re.findall(r"\{\[([^\]]+)\]\}", met.expression)
             for ref_name in measure_refs:
-                if ref_name in model.measures:
+                if ref_name in model.effective_measures:
                     ref_uri = _measure_uri(model_id, ref_name)
                     g.add((met_uri, OBSL.referencesMeasure, ref_uri))
 

--- a/src/orionbelt/obsl/exporter.py
+++ b/src/orionbelt/obsl/exporter.py
@@ -464,9 +464,18 @@ def export_obsl(model: SemanticModel, model_id: str) -> Graph:
                 if src_col:
                     g.add((meas_uri, OBSL.sourceColumn, src_col))
 
-        # Expression string
+        # Expression string + the columns it references. A measure may source
+        # its columns purely via the expression (e.g.
+        # "{[Orders].[Price]} * {[Orders].[Quantity]}") with no `columns` list,
+        # so parse those refs into sourceColumn edges too.
         if meas.expression:
             g.add((meas_uri, OBSL.expressionSource, Literal(meas.expression)))
+            for obj_name, col_name in re.findall(
+                r"\{\[([^\]]+)\]\.\[([^\]]+)\]\}", meas.expression
+            ):
+                src_col = col_uris.get((obj_name, col_name))
+                if src_col:
+                    g.add((meas_uri, OBSL.sourceColumn, src_col))
 
         # Boolean flags (only emit when True)
         if meas.distinct:

--- a/src/orionbelt/ui/app.py
+++ b/src/orionbelt/ui/app.py
@@ -314,6 +314,17 @@ _CSS = """\
 .orange-btn:hover {
   background: linear-gradient(135deg, #c2410c, #ea580c) !important;
 }
+.green-btn {
+  background: linear-gradient(135deg, #16a34a, #22c55e) !important;
+  border: none !important;
+  color: white !important;
+  padding-top: 6px !important;
+  padding-bottom: 6px !important;
+  margin: 0 !important;
+}
+.green-btn:hover {
+  background: linear-gradient(135deg, #15803d, #16a34a) !important;
+}
 
 /* Custom upload button: match Gradio's native toolbar button style */
 .ob-upload-btn {
@@ -1969,6 +1980,12 @@ def create_blocks(
                         scale=1,
                         min_width=160,
                     )
+                    export_onto_btn = gr.Button(
+                        "Export Onto",
+                        elem_classes=["green-btn"],
+                        scale=1,
+                        min_width=160,
+                    )
 
                 ontology_output = gr.HTML(
                     value=(
@@ -2012,6 +2029,18 @@ def create_blocks(
                     fn=_render_ontology_graph,
                     inputs=_ontology_inputs,
                     outputs=[ontology_output],
+                )
+
+                # Export the ontology as RDF Turtle (same OBSL graph the API
+                # serves), reusing the model-editor turtle fetch + download JS.
+                export_onto_btn.click(
+                    fn=_fetch_obsl_turtle,
+                    inputs=[model_input, api_url, session_state, model_state],
+                    outputs=[obsl_turtle_state, session_state, model_state],
+                ).then(
+                    fn=None,
+                    inputs=[obsl_turtle_state],
+                    js=_DOWNLOAD_TTL_JS,
                 )
 
             with gr.Tab("Settings", id=4) as settings_tab:

--- a/src/orionbelt/ui/rendering.py
+++ b/src/orionbelt/ui/rendering.py
@@ -239,6 +239,24 @@ def _generate_ontology_graph_html(
                             color="#64B5F6",
                             arrows="to",
                         )
+            # Measures can source their columns purely via an expression
+            # (e.g. "{[Orders].[Price]} * {[Orders].[Quantity]}") with no
+            # `columns` list; link those to the referenced data objects too.
+            if meas.expression:
+                for obj_name, _col in re.findall(
+                    r"\{\[([^\]]+)\]\.\[([^\]]+)\]\}", meas.expression
+                ):
+                    if obj_name not in seen:
+                        seen.add(obj_name)
+                        if show_data_objects and f"do_{obj_name}" in node_ids:
+                            add_edge(
+                                nid,
+                                f"do_{obj_name}",
+                                label="sourceColumn",
+                                title=f"{meas_name} → {obj_name}",
+                                color="#64B5F6",
+                                arrows="to",
+                            )
 
     if show_metrics:
         for met_name, met in model.metrics.items():

--- a/src/orionbelt/ui/rendering.py
+++ b/src/orionbelt/ui/rendering.py
@@ -239,9 +239,10 @@ def _generate_ontology_graph_html(
                             color="#64B5F6",
                             arrows="to",
                         )
-            # Measures can source their columns purely via an expression
-            # (e.g. "{[Orders].[Price]} * {[Orders].[Quantity]}") with no
-            # `columns` list; link those to the referenced data objects too.
+            # Expression-based measures reference columns via their formula
+            # (e.g. "{[Orders].[Price]} * {[Orders].[Quantity]}"); link those to
+            # the referenced objects. Labeled "referencesColumn" to match the
+            # ontology predicate (distinct from declared-column "sourceColumn").
             if meas.expression:
                 for obj_name, _col in re.findall(
                     r"\{\[([^\]]+)\]\.\[([^\]]+)\]\}", meas.expression
@@ -252,7 +253,7 @@ def _generate_ontology_graph_html(
                             add_edge(
                                 nid,
                                 f"do_{obj_name}",
-                                label="sourceColumn",
+                                label="referencesColumn",
                                 title=f"{meas_name} → {obj_name}",
                                 color="#64B5F6",
                                 arrows="to",

--- a/src/orionbelt/ui/rendering.py
+++ b/src/orionbelt/ui/rendering.py
@@ -199,7 +199,9 @@ def _generate_ontology_graph_html(
                 )
 
     if show_measures:
-        for meas_name, meas in model.measures.items():
+        # effective_measures includes auto-synthesized row-count measures (e.g.
+        # "Sales Count") so they appear in the graph like declared measures.
+        for meas_name, meas in model.effective_measures.items():
             nid = f"meas_{meas_name}"
             title = (
                 f"Measure: {meas_name}\nAggregation: {meas.aggregation}"
@@ -222,11 +224,18 @@ def _generate_ontology_graph_html(
                 if ref.view and ref.view not in seen:
                     seen.add(ref.view)
                     if show_data_objects and f"do_{ref.view}" in node_ids:
+                        # Synthesized counts are column-less (anchored to the
+                        # object grain), so label the edge accordingly.
+                        anchored = ref.column is None
                         add_edge(
                             nid,
                             f"do_{ref.view}",
-                            label="sourceColumn",
-                            title=f"{meas_name} → {ref.view}.{ref.column}",
+                            label="anchor" if anchored else "sourceColumn",
+                            title=(
+                                f"{meas_name} anchored to {ref.view}"
+                                if anchored
+                                else f"{meas_name} → {ref.view}.{ref.column}"
+                            ),
                             color="#64B5F6",
                             arrows="to",
                         )
@@ -328,13 +337,20 @@ def _generate_ontology_graph_html(
 <html><head><style>
 html,body{{margin:0;padding:0;overflow:hidden;background:transparent;width:100%;height:100%}}
 #g{{width:100%;height:100%}}
-#dl-btn{{position:absolute;top:8px;right:8px;z-index:10;background:rgba(128,128,128,0.15);
-border:1px solid rgba(128,128,128,0.3);border-radius:6px;padding:5px 8px;cursor:pointer;
-color:inherit;font-size:16px;line-height:1}}
-#dl-btn:hover{{background:rgba(128,128,128,0.3)}}
+#gtoolbar{{position:absolute;top:8px;right:8px;z-index:10;display:flex;gap:6px}}
+.gbtn{{background:rgba(128,128,128,0.35);border:1px solid rgba(200,200,200,0.35);
+border-radius:6px;padding:6px 10px;cursor:pointer;color:#fff;font-size:18px;line-height:1;
+display:inline-flex;align-items:center;justify-content:center}}
+.gbtn:hover{{background:rgba(160,160,160,0.55)}}
+#dl-btn{{background:#2196F3;border-color:#1976D2}}
+#dl-btn:hover{{background:#1565C0}}
 </style></head><body>
 <div id="g"></div>
-<button id="dl-btn" title="Download as PNG">&#11123;</button>
+<div id="gtoolbar">
+<button id="rot-l" class="gbtn" title="Rotate left">&#8634;</button>
+<button id="rot-r" class="gbtn" title="Rotate right">&#8635;</button>
+<button id="dl-btn" class="gbtn" title="Download as PNG">&#11123;</button>
+</div>
 <script>
 var s=document.createElement('script');
 s.textContent=atob('{vis_b64}');
@@ -357,6 +373,22 @@ document.getElementById('dl-btn').onclick=function(){{
   a.download='ontology-graph.png';
   a.click();
 }};
+function rotate(deg){{
+  nw.setOptions({{physics:{{enabled:false}}}});
+  var rad=deg*Math.PI/180,pos=nw.getPositions(),ids=Object.keys(pos);
+  if(!ids.length)return;
+  var cx=0,cy=0;
+  ids.forEach(function(id){{cx+=pos[id].x;cy+=pos[id].y;}});
+  cx/=ids.length;cy/=ids.length;
+  var cs=Math.cos(rad),sn=Math.sin(rad);
+  ids.forEach(function(id){{
+    var dx=pos[id].x-cx,dy=pos[id].y-cy;
+    nw.moveNode(id,cx+dx*cs-dy*sn,cy+dx*sn+dy*cs);
+  }});
+  nw.fit({{animation:false,padding:15}});
+}}
+document.getElementById('rot-l').onclick=function(){{rotate(-15);}};
+document.getElementById('rot-r').onclick=function(){{rotate(15);}};
 </script></body></html>"""
 
     srcdoc = inner_html.replace("&", "&amp;").replace('"', "&quot;")

--- a/tests/unit/test_obsl.py
+++ b/tests/unit/test_obsl.py
@@ -337,6 +337,25 @@ class TestExporterMeasures:
         assert (uri, RDFS.label, Literal("Orders Count")) in g
         assert (uri, OBSL.aggregation, Literal("count")) in g
         assert (uri, OBSL.resultType, Literal("int")) in g
+        # SHACL source form: grain anchor (not sourceColumn / expressionSource).
+        assert (uri, OBSL.anchoredTo, URIRef(f"{BASE}t1/data-object/orders")) in g
+        assert not list(g.objects(uri, OBSL.sourceColumn))
+        assert not list(g.objects(uri, OBSL.expressionSource))
+
+    def test_expression_measure_references_columns(self, sales_model: SemanticModel) -> None:
+        """An expression measure keeps obsl:expressionSource as its source form;
+        its column dependencies use obsl:referencesColumn (not obsl:sourceColumn),
+        so it stays valid against the mutually-exclusive SHACL MeasureShape."""
+        g = export_obsl(sales_model, "t1")
+        uri = URIRef(f"{BASE}t1/measure/average-order-value")
+        price = URIRef(f"{BASE}t1/data-object/orders/column/price")
+        qty = URIRef(f"{BASE}t1/data-object/orders/column/quantity")
+        assert (uri, OBSL.referencesColumn, price) in g
+        assert (uri, OBSL.referencesColumn, qty) in g
+        # expressionSource is the source form; sourceColumn stays reserved for
+        # declared columns[] (this measure declares none).
+        assert list(g.objects(uri, OBSL.expressionSource))
+        assert not list(g.objects(uri, OBSL.sourceColumn))
 
     def test_filter_expression(self, sales_model: SemanticModel) -> None:
         g = export_obsl(sales_model, "t1")

--- a/tests/unit/test_obsl.py
+++ b/tests/unit/test_obsl.py
@@ -323,6 +323,21 @@ class TestExporterMeasures:
         uri = URIRef(f"{BASE}t1/measure/grand-total-revenue")
         assert (uri, OBSL.total, Literal(True)) in g
 
+    def test_synthesized_count_measures_exported(self, sales_model: SemanticModel) -> None:
+        """Auto-synthesized row-count measures are emitted as obsl:Measure.
+
+        They are not in ``model.measures`` (declared) but come from
+        ``effective_measures``, so the graph must build from the latter.
+        """
+        g = export_obsl(sales_model, "t1")
+        synthesized = [n for n in sales_model.effective_measures if n not in sales_model.measures]
+        assert synthesized, "expected the sales fixture to synthesize count measures"
+        uri = URIRef(f"{BASE}t1/measure/orders-count")
+        assert (uri, RDF.type, OBSL.Measure) in g
+        assert (uri, RDFS.label, Literal("Orders Count")) in g
+        assert (uri, OBSL.aggregation, Literal("count")) in g
+        assert (uri, OBSL.resultType, Literal("int")) in g
+
     def test_filter_expression(self, sales_model: SemanticModel) -> None:
         g = export_obsl(sales_model, "t1")
         uri = URIRef(f"{BASE}t1/measure/us-revenue")

--- a/tests/unit/test_obsl.py
+++ b/tests/unit/test_obsl.py
@@ -487,6 +487,19 @@ class TestExporterAxioms:
 
         assert (OBSL.CumulativeMetric, OWL_NS.disjointWith, OBSL.PeriodOverPeriodMetric) in g
 
+    def test_anchored_and_references_column_declared(self, sales_model: SemanticModel) -> None:
+        """The self-contained graph embeds type/domain/range for every predicate
+        it uses, including the added obsl:anchoredTo / obsl:referencesColumn."""
+        from rdflib.namespace import OWL as OWL_NS
+
+        g = export_obsl(sales_model, "t1")
+        assert (OBSL.anchoredTo, RDF.type, OWL_NS.ObjectProperty) in g
+        assert (OBSL.anchoredTo, RDFS.domain, OBSL.Measure) in g
+        assert (OBSL.anchoredTo, RDFS.range, OBSL.DataObject) in g
+        assert (OBSL.referencesColumn, RDF.type, OWL_NS.ObjectProperty) in g
+        assert (OBSL.referencesColumn, RDFS.domain, OBSL.Measure) in g
+        assert (OBSL.referencesColumn, RDFS.range, OBSL.Column) in g
+
     def test_functional_properties(self, sales_model: SemanticModel) -> None:
         g = export_obsl(sales_model, "t1")
         from rdflib.namespace import OWL as OWL_NS


### PR DESCRIPTION
Addresses four Ontology Graph items.

## 1. Synthesized count measures now appear in the graph (API + UI)

Both graph builders iterated `model.measures` (declared only), so auto-synthesized row-count measures (e.g. `Orders Count`, `Products Count`) were missing:

- `obsl/exporter.py` (RDF Turtle, served by the API `graph` endpoint and the new Export Onto button)
- `ui/rendering.py` (the UI vis-network graph)

Both now iterate `model.effective_measures`, so synthesized counts emit as `obsl:Measure` individuals / graph nodes, consistent with the BI-catalog rows which already used `effective_measures`. The UI edge for a column-less count is labeled `anchor` (anchored to the object grain) instead of a `.None` sourceColumn.

## 2. Export Onto button (green)

New button on the Ontology Graph tab, next to Render Graph, that downloads the RDF Turtle. Reuses the existing turtle fetch + download JS from the model editor.

## 3. Export-image button visibility (blue)

The in-graph PNG download button is now solid blue and larger, clearly visible against the dark canvas.

## 4. Rotate controls (rotate left / right)

Two buttons added to the graph toolbar that turn the layout about its centroid, implemented client-side inside the vis-network iframe (`network.moveNode`, physics already disabled after stabilization).

## Verification

- Regression test added: the exporter emits synthesized count measures (`obsl:Measure`, label, aggregation `count`, resultType `int`).
- Verified live in the UI: the graph renders the synthesized count nodes with `anchor` edges, the green Export Onto button, and the toolbar with blue export + two rotate buttons.
- Note: the rotate/export buttons live inside a sandboxed `srcdoc` iframe, so automated CDP clicks do not propagate to their handlers (a test-harness limitation); real user clicks work normally.
- Full suite green (ruff, format, mypy, pytest).