### PR TITLE
demo commerce models: use synthesized counts (one override + drop two redundant declared counts)

### DIFF
--- a/demo/dremio/README.md
+++ b/demo/dremio/README.md
@@ -129,7 +129,7 @@ FROM orionbelt.commerce.model
 ORDER BY "Total Sales" DESC;
 ```
 
-`Average Sale` is a metric (`Total Sales / Sales Order Count`) defined in the
+`Average Sale` is a metric (`Total Sales / Sales Count`) defined in the
 model, not in the query. Single-fact metrics like this push down cleanly
 through Dremio's federation.
 

--- a/demo/dremio/demo-queries.sql
+++ b/demo/dremio/demo-queries.sql
@@ -79,7 +79,7 @@ LIMIT 4;
 
 
 -- A5. A governed metric, defined once in the model.
---     "Average Sale" = Total Sales / Sales Order Count - not in the query.
+--     "Average Sale" = Total Sales / Sales Count - not in the query.
 SELECT "Channel Name", "Total Sales", "Average Sale"
 FROM orionbelt.commerce.model
 ORDER BY "Total Sales" DESC;

--- a/docs/guide/postgres-wire-bi-tools.md
+++ b/docs/guide/postgres-wire-bi-tools.md
@@ -192,7 +192,7 @@ are:
 | OBSL accepts | Meaning |
 |---|---|
 | Bare measure label | Works **only without `GROUP BY`** — Dremio pushes the SELECT down whole, OBSL applies the OBML `aggregation:` server-side |
-| Wrapping aggregate that **matches** the measure's declared agg | e.g. `SUM("Total Sales")` on a `sum:`-declared measure, `COUNT(DISTINCT "Sales Order Count")` on a `count_distinct:`-declared measure |
+| Wrapping aggregate that **matches** the measure's declared agg | e.g. `SUM("Total Sales")` on a `sum:`-declared measure, `COUNT(DISTINCT "Returns Count")` on a `count_distinct:`-declared measure |
 | `MEASURE("<label>")` | The portable semantic shim — but **Calcite has no `MEASURE()` operator** ([CALCITE-4496](https://issues.apache.org/jira/browse/CALCITE-4496)), so Dremio rejects it before it reaches the wire |
 
 Calcite also **rewrites** several aggregates into subqueries that OBSL
@@ -212,7 +212,7 @@ fails to pass through Dremio cleanly. In practice this means:
 
 ```sql
 -- ✅ Bare label — works for any measure, no GROUP BY:
-SELECT "Country Name", "Sales Order Count", "Total Sales"
+SELECT "Country Name", "Returns Count", "Total Sales"
   FROM obsl_pg.orionbelt_1_commerce."model"
   LIMIT 10;
 
@@ -232,7 +232,7 @@ Dremio, three options:
    `ROLLUP` / `HAVING` because OBSL parses the SQL itself; the
    Calcite-imposed "wrap or group" rule never applies.
 2. **Express the average as a sum-decomposed derived metric in OBML.**
-   `expression: '{[Total Sales]} / {[Sales Order Count]}'` — both inputs
+   `expression: '{[Total Sales]} / {[Sales Count]}'` — both inputs
    are SUM/COUNT-style measures, the metric inherits the
    `aggregation: sum` shim path, and through Dremio you wrap the metric
    in `SUM(...)` like any other additive measure.

--- a/examples/orionbelt_1_commerce.yaml
+++ b/examples/orionbelt_1_commerce.yaml
@@ -715,13 +715,6 @@ measures:
     columns:
       - dataObject: Sales
         column: Sales Quantity
-  Sales Order Count:
-    aggregation: count_distinct
-    dataType: bigint
-    format: "#,##0"
-    columns:
-      - dataObject: Sales
-        column: Sales ID
   Total Purchases:
     aggregation: sum
     dataType: "decimal(18, 2)"
@@ -775,13 +768,6 @@ measures:
     columns:
       - dataObject: Shipments
         column: Shipment Quantity
-  Complaint Count:
-    aggregation: count_distinct
-    dataType: bigint
-    format: "#,##0"
-    columns:
-      - dataObject: Client Complaints
-        column: Complaint ID
   Total Account Balance:
     aggregation: sum
     dataType: "decimal(18, 2)"
@@ -800,7 +786,10 @@ measures:
 metrics:
   # ── Derived metrics — algebra over base measures ──
   Average Sale:
-    expression: "{[Total Sales]} / NULLIF({[Sales Order Count]}, 0)"
+    # References the auto-synthesized "Sales Count" (COUNT over the Sales
+    # object) instead of a redundant declared measure — synthesized counts are
+    # first-class and usable in metric expressions.
+    expression: "{[Total Sales]} / NULLIF({[Sales Count]}, 0)"
     dataType: "decimal(18, 2)"
     format: "#,##0.00"
   Return Rate:

--- a/examples/orionbelt_1_commerce.yaml
+++ b/examples/orionbelt_1_commerce.yaml
@@ -750,7 +750,11 @@ measures:
     columns:
       - dataObject: Returns
         column: Return Quantity
-  Return Count:
+  # Overrides the auto-synthesized "Returns Count" (COUNT(*) on the Returns
+  # object) with COUNT(DISTINCT Return ID). Return ID is the PK so the value is
+  # identical here; this demonstrates the declared-measure-overrides-synthesis
+  # rule (the pattern you'd use for a self-fanning model).
+  Returns Count:
     aggregation: count_distinct
     dataType: bigint
     format: "#,##0"

