### PR TITLE
CI: rebase-and-retry docs push to survive concurrent writes

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -64,9 +64,19 @@ jobs:
             Triggered by: ${{ github.event_name }}
             Branch: ${{ steps.version.outputs.branch }}"
             
-            git push
-            echo "✅ Documentation deployed to ralforion.com/orionbelt-semantic-layer/"
-            echo "Version: ${{ steps.version.outputs.version }}"
+            # Push with rebase-and-retry to tolerate concurrent pushes to main
+            # (another deploy run or a manual edit landing between checkout and push).
+            for attempt in 1 2 3 4 5; do
+              if git push; then
+                echo "✅ Documentation deployed to ralforion.com/orionbelt-semantic-layer/"
+                echo "Version: ${{ steps.version.outputs.version }}"
+                exit 0
+              fi
+              echo "Push rejected (attempt ${attempt}/5); rebasing on latest main and retrying..."
+              git pull --rebase origin main
+            done
+            echo "::error::Failed to push docs after 5 attempts"
+            exit 1
           else
             echo "📝 No documentation changes detected"
           fi


### PR DESCRIPTION
Hardens the deploy-docs push into ralforion.github.io against the concurrent-push race that fails runs with '! [rejected] main -> main (fetch first)' (seen when a manual edit or a second deploy run lands on main between checkout and push).

## Change
Replaces the bare `git push` with a try-push / rebase / retry loop (up to 5 attempts): on rejection it runs `git pull --rebase origin main` and retries, so a concurrent write to main self-heals instead of red-X-ing the run. A genuine rebase conflict still fails loudly (the shell runs with `-e`).

Since the docs commit only touches `public/orionbelt-semantic-layer`, a concurrent edit elsewhere on main rebases cleanly.