### PR TITLE
Fix Flight cache get/set to use the data-only result_codec (encode_data/decode_data)

### DIFF
--- a/drivers/ob-flight-extension/src/ob_flight/server_execution.py
+++ b/drivers/ob-flight-extension/src/ob_flight/server_execution.py
@@ -670,11 +670,12 @@ def execute_sql(
 def cache_get_table(server: OBFlightServer, key: str) -> pa.Table | None:
     """Look up a Flight cache entry. Returns the decoded ``pa.Table`` or None.
 
-    The cache stores gzip'd Arrow IPC payloads via the shared
-    ``orionbelt.cache.result_codec`` envelope, so a Flight reader consumes a
-    REST/pgwire writer's entry and vice versa (one entry per compiled query).
-    Flight only needs the columnar data; the envelope metadata (sql, dialect,
-    explain, …) rides in the schema and is harmless to carry along.
+    The cache stores the row data as a gzip'd Arrow IPC blob via the shared
+    ``result_codec.decode_data`` / ``encode_data`` codec, so a Flight reader
+    consumes a REST/pgwire writer's entry and vice versa (one entry per compiled
+    query). Only the columnar data lives in the blob; the response envelope
+    (sql, dialect, column types, …) is metadata each surface rebuilds fresh, so
+    Flight ignores it and just streams the data table.
     """
     import asyncio
 
@@ -690,58 +691,50 @@ def cache_get_table(server: OBFlightServer, key: str) -> pa.Table | None:
     if result is None or not getattr(result, "payload", None):
         return None
     try:
-        from orionbelt.cache import result_codec
+        from orionbelt.cache.result_codec import decode_data
 
-        return result_codec.decode_table(result.payload)
+        table: pa.Table = decode_data(result.payload)
+        return table
     except Exception:
         logger.debug("cache decode failed for key=%s", key, exc_info=True)
         return None
 
 
 def cache_put_table(server: OBFlightServer, table: pa.Table, cache_meta: dict[str, Any]) -> None:
-    """Serialize a ``pa.Table`` to the shared ``result_codec`` envelope and
-    store under ``cache_meta``.
+    """Serialize a ``pa.Table``'s row data to the shared blob codec and store it.
 
-    REST, pgwire, and Flight share the cache namespace — all encode the
-    same gzip'd Arrow IPC envelope so the other surfaces can decode ``sql``,
-    ``dialect``, ``columns``, etc. without falling back to defaults. Errors are
-    swallowed; cache writes must never break query execution.
+    REST, pgwire, and Flight share the cache namespace: all store the row data
+    as the same gzip'd Arrow IPC blob (``encode_data``) plus a ``columns_json``
+    schema sidecar, so any surface reads any other's entry. The blob holds only
+    data; the column *types* ride in ``columns_json`` (key ``type``, vocabulary
+    ``string`` / ``number`` / ``datetime`` / ``binary``) so a REST hit on a
+    Flight-written entry rebuilds exact types instead of falling back to
+    ``string``. Errors are swallowed; cache writes must never break execution.
     """
     import asyncio
+    import json
 
-    from orionbelt.cache import result_codec
+    from orionbelt.cache import query_hash as _query_hash
+    from orionbelt.cache.result_codec import encode_data
 
     rows = table.to_pylist()
-    list_of_lists: list[list[Any]] = [
-        [row.get(name) for name in table.column_names] for row in rows
-    ]
-    # REST's ColumnMetadata uses ``type`` (Pydantic field name) with the
-    # vocabulary ``string`` / ``number`` / ``datetime`` / ``binary`` —
-    # match it so a Flight-written cache entry decoded by REST yields
-    # the right column types instead of falling back to ``string``.
-    columns_meta = [
-        {"name": field.name, "type": _arrow_to_obsl_type_hint(field.type)} for field in table.schema
-    ]
+    column_names = table.column_names
+    list_of_lists: list[list[Any]] = [[row.get(name) for name in column_names] for row in rows]
 
     try:
-        payload = result_codec.encode(
-            columns=columns_meta,
-            rows=list_of_lists,
-            sql=cache_meta.get("sql", ""),
-            dialect=cache_meta.get("dialect", ""),
-            explain=None,
-            warnings=[],
-            sql_valid=True,
-            execution_time_ms=0.0,
-            timezone=None,
-            resolved={},
-            physical_tables=cache_meta.get("physical_tables", []),
-        )
+        payload = encode_data(column_names, list_of_lists)
     except Exception:
         logger.debug("cache encode failed", exc_info=True)
         return
 
-    from orionbelt.cache import query_hash as _query_hash
+    # Column schema sidecar — matches REST's ``[{name, type, format}]`` shape so
+    # a cross-surface reader recovers exact types.
+    columns_json = json.dumps(
+        [
+            {"name": field.name, "type": _arrow_to_obsl_type_hint(field.type), "format": None}
+            for field in table.schema
+        ]
+    )
 
     try:
         loop = asyncio.new_event_loop()
@@ -757,6 +750,7 @@ def cache_put_table(server: OBFlightServer, table: pa.Table, cache_meta: dict[st
                     query_hash=_query_hash(sql=cache_meta["sql"]),
                     dialect=cache_meta["dialect"],
                     row_count=table.num_rows,
+                    columns_json=columns_json,
                 )
             )
         finally:

--- a/drivers/ob-flight-extension/tests/test_server.py
+++ b/drivers/ob-flight-extension/tests/test_server.py
@@ -486,14 +486,17 @@ class TestVirtualTables:
 
 
 class TestFlightCacheEnvelope:
-    """Regression: Flight cache writes must use the shared ``result_codec``
-    envelope so REST/pgwire readers can decode ``sql``/``dialect``/``columns``
-    instead of falling back to empty defaults — one entry per compiled query
-    across all surfaces.
+    """Regression: Flight cache writes must use the shared data-only codec
+    (``encode_data`` blob + ``columns_json`` schema sidecar) so REST/pgwire
+    readers decode the same entry — one entry per compiled query across all
+    surfaces. (The blob is data only; sql/dialect/types are metadata each
+    surface rebuilds fresh, carried as ``cache.set`` kwargs.)
     """
 
     def test_flight_cache_payload_is_decodable_by_rest(self) -> None:
-        from orionbelt.cache import result_codec
+        import json
+
+        from orionbelt.cache.result_codec import decode_data
 
         server = _make_server()
         captured: dict = {}
@@ -520,36 +523,40 @@ class TestFlightCacheEnvelope:
             },
         )
 
