### PR TITLE
Bump copyright to 2026 and add OrionBelt trademark notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,7 +574,9 @@ uv sync --extra docs && uv run mkdocs serve  # docs on :8080
 
 ## License
 
-Copyright 2025 [RALFORION d.o.o.](https://ralforion.com)
+Copyright © 2026 [RALFORION d.o.o.](https://ralforion.com)
+
+OrionBelt® is a registered trademark of RALFORION d.o.o.
 
 Licensed under the [Business Source License 1.1](LICENSE). The Licensed Work will convert to Apache License 2.0 on 2030-03-16.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -197,5 +197,7 @@ Contact [RALFORION d.o.o.](https://ralforion.com) for details.
 <p align="center">
   <a href="https://ralforion.com"><img src="assets/RALFORION_doo_Logo.png" alt="RALFORION d.o.o." width="200"></a>
   <br>
-  Copyright 2025 RALFORION d.o.o. &mdash; Licensed under BSL 1.1
+  Copyright &copy; 2026 RALFORION d.o.o. &mdash; Licensed under BSL 1.1
+  <br>
+  OrionBelt&reg; is a registered trademark of RALFORION d.o.o.
 </p>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_description: "Open-source Semantic Sidecar for agentic AI, analytics, data 
 site_url: https://ralforion.com/orionbelt-semantic-layer/
 repo_url: https://github.com/ralforion/orionbelt-semantic-layer
 repo_name: orionbelt-semantic-layer
-copyright: Copyright &copy; 2025 RALFORION d.o.o., BSL 1.1
+copyright: Copyright &copy; 2026 RALFORION d.o.o., BSL 1.1 &mdash; OrionBelt&reg; is a registered trademark of RALFORION d.o.o.
 
 dev_addr: 127.0.0.1:8080
 


### PR DESCRIPTION
Updates the copyright year to 2026 and adds a registered-trademark notice across the three user-facing surfaces.

## Changes
- `docs/index.md` footer: `Copyright © 2026 RALFORION d.o.o. - Licensed under BSL 1.1` plus `OrionBelt® is a registered trademark of RALFORION d.o.o.`
- `mkdocs.yml` site footer: bumped to 2026, trademark notice appended
- `README.md` license section: bumped to 2026, trademark line added (BSL license paragraph unchanged)

License/CLA documents were intentionally left untouched (their year is the license effective year, not a footer).