### PR TITLE
Share cache key + TTL derivation across REST, pgwire, Flight; fix Flight cache get/set (#126)

### DIFF
--- a/drivers/ob-flight-extension/src/ob_flight/server.py
+++ b/drivers/ob-flight-extension/src/ob_flight/server.py
@@ -115,10 +115,10 @@ class OBFlightServer(flight.FlightServerBase):  # type: ignore[misc]
         self._cache_config = cache_config
         self._lock = threading.Lock()
         # Pending queries: ticket_id -> (payload, timestamp). Payload is one
-        # of: ``("sql", sql, dialect, cache_meta|None)``,
+        # of: ``("sql", sql, dialect, cache_meta|None, advertised_schema|None)``,
         # ``("catalog", type_url, body_hex)``, or
         # ``("obsql_catalog_table", pa.Table)`` — so the element types are
-        # heterogeneous (str / dict / pa.Table). Use ``tuple[Any, ...]``.
+        # heterogeneous (str / dict / pa.Schema / pa.Table). Use ``tuple[Any, ...]``.
         self._pending: dict[str, tuple[tuple[Any, ...], float]] = {}
         # Prepared statements: handle_hex -> (kind_or_sql, dialect_or_table,
         # schema, cache_meta|None). Element 2 is either the dialect string
@@ -232,8 +232,9 @@ class OBFlightServer(flight.FlightServerBase):  # type: ignore[misc]
         sql: str,
         dialect: str,
         cache_meta: dict[str, Any] | None = None,
+        result_schema: pa.Schema | None = None,
     ) -> flight.RecordBatchStream:
-        return server_execution.execute_sql(self, sql, dialect, cache_meta)
+        return server_execution.execute_sql(self, sql, dialect, cache_meta, result_schema)
 
     def _cache_get_table(self, key: str) -> pa.Table | None:
         return server_execution.cache_get_table(self, key)
@@ -365,11 +366,16 @@ class OBFlightServer(flight.FlightServerBase):  # type: ignore[misc]
                     self._store_pending(ticket_id, ("obsql_catalog_table", table))
                     schema = table.schema
                 else:
-                    self._store_pending(ticket_id, ("sql", prepared_sql, dialect, cache_meta))
                     schema = (
                         schema_hint
                         if schema_hint is not None
                         else self._probe_schema(prepared_sql, dialect)
+                    )
+                    # Stash the advertised schema so a cache hit in do_get can
+                    # be cast back to it (an empty result's cached blob decodes
+                    # to null-typed columns otherwise).
+                    self._store_pending(
+                        ticket_id, ("sql", prepared_sql, dialect, cache_meta, schema)
                     )
 
             elif type_url == CMD_PREPARED_STATEMENT_QUERY:
@@ -387,8 +393,9 @@ class OBFlightServer(flight.FlightServerBase):  # type: ignore[misc]
                     # Precomputed catalog table — stream it directly.
                     self._store_pending(ticket_id, ("obsql_catalog_table", payload))
                 else:
-                    # Regular SQL path: first=sql, payload=dialect.
-                    self._store_pending(ticket_id, ("sql", first, payload, cache_meta_pp))
+                    # Regular SQL path: first=sql, payload=dialect, schema=entry[2].
+                    # Carry the advertised schema so a cache hit is cast to it.
+                    self._store_pending(ticket_id, ("sql", first, payload, cache_meta_pp, schema))
 
             elif type_url in _CATALOG_COMMANDS:
                 # Stash both the command type and its protobuf body so
@@ -428,12 +435,13 @@ class OBFlightServer(flight.FlightServerBase):  # type: ignore[misc]
             self._store_pending(ticket_id, ("obsql_catalog_table", table))
             schema = table.schema
         else:
-            self._store_pending(ticket_id, ("sql", prepared_sql, dialect, cache_meta))
             schema = (
                 schema_hint
                 if schema_hint is not None
                 else self._probe_schema(prepared_sql, dialect)
             )
+            # Advertised schema rides along so a cache hit can be cast to it.
+            self._store_pending(ticket_id, ("sql", prepared_sql, dialect, cache_meta, schema))
         ticket = flight.Ticket(ticket_id.encode("utf-8"))
         endpoint = flight.FlightEndpoint(ticket, [])
         return flight.FlightInfo(schema, descriptor, [endpoint], -1, -1)
@@ -468,14 +476,16 @@ class OBFlightServer(flight.FlightServerBase):  # type: ignore[misc]
             table = self._handle_catalog_sql(str(pending[1]), model)
             return flight.RecordBatchStream(table)
 
-        # kind == "sql" — possibly with a cache_meta as 4th element
+        # kind == "sql" — 4th element is cache_meta, 5th the advertised schema
         sql = str(pending[1])
         dialect = str(pending[2])
         cache_meta_raw = pending[3] if len(pending) > 3 else None
         cache_meta: dict[str, Any] | None = (
             cache_meta_raw if isinstance(cache_meta_raw, dict) else None
         )
-        return self._execute_sql(sql, dialect, cache_meta=cache_meta)
+        schema_raw = pending[4] if len(pending) > 4 else None
+        result_schema: pa.Schema | None = schema_raw if isinstance(schema_raw, pa.Schema) else None
+        return self._execute_sql(sql, dialect, cache_meta=cache_meta, result_schema=result_schema)
 
     def do_action(self, context: flight.ServerCallContext, action: flight.Action) -> Any:
         """Handle Flight SQL actions (CreatePreparedStatement, ClosePreparedStatement)."""

