### PR TITLE
Cross-session content-addressed model cache

### DIFF
--- a/src/orionbelt/api/app.py
+++ b/src/orionbelt/api/app.py
@@ -253,11 +253,13 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
             ", ".join(n for n, _ in named_preloads),
         )
 
-    # Wipe persisted cache state on startup. ``model_id`` is regenerated as
-    # a fresh UUID on every model load, so any entries from a previous
-    # process run are orphans by construction (their cache keys reference
-    # model_ids that no longer exist). Starting empty avoids accumulating
-    # dead state between restarts. See PLAN_freshness_driven_cache.md §7.
+    # Wipe persisted cache state on startup. Shared models now use a stable
+    # content-derived ``model_id`` (see service/model_cache.py), so cache keys
+    # from a previous run are no longer orphaned by construction — but we still
+    # wipe conservatively: a change to the compiler or model semantics between
+    # runs could otherwise let a stale row survive under a matching key.
+    # Starting empty avoids that risk (a future compiler-version stamp could
+    # enable cross-restart reuse). See PLAN_freshness_driven_cache.md §7.
     _wipe_file_cache_state(settings.cache_backend, settings.cache_dir)
 
     cache = build_cache(settings)

--- a/src/orionbelt/service/model_cache.py
+++ b/src/orionbelt/service/model_cache.py
@@ -1,0 +1,119 @@
+"""Process-wide, content-addressed cache of compiled models.
+
+Every session owns its own :class:`~orionbelt.service.model_store.ModelStore`,
+so without this cache identical OBML content loaded into different sessions is
+compiled independently (parse + resolve + join graph + health + OBSL-graph
+export) and stamped with a fresh random ``model_id``. That is pure waste — the
+classic case being admin-curated ``MODEL_FILES`` mode, where the same curated
+model is re-compiled into every new user session.
+
+``ModelCache`` holds one :class:`CompiledModel` per content hash and hands the
+same immutable ``SemanticModel`` (and its derived artifacts) to every session
+that loads matching bytes, keyed by a stable content-derived ``model_id``.
+Entries are refcounted across sessions and evicted the instant the last
+referencing store releases them, so the cache only ever holds models that at
+least one live session is using.
+
+Only plain dedup-eligible YAML loads are shared. Loads that fold in state the
+YAML bytes don't capture (``raw_dict`` / ``extends`` / ``inherits`` /
+``dedup=False``) stay private to their store and never touch this cache.
+"""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from orionbelt.models.semantic import SemanticModel
+    from orionbelt.service.model_store import GraphArtifact, ModelSummary
+
+
+@dataclass
+class CompiledModel:
+    """One shared, refcounted compiled model keyed by its OBML content hash.
+
+    ``model`` is immutable after resolution, so sharing a single instance
+    across sessions is safe. ``raw`` is only ever read back through
+    :meth:`ModelStore.get_raw`, which deep-copies before returning, so callers
+    cannot mutate the shared dict.
+    """
+
+    model_id: str
+    content_hash: str
+    model: SemanticModel
+    raw: dict[str, object]
+    graph: GraphArtifact
+    summary: ModelSummary
+    refcount: int = 0
+
+
+class ModelCache:
+    """Thread-safe, refcounted, content-addressed store of compiled models.
+
+    One instance lives per :class:`~orionbelt.service.session_manager.SessionManager`
+    and is shared by every per-session ``ModelStore`` it creates.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._by_hash: dict[str, CompiledModel] = {}
+        # model_id -> content_hash, so ``release`` can find the entry by id.
+        self._by_id: dict[str, str] = {}
+
+    def acquire(self, content_hash: str) -> CompiledModel | None:
+        """Return the cached entry for ``content_hash`` (refcount += 1), or None.
+
+        The caller is responsible for releasing the reference (via
+        :meth:`ModelStore.remove_model` / :meth:`ModelStore.close`).
+        """
+        with self._lock:
+            entry = self._by_hash.get(content_hash)
+            if entry is not None:
+                entry.refcount += 1
+            return entry
+
+    def insert_or_acquire(self, compiled: CompiledModel) -> CompiledModel:
+        """Insert ``compiled`` at refcount 1, or adopt an existing entry.
+
+        If a concurrent load already inserted the same content hash, that
+        winner's refcount is incremented and it is returned (``compiled`` is
+        discarded). Either way the returned entry carries exactly one new
+        reference for the caller to hold.
+        """
+        with self._lock:
+            existing = self._by_hash.get(compiled.content_hash)
+            if existing is not None:
+                existing.refcount += 1
+                return existing
+            compiled.refcount = 1
+            self._by_hash[compiled.content_hash] = compiled
+            self._by_id[compiled.model_id] = compiled.content_hash
+            return compiled
+
+    def release(self, model_id: str) -> None:
+        """Drop one reference to a shared model; evict it at refcount 0.
+
+        A no-op for unknown ids (private / already-evicted models).
+        """
+        with self._lock:
+            content_hash = self._by_id.get(model_id)
+            if content_hash is None:
+                return
+            entry = self._by_hash.get(content_hash)
+            if entry is None:
+                self._by_id.pop(model_id, None)
+                return
+            entry.refcount -= 1
+            if entry.refcount <= 0:
+                self._by_hash.pop(content_hash, None)
+                self._by_id.pop(model_id, None)
+
+    def stats(self) -> dict[str, int]:
+        """Diagnostics: distinct shared entries and total live references."""
+        with self._lock:
+            return {
+                "entries": len(self._by_hash),
+                "refs": sum(e.refcount for e in self._by_hash.values()),
+            }

--- a/src/orionbelt/service/model_store.py
+++ b/src/orionbelt/service/model_store.py
@@ -25,6 +25,7 @@ from orionbelt.parser.merger import ExtendsMerger, MergeError
 from orionbelt.parser.resolver import ReferenceResolver
 from orionbelt.parser.schema_validation import validate_obml_document
 from orionbelt.parser.validator import SemanticValidator
+from orionbelt.service.model_cache import CompiledModel, ModelCache
 
 # ---------------------------------------------------------------------------
 # Data classes
@@ -203,8 +204,16 @@ class ModelStore:
     same singleton pattern as ``api/deps.py``.
     """
 