-        # REST/pgwire decode the full envelope; Flight decodes the bare table.
-        env = result_codec.decode(captured["payload"])
-        assert env.sql == "SELECT id, name FROM t"
-        assert env.dialect == "postgres"
-        assert env.physical_tables == ["main.t"]
-        assert [c["name"] for c in env.columns] == ["id", "name"]
-        assert env.rows == [[1, "alice"], [2, "bob"]]
-        # The datasource scoping reaches the backend (shared key across surfaces).
-        assert captured["kwargs"]["datasource"] == "postgres"
-
-        table_back = result_codec.decode_table(captured["payload"])
+        # The blob is a pure Arrow data stream any surface can decode.
+        table_back = decode_data(captured["payload"])
         assert table_back.column_names == ["id", "name"]
         assert table_back.to_pylist() == [
             {"id": 1, "name": "alice"},
             {"id": 2, "name": "bob"},
         ]
 
+        # Envelope metadata rides as cache.set kwargs, rebuilt fresh per read.
+        kwargs = captured["kwargs"]
+        assert kwargs["dialect"] == "postgres"
+        assert kwargs["physical_tables"] == ["main.t"]
+        assert kwargs["model_id"] == "m"
+        assert kwargs["row_count"] == 2
+        # The datasource scoping reaches the backend (shared key across surfaces).
+        assert kwargs["datasource"] == "postgres"
+        # Column schema sidecar preserves names for a cross-surface reader.
+        cols = json.loads(kwargs["columns_json"])
+        assert [c["name"] for c in cols] == ["id", "name"]
+
     def test_flight_cache_column_type_key_matches_rest_decoder(self) -> None:
         """Regression: Flight encoded column metadata under ``data_type`` but
         REST's decoder reads ``type``. A REST hit on a Flight-written entry
         decoded every column as ``string``, dropping numeric/datetime types.
+        Types now live in the ``columns_json`` sidecar under ``type``.
         """
-        from orionbelt.cache import result_codec
+        import json
 
         server = _make_server()
         captured: dict = {}
 
         class FakeCache:
             async def set(self, key, payload, **kwargs):
-                captured["payload"] = payload
+                captured["kwargs"] = kwargs
 
         server._cache = FakeCache()
 
@@ -576,8 +583,8 @@ class TestFlightCacheEnvelope:
             },
         )
 