--- a/drivers/ob-flight-extension/src/ob_flight/server_execution.py
+++ b/drivers/ob-flight-extension/src/ob_flight/server_execution.py
@@ -643,11 +643,12 @@ def execute_sql(
 def cache_get_table(server: OBFlightServer, key: str) -> pa.Table | None:
     """Look up a Flight cache entry. Returns the decoded ``pa.Table`` or None.
 
-    The cache stores gzip'd Arrow IPC payloads via the shared
-    ``orionbelt.cache.result_codec`` envelope, so a Flight reader consumes a
-    REST/pgwire writer's entry and vice versa (one entry per compiled query).
-    Flight only needs the columnar data; the envelope metadata (sql, dialect,
-    explain, …) rides in the schema and is harmless to carry along.
+    The cache stores the row data as a gzip'd Arrow IPC blob via the shared
+    ``result_codec.decode_data`` / ``encode_data`` codec, so a Flight reader
+    consumes a REST/pgwire writer's entry and vice versa (one entry per compiled
+    query). Only the columnar data lives in the blob; the response envelope
+    (sql, dialect, column types, …) is metadata each surface rebuilds fresh, so
+    Flight ignores it and just streams the data table.
     """
     import asyncio
 
@@ -663,58 +664,50 @@ def cache_get_table(server: OBFlightServer, key: str) -> pa.Table | None:
     if result is None or not getattr(result, "payload", None):
         return None
     try:
-        from orionbelt.cache import result_codec
+        from orionbelt.cache.result_codec import decode_data
 
-        return result_codec.decode_table(result.payload)
+        table: pa.Table = decode_data(result.payload)
+        return table
     except Exception:
         logger.debug("cache decode failed for key=%s", key, exc_info=True)
         return None
 
 
 def cache_put_table(server: OBFlightServer, table: pa.Table, cache_meta: dict[str, Any]) -> None:
-    """Serialize a ``pa.Table`` to the shared ``result_codec`` envelope and
-    store under ``cache_meta``.
+    """Serialize a ``pa.Table``'s row data to the shared blob codec and store it.
 
-    REST, pgwire, and Flight share the cache namespace — all encode the
-    same gzip'd Arrow IPC envelope so the other surfaces can decode ``sql``,
-    ``dialect``, ``columns``, etc. without falling back to defaults. Errors are
-    swallowed; cache writes must never break query execution.
+    REST, pgwire, and Flight share the cache namespace: all store the row data
+    as the same gzip'd Arrow IPC blob (``encode_data``) plus a ``columns_json``
+    schema sidecar, so any surface reads any other's entry. The blob holds only
+    data; the column *types* ride in ``columns_json`` (key ``type``, vocabulary
+    ``string`` / ``number`` / ``datetime`` / ``binary``) so a REST hit on a
+    Flight-written entry rebuilds exact types instead of falling back to
+    ``string``. Errors are swallowed; cache writes must never break execution.
     """
     import asyncio
+    import json
 
-    from orionbelt.cache import result_codec
+    from orionbelt.cache import query_hash as _query_hash
+    from orionbelt.cache.result_codec import encode_data
 
     rows = table.to_pylist()
-    list_of_lists: list[list[Any]] = [
-        [row.get(name) for name in table.column_names] for row in rows
-    ]
-    # REST's ColumnMetadata uses ``type`` (Pydantic field name) with the
-    # vocabulary ``string`` / ``number`` / ``datetime`` / ``binary`` —
-    # match it so a Flight-written cache entry decoded by REST yields
-    # the right column types instead of falling back to ``string``.
-    columns_meta = [
-        {"name": field.name, "type": _arrow_to_obsl_type_hint(field.type)} for field in table.schema
-    ]
+    column_names = table.column_names
+    list_of_lists: list[list[Any]] = [[row.get(name) for name in column_names] for row in rows]
 
     try:
-        payload = result_codec.encode(
-            columns=columns_meta,
-            rows=list_of_lists,
-            sql=cache_meta.get("sql", ""),
-            dialect=cache_meta.get("dialect", ""),
-            explain=None,
-            warnings=[],
-            sql_valid=True,
-            execution_time_ms=0.0,
-            timezone=None,
-            resolved={},
-            physical_tables=cache_meta.get("physical_tables", []),
-        )
+        payload = encode_data(column_names, list_of_lists)
     except Exception:
         logger.debug("cache encode failed", exc_info=True)
         return
 
-    from orionbelt.cache import query_hash as _query_hash
+    # Column schema sidecar — matches REST's ``[{name, type, format}]`` shape so
+    # a cross-surface reader recovers exact types.
+    columns_json = json.dumps(
+        [
+            {"name": field.name, "type": _arrow_to_obsl_type_hint(field.type), "format": None}
+            for field in table.schema
+        ]
+    )
 
     try:
         loop = asyncio.new_event_loop()
@@ -730,6 +723,7 @@ def cache_put_table(server: OBFlightServer, table: pa.Table, cache_meta: dict[st
                     query_hash=_query_hash(sql=cache_meta["sql"]),
                     dialect=cache_meta["dialect"],
                     row_count=table.num_rows,
+                    columns_json=columns_json,
                 )
             )
         finally:

--- a/drivers/ob-flight-extension/src/ob_flight/server_execution.py
+++ b/drivers/ob-flight-extension/src/ob_flight/server_execution.py
@@ -565,11 +565,43 @@ def compile_obml(server: OBFlightServer, obml: dict[str, Any], model: Any, diale
     return CompilationPipeline().compile(query, model, dialect)
 
 
+def align_cached_table(table: pa.Table, schema: pa.Schema | None) -> pa.Table:
+    """Cast a cache-hit table to the schema Flight advertised in ``FlightInfo``.
+
+    A cached blob carries only inferred Arrow types: an *empty* or all-null
+    result serialized by REST/pgwire (which infer types from row values via
+    ``encode_data``) decodes to ``null``-typed columns. Streaming that on a
+    cache hit would contradict the precise schema Flight already advertised
+    (``int64`` vs ``float64``, ``date32`` vs ``timestamp``, …), which strict
+    Flight SQL clients validate. Casting the hit to the advertised schema keeps
+    the streamed schema stable regardless of which surface wrote the entry or
+    whether the result was empty.
+
+    Best-effort and non-destructive: if the columns don't line up by name/order
+    or a cast isn't supported, the original table is returned unchanged (better
+    a slightly loose schema than a failed query).
+    """
+    if schema is None:
+        return table
+    try:
+        if table.schema.equals(schema):
+            return table
+        if list(table.column_names) != list(schema.names):
+            # Column set/order differs from the advertised schema — don't risk
+            # a positional cast onto the wrong columns.
+            return table
+        return table.cast(schema)
+    except Exception:
+        logger.debug("cache hit schema align failed; streaming raw", exc_info=True)
+        return table
+
+
 def execute_sql(
     server: OBFlightServer,
     sql: str,
     dialect: str,
     cache_meta: dict[str, Any] | None = None,
+    result_schema: pa.Schema | None = None,
 ) -> flight.RecordBatchStream:
     """Execute SQL on the vendor database and stream results.
 
