### PR TITLE
osi-orionbelt: link OSI schema via search path; drop dead constants

### DIFF
--- a/packages/osi-orionbelt/src/osi_orionbelt/_common.py
+++ b/packages/osi-orionbelt/src/osi_orionbelt/_common.py
@@ -16,8 +16,6 @@ import re
 # 0.1.x (via the legacy shim) and 0.2.x.
 _OSI_VERSION = "0.2.0.dev0"
 
-# Dialect / vendor enum extras new in v0.2.0.dev0
-_OSI_KNOWN_DIALECTS = ("ANSI_SQL", "SNOWFLAKE", "MDX", "TABLEAU", "DATABRICKS", "MAQL")
 # SQL dialects (of the OSI enum) whose aggregation expressions our regex-based
 # metric parser can read, in preference order. ANSI_SQL first; SNOWFLAKE and
 # DATABRICKS are SQL engines OrionBelt also targets, and their simple/expression
@@ -36,16 +34,6 @@ _COLUMN_REF_RE = re.compile(
     r"\s*\.\s*"
     r'(?P<col>[A-Za-z_]\w*|"[^"]+"|`[^`]+`|\[[^\]]+\])'
 )
-_OSI_KNOWN_VENDORS = (
-    "COMMON",
-    "ORIONBELT",
-    "SNOWFLAKE",
-    "SALESFORCE",
-    "DBT",
-    "DATABRICKS",
-    "GOODDATA",
-)
-
 # Vendor identities for custom_extensions.
 #   ORIONBELT - OrionBelt/OBML-proprietary payloads we author on OBML -> OSI.
 #   OSI       - OSI-native fields OBML can't hold (unique_keys, field label,

--- a/packages/osi-orionbelt/src/osi_orionbelt/converter.py
+++ b/packages/osi-orionbelt/src/osi_orionbelt/converter.py
@@ -42,12 +42,6 @@ from osi_orionbelt._common import (
     _OBML_VENDOR_READ as _OBML_VENDOR_READ,
 )
 from osi_orionbelt._common import (
-    _OSI_KNOWN_DIALECTS as _OSI_KNOWN_DIALECTS,
-)
-from osi_orionbelt._common import (
-    _OSI_KNOWN_VENDORS as _OSI_KNOWN_VENDORS,
-)
-from osi_orionbelt._common import (
     _OSI_VENDOR_READ as _OSI_VENDOR_READ,
 )
 from osi_orionbelt._common import (

--- a/packages/osi-orionbelt/src/osi_orionbelt/validation.py
+++ b/packages/osi-orionbelt/src/osi_orionbelt/validation.py
@@ -13,13 +13,40 @@ from typing import Any
 _SCRIPT_DIR = Path(__file__).resolve().parent
 _SCHEMAS_DIR = _SCRIPT_DIR / "schemas"
 
-# All three schemas are tracked files beside the converter, so the package is
-# self-contained (no repo-root dependency, sdist/wheel build in isolation). The
-# OBML schema is a vendored snapshot of the canonical repo-root
-# schema/obml-schema.json, kept in sync by a drift-guard test.
+# The OBML schema is OrionBelt's own format, always vendored beside the package
+# and kept in sync with the repo-root schema/obml-schema.json by a drift-guard
+# test.
 _OBML_SCHEMA_PATH = _SCHEMAS_DIR / "obml-schema.json"
-_OSI_SCHEMA_PATH = _SCHEMAS_DIR / "osi-schema.json"
-_OSI_ONTOLOGY_SCHEMA_PATH = _SCHEMAS_DIR / "osi-ontology-schema.json"
+
+
+def _osi_schema_path(filename: str) -> Path:
+    """Resolve an OSI core-spec schema without forcing a duplicate copy where a
+    canonical one already exists.
+
+    Resolution order:
+    1. A copy vendored beside this package (``schemas/<filename>``). The
+       standalone PyPI wheel and the OrionBelt product API rely on this, so the
+       package validates OSI documents self-contained and offline.
+    2. Otherwise ``core-spec/<filename>`` in an enclosing Ossie monorepo
+       checkout, found by walking up from this file. This lets the in-tree
+       converter drop its vendored copy and link the single canonical schema
+       rather than duplicating it.
+
+    Returns the vendored path unchanged when neither exists, so downstream
+    ``.exists()`` checks degrade to skip-with-warning rather than raising.
+    """
+    vendored = _SCHEMAS_DIR / filename
+    if vendored.exists():
+        return vendored
+    for parent in _SCRIPT_DIR.parents:
+        candidate = parent / "core-spec" / filename
+        if candidate.exists():
+            return candidate
+    return vendored
+
+
+_OSI_SCHEMA_PATH = _osi_schema_path("osi-schema.json")
+_OSI_ONTOLOGY_SCHEMA_PATH = _osi_schema_path("osi-ontology-schema.json")
 
 # The OSI ontology schema $refs the core-spec schema by its public raw URL for
 # ``ai_context`` and the embedded ``semantic_model``. Resolve that URL against


### PR DESCRIPTION
Addresses two review comments from @khush-bhatia on [apache/ossie#153](https://github.com/apache/ossie/pull/153).

## 1. Link the OSI schema instead of forcing a vendored copy
Her concern is that the ossie converter carries a copy of the OSI spec that has to track spec changes. Rather than drop OSI validation (which the OrionBelt product API at `/v1/convert/osi-to-obml` depends on to flag malformed/legacy OSI input), the schema is now resolved via a search path (`validation.py::_osi_schema_path`):

1. a copy vendored beside the package, if present (the self-contained PyPI wheel and the product API need this), **else**
2. `core-spec/<name>` in an enclosing Ossie monorepo checkout, found by walking up from the module.

So in the **ossie monorepo** the converter can delete its vendored `osi-schema.json` / `osi-ontology-schema.json` and it links the single canonical `core-spec` copy: no duplication there. In this repo the copy stays (a wheel must be self-contained), so behaviour is unchanged and all OSI validation + tests keep passing.

## 2. Remove the unused known-vendors list
`_OSI_KNOWN_VENDORS` and `_OSI_KNOWN_DIALECTS` were only re-exported, never used. Vendor passthrough keys off `_INTERNAL_VENDORS` (anything outside it is carried through verbatim), dialect parsing off `_SQL_PARSEABLE_DIALECTS`. Both dead constants are deleted.

## Notes
- 3 files changed (+33 / -24). No schema files or tests removed.
- 145 package tests pass; the `/v1/convert` input-validation integration tests pass; ruff + mypy clean.
- Canonical source (`packages/osi-orionbelt`); the ossie PR branch gets the same resolver plus deletion of its two vendored copies.