### PR TITLE
Restore full-width Query Results header row

### DIFF
--- a/src/orionbelt/ui/app.py
+++ b/src/orionbelt/ui/app.py
@@ -1558,33 +1558,33 @@ def create_blocks(
                 )
 
             with gr.Tab("Query Results", id=1, visible=query_exec_enabled) as results_tab:
-                # Execution info + actions on one row: a short info box, then the
-                # buttons inline to its right (all scale=0 so they pack left).
-                with gr.Row(elem_classes=["result-actions"]):
+                # Execution info + actions on one row: the info box fills the
+                # width (default scale), with the actions pinned to its right in
+                # a nested row (the ``result-actions`` CSS keeps them together).
+                with gr.Row():
                     result_info = gr.Textbox(
                         label="Execution Info",
                         interactive=False,
                         lines=1,
                         max_lines=1,
-                        scale=0,
-                        min_width=440,
                     )
-                    copy_data_btn = gr.Button(
-                        "Copy Data",
-                        visible=False,
-                        variant="secondary",
-                        size="sm",
-                        scale=0,
-                        min_width=110,
-                    )
-                    tsv_download = gr.DownloadButton(
-                        "↓ TSV",
-                        visible=False,
-                        variant="secondary",
-                        size="sm",
-                        scale=0,
-                        min_width=90,
-                    )
+                    # Keep both actions side by side on one row (the short
+                    # "↓ TSV" label lets them fit together even on phones).
+                    with gr.Row(elem_classes=["result-actions"]):
+                        copy_data_btn = gr.Button(
+                            "Copy Data",
+                            visible=False,
+                            variant="secondary",
+                            size="sm",
+                            min_width=100,
+                        )
+                        tsv_download = gr.DownloadButton(
+                            "↓ TSV",
+                            visible=False,
+                            variant="secondary",
+                            size="sm",
+                            min_width=80,
+                        )
                 # "Clear filters" button — full-width row so the filter list never
                 # wraps onto multiple lines.
                 with gr.Row():


### PR DESCRIPTION
## Problem
On the **Query Results** tab, the Execution Info box and the Copy Data / TSV actions pack to the left with a large empty gap on the right, instead of the info box filling the row with the actions pinned to the right.

This regressed in #170: the header was flattened into a single `result-actions` row with `result_info` at `scale=0, min_width=440` and both buttons `scale=0`, so everything is fixed-width and left-clumped.

## Fix
Revert this one block to the pre-#170 layout: an outer `Row` with `result_info` at default scale (fills the width) and the two actions in a nested `result-actions` row (what that CSS class was written for). Behavior is unchanged; only the layout is restored.

## Verification
`tests/unit/test_ui_build.py` + UI tests pass (17); ruff clean.