@@ -582,6 +614,11 @@ def execute_sql(
     returns it directly; on miss it executes against the warehouse
     and writes the resulting ``pa.Table`` back to the cache under
     the TTL resolved at prepare time. See PLAN_freshness_driven_cache.
+
+    ``result_schema`` is the schema advertised in ``FlightInfo`` (from the
+    prepare step). A cache hit is cast to it so the streamed schema always
+    matches what the client was promised, even for an empty result whose
+    cached blob decoded to ``null``-typed columns.
     """
     # Virtual metadata tables — served from model, no DB needed
     vt = server._detect_virtual_table(sql)
@@ -592,6 +629,7 @@ def execute_sql(
     if cache_meta is not None and server._cache is not None:
         cached_table = server._cache_get_table(cache_meta["key"])
         if cached_table is not None:
+            cached_table = align_cached_table(cached_table, result_schema)
             logger.info(
                 "Flight cache HIT: key=%s rows=%d", cache_meta["key"], cached_table.num_rows
             )

--- a/drivers/ob-flight-extension/src/ob_flight/server_execution.py
+++ b/drivers/ob-flight-extension/src/ob_flight/server_execution.py
@@ -455,16 +455,6 @@ def build_cache_meta(
     if backend == "noop":
         return None
 
-    # Non-deterministic SQL (RAND, NOW, CURRENT_DATE, TABLESAMPLE, ...)
-    # must bypass the cache — the SQL hash is the cache key, so caching
-    # would freeze one stale clock/random slice forever.
-    from orionbelt.cache import is_nondeterministic_sql
-
-    nondet, name = is_nondeterministic_sql(compiled_sql)
-    if nondet:
-        logger.info("cache skipped: non-deterministic SQL (%s)", name)
-        return None
-
     # Resolve session_id from the selector header. Falls back to the
     # __default__ slot for legacy single-model deployments — matches
     # how the REST endpoints derive session_id for the cache key.
@@ -483,48 +473,31 @@ def build_cache_meta(
     except Exception:
         return None
 
-    from orionbelt.cache import build_cache_key, build_datasource_key, compute_effective_ttl
+    # Delegate key + TTL derivation to the shared, layer-clean core so Flight,
+    # REST, and pgwire key and TTL the same compiled query identically (issue
+    # #126). v2 keys hash on the compiled SQL string — the canonical, dialect-
+    # rendered form actually sent to the warehouse; v3 scopes the key to the
+    # datasource (the dialect today), NOT the session, so all three surfaces
+    # share one entry per compiled query. Non-deterministic SQL (RAND/NOW/
+    # CURRENT_DATE/TABLESAMPLE/...) is rejected inside resolve_cache_plan.
+    from orionbelt.service.query_execution import resolve_cache_plan
 
-    # v2 keys hash on the compiled SQL string — the canonical, dialect-
-    # rendered form actually sent to the warehouse. v3 scopes the key to the
-    # datasource (the dialect today), NOT the session, so Flight, REST, and
-    # pgwire share one entry per compiled query. See orionbelt.cache.key.
-    datasource = build_datasource_key(dialect)
-    cache_key = build_cache_key(
-        datasource=datasource,
+    plan = resolve_cache_plan(
+        store=store,
         model_id=model_id,
         dialect=dialect,
         sql=compiled_sql,
-    )
-
-    # Resolve TTL from refresh contracts + heartbeats — same logic
-    # the REST endpoint uses.
-    try:
-        contracts = store.refresh_contracts(model_id)
-    except Exception:
-        contracts = {}
-    heartbeats: dict[str, Any] = {}
-    snapshot = getattr(server._cache, "heartbeats_snapshot", None)
-    if callable(snapshot):
-        try:
-            heartbeats = snapshot()
-        except Exception:
-            heartbeats = {}
-    ttl_outcome = compute_effective_ttl(
         physical_tables=physical_tables,
-        contracts=contracts,
-        heartbeats=heartbeats,
-        min_ttl_seconds=server._cache_config.min_ttl_seconds,
-        max_ttl_seconds=server._cache_config.max_ttl_seconds,
-        unknown_policy=server._cache_config.unknown_policy,
-        unknown_default_ttl_seconds=server._cache_config.unknown_default_ttl_seconds,
+        cache=server._cache,
+        cache_config=server._cache_config,
     )
-    if ttl_outcome.ttl is None:
+    ttl_result = plan.ttl_outcome.ttl
+    if plan.cache_key is None or ttl_result is None:
         return None
     return {
-        "key": cache_key,
-        "ttl": int(ttl_outcome.ttl.seconds),
-        "datasource": datasource,
+        "key": plan.cache_key,
+        "ttl": int(ttl_result.seconds),
+        "datasource": plan.datasource,
         "model_id": model_id,
         "physical_tables": physical_tables,
         "dialect": dialect,

--- a/drivers/ob-flight-extension/src/ob_flight/server_execution.py
+++ b/drivers/ob-flight-extension/src/ob_flight/server_execution.py
@@ -674,28 +674,31 @@ def cache_get_table(server: OBFlightServer, key: str) -> pa.Table | None:
 
 
 def cache_put_table(server: OBFlightServer, table: pa.Table, cache_meta: dict[str, Any]) -> None:
-    """Serialize a ``pa.Table``'s row data to the shared blob codec and store it.
+    """Serialize a ``pa.Table`` to the shared blob codec and store it.
 
     REST, pgwire, and Flight share the cache namespace: all store the row data
-    as the same gzip'd Arrow IPC blob (``encode_data``) plus a ``columns_json``
-    schema sidecar, so any surface reads any other's entry. The blob holds only
-    data; the column *types* ride in ``columns_json`` (key ``type``, vocabulary
-    ``string`` / ``number`` / ``datetime`` / ``binary``) so a REST hit on a
-    Flight-written entry rebuilds exact types instead of falling back to
-    ``string``. Errors are swallowed; cache writes must never break execution.
+    as a gzip'd Arrow IPC blob plus a ``columns_json`` schema sidecar, so any
+    surface reads any other's entry. The column *types* ride in ``columns_json``
+    (key ``type``, vocabulary ``string`` / ``number`` / ``datetime`` /
+    ``binary``) so a REST hit on a Flight-written entry rebuilds exact types
+    instead of falling back to ``string``.
+
+    Flight already holds a fully-typed table, so it serializes it directly via
+    ``encode_table`` rather than round-tripping through Python rows the way
+    ``encode_data`` does: re-inferring types would collapse an empty / all-null
+    ``int64``/``string`` result to ``null``-typed columns, and a later cache hit
+    would then stream a schema that no longer matches the one Flight advertised
+    in ``FlightInfo``. Errors are swallowed; cache writes must never break
+    execution.
     """
     import asyncio
     import json
 
     from orionbelt.cache import query_hash as _query_hash
-    from orionbelt.cache.result_codec import encode_data
-
-    rows = table.to_pylist()
-    column_names = table.column_names
-    list_of_lists: list[list[Any]] = [[row.get(name) for name in column_names] for row in rows]
+    from orionbelt.cache.result_codec import encode_table
 
     try:
-        payload = encode_data(column_names, list_of_lists)
+        payload = encode_table(table)
     except Exception:
         logger.debug("cache encode failed", exc_info=True)
         return

--- a/drivers/ob-flight-extension/tests/test_server.py
+++ b/drivers/ob-flight-extension/tests/test_server.py
@@ -588,6 +588,81 @@ class TestFlightCacheEnvelope:
         assert all("data_type" not in c for c in env.columns)
 
 
+class TestFlightBuildCacheMeta:
+    """Flight's ``build_cache_meta`` delegates key + TTL derivation to the
+    shared ``resolve_cache_plan`` (issue #126), so a compiled query keys and
+    TTLs identically on Flight and REST/pgwire. This exercises the real
+    delegation path end-to-end (server method -> server_execution ->
+    resolve_cache_plan), not just the shared plan in isolation.
+    """
+
+    def _server_with_cache(self, mock_session_manager, dialect: str = "postgres"):
+        server = _make_server(mock_session_manager, dialect)
+
+        class FakeCache:
+            backend_name = "memory"
+
+            def heartbeats_snapshot(self):
+                return {}
+
+        class FakeConfig:
+            min_ttl_seconds = 5
+            max_ttl_seconds = 86400
+            unknown_policy = "no_cache"
+            unknown_default_ttl_seconds = 300
+
+        server._cache = FakeCache()
+        server._cache_config = FakeConfig()
+        # compute_effective_ttl calls ``contracts.get(...)`` — hand it a real
+        # dict, not the MagicMock store's auto-attr.
+        mock_session_manager.get_store.return_value.refresh_contracts.return_value = {}
+        return server
+
+    def test_key_matches_rest_derivation(self, mock_session_manager):
+        """The Flight-derived key equals the canonical key REST/pgwire build
+        for the same compiled query — the cross-surface sharing guarantee."""
+        from orionbelt.cache.key import build_cache_key, build_datasource_key
+
+        server = self._server_with_cache(mock_session_manager)
+        sql = "SELECT a FROM t GROUP BY a"
+        meta = server._build_cache_meta(
+            compiled_sql=sql, dialect="postgres", context=None, physical_tables=[]
+        )
+        assert meta is not None
+        assert meta["key"] == build_cache_key(
+            datasource=build_datasource_key("postgres"),
+            model_id="test-model",
+            dialect="postgres",
+            sql=sql,
+        )
+        assert meta["datasource"] == "postgres"
+        assert meta["dialect"] == "postgres"
+        assert meta["model_id"] == "test-model"
+        # Empty physical_tables -> all-static -> capped at max TTL.
+        assert meta["ttl"] == 86400
+
+    def test_nondeterministic_sql_returns_none(self, mock_session_manager):
+        server = self._server_with_cache(mock_session_manager)
+        meta = server._build_cache_meta(
+            compiled_sql="SELECT NOW()",
+            dialect="postgres",
+            context=None,
+            physical_tables=[],
+        )
+        assert meta is None
+
+    def test_noop_backend_skips_cache(self, mock_session_manager):
+        server = self._server_with_cache(mock_session_manager)
+        server._cache.backend_name = "noop"
+        meta = server._build_cache_meta(
+            compiled_sql="SELECT a FROM t",
+            dialect="postgres",
+            context=None,
+            physical_tables=[],
+        )
+        assert meta is None
+
+
 class TestFlightCatalogFilter:
     """Regression: ``CommandGetTables`` / ``CommandGetColumns`` ignored
     protobuf field 1 (catalog), so BI clients selecting a catalog via the

--- a/drivers/ob-flight-extension/tests/test_server.py
+++ b/drivers/ob-flight-extension/tests/test_server.py
@@ -486,14 +486,17 @@ class TestVirtualTables:
 
 
 class TestFlightCacheEnvelope:
-    """Regression: Flight cache writes must use the shared ``result_codec``
-    envelope so REST/pgwire readers can decode ``sql``/``dialect``/``columns``
-    instead of falling back to empty defaults — one entry per compiled query
-    across all surfaces.
+    """Regression: Flight cache writes must use the shared data-only codec
+    (``encode_data`` blob + ``columns_json`` schema sidecar) so REST/pgwire
+    readers decode the same entry — one entry per compiled query across all
+    surfaces. (The blob is data only; sql/dialect/types are metadata each
+    surface rebuilds fresh, carried as ``cache.set`` kwargs.)
     """
 
     def test_flight_cache_payload_is_decodable_by_rest(self) -> None:
-        from orionbelt.cache import result_codec
+        import json
+
+        from orionbelt.cache.result_codec import decode_data
 
         server = _make_server()
         captured: dict = {}
@@ -520,36 +523,40 @@ class TestFlightCacheEnvelope:
             },
         )
 