--- a/tests/integration/_commerce.py
+++ b/tests/integration/_commerce.py
@@ -167,7 +167,7 @@ COMMERCE_CASES: tuple[CommerceCase, ...] = (
         QueryObject(
             select=QuerySelect(
                 dimensions=["Product Category"],
-                measures=["Total Sales", "Sales Order Count"],
+                measures=["Total Sales", "Sales Count"],
             ),
         ),
     ),

--- a/tests/integration/correctness/corpus.yaml
+++ b/tests/integration/correctness/corpus.yaml
@@ -50,7 +50,7 @@
   description: >-
     Corpus #7 — CoalesceDimension over two role-playing client dims (Sales
     Client Name via Sales, Complaint Client Name via Client Complaints),
-    with HAVING on Complaint Count > 0 to filter to clients with complaints.
+    with HAVING on Client Complaints Count > 0 to filter to clients with complaints.
     Outer SELECT collapses the two role-playing legs with COALESCE(d1, d2)
     AS "Client" and groups by the alias — one row per physical client.
   lastVerifiedBy: tests/integration/correctness/test_hand_sql_reference.py::test_obsl_matches_hand_sql[07_total_sales_by_client_with_complaints]
@@ -59,7 +59,7 @@
     sortKeys: [Client]
 
 - id: 08_average_sale
-  description: Corpus #8 — derived metric (Total Sales / Sales Order Count).
+  description: Corpus #8 — derived metric (Total Sales / Sales Count).
   lastVerifiedBy: tests/integration/correctness/test_metric_algebra.py::test_average_sale_equals_total_sales_over_order_count
 
 - id: 09_return_rate

--- a/tests/integration/correctness/queries/07_total_sales_by_client_with_complaints.yaml
+++ b/tests/integration/correctness/queries/07_total_sales_by_client_with_complaints.yaml
@@ -2,8 +2,8 @@ select:
   dimensions:
     - coalesce: [Sales Client Name, Complaint Client Name]
       as: Client
-  measures: [Total Sales, Complaint Count]
+  measures: [Total Sales, Client Complaints Count]
 having:
-  - field: Complaint Count
+  - field: Client Complaints Count
     op: gt
     value: 0

--- a/tests/integration/correctness/reference_sql/total_sales_by_client_with_complaints.sql
+++ b/tests/integration/correctness/reference_sql/total_sales_by_client_with_complaints.sql
@@ -8,7 +8,7 @@
 --           ...
 --    GROUP BY COALESCE("Sales Client Name", "Complaint Client Name")
 --
--- HAVING Complaint Count > 0 enforces the membership filter.
+-- HAVING Client Complaints Count > 0 enforces the membership filter.
 --
 -- Hand reference computes the two per-client aggregates independently
 -- and INNER-JOINs on client_id to enforce the filter, avoiding the fan
@@ -36,7 +36,7 @@ complaints_per_client AS (
 )
 SELECT s.clientname             AS "Client",
        s.total_sales            AS "Total Sales",
-       CAST(c.complaint_count AS BIGINT) AS "Complaint Count"
+       CAST(c.complaint_count AS BIGINT) AS "Client Complaints Count"
 FROM sales_per_client s
 INNER JOIN complaints_per_client c ON s.clientid = c.clientid
 WHERE c.complaint_count > 0

--- a/tests/integration/correctness/test_having_auto_include.py
+++ b/tests/integration/correctness/test_having_auto_include.py
@@ -42,22 +42,22 @@ def _to_decimal(v: Any) -> Decimal:
 def test_having_on_non_selected_measure_matches_explicit_form(
     run_query: Callable[[QueryObject], list[dict[str, Any]]],
 ) -> None:
-    """``Total Sales by Client Name HAVING Complaint Count > 0`` is well-formed.
+    """``Total Sales by Client Name HAVING Client Complaints Count > 0`` is well-formed.
 
     Compares two forms that should produce the same per-client Total
     Sales values:
 
     * **Implicit** — ``select.measures = ["Total Sales"]``,
-      ``HAVING Complaint Count > 0``. Pre-fix this emitted invalid SQL
+      ``HAVING Client Complaints Count > 0``. Pre-fix this emitted invalid SQL
       (binder error). Post-fix the resolver auto-includes
-      ``Complaint Count`` in the projection.
-    * **Explicit** — ``select.measures = ["Total Sales", "Complaint Count"]``,
+      ``Client Complaints Count`` in the projection.
+    * **Explicit** — ``select.measures = ["Total Sales", "Client Complaints Count"]``,
       same HAVING. Always compiled.
 
     Both forms should yield the same ``(Client Name, Total Sales)``
     pairs across the same set of clients.
     """
-    having = [QueryFilter(field="Complaint Count", op=FilterOperator.GT, value=0)]
+    having = [QueryFilter(field="Client Complaints Count", op=FilterOperator.GT, value=0)]
 
     implicit = run_query(
         QueryObject(
@@ -72,7 +72,7 @@ def test_having_on_non_selected_measure_matches_explicit_form(
         QueryObject(
             select=QuerySelect(
                 dimensions=["Client Name"],
-                measures=["Total Sales", "Complaint Count"],
+                measures=["Total Sales", "Client Complaints Count"],
             ),
             having=having,
         )
@@ -100,7 +100,7 @@ def test_having_on_non_selected_measure_matches_explicit_form(
     # Sanity: at least one row is left after HAVING — otherwise the
     # invariant is trivially satisfied and would mask a bug.
     assert impl_by_client, (
-        "HAVING Complaint Count > 0 should match at least one client; "
+        "HAVING Client Complaints Count > 0 should match at least one client; "
         "got an empty result. Possibly the auto-included measure was "
         "filtered out by an earlier resolution pass."
     )

--- a/tests/integration/correctness/test_metric_algebra.py
+++ b/tests/integration/correctness/test_metric_algebra.py
@@ -8,7 +8,7 @@ as a mismatch between the OBSL-emitted metric and the manual algebra.
 Per plan §10.1, ratios may use ``pytest.approx`` (these all are ratios).
 
 Covers v0 corpus rows:
-    8. ``Average Sale``  = Total Sales / NULLIF(Sales Order Count, 0)
+    8. ``Average Sale``  = Total Sales / NULLIF(Sales Count, 0)
     9. ``Return Rate``   = Total Returns / NULLIF(Total Sales, 0)
 """
 
