### PR TITLE
Query Results header cleanup: one-row Execution Info + drop redundant table heading

### DIFF
--- a/src/orionbelt/ui/app.py
+++ b/src/orionbelt/ui/app.py
@@ -1632,7 +1632,11 @@ def create_blocks(
                     show_label=False,
                 )
                 result_table = gr.Dataframe(
+                    # Label kept for accessibility but hidden — the tab is
+                    # already named "Query Results", so a visible heading above
+                    # the table is redundant.
                     label="Query Results",
+                    show_label=False,
                     interactive=False,
                     wrap=True,
                     max_height=800,

--- a/src/orionbelt/ui/app.py
+++ b/src/orionbelt/ui/app.py
@@ -491,6 +491,22 @@ _CSS = """\
   min-width: 0 !important;
 }
 
+/* Execution Info: lay the textbox's own label inline (left of the value)
+   instead of stacking it above, so label + value sit on one line. */
+#exec-info label {
+  display: flex !important;
+  flex-direction: row !important;
+  align-items: center !important;
+  gap: 10px !important;
+}
+#exec-info label > span[data-testid="block-info"] {
+  flex: 0 0 auto !important;
+  white-space: nowrap !important;
+  margin: 0 !important;
+  font-weight: 600 !important;
+}
+#exec-info .input-container { flex: 1 1 auto !important; }
+
 /* ── Responsive: narrower viewports ── */
 @media (max-width: 900px) {
   .settings-row { flex-wrap: wrap !important; }
@@ -1558,33 +1574,36 @@ def create_blocks(
                 )
 
             with gr.Tab("Query Results", id=1, visible=query_exec_enabled) as results_tab:
-                # Execution info + actions on one row: the info box fills the
-                # width (default scale), with the actions pinned to its right in
-                # a nested row (the ``result-actions`` CSS keeps them together).
+                # Execution info + actions all on one row: the info box grows to
+                # fill (scale=1) with the two actions pinned to its right
+                # (scale=0). The ``#exec-info`` CSS additionally lays the
+                # textbox's own "Execution Info" label inline to the left of the
+                # value instead of stacking it above.
                 with gr.Row():
                     result_info = gr.Textbox(
                         label="Execution Info",
                         interactive=False,
                         lines=1,
                         max_lines=1,
+                        scale=1,
+                        elem_id="exec-info",
                     )
-                    # Keep both actions side by side on one row (the short
-                    # "↓ TSV" label lets them fit together even on phones).
-                    with gr.Row(elem_classes=["result-actions"]):
-                        copy_data_btn = gr.Button(
-                            "Copy Data",
-                            visible=False,
-                            variant="secondary",
-                            size="sm",
-                            min_width=100,
-                        )
-                        tsv_download = gr.DownloadButton(
-                            "↓ TSV",
-                            visible=False,
-                            variant="secondary",
-                            size="sm",
-                            min_width=80,
-                        )
+                    copy_data_btn = gr.Button(
+                        "Copy Data",
+                        visible=False,
+                        variant="secondary",
+                        size="sm",
+                        scale=0,
+                        min_width=110,
+                    )
+                    tsv_download = gr.DownloadButton(
+                        "↓ TSV",
+                        visible=False,
+                        variant="secondary",
+                        size="sm",
+                        scale=0,
+                        min_width=90,
+                    )
                 # "Clear filters" button — full-width row so the filter list never
                 # wraps onto multiple lines.
                 with gr.Row():


### PR DESCRIPTION
Two small Query Results tab cleanups, verified end-to-end in the running app via Playwright.

## 1. Execution Info label + value + actions on one row
After #189 the header stacked onto three lines. Now a single flat row: `result_info` grows (`scale=1`), `Copy Data` / `↓ TSV` pinned right (`scale=0`). CSS on `#exec-info` lays the textbox's own label inline (`display:flex` on the label; `.input-container` flexes to fill), so it reads:

`Execution Info  [ 100 rows in 38 ms (cache) · TZ · Locale ]  [Copy Data] [↓ TSV]`

`result_info` stays a Textbox holding just the info string (empty when no results), so the `bool(info)` show/hide logic for the actions is untouched.

## 2. Drop the redundant "Query Results" heading above the table
The `gr.Dataframe` carried a visible `label="Query Results"`, duplicating the tab name right above the table. Hidden via `show_label=False` (label attribute kept for accessibility).

## Verification
Ran the real UI (`orionbelt-ui`) against a local API on the demo DuckDB model, executed a query via Playwright, and screenshotted the Query Results tab: Execution Info on one row, actions on the same row, and no heading above the table. `test_ui_build.py` passes; ruff clean.