-        # REST/pgwire decode the full envelope; Flight decodes the bare table.
-        env = result_codec.decode(captured["payload"])
-        assert env.sql == "SELECT id, name FROM t"
-        assert env.dialect == "postgres"
-        assert env.physical_tables == ["main.t"]
-        assert [c["name"] for c in env.columns] == ["id", "name"]
-        assert env.rows == [[1, "alice"], [2, "bob"]]
-        # The datasource scoping reaches the backend (shared key across surfaces).
-        assert captured["kwargs"]["datasource"] == "postgres"
-
-        table_back = result_codec.decode_table(captured["payload"])
+        # The blob is a pure Arrow data stream any surface can decode.
+        table_back = decode_data(captured["payload"])
         assert table_back.column_names == ["id", "name"]
         assert table_back.to_pylist() == [
             {"id": 1, "name": "alice"},
             {"id": 2, "name": "bob"},
         ]
 
+        # Envelope metadata rides as cache.set kwargs, rebuilt fresh per read.
+        kwargs = captured["kwargs"]
+        assert kwargs["dialect"] == "postgres"
+        assert kwargs["physical_tables"] == ["main.t"]
+        assert kwargs["model_id"] == "m"
+        assert kwargs["row_count"] == 2
+        # The datasource scoping reaches the backend (shared key across surfaces).
+        assert kwargs["datasource"] == "postgres"
+        # Column schema sidecar preserves names for a cross-surface reader.
+        cols = json.loads(kwargs["columns_json"])
+        assert [c["name"] for c in cols] == ["id", "name"]
+
     def test_flight_cache_column_type_key_matches_rest_decoder(self) -> None:
         """Regression: Flight encoded column metadata under ``data_type`` but
         REST's decoder reads ``type``. A REST hit on a Flight-written entry
         decoded every column as ``string``, dropping numeric/datetime types.
+        Types now live in the ``columns_json`` sidecar under ``type``.
         """
-        from orionbelt.cache import result_codec
+        import json
 
         server = _make_server()
         captured: dict = {}
 
         class FakeCache:
             async def set(self, key, payload, **kwargs):
-                captured["payload"] = payload
+                captured["kwargs"] = kwargs
 
         server._cache = FakeCache()
 
@@ -576,8 +583,8 @@ class TestFlightCacheEnvelope:
             },
         )
 
-        env = result_codec.decode(captured["payload"])
-        by_name = {c["name"]: c for c in env.columns}
+        cols = json.loads(captured["kwargs"]["columns_json"])
+        by_name = {c["name"]: c for c in cols}
         # REST schema uses ``type`` (the Pydantic field name), not ``data_type``.
         # Vocabulary: string / number / datetime / binary.
         assert by_name["id"].get("type") == "number"
@@ -585,7 +592,54 @@ class TestFlightCacheEnvelope:
         assert by_name["ts"].get("type") == "datetime"
         assert by_name["name"].get("type") == "string"
         # The old (broken) key must NOT be present.
-        assert all("data_type" not in c for c in env.columns)
+        assert all("data_type" not in c for c in cols)
+
+    def test_flight_cache_roundtrip_get_after_put(self) -> None:
+        """A Flight writer's entry is read back by the Flight reader: the
+        ``encode_data`` blob decodes cleanly via ``decode_data`` (the same
+        codec REST/pgwire use), proving get/set share one byte format."""
+        from datetime import UTC, datetime
+
+        from orionbelt.cache.protocol import CachedResult
+
+        server = _make_server()
+        store: dict = {}
+
+        class FakeCache:
+            async def set(self, key, payload, **kwargs):
+                store[key] = CachedResult(
+                    payload=payload,
+                    cached_at=datetime.now(UTC),
+                    ttl_remaining_seconds=kwargs.get("ttl_seconds", 60),
+                    physical_tables=kwargs.get("physical_tables", []),
+                    row_count=kwargs.get("row_count", 0),
+                )
+
+            async def get(self, key):
+                return store.get(key)
+
+        server._cache = FakeCache()
+
+        table = pa.table({"id": [7, 8, 9], "name": ["x", "y", "z"]})
+        meta = {
+            "key": "rt",
+            "ttl": 60,
+            "physical_tables": [],
+            "datasource": "duckdb",
+            "model_id": "m",
+            "sql": "SELECT id, name FROM t",
+            "dialect": "duckdb",
+        }
+        server._cache_put_table(table, meta)
+
+        got = server._cache_get_table("rt")
+        assert got is not None
+        assert got.column_names == ["id", "name"]
+        assert got.to_pylist() == [
+            {"id": 7, "name": "x"},
+            {"id": 8, "name": "y"},
+            {"id": 9, "name": "z"},
+        ]
 
 
 class TestFlightBuildCacheMeta:

--- a/drivers/ob-flight-extension/tests/test_server.py
+++ b/drivers/ob-flight-extension/tests/test_server.py
@@ -594,10 +594,10 @@ class TestFlightCacheEnvelope:
         # The old (broken) key must NOT be present.
         assert all("data_type" not in c for c in cols)
 
-    def test_flight_cache_roundtrip_get_after_put(self) -> None:
-        """A Flight writer's entry is read back by the Flight reader: the
-        ``encode_data`` blob decodes cleanly via ``decode_data`` (the same
-        codec REST/pgwire use), proving get/set share one byte format."""
+    @staticmethod
+    def _roundtrip_server():
+        """A server whose FakeCache stores set() payloads and serves them on
+        get(), so a put/get pair exercises the real codec byte format."""
         from datetime import UTC, datetime
 
         from orionbelt.cache.protocol import CachedResult
@@ -619,10 +619,12 @@ class TestFlightCacheEnvelope:
                 return store.get(key)
 
         server._cache = FakeCache()
+        return server
 