-    def __init__(self, max_models: int = 10) -> None:
+    def __init__(self, max_models: int = 10, shared_cache: ModelCache | None = None) -> None:
         self._lock = threading.Lock()
+        # Process-wide content-addressed cache shared across sessions. When
+        # None (CLI, stateless helpers, bare unit tests) every model stays
+        # private to this store and ids are random — behaviour identical to
+        # before the cache existed.
+        self._shared_cache = shared_cache
+        # model_ids in this store that are backed by ``_shared_cache`` (so
+        # remove_model/close release the shared reference).
+        self._shared_ids: set[str] = set()
         self._models: dict[str, SemanticModel] = {}
         # Parallel storage of each loaded model's *merged* raw YAML dict
         # so inheritance can re-merge against the exact same content the
@@ -239,7 +248,58 @@ class ModelStore:
 
     @staticmethod
     def _new_id() -> str:
-        return uuid.uuid4().hex[:8]
+        return uuid.uuid4().hex[:16]
+
+    @staticmethod
+    def _content_id(content_hash: str) -> str:
+        """Stable content-derived id for a shared model.
+
+        A 64-bit prefix of the content hash: identical OBML always yields the
+        same id (so sessions loading matching bytes collapse to one shared
+        compiled model and one result-cache key), while the full 64-hex
+        ``content_hash`` remains the sharing key, so an id-label collision can
+        never cause a wrong-model share.
+        """
+        return content_hash[:16]
+
+    def _register_shared(self, entry: CompiledModel) -> None:
+        """Register a shared cache entry into this store's local view.
+
+        Caller must hold ``self._lock``. The store's read-through getters
+        (get_model/get_raw/get_graph/describe/list_models/...) then serve the
+        shared entry with no further changes.
+        """
+        self._models[entry.model_id] = entry.model
+        self._raws[entry.model_id] = entry.raw
+        self._graphs[entry.model_id] = entry.graph
+        self._summaries[entry.model_id] = entry.summary
+        self._content_hash_index[entry.content_hash] = entry.model_id
+        self._shared_ids.add(entry.model_id)
+
+    def _adopt_shared(self, entry: CompiledModel) -> None:
+        """Take ownership of one reference to ``entry`` for this store.
+
+        ``entry``'s refcount was already incremented by the caller (via
+        ``acquire`` / ``insert_or_acquire``). This store holds exactly one
+        reference per shared model_id it exposes, so a surplus reference (the
+        store already references this content, e.g. concurrent identical loads)
+        is released. Raises ``ModelCapacityError`` (releasing the reference
+        first) when the store is full.
+        """
+        assert self._shared_cache is not None  # only called on shared paths
+        with self._lock:
+            if entry.model_id in self._shared_ids:
+                surplus, over_cap = True, False
+            else:
+                surplus = False
+                over_cap = len(self._models) >= self._max_models
+            if not surplus and not over_cap:
+                self._register_shared(entry)
+        if surplus or over_cap:
+            # Release outside the store lock — the cache has its own lock.
+            self._shared_cache.release(entry.model_id)
+        if over_cap:
+            raise ModelCapacityError(f"Maximum models per session reached ({self._max_models})")
 
     @staticmethod
     def _health_for(model: SemanticModel) -> ModelHealthSummary:
