### PR TITLE
CI: bump deploy-docs and pypi-publish actions to Node 24 runtime

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -18,22 +18,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout orionbelt-semantic-layer
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: docs-source
 
       - name: Checkout ralforion.github.io
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ralforion/ralforion.github.io
           token: ${{ secrets.DOCS_DEPLOY_TOKEN }}
           path: main-site
 
-      - name: Set up Python with uv
-        uses: drivendataorg/setup-python-uv-action@v1
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
         with:
-          python-version: "3.11"
-      
+          enable-cache: true
+
+      - name: Install Python
+        run: uv python install 3.11
+
       - name: Build documentation
         working-directory: docs-source
         run: |

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -30,10 +30,10 @@ jobs:
     permissions:
       id-token: write # required for Trusted Publishing
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.12"
 
@@ -61,10 +61,10 @@ jobs:
     permissions:
       id-token: write # required for Trusted Publishing
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
Clears the GitHub Actions Node.js 20 deprecation warnings in the two workflows still on old action majors, aligning them with the Node 24 pattern already used by ci.yml / notebook.yml / docker-publish.yml.

## deploy-docs.yml
- `actions/checkout@v4` -> `@v6` (both checkouts)
- Replaced `drivendataorg/setup-python-uv-action@v1` (which pulled in `actions/setup-python@v5`, the source of the setup-python Node 20 warning) with the repo-standard `astral-sh/setup-uv@v7` + `uv python install 3.11`. `uv run mkdocs build` is unchanged; mkdocs is in the default `dev` group that `uv run` auto-syncs.

## pypi-publish.yml
- `actions/checkout@v4` -> `@v6`
- `astral-sh/setup-uv@v5` -> `@v7` (both publish jobs); `python-version` input preserved

Verified: both workflow YAMLs parse.