### PR TITLE
Add ® to OrionBelt in mkdocs site header

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: OrionBelt Semantic Layer
+site_name: OrionBelt® Semantic Layer
 site_description: "Open-source Semantic Sidecar for agentic AI, analytics, data quality, and governance: inject governed business semantics into systems that never had them. YAML models compile to SQL across 8 dialects, surfaced via REST, MCP, Arrow Flight SQL, and PostgreSQL wire."
 site_url: https://ralforion.com/orionbelt-semantic-layer/
 repo_url: https://github.com/ralforion/orionbelt-semantic-layer


### PR DESCRIPTION
Adds the registered-trademark symbol to `site_name`, which renders as the persistent brand in the docs top bar (and the browser tab title). Uses the literal ® character rather than the `&reg;` entity so it displays correctly in the HTML title and meta tags, which do not reliably decode entities.

## Change
- `mkdocs.yml` `site_name`: `OrionBelt® Semantic Layer`