@@ -600,6 +660,25 @@ class ModelStore:
                 if existing_id is not None:
                     self._content_hash_index.pop(content_hash, None)
 
+        # Cross-session hit: another session already compiled these exact
+        # bytes. Adopt the shared compiled model with no recompile. From this
+        # store's perspective the load is still "fresh" (a new reference for
+        # this session); the compile-skip is a transparent optimisation.
+        if dedup_eligible and self._shared_cache is not None and content_hash is not None:
+            shared = self._shared_cache.acquire(content_hash)
+            if shared is not None:
+                self._adopt_shared(shared)
+                return LoadResult(
+                    model_id=shared.model_id,
+                    data_objects=shared.summary.data_objects,
+                    dimensions=shared.summary.dimensions,
+                    measures=shared.summary.measures,
+                    metrics=shared.summary.metrics,
+                    warnings=[],
+                    model_load="fresh",
+                    health=self._health_for(shared.model),
+                )
+
         with self._lock:
             if len(self._models) >= self._max_models:
                 raise ModelCapacityError(f"Maximum models per session reached ({self._max_models})")
@@ -613,7 +692,15 @@ class ModelStore:
         if errors:
             raise ModelValidationError(errors, warnings)
 
-        model_id = self._new_id()
+        shared_load = dedup_eligible and self._shared_cache is not None and content_hash is not None
+        # Content-derived id for shared models so identical bytes collapse to
+        # one id (and one result-cache key) across sessions; random id
+        # otherwise, preserving the ``dedup=False`` "distinct model" contract.
+        model_id = (
+            self._content_id(content_hash)
+            if content_hash is not None and shared_load
+            else self._new_id()
+        )
 
         # Eagerly export OBSL-Core graph (Option C: at model load time).
         graph = export_obsl(model, model_id)
@@ -627,6 +714,31 @@ class ModelStore:
             measures=len(model.measures),
             metrics=len(model.metrics),
         )
+
+        if shared_load:
+            assert self._shared_cache is not None and content_hash is not None
+            compiled = CompiledModel(
+                model_id=model_id,
+                content_hash=content_hash,
+                model=model,
+                raw=merged_raw,
+                graph=artifact,
+                summary=summary,
+            )
+            # A concurrent load of the same content may have won the race;
+            # insert_or_acquire returns the surviving entry either way.
+            entry = self._shared_cache.insert_or_acquire(compiled)
+            self._adopt_shared(entry)
+            return LoadResult(
+                model_id=entry.model_id,
+                data_objects=entry.summary.data_objects,
+                dimensions=entry.summary.dimensions,
+                measures=entry.summary.measures,
+                metrics=entry.summary.metrics,
+                warnings=warnings,
+                model_load="fresh",
+                health=self._health_for(entry.model),
+            )
 
         with self._lock:
             # Re-check capacity under lock — the first check (above) ran
@@ -770,6 +882,32 @@ class ModelStore:
             stale_hashes = [h for h, mid in self._content_hash_index.items() if mid == model_id]
             for h in stale_hashes:
                 del self._content_hash_index[h]