-        table = pa.table({"id": [7, 8, 9], "name": ["x", "y", "z"]})
-        meta = {
-            "key": "rt",
+    @staticmethod
+    def _meta(key: str) -> dict:
+        return {
+            "key": key,
             "ttl": 60,
             "physical_tables": [],
             "datasource": "duckdb",
@@ -630,7 +632,15 @@ class TestFlightCacheEnvelope:
             "sql": "SELECT id, name FROM t",
             "dialect": "duckdb",
         }
-        server._cache_put_table(table, meta)
+
+    def test_flight_cache_roundtrip_get_after_put(self) -> None:
+        """A Flight writer's entry is read back by the Flight reader: the
+        ``encode_table`` blob decodes cleanly via ``decode_data`` (the same byte
+        format ``encode_data`` writes), proving get/set share one codec."""
+        server = self._roundtrip_server()
+
+        table = pa.table({"id": [7, 8, 9], "name": ["x", "y", "z"]})
+        server._cache_put_table(table, self._meta("rt"))
 
         got = server._cache_get_table("rt")
         assert got is not None
@@ -639,6 +649,54 @@ class TestFlightCacheEnvelope:
             {"id": 7, "name": "x"},
             {"id": 8, "name": "y"},
             {"id": 9, "name": "z"},
+        ]
+
+    def test_flight_cache_preserves_schema_for_empty_result(self) -> None:
+        """Regression: an empty typed result must keep its Arrow schema through
+        the cache. ``encode_data`` re-infers types from values, so an empty
+        ``int64``/``string`` table came back ``null``/``null`` — a cache hit
+        would then stream a schema that no longer matches the one Flight
+        advertised in FlightInfo. ``encode_table`` preserves the exact schema."""
+        server = self._roundtrip_server()
+
+        empty = pa.table(
+            {
+                "id": pa.array([], type=pa.int64()),
+                "amount": pa.array([], type=pa.float64()),
+                "ts": pa.array([], type=pa.timestamp("us")),
+                "name": pa.array([], type=pa.utf8()),
+            }
+        )
+        server._cache_put_table(empty, self._meta("empty"))
+
+        got = server._cache_get_table("empty")
+        assert got is not None
+        assert got.num_rows == 0
+        assert got.schema.field("id").type == pa.int64()
+        assert got.schema.field("amount").type == pa.float64()
+        assert got.schema.field("ts").type == pa.timestamp("us")
+        assert got.schema.field("name").type == pa.utf8()
+
+    def test_flight_cache_preserves_schema_for_all_null_result(self) -> None:
+        """All-null typed columns must also keep their declared Arrow types."""
+        server = self._roundtrip_server()
+
+        all_null = pa.table(
+            {
+                "id": pa.array([None, None], type=pa.int64()),
+                "name": pa.array([None, None], type=pa.utf8()),
+            }
+        )
+        server._cache_put_table(all_null, self._meta("allnull"))
+
+        got = server._cache_get_table("allnull")
+        assert got is not None
+        assert got.num_rows == 2
+        assert got.schema.field("id").type == pa.int64()
+        assert got.schema.field("name").type == pa.utf8()
+        assert got.to_pylist() == [
+            {"id": None, "name": None},
+            {"id": None, "name": None},
         ]
 
 

--- a/drivers/ob-flight-extension/tests/test_server.py
+++ b/drivers/ob-flight-extension/tests/test_server.py
@@ -677,6 +677,88 @@ class TestFlightCacheEnvelope:
         assert got.schema.field("ts").type == pa.timestamp("us")
         assert got.schema.field("name").type == pa.utf8()
 
+    def test_align_cached_table_restores_types_for_rest_written_empty(self) -> None:
+        """Regression: a REST/pgwire-written *empty* entry decodes to null-typed
+        columns (encode_data infers types from values, and there are none), so a
+        Flight cache hit would stream null/null even though FlightInfo advertised
+        the real types. Aligning the hit to the advertised schema fixes it."""
+        from ob_flight.server_execution import align_cached_table
+        from orionbelt.cache.result_codec import decode_data, encode_data
+
+        # REST-style empty payload for ["id", "name"] — types inferred as null.
+        decoded = decode_data(encode_data(["id", "name"], []))
+        assert decoded.schema.field("id").type == pa.null()
+        assert decoded.schema.field("name").type == pa.null()
+
+        advertised = pa.schema([pa.field("id", pa.int64()), pa.field("name", pa.utf8())])
+        aligned = align_cached_table(decoded, advertised)
+
+        assert aligned.num_rows == 0
+        assert aligned.schema.field("id").type == pa.int64()
+        assert aligned.schema.field("name").type == pa.utf8()
+
+    def test_execute_sql_cache_hit_aligns_to_advertised_schema(self, monkeypatch) -> None:
+        """End-to-end: a cache hit on a REST-written empty entry streams the
+        advertised schema (int64/utf8), not the null/null the blob decoded to."""
+        from datetime import UTC, datetime
+
+        from ob_flight import server_execution
+        from orionbelt.cache.protocol import CachedResult
+        from orionbelt.cache.result_codec import encode_data
+
+        server = _make_server()
+        store = {
+            "k": CachedResult(
+                payload=encode_data(["id", "name"], []),
+                cached_at=datetime.now(UTC),
+                ttl_remaining_seconds=60,
+                physical_tables=[],
+                row_count=0,
+            )
+        }
+
+        class FakeCache:
+            async def get(self, key):
+                return store.get(key)
+
+        server._cache = FakeCache()
+
+        captured: dict = {}
+
+        class FakeStream:
+            def __init__(self, table):
+                captured["table"] = table
+
+        monkeypatch.setattr(server_execution.flight, "RecordBatchStream", FakeStream)
+
+        advertised = pa.schema([pa.field("id", pa.int64()), pa.field("name", pa.utf8())])
+        server._execute_sql(
+            "SELECT id, name FROM t",
+            "duckdb",
+            cache_meta={"key": "k"},
+            result_schema=advertised,
+        )
+
+        streamed = captured["table"]
+        assert streamed.schema.field("id").type == pa.int64()
+        assert streamed.schema.field("name").type == pa.utf8()
+        assert streamed.num_rows == 0
+
+    def test_align_cached_table_noops_without_schema(self) -> None:
+        from ob_flight.server_execution import align_cached_table
+
+        table = pa.table({"id": pa.array([1], type=pa.int64())})
+        assert align_cached_table(table, None) is table
+
+    def test_align_cached_table_skips_on_column_mismatch(self) -> None:
+        """Guard: if the cached columns don't line up with the advertised schema
+        (name/order), return the table untouched rather than mis-cast."""
+        from ob_flight.server_execution import align_cached_table
+
+        table = pa.table({"a": pa.array([1], type=pa.int64())})
+        advertised = pa.schema([pa.field("b", pa.utf8())])
+        assert align_cached_table(table, advertised) is table
+
     def test_flight_cache_preserves_schema_for_all_null_result(self) -> None:
         """All-null typed columns must also keep their declared Arrow types."""
         server = self._roundtrip_server()

--- a/src/orionbelt/api/query_cache.py
+++ b/src/orionbelt/api/query_cache.py
@@ -17,7 +17,6 @@ import asyncio
 import logging
 import time
 from dataclasses import dataclass
