### PR TITLE
Deploy docs only on push to main, not on release

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -8,8 +8,6 @@ on:
       - 'mkdocs.yml'
       - 'pyproject.toml'  # In case version changes
       - '.github/workflows/deploy-docs.yml'
-  release:
-    types: [published]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Problem
The `Deploy Documentation` workflow triggers on both `push: main` and `release: published`. On a release, both runs fire near-simultaneously and race to `git push` into `ralforion.github.io`. The loser fails with `! [rejected] main -> main (fetch first)`, so **every release shows a red X** on this workflow even though the docs deploy fine (the winning run pushes them).

Seen on v2.21.0: run on `push/main` succeeded and pushed `Update OrionBelt docs to 2.21.0`; the `release/v2.21.0` twin failed on the rejected push.

## Fix
Drop the `release` trigger. A release always follows a version-bump merge to `main` that touches `pyproject.toml` and `mkdocs.yml` (both in the `push` path filter), so `push: main` already deploys the docs. The `release` trigger was redundant and the sole cause of the race. `push: main` + `workflow_dispatch` remain as the single deploy path.