### PR TITLE
Add ® to OrionBelt first mention in README and docs landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="https://raw.githubusercontent.com/ralforion/orionbelt-semantic-layer/main/docs/assets/ORIONBELT_Logo.png" alt="OrionBelt Semantic Layer logo — a stylized belt of three stars" width="400">
 </p>
 
-<h1 align="center">OrionBelt Semantic Layer and Sidecar</h1>
+<h1 align="center">OrionBelt&reg; Semantic Layer and Sidecar</h1>
 
 <p align="center"><strong>An Open Source <a href="https://ralforion.com/semantic-sidecar.html">Semantic Sidecar</a> for <a href="https://ralforion.com/agentic-ai-data-access.html">Agentic AI</a>, Analytics, Quality and Governance Systems.</strong></p>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ description: OrionBelt Semantic Layer is an open-source Semantic Sidecar for age
   <img src="assets/ORIONBELT_Logo.png" alt="OrionBelt Logo" width="400">
 </p>
 
-# OrionBelt Semantic Layer and Sidecar
+# OrionBelt&reg; Semantic Layer and Sidecar
 
 **An open-source Semantic Sidecar for agentic AI, analytics, data quality, and governance systems.**
 


### PR DESCRIPTION
Adds the registered-trademark symbol to the first prominent mention of the OrionBelt brand, per standard practice (mark the first/prominent use, not every occurrence).

## Changes
- `README.md` H1: `OrionBelt® Semantic Layer and Sidecar`
- `docs/index.md` H1: `OrionBelt® Semantic Layer and Sidecar`

All other ~455 occurrences (code, identifiers, package names, body text, changelog, config) intentionally left plain. The attribution notice added in #194 asserts the mark.