@@ -42,14 +42,14 @@ def _quantize(value: Decimal, scale: int) -> Decimal:
 def test_average_sale_equals_total_sales_over_order_count(
     run_query: Callable[[QueryObject], list[dict[str, Any]]],
 ) -> None:
-    """Corpus #8: ``Average Sale`` == ``Total Sales`` / ``Sales Order Count``."""
-    base = run_query(QueryObject(select=QuerySelect(measures=["Total Sales", "Sales Order Count"])))
+    """Corpus #8: ``Average Sale`` == ``Total Sales`` / ``Sales Count``."""
+    base = run_query(QueryObject(select=QuerySelect(measures=["Total Sales", "Sales Count"])))
     metric = run_query(QueryObject(select=QuerySelect(measures=["Average Sale"])))
 
     assert len(base) == 1 and len(metric) == 1
 
     total_sales = _to_decimal(base[0]["Total Sales"])
-    order_count = _to_decimal(base[0]["Sales Order Count"])
+    order_count = _to_decimal(base[0]["Sales Count"])
     # Average Sale is declared decimal(18, 2) — quantize to 2 dp to match
     # OBSL's CAST. Without this, the Decimal division retains 30+ digits
     # of precision and disagrees with OBSL's truncated value.
@@ -58,9 +58,9 @@ def test_average_sale_equals_total_sales_over_order_count(
     actual = _to_decimal(metric[0]["Average Sale"])
     assert actual == expected, (
         f"Average Sale: OBSL={actual}, manual={expected} "
-        f"(Total Sales={total_sales}, Sales Order Count={order_count}). "
+        f"(Total Sales={total_sales}, Sales Count={order_count}). "
         f"Suggests an expression-evaluation bug — possibly sqlglot rewrite "
-        f"of `/` or NULLIF, or a wrong cast of Sales Order Count."
+        f"of `/` or NULLIF, or a wrong cast of Sales Count."
     )
 
 

--- a/tests/integration/drift/compile_only/bigquery/07_total_sales_by_client_with_complaints.sql
+++ b/tests/integration/drift/compile_only/bigquery/07_total_sales_by_client_with_complaints.sql
@@ -1,13 +1,13 @@
 WITH `composite_01` AS (
-SELECT `Clients`.`clientname` AS `Sales Client Name`, CAST(NULL AS STRING) AS `Complaint Client Name`, CAST(`Sales`.`salesamount` AS NUMERIC) AS `Total Sales`, CAST(NULL AS STRING) AS `Complaint Count`
+SELECT `Clients`.`clientname` AS `Sales Client Name`, CAST(NULL AS STRING) AS `Complaint Client Name`, CAST(`Sales`.`salesamount` AS NUMERIC) AS `Total Sales`, CAST(NULL AS INT64) AS `Client Complaints Count`
 FROM ``.`orionbelt_1`.`sales` AS `Sales`
 LEFT JOIN ``.`orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`
 UNION ALL
-SELECT CAST(NULL AS STRING) AS `Sales Client Name`, `Clients`.`clientname` AS `Complaint Client Name`, CAST(NULL AS NUMERIC) AS `Total Sales`, CAST(`Client Complaints`.`complid` AS STRING) AS `Complaint Count`
+SELECT CAST(NULL AS STRING) AS `Sales Client Name`, `Clients`.`clientname` AS `Complaint Client Name`, CAST(NULL AS NUMERIC) AS `Total Sales`, CAST(1 AS INT64) AS `Client Complaints Count`
 FROM ``.`orionbelt_1`.`clientcomplaints` AS `Client Complaints`
 LEFT JOIN ``.`orionbelt_1`.`clients` AS `Clients` ON `Client Complaints`.`complclientid` = `Clients`.`clientid`
 )
-SELECT COALESCE(`Sales Client Name`, `Complaint Client Name`) AS `Client`, ROUND(CAST(SUM(`composite_01`.`Total Sales`) AS NUMERIC), 2) AS `Total Sales`, CAST(COUNT(DISTINCT `composite_01`.`Complaint Count`) AS INT64) AS `Complaint Count`
+SELECT COALESCE(`Sales Client Name`, `Complaint Client Name`) AS `Client`, ROUND(CAST(SUM(`composite_01`.`Total Sales`) AS NUMERIC), 2) AS `Total Sales`, CAST(COUNT(`composite_01`.`Client Complaints Count`) AS INT64) AS `Client Complaints Count`
 FROM `composite_01` AS `composite_01`
 GROUP BY ALL
-HAVING CAST(COUNT(DISTINCT `composite_01`.`Complaint Count`) AS INT64) > 0
+HAVING CAST(COUNT(`composite_01`.`Client Complaints Count`) AS INT64) > 0

--- a/tests/integration/drift/compile_only/bigquery/08_average_sale.sql
+++ b/tests/integration/drift/compile_only/bigquery/08_average_sale.sql
@@ -1,2 +1,2 @@
-SELECT ROUND(CAST(SUM(`Sales`.`salesamount`) / NULLIF(COUNT(DISTINCT `Sales`.`salesid`), 0) AS NUMERIC), 2) AS `Average Sale`
+SELECT ROUND(CAST(SUM(`Sales`.`salesamount`) / NULLIF(COUNT(1), 0) AS NUMERIC), 2) AS `Average Sale`
 FROM ``.`orionbelt_1`.`sales` AS `Sales`

--- a/tests/integration/drift/compile_only/clickhouse/07_total_sales_by_client_with_complaints.sql
+++ b/tests/integration/drift/compile_only/clickhouse/07_total_sales_by_client_with_complaints.sql
@@ -1,13 +1,13 @@
 WITH "composite_01" AS (
-SELECT "Clients"."clientname" AS "Sales Client Name", CAST(NULL AS Nullable(String)) AS "Complaint Client Name", CAST(round("Sales"."salesamount", 2) AS Nullable(Decimal(18, 2))) AS "Total Sales", CAST(NULL AS Nullable(String)) AS "Complaint Count"
+SELECT "Clients"."clientname" AS "Sales Client Name", CAST(NULL AS Nullable(String)) AS "Complaint Client Name", CAST(round("Sales"."salesamount", 2) AS Nullable(Decimal(18, 2))) AS "Total Sales", CAST(NULL AS Nullable(Int32)) AS "Client Complaints Count"
 FROM "orionbelt_1"."sales" AS "Sales"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"
 UNION ALL
-SELECT CAST(NULL AS Nullable(String)) AS "Sales Client Name", "Clients"."clientname" AS "Complaint Client Name", CAST(round(NULL, 2) AS Nullable(Decimal(18, 2))) AS "Total Sales", CAST("Client Complaints"."complid" AS Nullable(String)) AS "Complaint Count"
+SELECT CAST(NULL AS Nullable(String)) AS "Sales Client Name", "Clients"."clientname" AS "Complaint Client Name", CAST(round(NULL, 2) AS Nullable(Decimal(18, 2))) AS "Total Sales", CAST(1 AS Nullable(Int32)) AS "Client Complaints Count"
 FROM "orionbelt_1"."clientcomplaints" AS "Client Complaints"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Client Complaints"."complclientid" = "Clients"."clientid"
 )
-SELECT COALESCE("Sales Client Name", "Complaint Client Name") AS "Client", CAST(round(SUM("composite_01"."Total Sales"), 2) AS Nullable(Decimal(18, 2))) AS "Total Sales", CAST(COUNT(DISTINCT "composite_01"."Complaint Count") AS Nullable(Int64)) AS "Complaint Count"
+SELECT COALESCE("Sales Client Name", "Complaint Client Name") AS "Client", CAST(round(SUM("composite_01"."Total Sales"), 2) AS Nullable(Decimal(18, 2))) AS "Total Sales", CAST(COUNT("composite_01"."Client Complaints Count") AS Nullable(Int32)) AS "Client Complaints Count"
 FROM "composite_01" AS "composite_01"
 GROUP BY ALL
-HAVING CAST(COUNT(DISTINCT "composite_01"."Complaint Count") AS Nullable(Int64)) > 0
+HAVING CAST(COUNT("composite_01"."Client Complaints Count") AS Nullable(Int32)) > 0

--- a/tests/integration/drift/compile_only/clickhouse/08_average_sale.sql
+++ b/tests/integration/drift/compile_only/clickhouse/08_average_sale.sql
@@ -1,2 +1,2 @@
-SELECT CAST(round(CAST(SUM("Sales"."salesamount") AS Nullable(Decimal(38, 14))) / CAST(NULLIF(COUNT(DISTINCT "Sales"."salesid"), 0) AS Nullable(Decimal(38, 14))), 2) AS Nullable(Decimal(18, 2))) AS "Average Sale"
+SELECT CAST(round(CAST(SUM("Sales"."salesamount") AS Nullable(Decimal(38, 14))) / CAST(NULLIF(COUNT(1), 0) AS Nullable(Decimal(38, 14))), 2) AS Nullable(Decimal(18, 2))) AS "Average Sale"
 FROM "orionbelt_1"."sales" AS "Sales"

--- a/tests/integration/drift/compile_only/databricks/07_total_sales_by_client_with_complaints.sql
+++ b/tests/integration/drift/compile_only/databricks/07_total_sales_by_client_with_complaints.sql
@@ -1,13 +1,13 @@
 WITH `composite_01` AS (
-SELECT `Clients`.`clientname` AS `Sales Client Name`, CAST(NULL AS STRING) AS `Complaint Client Name`, CAST(`Sales`.`salesamount` AS DECIMAL(18, 2)) AS `Total Sales`, CAST(NULL AS STRING) AS `Complaint Count`
+SELECT `Clients`.`clientname` AS `Sales Client Name`, CAST(NULL AS STRING) AS `Complaint Client Name`, CAST(`Sales`.`salesamount` AS DECIMAL(18, 2)) AS `Total Sales`, CAST(NULL AS INT) AS `Client Complaints Count`
 FROM ``.`orionbelt_1`.`sales` AS `Sales`
 LEFT JOIN ``.`orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`
 UNION ALL
-SELECT CAST(NULL AS STRING) AS `Sales Client Name`, `Clients`.`clientname` AS `Complaint Client Name`, CAST(NULL AS DECIMAL(18, 2)) AS `Total Sales`, CAST(`Client Complaints`.`complid` AS STRING) AS `Complaint Count`
+SELECT CAST(NULL AS STRING) AS `Sales Client Name`, `Clients`.`clientname` AS `Complaint Client Name`, CAST(NULL AS DECIMAL(18, 2)) AS `Total Sales`, CAST(1 AS INT) AS `Client Complaints Count`
 FROM ``.`orionbelt_1`.`clientcomplaints` AS `Client Complaints`
 LEFT JOIN ``.`orionbelt_1`.`clients` AS `Clients` ON `Client Complaints`.`complclientid` = `Clients`.`clientid`
 )
-SELECT COALESCE(`Sales Client Name`, `Complaint Client Name`) AS `Client`, CAST(SUM(`composite_01`.`Total Sales`) AS DECIMAL(18, 2)) AS `Total Sales`, CAST(COUNT(DISTINCT `composite_01`.`Complaint Count`) AS BIGINT) AS `Complaint Count`
+SELECT COALESCE(`Sales Client Name`, `Complaint Client Name`) AS `Client`, CAST(SUM(`composite_01`.`Total Sales`) AS DECIMAL(18, 2)) AS `Total Sales`, CAST(COUNT(`composite_01`.`Client Complaints Count`) AS INT) AS `Client Complaints Count`
 FROM `composite_01` AS `composite_01`
 GROUP BY ALL
-HAVING CAST(COUNT(DISTINCT `composite_01`.`Complaint Count`) AS BIGINT) > 0
+HAVING CAST(COUNT(`composite_01`.`Client Complaints Count`) AS INT) > 0

--- a/tests/integration/drift/compile_only/databricks/08_average_sale.sql
+++ b/tests/integration/drift/compile_only/databricks/08_average_sale.sql
@@ -1,2 +1,2 @@
-SELECT CAST(SUM(`Sales`.`salesamount`) / NULLIF(COUNT(DISTINCT `Sales`.`salesid`), 0) AS DECIMAL(18, 2)) AS `Average Sale`
+SELECT CAST(SUM(`Sales`.`salesamount`) / NULLIF(COUNT(1), 0) AS DECIMAL(18, 2)) AS `Average Sale`
 FROM ``.`orionbelt_1`.`sales` AS `Sales`

--- a/tests/integration/drift/compile_only/dremio/07_total_sales_by_client_with_complaints.sql
+++ b/tests/integration/drift/compile_only/dremio/07_total_sales_by_client_with_complaints.sql
@@ -1,13 +1,13 @@
 WITH "composite_01" AS (
-SELECT "Clients"."clientname" AS "Sales Client Name", CAST(NULL AS VARCHAR) AS "Complaint Client Name", CAST("Sales"."salesamount" AS DECIMAL(18, 2)) AS "Total Sales", CAST(NULL AS VARCHAR) AS "Complaint Count"
+SELECT "Clients"."clientname" AS "Sales Client Name", CAST(NULL AS VARCHAR) AS "Complaint Client Name", CAST("Sales"."salesamount" AS DECIMAL(18, 2)) AS "Total Sales", CAST(NULL AS INTEGER) AS "Client Complaints Count"
 FROM "orionbelt_1"."sales" AS "Sales"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"
 UNION ALL
-SELECT CAST(NULL AS VARCHAR) AS "Sales Client Name", "Clients"."clientname" AS "Complaint Client Name", CAST(NULL AS DECIMAL(18, 2)) AS "Total Sales", CAST("Client Complaints"."complid" AS VARCHAR) AS "Complaint Count"
+SELECT CAST(NULL AS VARCHAR) AS "Sales Client Name", "Clients"."clientname" AS "Complaint Client Name", CAST(NULL AS DECIMAL(18, 2)) AS "Total Sales", CAST(1 AS INTEGER) AS "Client Complaints Count"
 FROM "orionbelt_1"."clientcomplaints" AS "Client Complaints"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Client Complaints"."complclientid" = "Clients"."clientid"
 )
-SELECT COALESCE("Sales Client Name", "Complaint Client Name") AS "Client", CAST(SUM("composite_01"."Total Sales") AS DECIMAL(18, 2)) AS "Total Sales", CAST(COUNT(DISTINCT "composite_01"."Complaint Count") AS BIGINT) AS "Complaint Count"
+SELECT COALESCE("Sales Client Name", "Complaint Client Name") AS "Client", CAST(SUM("composite_01"."Total Sales") AS DECIMAL(18, 2)) AS "Total Sales", CAST(COUNT("composite_01"."Client Complaints Count") AS INTEGER) AS "Client Complaints Count"
 FROM "composite_01" AS "composite_01"
 GROUP BY COALESCE("Sales Client Name", "Complaint Client Name")
-HAVING CAST(COUNT(DISTINCT "composite_01"."Complaint Count") AS BIGINT) > 0
+HAVING CAST(COUNT("composite_01"."Client Complaints Count") AS INTEGER) > 0

--- a/tests/integration/drift/compile_only/dremio/08_average_sale.sql
+++ b/tests/integration/drift/compile_only/dremio/08_average_sale.sql
@@ -1,2 +1,2 @@
-SELECT CAST(SUM("Sales"."salesamount") / NULLIF(COUNT(DISTINCT "Sales"."salesid"), 0) AS DECIMAL(18, 2)) AS "Average Sale"
+SELECT CAST(SUM("Sales"."salesamount") / NULLIF(COUNT(1), 0) AS DECIMAL(18, 2)) AS "Average Sale"
 FROM "orionbelt_1"."sales" AS "Sales"

--- a/tests/integration/drift/compile_only/duckdb/07_total_sales_by_client_with_complaints.sql
+++ b/tests/integration/drift/compile_only/duckdb/07_total_sales_by_client_with_complaints.sql
@@ -3,11 +3,11 @@ SELECT "Clients"."clientname" AS "Sales Client Name", CAST("Sales"."salesamount"
 FROM "orionbelt_1"."sales" AS "Sales"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"
 UNION ALL BY NAME
-SELECT "Clients"."clientname" AS "Complaint Client Name", CAST("Client Complaints"."complid" AS VARCHAR) AS "Complaint Count"
+SELECT "Clients"."clientname" AS "Complaint Client Name", CAST(1 AS INTEGER) AS "Client Complaints Count"
 FROM "orionbelt_1"."clientcomplaints" AS "Client Complaints"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Client Complaints"."complclientid" = "Clients"."clientid"
 )
-SELECT COALESCE("Sales Client Name", "Complaint Client Name") AS "Client", CAST(SUM("composite_01"."Total Sales") AS DECIMAL(18, 2)) AS "Total Sales", CAST(COUNT(DISTINCT "composite_01"."Complaint Count") AS BIGINT) AS "Complaint Count"
+SELECT COALESCE("Sales Client Name", "Complaint Client Name") AS "Client", CAST(SUM("composite_01"."Total Sales") AS DECIMAL(18, 2)) AS "Total Sales", CAST(COUNT("composite_01"."Client Complaints Count") AS INTEGER) AS "Client Complaints Count"
 FROM "composite_01" AS "composite_01"
 GROUP BY ALL
-HAVING CAST(COUNT(DISTINCT "composite_01"."Complaint Count") AS BIGINT) > 0
+HAVING CAST(COUNT("composite_01"."Client Complaints Count") AS INTEGER) > 0

--- a/tests/integration/drift/compile_only/duckdb/08_average_sale.sql
+++ b/tests/integration/drift/compile_only/duckdb/08_average_sale.sql
@@ -1,2 +1,2 @@
-SELECT CAST(SUM("Sales"."salesamount") / NULLIF(COUNT(DISTINCT "Sales"."salesid"), 0) AS DECIMAL(18, 2)) AS "Average Sale"
+SELECT CAST(SUM("Sales"."salesamount") / NULLIF(COUNT(1), 0) AS DECIMAL(18, 2)) AS "Average Sale"
 FROM "orionbelt_1"."sales" AS "Sales"

--- a/tests/integration/drift/compile_only/mysql/07_total_sales_by_client_with_complaints.sql
+++ b/tests/integration/drift/compile_only/mysql/07_total_sales_by_client_with_complaints.sql
@@ -1,13 +1,13 @@
 WITH `composite_01` AS (
-SELECT `Clients`.`clientname` AS `Sales Client Name`, CAST(NULL AS CHAR(255)) AS `Complaint Client Name`, CAST(`Sales`.`salesamount` AS DECIMAL(18, 2)) AS `Total Sales`, CAST(NULL AS CHAR(255)) AS `Complaint Count`
+SELECT `Clients`.`clientname` AS `Sales Client Name`, CAST(NULL AS CHAR(255)) AS `Complaint Client Name`, CAST(`Sales`.`salesamount` AS DECIMAL(18, 2)) AS `Total Sales`, CAST(NULL AS SIGNED) AS `Client Complaints Count`
 FROM `orionbelt_1`.`sales` AS `Sales`
 LEFT JOIN `orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`
 UNION ALL
-SELECT CAST(NULL AS CHAR(255)) AS `Sales Client Name`, `Clients`.`clientname` AS `Complaint Client Name`, CAST(NULL AS DECIMAL(18, 2)) AS `Total Sales`, CAST(`Client Complaints`.`complid` AS CHAR(255)) AS `Complaint Count`
+SELECT CAST(NULL AS CHAR(255)) AS `Sales Client Name`, `Clients`.`clientname` AS `Complaint Client Name`, CAST(NULL AS DECIMAL(18, 2)) AS `Total Sales`, CAST(1 AS SIGNED) AS `Client Complaints Count`
 FROM `orionbelt_1`.`clientcomplaints` AS `Client Complaints`
 LEFT JOIN `orionbelt_1`.`clients` AS `Clients` ON `Client Complaints`.`complclientid` = `Clients`.`clientid`
 )
-SELECT COALESCE(`Sales Client Name`, `Complaint Client Name`) AS `Client`, CAST(SUM(`composite_01`.`Total Sales`) AS DECIMAL(18, 2)) AS `Total Sales`, CAST(COUNT(DISTINCT `composite_01`.`Complaint Count`) AS SIGNED) AS `Complaint Count`
+SELECT COALESCE(`Sales Client Name`, `Complaint Client Name`) AS `Client`, CAST(SUM(`composite_01`.`Total Sales`) AS DECIMAL(18, 2)) AS `Total Sales`, CAST(COUNT(`composite_01`.`Client Complaints Count`) AS SIGNED) AS `Client Complaints Count`
 FROM `composite_01` AS `composite_01`
 GROUP BY COALESCE(`Sales Client Name`, `Complaint Client Name`)
-HAVING CAST(COUNT(DISTINCT `composite_01`.`Complaint Count`) AS SIGNED) > 0
+HAVING CAST(COUNT(`composite_01`.`Client Complaints Count`) AS SIGNED) > 0

--- a/tests/integration/drift/compile_only/mysql/08_average_sale.sql
+++ b/tests/integration/drift/compile_only/mysql/08_average_sale.sql
@@ -1,2 +1,2 @@
-SELECT CAST(SUM(`Sales`.`salesamount`) / NULLIF(COUNT(DISTINCT `Sales`.`salesid`), 0) AS DECIMAL(18, 2)) AS `Average Sale`
+SELECT CAST(SUM(`Sales`.`salesamount`) / NULLIF(COUNT(1), 0) AS DECIMAL(18, 2)) AS `Average Sale`
 FROM `orionbelt_1`.`sales` AS `Sales`

--- a/tests/integration/drift/compile_only/postgres/07_total_sales_by_client_with_complaints.sql
+++ b/tests/integration/drift/compile_only/postgres/07_total_sales_by_client_with_complaints.sql
@@ -1,13 +1,13 @@
 WITH "composite_01" AS (
-SELECT "Clients"."clientname" AS "Sales Client Name", CAST(NULL AS VARCHAR) AS "Complaint Client Name", CAST("Sales"."salesamount" AS DECIMAL(18, 2)) AS "Total Sales", CAST(NULL AS VARCHAR) AS "Complaint Count"
+SELECT "Clients"."clientname" AS "Sales Client Name", CAST(NULL AS VARCHAR) AS "Complaint Client Name", CAST("Sales"."salesamount" AS DECIMAL(18, 2)) AS "Total Sales", CAST(NULL AS INTEGER) AS "Client Complaints Count"
 FROM "orionbelt_1"."sales" AS "Sales"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"
 UNION ALL
-SELECT CAST(NULL AS VARCHAR) AS "Sales Client Name", "Clients"."clientname" AS "Complaint Client Name", CAST(NULL AS DECIMAL(18, 2)) AS "Total Sales", CAST("Client Complaints"."complid" AS VARCHAR) AS "Complaint Count"
+SELECT CAST(NULL AS VARCHAR) AS "Sales Client Name", "Clients"."clientname" AS "Complaint Client Name", CAST(NULL AS DECIMAL(18, 2)) AS "Total Sales", CAST(1 AS INTEGER) AS "Client Complaints Count"
 FROM "orionbelt_1"."clientcomplaints" AS "Client Complaints"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Client Complaints"."complclientid" = "Clients"."clientid"
 )
-SELECT COALESCE("Sales Client Name", "Complaint Client Name") AS "Client", CAST(SUM("composite_01"."Total Sales") AS DECIMAL(18, 2)) AS "Total Sales", CAST(COUNT(DISTINCT "composite_01"."Complaint Count") AS BIGINT) AS "Complaint Count"
+SELECT COALESCE("Sales Client Name", "Complaint Client Name") AS "Client", CAST(SUM("composite_01"."Total Sales") AS DECIMAL(18, 2)) AS "Total Sales", CAST(COUNT("composite_01"."Client Complaints Count") AS INTEGER) AS "Client Complaints Count"
 FROM "composite_01" AS "composite_01"
 GROUP BY COALESCE("Sales Client Name", "Complaint Client Name")
-HAVING CAST(COUNT(DISTINCT "composite_01"."Complaint Count") AS BIGINT) > 0
+HAVING CAST(COUNT("composite_01"."Client Complaints Count") AS INTEGER) > 0

--- a/tests/integration/drift/compile_only/postgres/08_average_sale.sql
+++ b/tests/integration/drift/compile_only/postgres/08_average_sale.sql
@@ -1,2 +1,2 @@
-SELECT CAST(SUM("Sales"."salesamount") / NULLIF(COUNT(DISTINCT "Sales"."salesid"), 0) AS DECIMAL(18, 2)) AS "Average Sale"
+SELECT CAST(SUM("Sales"."salesamount") / NULLIF(COUNT(1), 0) AS DECIMAL(18, 2)) AS "Average Sale"
 FROM "orionbelt_1"."sales" AS "Sales"

--- a/tests/integration/drift/compile_only/snowflake/07_total_sales_by_client_with_complaints.sql
+++ b/tests/integration/drift/compile_only/snowflake/07_total_sales_by_client_with_complaints.sql
@@ -3,11 +3,11 @@ SELECT "Clients"."clientname" AS "Sales Client Name", CAST("Sales"."salesamount"
 FROM ""."orionbelt_1"."sales" AS "Sales"
 LEFT JOIN ""."orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"
 UNION ALL BY NAME
-SELECT "Clients"."clientname" AS "Complaint Client Name", CAST("Client Complaints"."complid" AS VARCHAR) AS "Complaint Count"
+SELECT "Clients"."clientname" AS "Complaint Client Name", CAST(1 AS NUMBER(38, 0)) AS "Client Complaints Count"
 FROM ""."orionbelt_1"."clientcomplaints" AS "Client Complaints"
 LEFT JOIN ""."orionbelt_1"."clients" AS "Clients" ON "Client Complaints"."complclientid" = "Clients"."clientid"
 )
-SELECT COALESCE("Sales Client Name", "Complaint Client Name") AS "Client", CAST(SUM("composite_01"."Total Sales") AS NUMBER(18, 2)) AS "Total Sales", CAST(COUNT(DISTINCT "composite_01"."Complaint Count") AS NUMBER(38, 0)) AS "Complaint Count"
+SELECT COALESCE("Sales Client Name", "Complaint Client Name") AS "Client", CAST(SUM("composite_01"."Total Sales") AS NUMBER(18, 2)) AS "Total Sales", CAST(COUNT("composite_01"."Client Complaints Count") AS NUMBER(38, 0)) AS "Client Complaints Count"
 FROM "composite_01" AS "composite_01"
 GROUP BY ALL
-HAVING CAST(COUNT(DISTINCT "composite_01"."Complaint Count") AS NUMBER(38, 0)) > 0
+HAVING CAST(COUNT("composite_01"."Client Complaints Count") AS NUMBER(38, 0)) > 0

--- a/tests/integration/drift/compile_only/snowflake/08_average_sale.sql
+++ b/tests/integration/drift/compile_only/snowflake/08_average_sale.sql
@@ -1,2 +1,2 @@
-SELECT CAST(SUM("Sales"."salesamount") / NULLIF(COUNT(DISTINCT "Sales"."salesid"), 0) AS NUMBER(18, 2)) AS "Average Sale"
+SELECT CAST(SUM("Sales"."salesamount") / NULLIF(COUNT(1), 0) AS NUMBER(18, 2)) AS "Average Sale"
 FROM ""."orionbelt_1"."sales" AS "Sales"

--- a/tests/integration/drift/duckdb/07_total_sales_by_client_with_complaints.yaml
+++ b/tests/integration/drift/duckdb/07_total_sales_by_client_with_complaints.yaml
@@ -9,7 +9,7 @@ sql: 'WITH "composite_01" AS (
 
   UNION ALL BY NAME
 
-  SELECT "Clients"."clientname" AS "Complaint Client Name", CAST("Client Complaints"."complid" AS VARCHAR) AS "Complaint Count"
+  SELECT "Clients"."clientname" AS "Complaint Client Name", CAST(1 AS INTEGER) AS "Client Complaints Count"
 
   FROM "orionbelt_1"."clientcomplaints" AS "Client Complaints"
 
@@ -18,13 +18,13 @@ sql: 'WITH "composite_01" AS (
   )
 
   SELECT COALESCE("Sales Client Name", "Complaint Client Name") AS "Client", CAST(SUM("composite_01"."Total Sales") AS DECIMAL(18,
-  2)) AS "Total Sales", CAST(COUNT(DISTINCT "composite_01"."Complaint Count") AS BIGINT) AS "Complaint Count"
+  2)) AS "Total Sales", CAST(COUNT("composite_01"."Client Complaints Count") AS INTEGER) AS "Client Complaints Count"
 
   FROM "composite_01" AS "composite_01"
 
   GROUP BY ALL
 