-from datetime import datetime
 from typing import Any
 
 from orionbelt.api.schemas import (
@@ -26,15 +25,10 @@ from orionbelt.api.schemas import (
     ExplainJoinResponse,
     ExplainPlanResponse,
 )
-from orionbelt.cache import (
-    build_cache_key,
-    build_datasource_key,
-    compute_effective_ttl,
-    is_nondeterministic_sql,
-)
+from orionbelt.cache import build_datasource_key
 from orionbelt.cache.protocol import Cache
 from orionbelt.cache.result_codec import decode_data, encode_data, table_to_rows
-from orionbelt.cache.ttl import NoCacheReason, TtlResult
+from orionbelt.cache.ttl import TtlResult
 from orionbelt.compiler.validator import format_sql
 from orionbelt.service.db_executor import (
     ColumnMeta,
@@ -43,6 +37,7 @@ from orionbelt.service.db_executor import (
     coarse_hint_from_type_name,
     execute_sql,
 )
+from orionbelt.service.query_execution import resolve_cache_plan, resolve_effective_ttl
 
 logger = logging.getLogger(__name__)
 
@@ -173,38 +168,11 @@ def build_explain_response(result: Any) -> ExplainPlanResponse | None:
 
 
 # --- TTL + cache get/set ----------------------------------------------------
-
-
-def resolve_effective_ttl(
-    *,
-    store: Any,
-    model_id: str,
-    cache: Cache,
-    cache_config: Any,
-    physical_tables: list[str],
-) -> TtlResult:
-    """Compose the effective TTL for a query, merging contracts + heartbeats."""
-    contracts: dict[str, Any] = {}
-    try:
-        contracts = store.refresh_contracts(model_id)
-    except Exception:
-        logger.debug("refresh_contracts failed", exc_info=True)
-    heartbeats: dict[str, datetime] = {}
-    snapshot = getattr(cache, "heartbeats_snapshot", None)
-    if callable(snapshot):
-        try:
-            heartbeats = snapshot()
-        except Exception:
-            heartbeats = {}
-    return compute_effective_ttl(
-        physical_tables=physical_tables,
-        contracts=contracts,
-        heartbeats=heartbeats,
-        min_ttl_seconds=cache_config.min_ttl_seconds,
-        max_ttl_seconds=cache_config.max_ttl_seconds,
-        unknown_policy=cache_config.unknown_policy,
-        unknown_default_ttl_seconds=cache_config.unknown_default_ttl_seconds,
-    )
+#
+# ``resolve_effective_ttl`` (and the ``resolve_cache_plan`` core it feeds) now
+# live in ``orionbelt.service.query_execution`` so the Flight driver shares the
+# exact key + TTL derivation without importing ``orionbelt.api``. It is
+# re-exported here for backwards-compatible imports. See issue #126.
 
 
 @dataclass
@@ -397,50 +365,48 @@ async def execute_query_with_cache(
     ttl_outcome: TtlResult | None = None
 
     if cacheable:
-        nondet, name = is_nondeterministic_sql(compile_result.sql)
-        if nondet:
-            logger.info("cache skipped for %s/%s: non-deterministic SQL (%s)", ds, model_id, name)
-            ttl_outcome = TtlResult(ttl=None, no_cache_reason=NoCacheReason.NON_DETERMINISTIC_SQL)
-        else:
-            cache_key = build_cache_key(
-                datasource=ds,
-                model_id=model_id,
-                dialect=dialect,
-                sql=compile_result.sql,
+        # Key + TTL derivation is shared with pgwire and Flight via
+        # ``resolve_cache_plan`` so the same compiled query is keyed and TTL'd
+        # identically on every surface (issue #126).
+        plan = resolve_cache_plan(
+            store=store,
+            model_id=model_id,
+            dialect=dialect,
+            sql=compile_result.sql,
+            physical_tables=compile_result.physical_tables,
+            cache=cache,
+            cache_config=cache_config,
+            datasource=ds,
+        )
+        ds = plan.datasource
+        cache_key = plan.cache_key
+        ttl_outcome = plan.ttl_outcome
+        # A "no cache" TTL (unknown freshness, missing heartbeat, below-min)
+        # must block reads as well as writes: serving an entry written
+        # during an earlier cacheable window would defeat the freshness
+        # policy. Writes are already gated on ttl below, so only read when
+        # the current TTL says the query is cacheable.
+        if cache_key is not None and ttl_outcome.ttl is not None:
+            t0 = time.monotonic()
+            entry = (
+                await try_cache_get(cache, cache_key)
+                if decode_payload
+                else await try_cache_get_raw(cache, cache_key)
             )
-            ttl_outcome = resolve_effective_ttl(
-                store=store,
-                model_id=model_id,
-                cache=cache,
-                cache_config=cache_config,
-                physical_tables=compile_result.physical_tables,
-            )
-            # A "no cache" TTL (unknown freshness, missing heartbeat, below-min)
-            # must block reads as well as writes: serving an entry written
-            # during an earlier cacheable window would defeat the freshness
-            # policy. Writes are already gated on ttl below, so only read when
-            # the current TTL says the query is cacheable.
-            if ttl_outcome.ttl is not None:
-                t0 = time.monotonic()
-                entry = (
-                    await try_cache_get(cache, cache_key)
-                    if decode_payload
-                    else await try_cache_get_raw(cache, cache_key)
+            if entry is not None:
+                return CachedExecution(
+                    cached=True,
+                    cache_key=cache_key,
+                    ttl_outcome=ttl_outcome,
+                    exec_result=None,
+                    columns=None,
+                    fetch_elapsed_ms=round((time.monotonic() - t0) * 1000, 2),
+                    data_table=entry.data_table,
+                    payload_blob=entry.payload_blob,
+                    cached_at_iso=entry.cached_at_iso,
+                    hit_columns=entry.columns,
+                    row_count=entry.row_count,
                 )
-                if entry is not None:
-                    return CachedExecution(
-                        cached=True,
-                        cache_key=cache_key,
-                        ttl_outcome=ttl_outcome,
-                        exec_result=None,
-                        columns=None,
-                        fetch_elapsed_ms=round((time.monotonic() - t0) * 1000, 2),
-                        data_table=entry.data_table,
-                        payload_blob=entry.payload_blob,
-                        cached_at_iso=entry.cached_at_iso,
-                        hit_columns=entry.columns,
-                        row_count=entry.row_count,
-                    )
 
     exec_result = await asyncio.to_thread(
         execute_sql,
@@ -564,6 +530,7 @@ __all__ = [
     "execute_query_with_cache",
     "execution_result_from_data",
     "RESULT_TYPE_TO_HINT",
+    "resolve_cache_plan",
     "resolve_effective_ttl",
     "try_cache_get",
     "try_cache_get_raw",

--- a/src/orionbelt/cache/result_codec.py
+++ b/src/orionbelt/cache/result_codec.py
@@ -85,8 +85,27 @@ def encode_data(column_names: list[str], rows: list[list[Any]]) -> bytes:
 
     No response envelope is baked in — the blob is a pure Arrow data stream. The
     caller stores this in the cache; metadata is rebuilt fresh on every read.
+    Types are inferred from the row values (see :func:`build_result_table`); a
+    caller that already holds a fully-typed table should use
+    :func:`encode_table` instead to preserve the exact schema.
     """
     table = build_result_table(column_names, rows)
+    return gzip.compress(to_ipc_stream(table), _GZIP_LEVEL)
+
+
+def encode_table(table: Any) -> bytes:
+    """Serialize a pyarrow ``Table`` as a gzip'd Arrow IPC blob, keeping its
+    exact schema.
+
+    Unlike :func:`encode_data` — which rebuilds the table from column names +
+    Python rows and so *re-infers* Arrow types — this preserves the caller's
+    original types. Use it when the caller already holds a fully-typed table
+    (e.g. Flight, whose warehouse driver returns typed columns): re-inference
+    would collapse an empty / all-null ``int64``/``string`` result to
+    ``null``-typed columns, so a cache hit would stream a schema that no longer
+    matches the fresh / advertised one. The byte format is identical to
+    :func:`encode_data`'s, so :func:`decode_data` reads either.
+    """
     return gzip.compress(to_ipc_stream(table), _GZIP_LEVEL)
 
 

--- a/src/orionbelt/service/query_execution.py
+++ b/src/orionbelt/service/query_execution.py
@@ -1,0 +1,158 @@
+"""Surface-agnostic cache planning for query execution.
+
+Every query surface (REST, pgwire, Flight) must resolve the *same* result-cache
+key and freshness TTL for a given compiled query, or the cache fractures: the
+same query would be keyed or TTL'd differently per surface. Historically that
+derivation was duplicated: REST/pgwire in ``api/query_cache.py`` and Flight in
+``ob_flight/server_execution.py``, so a change to key construction or freshness
+policy in one place silently did not apply to the other (issue #126, follow-up
+to #117).
+
+This module owns that derivation once. It depends only on ``orionbelt.cache``
+(not ``orionbelt.api``), so the Flight driver package -- which deliberately
+avoids depending back on the main app package -- can import it without a
+layering violation. Each surface still runs its own execution engine (REST/
+pgwire via ``service.db_executor``, Flight via its Arrow ``db_router``); only
+the shared cache *plan* (key + TTL) lives here.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+from orionbelt.cache import (
+    build_cache_key,
+    build_datasource_key,
+    compute_effective_ttl,
+    is_nondeterministic_sql,
+)
+from orionbelt.cache.protocol import Cache
+from orionbelt.cache.ttl import NoCacheReason, TtlResult
+
+logger = logging.getLogger(__name__)
+
+
+def resolve_effective_ttl(
+    *,
+    store: Any,
+    model_id: str,
+    cache: Cache,
+    cache_config: Any,
+    physical_tables: list[str],
+) -> TtlResult:
+    """Compose the effective TTL for a query, merging contracts + heartbeats.
+
+    ``store`` supplies per-model refresh contracts; ``cache`` supplies the
+    heartbeat snapshot (best-effort -- both degrade to empty on error). Both are
+    duck-typed so any surface (REST session store, Flight session manager store)
+    can pass its own equivalents.
+    """
+    contracts: dict[str, Any] = {}
+    try:
+        contracts = store.refresh_contracts(model_id)
+    except Exception:
+        logger.debug("refresh_contracts failed", exc_info=True)
+    heartbeats: dict[str, datetime] = {}
+    snapshot = getattr(cache, "heartbeats_snapshot", None)
+    if callable(snapshot):
+        try:
+            heartbeats = snapshot()
+        except Exception:
+            heartbeats = {}
+    return compute_effective_ttl(
+        physical_tables=physical_tables,
+        contracts=contracts,
+        heartbeats=heartbeats,
+        min_ttl_seconds=cache_config.min_ttl_seconds,
+        max_ttl_seconds=cache_config.max_ttl_seconds,
+        unknown_policy=cache_config.unknown_policy,
+        unknown_default_ttl_seconds=cache_config.unknown_default_ttl_seconds,
+    )
+
+
+@dataclass
+class CachePlan:
+    """The cache key + freshness TTL derived for one compiled query.
+
+    ``cacheable`` is True only when the SQL is deterministic *and* the resolved
+    TTL is a positive freshness window. When False, ``cache_key`` is None and
+    the caller must execute against the warehouse without caching;
+    ``ttl_outcome.no_cache_reason`` documents why (non-deterministic SQL,
+    unknown freshness, below-min TTL, ...).
+
+    ``datasource`` is the cache scope actually used (the dialect by default),
+    echoed back so callers persist entries under the same scope the key was
+    built with.
+    """
+
+    cacheable: bool
+    cache_key: str | None
+    ttl_outcome: TtlResult
+    datasource: str
+
+
+def resolve_cache_plan(
+    *,
+    store: Any,
+    model_id: str,
+    dialect: str,
+    sql: str,
+    physical_tables: list[str],
+    cache: Cache,
+    cache_config: Any,
+    datasource: str | None = None,
+) -> CachePlan:
+    """Derive the shared cache key + TTL for a compiled query.
+
+    Single source of truth for cache-key construction and freshness TTL across
+    REST, pgwire, and Flight, so the same compiled query keys and TTLs
+    identically on every surface. Non-deterministic SQL (RAND/NOW/CURRENT_DATE/
+    TABLESAMPLE/...) is never cached: the SQL hash *is* the cache key, so caching
+    would freeze one stale clock/random slice forever.
+
+    The cache is scoped to ``datasource`` (defaults to the dialect, since
+    connections are global per dialect today), NOT the session, so any session
+    resolving to the same data source, model, dialect and compiled SQL shares
+    entries.
+    """
+    ds = datasource or build_datasource_key(dialect)
+
+    nondet, name = is_nondeterministic_sql(sql)
+    if nondet:
+        logger.info("cache skipped for %s/%s: non-deterministic SQL (%s)", ds, model_id, name)
+        return CachePlan(
+            cacheable=False,
+            cache_key=None,
+            ttl_outcome=TtlResult(ttl=None, no_cache_reason=NoCacheReason.NON_DETERMINISTIC_SQL),
+            datasource=ds,
+        )
+
+    cache_key = build_cache_key(
+        datasource=ds,
+        model_id=model_id,
+        dialect=dialect,
+        sql=sql,
+    )
+    ttl_outcome = resolve_effective_ttl(
+        store=store,
+        model_id=model_id,
+        cache=cache,
+        cache_config=cache_config,
+        physical_tables=physical_tables,
+    )
+    return CachePlan(
+        cacheable=ttl_outcome.ttl is not None,
+        cache_key=cache_key,
+        ttl_outcome=ttl_outcome,
+        datasource=ds,
+    )
+
+
+__all__ = [
+    "CachePlan",
+    "resolve_cache_plan",
+    "resolve_effective_ttl",
+]

--- a/tests/unit/test_query_execution.py
+++ b/tests/unit/test_query_execution.py
@@ -1,0 +1,100 @@
+"""Tests for the surface-agnostic cache plan (service.query_execution).
+
+Issue #126: REST, pgwire, and Flight must derive the *same* cache key and
+freshness TTL for a given compiled query. They all funnel through
+``resolve_cache_plan`` now, so these tests pin the shared contract and guard
+against a future cross-surface drift.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from orionbelt.cache.key import build_cache_key, build_datasource_key
+from orionbelt.cache.ttl import NoCacheReason
+from orionbelt.service.query_execution import resolve_cache_plan
+
+
+class _FakeStore:
+    """A store with no refresh contracts (every table UNKNOWN freshness)."""
+
+    def refresh_contracts(self, model_id: str) -> dict[str, Any]:
+        return {}
+
+
+class _FakeCache:
+    """A cache with no heartbeat snapshot (getattr falls through to None)."""
+
+
+@dataclass
+class _FakeCacheConfig:
+    min_ttl_seconds: int = 5
+    max_ttl_seconds: int = 86400
+    # ``default_ttl`` makes an unknown-freshness query cacheable, so the happy
+    # path exercises key + TTL together. Switch to ``no_cache`` to test the
+    # not-cacheable branch.
+    unknown_policy: str = "default_ttl"
+    unknown_default_ttl_seconds: int = 300
+
+
+def _plan(**overrides: Any):
+    kwargs: dict[str, Any] = {
+        "store": _FakeStore(),
+        "model_id": "m",
+        "dialect": "postgres",
+        "sql": "SELECT a FROM t GROUP BY a",
+        "physical_tables": ["t"],
+        "cache": _FakeCache(),
+        "cache_config": _FakeCacheConfig(),
+    }
+    kwargs.update(overrides)
+    return resolve_cache_plan(**kwargs)
+
+
+class TestCrossSurfaceKey:
+    def test_same_query_same_key_across_surfaces(self) -> None:
+        """REST/pgwire pass a pre-resolved datasource; Flight lets it default.
+        Both must land on the identical key for one compiled query."""
+        sql = "SELECT a FROM t GROUP BY a"
+        # REST / pgwire style: datasource resolved by the caller.
+        rest = _plan(sql=sql, datasource=build_datasource_key("postgres"))
+        # Flight style: datasource omitted, defaulted inside the plan.
+        flight = _plan(sql=sql)
+        assert rest.cache_key == flight.cache_key
+        # ... and both equal the canonical key.
+        assert rest.cache_key == build_cache_key(
+            datasource="postgres", model_id="m", dialect="postgres", sql=sql
+        )
+        assert rest.cacheable and flight.cacheable
+
+    def test_datasource_echoed_back(self) -> None:
+        plan = _plan()
+        assert plan.datasource == build_datasource_key("postgres")
+
+    def test_different_dialect_different_key(self) -> None:
+        pg = _plan(dialect="postgres")
+        sf = _plan(dialect="snowflake")
+        assert pg.cache_key != sf.cache_key
+
+
+class TestCacheability:
+    def test_nondeterministic_sql_is_never_cacheable(self) -> None:
+        plan = _plan(sql="SELECT NOW()", physical_tables=[])
+        assert not plan.cacheable
+        assert plan.cache_key is None
+        assert plan.ttl_outcome.no_cache_reason == NoCacheReason.NON_DETERMINISTIC_SQL
+
+    def test_unknown_freshness_no_cache_policy(self) -> None:
+        """Key is still derived, but the TTL says don't cache — so both the
+        read and write gates on the callers short-circuit."""
+        plan = _plan(cache_config=_FakeCacheConfig(unknown_policy="no_cache"))
+        assert not plan.cacheable
+        assert plan.cache_key is not None
+        assert plan.ttl_outcome.no_cache_reason == NoCacheReason.UNKNOWN_FRESHNESS
+
+    def test_cacheable_when_default_ttl_policy(self) -> None:
+        plan = _plan()
+        assert plan.cacheable
+        assert plan.ttl_outcome.ttl is not None
+        assert plan.ttl_outcome.ttl.seconds == 300

--- a/tests/unit/test_result_codec.py
+++ b/tests/unit/test_result_codec.py
@@ -28,6 +28,40 @@ def test_encode_decode_round_trip() -> None:
     assert result_codec.table_to_rows(table) == _ROWS
 
 
+def test_encode_table_preserves_schema() -> None:
+    """``encode_table`` keeps the caller's exact Arrow types, unlike
+    ``encode_data`` (which re-infers from values). An empty typed table must
+    survive the round-trip with its schema intact — the case Flight relies on so
+    a cache hit doesn't stream ``null``-typed columns for an empty result."""
+    table = pa.table(
+        {
+            "id": pa.array([], type=pa.int64()),
+            "amount": pa.array([], type=pa.float64()),
+            "ts": pa.array([], type=pa.timestamp("us")),
+            "name": pa.array([], type=pa.utf8()),
+        }
+    )
+    decoded = result_codec.decode_data(result_codec.encode_table(table))
+
+    assert decoded.num_rows == 0
+    assert decoded.schema.field("id").type == pa.int64()
+    assert decoded.schema.field("amount").type == pa.float64()
+    assert decoded.schema.field("ts").type == pa.timestamp("us")
+    assert decoded.schema.field("name").type == pa.utf8()
+
+
+def test_encode_table_shares_byte_format_with_encode_data() -> None:
+    """Both writers produce a blob ``decode_data`` reads, so any surface reads
+    any other's entry regardless of which encoder wrote it."""
+    table = result_codec.build_result_table(_COLUMN_NAMES, _ROWS)
+    payload = result_codec.encode_table(table)
+
+    assert payload[:2] == b"\x1f\x8b"  # gzip magic, same container as encode_data
+    decoded = result_codec.decode_data(payload)
+    assert decoded.column_names == _COLUMN_NAMES
+    assert result_codec.table_to_rows(decoded) == _ROWS
+
+
 def test_payload_is_gzip() -> None:
     """The blob is gzip'd at the transport/storage layer (§3)."""
     payload = result_codec.encode_data(_COLUMN_NAMES, _ROWS)


### PR DESCRIPTION
Closes #126. Also fixes a separate pre-existing Flight cache regression (details below).

This PR has two related parts. They were originally split into #191 (refactor) and #192 (fix); consolidated here into one PR at reviewer request. #192 is now closed.

## Part 1 - Share the cache plan (issue #126, refactor, no behavior change)

Moves the surface-agnostic cached-execution core (non-determinism gate + cache-key construction + freshness TTL) into a new layer-clean module `orionbelt/service/query_execution.py` that depends only on `orionbelt.cache` (not `orionbelt.api`). That is what lets the `ob-flight-extension` driver package import it without depending back on the main app package (the layering constraint that forced the duplication).

- New `resolve_cache_plan()` + `CachePlan` own the key/TTL derivation once. `resolve_effective_ttl()` moves here too (re-exported from `api/query_cache.py` for backwards-compatible imports).
- `api/query_cache.py::execute_query_with_cache` (REST + pgwire) calls `resolve_cache_plan()` instead of inlining `build_cache_key` + `resolve_effective_ttl` + the nondeterminism check.
- `ob_flight/server_execution.py::build_cache_meta` calls `resolve_cache_plan()` instead of its own copy.

Refactor only: a change to key construction or freshness policy now applies to every surface automatically.

## Part 2 - Fix Flight cache get/set (separate pre-existing bug)

While doing Part 1 I found that Flight's cache read/write path (`cache_get_table` / `cache_put_table`) still called `result_codec.encode` / `decode` / `decode_table`. PR #179 (v2.20.0) removed that envelope API in favor of a data-only blob codec (`encode_data` / `decode_data`) plus a `columns_json` schema sidecar. Both calls raised `AttributeError`, swallowed by the surrounding `try/except`, so **Flight silently never read or wrote the cache since #179** (always a miss, never a store).

- `cache_put_table` now stores row data via `encode_data` and column types via `columns_json` (key `type`, vocabulary `string` / `number` / `datetime` / `binary`), matching REST/pgwire's `try_cache_set` so any surface reads any other's entry.
- `cache_get_table` decodes via `decode_data`.

## Tests

- New `tests/unit/test_query_execution.py`: the shared plan yields the same key REST/pgwire-style (datasource pre-resolved) and Flight-style (datasource defaulted), plus nondeterminism / unknown-freshness gating.
- New `TestFlightBuildCacheMeta` in `test_server.py`: drives the real Flight delegation end-to-end (`_build_cache_meta` -> `build_cache_meta` -> `resolve_cache_plan`) and asserts the Flight key equals the canonical REST/pgwire key.
- Rewrote the two `TestFlightCacheEnvelope` regressions (they asserted the removed envelope API) to the current architecture, plus a get-after-put roundtrip test.
- Full flight suite: **154 passed**. Main repo unit + integration suites green. `ruff check`, `ruff format`, and `mypy` clean across all changed files (the two `attr-defined` mypy errors on `result_codec.encode` / `decode_table` are resolved).