+            was_shared = model_id in self._shared_ids
+            self._shared_ids.discard(model_id)
+        # Release the shared reference outside the store lock. The shared model
+        # stays compiled while any other session still references it.
+        if was_shared and self._shared_cache is not None:
+            self._shared_cache.release(model_id)
+
+    def close(self) -> None:
+        """Drop this store, releasing every shared reference it holds.
+
+        Called by :class:`SessionManager` when a session is purged/expired/
+        closed, so shared models are refcount-released and can be evicted once
+        no live session references them. Private (non-shared) models are simply
+        discarded with the store.
+        """
+        with self._lock:
+            shared_ids = list(self._shared_ids)
+            self._shared_ids.clear()
+            self._models.clear()
+            self._raws.clear()
+            self._graphs.clear()
+            self._summaries.clear()
+            self._content_hash_index.clear()
+        if self._shared_cache is not None:
+            for mid in shared_ids:
+                self._shared_cache.release(mid)
 
     def compile_query(
         self,

--- a/src/orionbelt/service/model_store.py
+++ b/src/orionbelt/service/model_store.py
@@ -199,9 +199,10 @@ class ModelCapacityError(Exception):
 class ModelStore:
     """In-memory model registry.  Thread-safe via ``threading.Lock``.
 
-    Models are keyed by short UUID (8-char hex).  All parsing, validation,
-    and compilation infrastructure is instantiated internally, following the
-    same singleton pattern as ``api/deps.py``.
+    Models are keyed by a 16-char hex id: content-derived for shared models
+    (see ``service/model_cache.py``) or random for private ones. All parsing,
+    validation, and compilation infrastructure is instantiated internally,
+    following the same singleton pattern as ``api/deps.py``.
     """
 
     def __init__(self, max_models: int = 10, shared_cache: ModelCache | None = None) -> None:

--- a/src/orionbelt/service/session_manager.py
+++ b/src/orionbelt/service/session_manager.py
@@ -9,6 +9,7 @@ import time
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 
+from orionbelt.service.model_cache import ModelCache
 from orionbelt.service.model_store import ModelStore
 
 logger = logging.getLogger("orionbelt.session")
@@ -107,6 +108,9 @@ class SessionManager:
         self._cleanup_interval = cleanup_interval
         self._is_single_model_mode = is_single_model_mode
         self._lock = threading.Lock()
+        # One process-wide content-addressed model cache shared by every
+        # per-session store, so identical OBML compiles once across sessions.
+        self._model_cache = ModelCache()
         self._sessions: dict[str, _Session] = {}
         self._stop_event = threading.Event()
         self._cleanup_thread: threading.Thread | None = None
@@ -172,7 +176,7 @@ class SessionManager:
         session_id = secrets.token_hex(16)  # 32-char hex (128-bit)
         session = _Session(
             session_id=session_id,
-            store=ModelStore(max_models=self._max_models),
+            store=ModelStore(max_models=self._max_models, shared_cache=self._model_cache),
             created_at=now_wall,
             created_at_mono=now_mono,
             last_accessed=now_mono,
@@ -213,6 +217,7 @@ class SessionManager:
                 raise SessionNotFoundError(f"Session '{session_id}' not found")
             if self._is_expired(session, now_mono):
                 reason = self._expiry_reason(session, now_mono)
+                session.store.close()
                 del self._sessions[session_id]
                 logger.info("Session expired on access: %s (%s)", session_id, reason)
                 raise SessionExpiredError(f"Session '{session_id}' has expired ({reason})")
@@ -229,6 +234,7 @@ class SessionManager:
                 raise SessionNotFoundError(f"Session '{session_id}' not found")
             if self._is_expired(session, now_mono):
                 reason = self._expiry_reason(session, now_mono)
+                session.store.close()
                 del self._sessions[session_id]
                 logger.info("Session expired on access: %s (%s)", session_id, reason)
                 raise SessionExpiredError(f"Session '{session_id}' has expired ({reason})")
@@ -239,8 +245,10 @@ class SessionManager:
     def close_session(self, session_id: str) -> None:
         """Explicitly close a session."""
         with self._lock:
-            if session_id not in self._sessions:
+            session = self._sessions.get(session_id)
+            if session is None:
                 raise SessionNotFoundError(f"Session '{session_id}' not found")
+            session.store.close()
             del self._sessions[session_id]
         logger.info("Session closed: %s", session_id)
 
@@ -289,7 +297,7 @@ class SessionManager:
             now_wall = datetime.now(UTC)
             session = _Session(
                 session_id=_DEFAULT_SESSION_ID,
-                store=ModelStore(max_models=self._max_models),
+                store=ModelStore(max_models=self._max_models, shared_cache=self._model_cache),
                 created_at=now_wall,
                 created_at_mono=now_mono,
                 last_accessed=now_mono,
@@ -318,7 +326,7 @@ class SessionManager:
             now_wall = datetime.now(UTC)
             session = _Session(
                 session_id=session_id,
-                store=ModelStore(max_models=self._max_models),
+                store=ModelStore(max_models=self._max_models, shared_cache=self._model_cache),
                 created_at=now_wall,
                 created_at_mono=now_mono,
                 last_accessed=now_mono,
@@ -402,6 +410,7 @@ class SessionManager:
             ]
             for sid in expired:
                 reason = self._expiry_reason(self._sessions[sid], now_mono)
+                self._sessions[sid].store.close()
                 del self._sessions[sid]
                 logger.info("Session purged: %s (%s)", sid, reason)
         if expired:

--- a/tests/integration/test_oneshot_batch.py
+++ b/tests/integration/test_oneshot_batch.py
@@ -62,13 +62,15 @@ class TestModelLoadDedup:
         assert r1.json()["model_id"] != r2.json()["model_id"]
         assert r2.json()["model_load"] == "fresh"
 
-    async def test_dedup_isolated_per_session(self, client: AsyncClient) -> None:
+    async def test_identical_yaml_shared_across_sessions(self, client: AsyncClient) -> None:
         s1 = (await client.post("/v1/sessions")).json()["session_id"]
         s2 = (await client.post("/v1/sessions")).json()["session_id"]
         r1 = await client.post(f"/v1/sessions/{s1}/models", json={"model_yaml": SAMPLE_MODEL_YAML})
         r2 = await client.post(f"/v1/sessions/{s2}/models", json={"model_yaml": SAMPLE_MODEL_YAML})
-        # Different sessions = different models, even with identical YAML.
-        assert r1.json()["model_id"] != r2.json()["model_id"]
+        # Identical YAML shares one content-addressed compiled model across
+        # sessions, so the model_id is stable. Each session still reports the
+        # load as "fresh" for its own store (the compile-skip is transparent).
+        assert r1.json()["model_id"] == r2.json()["model_id"]
         assert r2.json()["model_load"] == "fresh"
 
     async def test_dedup_after_remove_loads_fresh(self, client: AsyncClient) -> None:
@@ -77,7 +79,10 @@ class TestModelLoadDedup:
         mid = r1.json()["model_id"]
         await client.delete(f"/v1/sessions/{sid}/models/{mid}")
         r2 = await client.post(f"/v1/sessions/{sid}/models", json={"model_yaml": SAMPLE_MODEL_YAML})
-        assert r2.json()["model_id"] != mid
+        # Content-derived ids are stable, so reloading identical YAML yields
+        # the same id — but it is a genuine recompile (model_load="fresh"),
+        # since the removal released the shared entry.
+        assert r2.json()["model_id"] == mid
         assert r2.json()["model_load"] == "fresh"
 
 

--- a/tests/unit/test_model_cache.py
+++ b/tests/unit/test_model_cache.py
@@ -1,0 +1,114 @@
+"""Unit tests for the cross-session content-addressed ModelCache.
+
+Two ``ModelStore`` instances sharing one ``ModelCache`` model the real
+topology: distinct sessions, one process-wide cache. Identical OBML must
+compile once and be shared under a stable content-derived id, with
+refcounted lifecycle so a model survives until its last referencing session
+drops it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from orionbelt.service import model_store as model_store_mod
+from orionbelt.service.model_cache import ModelCache
+from orionbelt.service.model_store import ModelStore
+from tests.conftest import SAMPLE_MODEL_YAML
+
+
+@pytest.fixture
+def cache() -> ModelCache:
+    return ModelCache()
+
+
+def test_identical_yaml_shares_one_compiled_model(cache: ModelCache) -> None:
+    a = ModelStore(shared_cache=cache)
+    b = ModelStore(shared_cache=cache)
+
+    ra = a.load_model(SAMPLE_MODEL_YAML)
+    rb = b.load_model(SAMPLE_MODEL_YAML)
+
+    # Same content -> same stable content-derived id across sessions.
+    assert ra.model_id == rb.model_id
+    # And the very same compiled SemanticModel object is shared, not copied.
+    assert a.get_model(ra.model_id) is b.get_model(rb.model_id)
+
+    stats = cache.stats()
+    assert stats["entries"] == 1
+    assert stats["refs"] == 2
+
+
+def test_second_session_does_not_recompile(
+    cache: ModelCache, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls = {"n": 0}
+    real_export = model_store_mod.export_obsl
+
+    def counting_export(model: object, model_id: str) -> object:
+        calls["n"] += 1
+        return real_export(model, model_id)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(model_store_mod, "export_obsl", counting_export)
+
+    a = ModelStore(shared_cache=cache)
+    b = ModelStore(shared_cache=cache)
+    a.load_model(SAMPLE_MODEL_YAML)
+    b.load_model(SAMPLE_MODEL_YAML)
+
+    # export_obsl runs at compile time only; the 2nd (cross-session) load
+    # adopts the shared entry without recompiling.
+    assert calls["n"] == 1
+
+
+def test_dedup_false_stays_private_and_distinct(cache: ModelCache) -> None:
+    a = ModelStore(shared_cache=cache)
+    r1 = a.load_model(SAMPLE_MODEL_YAML, dedup=False)
+    r2 = a.load_model(SAMPLE_MODEL_YAML, dedup=False)
+    assert r1.model_id != r2.model_id
+    # Private (non-dedup-eligible) loads never touch the shared cache.
+    assert cache.stats()["entries"] == 0
+
+
+def test_release_keeps_model_alive_until_last_reference(cache: ModelCache) -> None:
+    a = ModelStore(shared_cache=cache)
+    b = ModelStore(shared_cache=cache)
+    ra = a.load_model(SAMPLE_MODEL_YAML)
+    b.load_model(SAMPLE_MODEL_YAML)
+    assert cache.stats()["refs"] == 2
+
+    # One session drops it — the model survives for the other.
+    a.close()
+    assert cache.stats()["entries"] == 1
+    assert cache.stats()["refs"] == 1
+    assert len(b.get_model(ra.model_id).data_objects) == 2
+
+    # Last reference gone -> evicted.
+    b.close()
+    assert cache.stats()["entries"] == 0
+
+
+def test_remove_model_releases_shared_reference(cache: ModelCache) -> None:
+    a = ModelStore(shared_cache=cache)
+    r = a.load_model(SAMPLE_MODEL_YAML)
+    assert cache.stats()["refs"] == 1
+    a.remove_model(r.model_id)
+    assert cache.stats()["entries"] == 0
+
+
+def test_same_store_reload_reuses_without_extra_reference(cache: ModelCache) -> None:
+    a = ModelStore(shared_cache=cache)
+    r1 = a.load_model(SAMPLE_MODEL_YAML)
+    r2 = a.load_model(SAMPLE_MODEL_YAML)  # local dedup hit
+    assert r1.model_id == r2.model_id
+    assert r2.model_load == "reused"
+    # Reloading into the same store must not double-count the reference.
+    assert cache.stats()["refs"] == 1
+
+
+def test_no_shared_cache_keeps_models_private(cache: ModelCache) -> None:
+    # A bare store (no shared cache) behaves as before: nothing is shared.
+    a = ModelStore()
+    r = a.load_model(SAMPLE_MODEL_YAML)
+    assert len(r.model_id) == 16
+    assert cache.stats()["entries"] == 0

--- a/tests/unit/test_model_store.py
+++ b/tests/unit/test_model_store.py
@@ -23,7 +23,7 @@ def store() -> ModelStore:
 class TestLoadModel:
     def test_load_valid_model(self, store: ModelStore) -> None:
         result = store.load_model(SAMPLE_MODEL_YAML)
-        assert len(result.model_id) == 8
+        assert len(result.model_id) == 16
         assert result.data_objects == 2
         assert result.dimensions == 1
         assert result.measures == 3

--- a/tests/unit/test_session_manager.py
+++ b/tests/unit/test_session_manager.py
@@ -386,3 +386,44 @@ class TestSessionIsolation:
 
         assert len(store_a.list_models()) == 1
         assert len(store_b.list_models()) == 0
+
+
+class TestCrossSessionModelCache:
+    def test_identical_model_shared_across_sessions(self, session_manager: SessionManager) -> None:
+        """Two sessions loading identical OBML share one compiled model + id."""
+        from tests.conftest import SAMPLE_MODEL_YAML
+
+        info_a = session_manager.create_session()
+        info_b = session_manager.create_session()
+        store_a = session_manager.get_store(info_a.session_id)
+        store_b = session_manager.get_store(info_b.session_id)
+
+        ra = store_a.load_model(SAMPLE_MODEL_YAML)
+        rb = store_b.load_model(SAMPLE_MODEL_YAML)
+
+        assert ra.model_id == rb.model_id
+        assert store_a.get_model(ra.model_id) is store_b.get_model(rb.model_id)
+
+    def test_closing_one_session_keeps_shared_model_for_the_other(
+        self, session_manager: SessionManager
+    ) -> None:
+        from tests.conftest import SAMPLE_MODEL_YAML
+
+        info_a = session_manager.create_session()
+        info_b = session_manager.create_session()
+        store_a = session_manager.get_store(info_a.session_id)
+        store_b = session_manager.get_store(info_b.session_id)
+        ra = store_a.load_model(SAMPLE_MODEL_YAML)
+        store_b.load_model(SAMPLE_MODEL_YAML)
+
+        cache = session_manager._model_cache
+        assert cache.stats()["refs"] == 2
+
+        # Closing one session releases its reference; the model survives.
+        session_manager.close_session(info_a.session_id)
+        assert cache.stats()["entries"] == 1
+        assert store_b.get_model(ra.model_id) is not None
+
+        # Closing the last session evicts the shared model.
+        session_manager.close_session(info_b.session_id)
+        assert cache.stats()["entries"] == 0


### PR DESCRIPTION
## Why

Every session owns its own `ModelStore`, so identical OBML loaded into different sessions was **compiled independently** and stamped with a random `model_id`. In admin-curated (`MODEL_FILES`) mode this recompiled the same curated model (parse + resolve + join graph + health + OBSL-graph export) into **every** new user session. As raised in the MCP audit thread: a model cache that is not across sessions makes no sense. The distinct ids were also what made shortcut resolution see "multiple models loaded across sessions".

## What

A process-wide, refcounted `ModelCache` (`service/model_cache.py`) owned by `SessionManager` and shared by every per-session store. Plain dedup-eligible YAML now compiles **once** and is shared across sessions under a **stable content-derived `model_id`**. Because `model_id` is part of the result-cache key (`cache/key.py`), the result cache is now shareable across sessions for the same model + SQL, which falls out for free.

### Scope guard
Loads that fold in state the YAML bytes do not capture (`raw_dict`, `extends`, `inherits`, `dedup=False`) stay **private** to their store with a random id, preserving the `dedup=False` "distinct model" contract. `SemanticModel` is immutable after resolve, so sharing one instance is safe.

### Lifecycle
Entries are refcounted across sessions and evicted the instant the last referencing store releases them (evict-at-refcount-0, no warm LRU). `ModelStore.close()` releases a store's shared references and is called on every session-drop path (expiry-on-access, `close_session`, purge), so refcounts cannot leak. Protected sessions never drop, so a curated model stays compiled once for the process lifetime.

## Changes
- `service/model_cache.py`: new `ModelCache` + `CompiledModel` (`acquire` / `insert_or_acquire` / `release`).
- `service/model_store.py`: `shared_cache` param, content-derived ids (widened to 16 hex), shared load path, `close()`.
- `service/session_manager.py`: own one `ModelCache`, inject into stores, `close()` before every session drop.
- `api/app.py`: reword the startup cache-wipe rationale (ids are stable now; wipe kept conservatively).

## Behavior change (intentional)
`model_id` is now stable and content-derived for shared models: identical YAML always yields the same id, including after a remove + reload. Two oneshot dedup tests that encoded the old "ephemeral id" contract were updated accordingly.

## Interaction with #185
This is complementary to #185 (scope single-model shortcut resolution to protected sessions). With shared ids, sessions referencing one curated model report the same `model_id`, which independently reduces the "multiple models" ambiguity. This PR does not touch `shortcuts.py`, so it will not conflict with #185; #185's protected-scoping remains valid belt-and-suspenders.

## Tests
- New `tests/unit/test_model_cache.py`: sharing, no-recompile on second session, refcount lifecycle (survive-until-last-reference), `remove_model` release, same-store reload does not double-count.
- New cross-session case in `tests/unit/test_session_manager.py` (shared id + eviction on close).
- Full suite: 2612 passed; ruff + mypy clean.

## Out of scope (follow-ups)
- Warm-retention LRU for released models.
- Removing the startup cache wipe to enable cross-restart reuse (needs a compiler-version stamp first).
- Version bump + CHANGELOG (deliberate separate step).