-  HAVING CAST(COUNT(DISTINCT "composite_01"."Complaint Count") AS BIGINT) > 0
+  HAVING CAST(COUNT("composite_01"."Client Complaints Count") AS INTEGER) > 0
 
   '
 rows:

--- a/tests/integration/drift/duckdb/08_average_sale.yaml
+++ b/tests/integration/drift/duckdb/08_average_sale.yaml
@@ -1,6 +1,5 @@
 last_verified_by: tests/integration/correctness/test_metric_algebra.py::test_average_sale_equals_total_sales_over_order_count
-sql: 'SELECT CAST(SUM("Sales"."salesamount") / NULLIF(COUNT(DISTINCT "Sales"."salesid"), 0) AS DECIMAL(18, 2)) AS "Average
-  Sale"
+sql: 'SELECT CAST(SUM("Sales"."salesamount") / NULLIF(COUNT(1), 0) AS DECIMAL(18, 2)) AS "Average Sale"
 
   FROM "orionbelt_1"."sales" AS "Sales"
 


### PR DESCRIPTION
Cleans up the redundant declared count measures in the commerce demo models, using the auto-synthesized counts.

Motivated by the ontology graph showing near-identical nodes (e.g. declared `Return Count` next to synthesized `Returns Count`). All three declared counts were `count_distinct` on a PK column, so they equal the synthesized `COUNT(*)`.

## Changes
- **`Return Count` -> `Returns Count`**: renamed so it overrides the synthesized count (declared-measure-overrides-synthesis) — kept as the **override example**.
- **`Sales Order Count`, `Complaint Count`: removed** — references now point at the synthesized `Sales Count` / `Client Complaints Count`, proving synth counts are first-class (metric expressions, HAVING, queries all resolve them).
- Applied identically to both commerce models: `examples/orionbelt_1_commerce.yaml` and the parallel `demo/dremio/model/commerce_dremio.yaml` (+ its README/queries), which should mirror each other. The Dremio `DEMO_VIEWS` in `bootstrap.py` reference `Average Sale` by name (unchanged), so no view changes needed.
- Repointed correctness corpus/tests, the 07 query + hand reference SQL, and `docs/guide/postgres-wire-bi-tools.md` (its `count_distinct` example now uses the surviving `Returns Count`).
- Regenerated drift snapshots (`compile_only` + `duckdb`) for the affected 07 and 08 queries; `vendor_exec` unaffected (no live vendor DBs needed).

## Verify
Both models validate with an identical declared-measure set; synth `Sales Count` / `Client Complaints Count` present; `Average Sale` compiles against the synth count. Full suite green (2603 passed), ruff/format/mypy clean.