### PR TITLE
Docs: note OSI is now Apache Ossie (incubating), fix stale repo links

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ Also works with Copilot, Cursor, and Windsurf. See the [MCP repo](https://github
 - **Cross-Schema Queries** — model data objects across multiple databases and schemas in a single model
 - **Static Model Filters** — mandatory WHERE conditions baked into the model, auto-applied with join extension
 - **OBSL Graph & SPARQL** — RDF graph export and read-only SPARQL querying for every loaded model
-- **OSI Interoperability** — bidirectional conversion between OBML and Open Semantic Interchange format
+- **OSI Interoperability** — bidirectional conversion between OBML and the Open Semantic Interchange format, now developed as [Apache Ossie (incubating)](https://github.com/apache/ossie)
 
 ### SQL Compilation
 

--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -625,11 +625,11 @@ Per-query `status` is `"ok"`, `"error"` (with an `error` envelope: `{code, messa
 
 ## OSI ↔ OBML Conversion
 
-Stateless endpoints for converting between [OSI (Open Semantic Interchange)](https://github.com/open-semantic-interchange/OSI) and OBML formats. No session required.
+Stateless endpoints for converting between [OSI (Open Semantic Interchange)](https://github.com/apache/ossie) and OBML formats. No session required.
 
 ### `POST /v1/convert/osi-to-obml`
 
-Convert an OSI YAML model to OBML format. OBSL emits and validates against [OSI v0.2.0.dev0](https://github.com/open-semantic-interchange/OSI/blob/main/core-spec/osi-schema.json); v0.1.x inputs still load via a legacy reader shim.
+Convert an OSI YAML model to OBML format. OBSL emits and validates against [OSI v0.2.0.dev0](https://github.com/apache/ossie/blob/main/core-spec/osi-schema.json); v0.1.x inputs still load via a legacy reader shim.
 
 **Request:**
 

--- a/docs/guide/osi.md
+++ b/docs/guide/osi.md
@@ -2,7 +2,10 @@
 
 **OSI (Open Semantic Interchange)** is an open standard for portable semantic models, founded with the goal of letting metric and dimension definitions move between BI tools, semantic layers, and data platforms without rewriting. See [open-semantic-interchange.org](https://open-semantic-interchange.org/) for the specification and contributor list.
 
-OrionBelt includes a bidirectional converter between OBML and the [OSI specification](https://github.com/open-semantic-interchange/OSI) format. The converter handles structural differences between the two formats — including metric decomposition, relationship restructuring, and lossless `ai_context` preservation via `customExtensions` — with built-in validation for both directions.
+!!! note "Now at the Apache Incubator"
+    OSI has been contributed to the Apache Software Foundation and is now developed as **[Apache Ossie (incubating)](https://github.com/apache/ossie)**. The specification and its converters (including the OrionBelt converter) live there going forward. Existing `github.com/open-semantic-interchange/OSI` links redirect to the new repository.
+
+OrionBelt includes a bidirectional converter between OBML and the [OSI specification](https://github.com/apache/ossie) format. The converter handles structural differences between the two formats — including metric decomposition, relationship restructuring, and lossless `ai_context` preservation via `customExtensions` — with built-in validation for both directions.
 
 The converter ships as a standalone `osi-orionbelt` package. It is an **optional** dependency: install it with `pip install 'orionbelt-semantic-layer[osi]'` (or standalone via `pip install osi-orionbelt`). The published API Docker images bundle it, so the `/convert`, `/models/from-osi`, and `/osi` endpoints work out of the box; on a bare install without the extra, those endpoints return a `503`.
 


### PR DESCRIPTION
Adds a short note that the OSI standard has been contributed to the Apache Incubator as Apache Ossie (incubating), and repoints the stale old-repo links to github.com/apache/ossie.

## Changes
- `docs/guide/osi.md`: admonition note linking github.com/apache/ossie; spec link repointed
- `docs/api/endpoints.md`: two OSI links repointed to apache/ossie (repo + core-spec/osi-schema.json)
- `README.md`: OSI Interoperability bullet notes the Apache Ossie (incubating) home + link

Scoped intentionally: a short note plus correct links. Existing `github.com/open-semantic-interchange/OSI` links only work via GitHub's redirect, which is not guaranteed to persist. Kept the OSI terminology elsewhere for now since the project is still incubating; a full OSI to Ossie rename across UI/API/docs can follow later.

Verified: `mkdocs build` succeeds and the note renders on the OSI guide page.