-        env = result_codec.decode(captured["payload"])
-        by_name = {c["name"]: c for c in env.columns}
+        cols = json.loads(captured["kwargs"]["columns_json"])
+        by_name = {c["name"]: c for c in cols}
         # REST schema uses ``type`` (the Pydantic field name), not ``data_type``.
         # Vocabulary: string / number / datetime / binary.
         assert by_name["id"].get("type") == "number"
@@ -585,7 +592,54 @@ class TestFlightCacheEnvelope:
         assert by_name["ts"].get("type") == "datetime"
         assert by_name["name"].get("type") == "string"
         # The old (broken) key must NOT be present.
-        assert all("data_type" not in c for c in env.columns)
+        assert all("data_type" not in c for c in cols)
+
+    def test_flight_cache_roundtrip_get_after_put(self) -> None:
+        """A Flight writer's entry is read back by the Flight reader: the
+        ``encode_data`` blob decodes cleanly via ``decode_data`` (the same
+        codec REST/pgwire use), proving get/set share one byte format."""
+        from datetime import UTC, datetime
+
+        from orionbelt.cache.protocol import CachedResult
+
+        server = _make_server()
+        store: dict = {}
+
+        class FakeCache:
+            async def set(self, key, payload, **kwargs):
+                store[key] = CachedResult(
+                    payload=payload,
+                    cached_at=datetime.now(UTC),
+                    ttl_remaining_seconds=kwargs.get("ttl_seconds", 60),
+                    physical_tables=kwargs.get("physical_tables", []),
+                    row_count=kwargs.get("row_count", 0),
+                )
+
+            async def get(self, key):
+                return store.get(key)
+
+        server._cache = FakeCache()
+
+        table = pa.table({"id": [7, 8, 9], "name": ["x", "y", "z"]})
+        meta = {
+            "key": "rt",
+            "ttl": 60,
+            "physical_tables": [],
+            "datasource": "duckdb",
+            "model_id": "m",
+            "sql": "SELECT id, name FROM t",
+            "dialect": "duckdb",
+        }
+        server._cache_put_table(table, meta)
+
+        got = server._cache_get_table("rt")
+        assert got is not None
+        assert got.column_names == ["id", "name"]
+        assert got.to_pylist() == [
+            {"id": 7, "name": "x"},
+            {"id": 8, "name": "y"},
+            {"id": 9, "name": "z"},
+        ]
 
 
 class TestFlightCatalogFilter:


### PR DESCRIPTION
Follow-up to #191 (issue #126). Fixes the separate pre-existing Flight cache bug found while doing that refactor.

## The bug

Flight's cache read/write path (`cache_get_table` / `cache_put_table` in `ob_flight/server_execution.py`) still called `result_codec.encode`, `result_codec.decode`, and `result_codec.decode_table`. PR #179 ("Cache row data only; rebuild result metadata fresh per request", v2.20.0) removed that envelope API and replaced it with a data-only blob codec (`encode_data` / `decode_data`) plus a `columns_json` schema sidecar carried as `cache.set` kwargs.

Both calls raised `AttributeError`, which the surrounding `try/except` swallowed (logging at debug). Net effect: **Flight silently never read or wrote the result cache since #179** - every Flight query was an unconditional cache miss and never stored a result, even though key + TTL were resolved correctly. Two `TestFlightCacheEnvelope` tests were already failing on `main` for this reason.

## The fix

- `cache_put_table` stores the row data via `encode_data(column_names, rows)` and the column schema via `columns_json` (key `type`, vocabulary `string` / `number` / `datetime` / `binary`), matching REST/pgwire's `try_cache_set`. So a Flight-written entry is now readable by REST/pgwire and vice versa - one entry per compiled query across all surfaces.
- `cache_get_table` decodes the blob via `decode_data`.

## Tests

- Rewrote the two `TestFlightCacheEnvelope` regressions (they asserted the removed envelope API - `result_codec.decode(...).sql` etc.) to the current architecture: blob decodes via `decode_data`, metadata rides as `cache.set` kwargs, types live in the `columns_json` sidecar under `type`.
- Added a get-after-put roundtrip test proving Flight reads back its own write through the shared codec.
- Full flight suite: **151 passed** (was 148 passed + 2 failed). `ruff check`, `ruff format`, and `mypy` on the changed files are clean (the two `attr-defined` mypy errors on `result_codec.encode` / `decode_table` are resolved).

## Merge order

Independent of #191 (touches different functions in the same file - no overlap). Either can merge first.