### PR TITLE
chore: add Dependabot config (uv, github-actions, docker)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,43 @@
+# Dependabot configuration.
+# Docs: https://docs.github.com/code-security/dependabot/dependabot-version-updates
+#
+# Weekly, grouped updates to keep noise low. Major Python bumps are ungrouped so
+# they get an individual PR to review; minor/patch are batched into one.
+version: 2
+updates:
+  # Python dependencies. This is a single uv workspace: the root uv.lock covers
+  # the app plus the packages/osi-orionbelt and drivers/* members, so one entry
+  # at the root keeps everything in sync.
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      python-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions used by the workflows in .github/workflows.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  # Base images in the Dockerfiles (Dockerfile, Dockerfile.ui, Dockerfile.flight).
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      docker:
+        patterns:
+          - "*"


### PR DESCRIPTION
Adds `.github/dependabot.yml` so the canonical repo gets automated dependency-update PRs, mirroring the Dependabot coverage `apache/ossie` already runs on the converter (that's where the `Bump pydantic-settings ... in /converters/orionbelt` commit came from).

## What it covers
| Ecosystem | Scope | Notes |
|---|---|---|
| `uv` | root `uv.lock` | Single uv workspace, so one entry covers the app + `packages/osi-orionbelt` + `drivers/*`. Minor/patch grouped into one PR; major bumps get their own. |
| `github-actions` | `.github/workflows` | Keeps action versions current (grouped). |
| `docker` | Dockerfiles | Base-image updates (grouped). |

## Cadence
Weekly on Monday, grouped, `open-pull-requests-limit: 10` for Python. Chosen to keep PR volume low - easy to change if you want daily or a different day.

## Notes
- `uv` is a first-class Dependabot ecosystem (verified against GitHub's dependabot-options-reference).
- The main `Dockerfile` is definitely picked up; if the `Dockerfile.ui` / `Dockerfile.flight` variants aren't detected by the docker ecosystem's naming rules, that's a minor follow-up (they'd just be skipped, nothing breaks).
- No effect on CI or runtime - config only. Independent of the #201 work.