### PR TITLE
Scope single-model shortcut resolution to protected sessions

### DIFF
--- a/src/orionbelt/api/routers/shortcuts.py
+++ b/src/orionbelt/api/routers/shortcuts.py
@@ -73,8 +73,14 @@ router = APIRouter()
 def _candidate_session_ids(mgr: SessionManager) -> list[str]:
     """Ordered, deduplicated list of session ids the shortcut routes consult.
 
-    Order: ``__default__`` first (legacy single-model mode), then admin-
-    curated protected sessions (``MODEL_FILES``), then user-created sessions.
+    In admin-curated mode (``MODEL_FILES``) the shortcut resolves to the
+    curated **protected** session(s) *only* — transient ``__default__`` and
+    user-created sessions are ignored. Otherwise a short-lived extra model in a
+    scratch session would make the unique-model shortcut 409 even though the
+    curated model is unambiguous (observed on the demo deployment, where the
+    MCP audit's single-model shortcut intermittently 409'd against transient
+    sessions). Outside admin-curated mode, order is ``__default__`` (legacy
+    single-model), then protected, then user-created sessions.
     """
     seen: set[str] = set()
     ordered: list[str] = []
@@ -84,6 +90,11 @@ def _candidate_session_ids(mgr: SessionManager) -> list[str]:
             return
         seen.add(session_id)
         ordered.append(session_id)
+
+    if mgr.is_single_model_mode:
+        for sid in mgr.list_protected_session_ids():
+            _add(sid)
+        return ordered
 
     _add("__default__")
     for sid in mgr.list_protected_session_ids():

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -970,6 +970,35 @@ class TestSingleModelMode:
         assert response.status_code == 200, response.text
         assert "SELECT" in response.json()["sql"]
 
+    async def test_shortcut_ignores_transient_user_sessions(
+        self, single_model_client: AsyncClient
+    ) -> None:
+        """Regression: in admin-curated mode the shortcut must resolve to the
+        curated protected model even when transient user sessions exist.
+
+        Each ``POST /v1/sessions`` re-loads a *copy* of the protected model into
+        the new session (with a fresh uuid model_id). The unique-model shortcut
+        used to scan those copies too and 409 with "Multiple models loaded
+        across sessions" — observed intermittently on the demo deployment. The
+        shortcut now scopes to protected sessions in single-model mode.
+        """
+        # Create two user sessions — each inherits its own copy of the model.
+        for _ in range(2):
+            r = await single_model_client.post("/v1/sessions")
+            assert r.status_code == 201, r.text
+            assert r.json()["model_count"] == 1
+
+        # The shortcuts must still resolve the single curated model, not 409.
+        schema = await single_model_client.get("/v1/schema")
+        assert schema.status_code == 200, schema.text
+        assert schema.json().get("data_objects")
+
+        compiled = await single_model_client.post(
+            "/v1/query/sql?dialect=postgres",
+            json={"select": {"dimensions": ["Customer Country"], "measures": ["Total Revenue"]}},
+        )
+        assert compiled.status_code == 200, compiled.text
+
 
 # ---------------------------------------------------------------------------
 # Query execution endpoint


### PR DESCRIPTION
Fixes an intermittent 409 on the top-level shortcut routes in admin-curated (`MODEL_FILES`) mode, surfaced by the MCP audit against the demo deployment: `/v1/settings` reports `single_model_mode: true` and `/v1/models` shows one model, yet the pre-loaded-model shortcut returns `409 Multiple models loaded across sessions`.

## Root cause
In single-model mode the shortcut resolvers (`_resolve_single_model`, `_resolve_store_and_model`) scanned `__default__` + protected + **every user session**. But `POST /v1/sessions` re-loads a *copy* of the protected model into each new user session (`user_store.load_model(preload_yaml)`), and `model_id` is `uuid.uuid4().hex[:8]` per load with a **per-store** content-hash dedup index — so every active session holds a model copy with a distinct id. With any live user/MCP sessions, the resolver saw N models and 409`d even though the curated model is unambiguous.

## Why not count distinct model_ids
Because ids are random per load (no cross-session model cache), each session copy has a *different* `model_id` — distinct-id counting would still see N and 409.

## Fix
In single-model mode, `_candidate_session_ids` returns **only the curated protected sessions**, ignoring `__default__` and transient user/scratch sessions. This matches `SessionManager.is_single_model_mode`s own documented contract ("expose only the curated models, not transient user/scratch sessions"). Both shortcut resolvers and the cache-key session lookup inherit the fix; non-curated mode is unchanged.

## Test
New regression `test_shortcut_ignores_transient_user_sessions`: creates transient user sessions (each inheriting a model copy) and asserts `/v1/schema` + `/v1/query/sql` still resolve the single curated model instead of 409`ing.

Full suite green (2604 passed), ruff/format/mypy clean.