### PR TITLE
chore: adapt code to sqlglot 30

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
     "structlog>=25.1,<27.0",
     "opentelemetry-api>=1.39,<2.0",
     "httpx>=0.28,<1.0",
-    "sqlglot>=26.0,<27.0",
+    "sqlglot>=30.0,<31.0",
     "jsonschema>=4.23,<5.0",
     "rdflib>=7.0,<8.0",
     # IANA timezone database for Python's zoneinfo on systems without

--- a/src/orionbelt/compiler/sql_translator.py
+++ b/src/orionbelt/compiler/sql_translator.py
@@ -576,7 +576,7 @@ def _reject_unsupported_structure(ast: exp.Select, errors: list[SemanticError]) 
                 ),
             )
         )
-    if ast.args.get("with") is not None:
+    if ast.args.get("with_") is not None:
         errors.append(
             SemanticError(
                 code="UNSUPPORTED_SQL_FEATURE",
@@ -660,7 +660,7 @@ def _collect_count_tautology_aggs(having_node: exp.Expression | None) -> list[ex
     return found
 
 
-def _flatten_and(expr: exp.Expression) -> list[exp.Expression]:
+def _flatten_and(expr: exp.Expr) -> list[exp.Expr]:
     """Like ``_walk_and`` but doesn't record errors — read-only."""
 
     if isinstance(expr, exp.And):
@@ -670,7 +670,7 @@ def _flatten_and(expr: exp.Expression) -> list[exp.Expression]:
     return [expr]
 
 
-def _match_count_tautology(atom: exp.Expression) -> exp.AggFunc | None:
+def _match_count_tautology(atom: exp.Expr) -> exp.AggFunc | None:
     """Return the COUNT aggregate iff ``atom`` is a tautology like
     ``COUNT(*) > 0`` / ``COUNT(*) >= 1`` / ``COUNT(*) != 0`` — i.e.
     a comparison that's trivially true for every non-empty group.
@@ -740,7 +740,7 @@ def _is_nonempty_group_tautology(
 
 # sqlglot expression types for comparison operators; used to mirror an
 # operator when the COUNT(*) appears on the right of the comparison.
-_MIRROR_OPS: dict[type[exp.Expression], type[exp.Expression]] = {
+_MIRROR_OPS: dict[type[exp.Expr], type[exp.Expr]] = {
     exp.GT: exp.LT,
     exp.GTE: exp.LTE,
     exp.LT: exp.GT,
@@ -1058,7 +1058,7 @@ def _build_raw_mode_query(
 
 
 def _atom_to_raw_filter(
-    atom: exp.Expression,
+    atom: exp.Expr,
     model: SemanticModel,  # noqa: ARG001 — reserved for future column-existence checks
     errors: list[SemanticError],
 ) -> QueryFilter | None:
@@ -1220,7 +1220,7 @@ def _split_predicates(
             where_filters.append(item)
 
 
-def _walk_and(expr: exp.Expression, errors: list[SemanticError]) -> list[exp.Expression]:
+def _walk_and(expr: exp.Expr, errors: list[SemanticError]) -> list[exp.Expr]:
     """Flatten an AND tree into a list of atomic predicates."""
     if isinstance(expr, exp.And):
         return [
@@ -1244,7 +1244,7 @@ def _walk_and(expr: exp.Expression, errors: list[SemanticError]) -> list[exp.Exp
 
 
 def _atom_to_query_filter(
-    atom: exp.Expression,
+    atom: exp.Expr,
     classify: Callable[[str], str | None],
     canonical: Callable[[str], str],
     errors: list[SemanticError],
@@ -1478,7 +1478,7 @@ def _translate_exists(
                 )
             )
             return None
-    from_node = inner.args.get("from")
+    from_node = inner.args.get("from_")
     if from_node is None or not isinstance(from_node.this, exp.Table):
         errors.append(
             SemanticError(
@@ -1519,9 +1519,7 @@ def _translate_exists(
     )
 
 
-def _atom_to_subquery_filter(
-    atom: exp.Expression, errors: list[SemanticError]
-) -> QueryFilter | None:
+def _atom_to_subquery_filter(atom: exp.Expr, errors: list[SemanticError]) -> QueryFilter | None:
     """Translate a single predicate inside an EXISTS subquery body.
 
     ``field`` is interpreted as a bare column name on the target data

--- a/src/orionbelt/pgwire/router.py
+++ b/src/orionbelt/pgwire/router.py
@@ -675,6 +675,9 @@ def _rewrite_fetch_to_limit(sql: str) -> str:
 
 
 _FLATTEN_HOISTABLE = ("where", "order", "limit")
+# Select args allowed on a flattenable wrapper: the projection list, the FROM
+# (renamed "from" -> "from_" in sqlglot 30), and the hoistable clauses.
+_FLATTEN_ALLOWED_ARGS = ("expressions", "from_", *_FLATTEN_HOISTABLE)
 _FLATTEN_MAX_DEPTH = 8
 
 
@@ -711,7 +714,7 @@ def _flatten_literal_value(node: exp.Expression) -> str | None:
 
 def _flatten_constant_projection(
     proj: exp.Expression, wheres: list[exp.Expression]
-) -> exp.Expression | None:
+) -> exp.Expr | None:
     """Map Dremio's constant-folded ``<literal> AS <dim>`` projection to a bare column.
 
     When a view is filtered with ``WHERE <dim> = <value>``, Dremio proves the
@@ -737,7 +740,7 @@ def _flatten_constant_projection(
                     and col.name == name
                     and _flatten_literal_value(lit_side) == lit
                 ):
-                    aliased: exp.Expression = exp.alias_(col.copy(), name)
+                    aliased: exp.Expr = exp.alias_(col.copy(), name)
                     return aliased
     return None
 
@@ -775,7 +778,7 @@ def _flatten_federation_subquery(sql: str) -> str:
         return sql
     # Only the projection list, FROM, and the hoistable clauses may appear; a
     # GROUP / DISTINCT / HAVING / CTE at any level means real work -> bail.
-    if any(v for k, v in ast.args.items() if k not in ("expressions", "from", *_FLATTEN_HOISTABLE)):
+    if any(v for k, v in ast.args.items() if k not in _FLATTEN_ALLOWED_ARGS):
         return sql
 
     outer_projs = ast.expressions
@@ -796,7 +799,7 @@ def _flatten_federation_subquery(sql: str) -> str:
     node: exp.Select = ast
     base: exp.Table | None = None
     for depth in range(1, _FLATTEN_MAX_DEPTH + 1):
-        from_ = node.args.get("from")
+        from_ = node.args.get("from_")
         if from_ is None:
             return sql
         src = from_.this
@@ -808,11 +811,7 @@ def _flatten_federation_subquery(sql: str) -> str:
         inner = src.this
         if not isinstance(inner, exp.Select) or inner.args.get("joins"):
             return sql
-        if any(
-            v
-            for k, v in inner.args.items()
-            if k not in ("expressions", "from", *_FLATTEN_HOISTABLE)
-        ):
+        if any(v for k, v in inner.args.items() if k not in _FLATTEN_ALLOWED_ARGS):
             return sql
         # Intermediate layers must be pure pass-through projections.
         if not all(_flatten_is_passthrough(p) for p in inner.expressions):
@@ -851,7 +850,7 @@ def _flatten_federation_subquery(sql: str) -> str:
     # translator only accepts bare artefact references, and the semantic layer
     # re-derives the real type. A constant-folded literal projection maps back
     # to its dimension column.
-    new_projs: list[exp.Expression] = []
+    new_projs: list[exp.Expr] = []
     for proj in outer_projs:
         if _flatten_is_passthrough(proj):
             inner = _flatten_unwrap(proj.this if isinstance(proj, exp.Alias) else proj)
@@ -865,9 +864,9 @@ def _flatten_federation_subquery(sql: str) -> str:
 
     flat = exp.Select()
     flat.set("expressions", new_projs)
-    flat.set("from", exp.From(this=base.copy()))
+    flat.set("from_", exp.From(this=base.copy()))
     if wheres:
-        cond = wheres[0].copy()
+        cond: exp.Expr = wheres[0].copy()
         for extra in wheres[1:]:
             cond = exp.and_(cond, extra.copy())
         flat.set("where", exp.Where(this=cond))

--- a/uv.lock
+++ b/uv.lock
@@ -2444,7 +2444,7 @@ requires-dist = [
     { name = "rdflib", specifier = ">=7.0,<8.0" },
     { name = "ruamel-yaml", specifier = ">=0.19,<1.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15" },
-    { name = "sqlglot", specifier = ">=26.0,<27.0" },
+    { name = "sqlglot", specifier = ">=30.0,<31.0" },
     { name = "structlog", specifier = ">=25.1,<27.0" },
     { name = "testcontainers", marker = "extra == 'dev'", specifier = ">=4.0" },
     { name = "typer", specifier = ">=0.12,<1.0" },
@@ -3713,11 +3713,11 @@ wheels = [
 
 [[package]]
 name = "sqlglot"
-version = "26.33.0"
+version = "30.12.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/25/9d/fcd59b4612d5ad1e2257c67c478107f073b19e1097d3bfde2fb517884416/sqlglot-26.33.0.tar.gz", hash = "sha256:2817278779fa51d6def43aa0d70690b93a25c83eb18ec97130fdaf707abc0d73", size = 5353340, upload-time = "2025-07-01T13:09:06.311Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/ed/a6c45aec29353b6392ea34548c40af3ac6ffd6bc5572cf23b2ce250876fc/sqlglot-30.12.0.tar.gz", hash = "sha256:6b8369704662d4f654bc934cea4dd31c916c2a571b389210cb9e951a275e5fd9", size = 5905110, upload-time = "2026-06-26T14:09:40.408Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/31/8d/f1d9cb5b18e06aa45689fbeaaea6ebab66d5f01d1e65029a8f7657c06be5/sqlglot-26.33.0-py3-none-any.whl", hash = "sha256:031cee20c0c796a83d26d079a47fdce667604df430598c7eabfa4e4dfd147033", size = 477610, upload-time = "2025-07-01T13:09:03.926Z" },
+    { url = "https://files.pythonhosted.org/packages/db/9e/82a390ecc85f066ff80affa01d195f744e3de60ad4d695b8de31c9a66da3/sqlglot-30.12.0-py3-none-any.whl", hash = "sha256:86cccc610073c645c03e72b55b60ae0518aa3253a7fc3bd56551370d003c6554", size = 707583, upload-time = "2026-06-26T14:09:38.525Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Supersedes Dependabot #212, which bumped sqlglot 26→30 with no code change and **broke 15 tests**. sqlglot 30 has two breaking changes that touch us:

## 1. Select args renamed for Python keywords
`from` → `from_` and `with` → `with_`. Every `.args.get("from")` / `.args["from"]` / `.set("from", ...)` (and `with`) now reads `None`, which silently broke:
- OBSQL EXISTS + CTE translation (`compiler/sql_translator.py`)
- pgwire federation-subquery flattening (`pgwire/router.py`) — the wrapper stopped collapsing

Fixed all sites; also extracted `_FLATTEN_ALLOWED_ARGS` to dedupe the two flatten guards.

## 2. `exp.Expr` is the new common base
`Condition` / `Binary` now subclass `Expr`, **not** `Expression` (they're siblings under `Expr`). Builders (`and_`, `alias_`) and `.left`/`.right` return `Expr`, so the condition-handling annotations widen `exp.Expression` → `exp.Expr` (8 mypy errors, no runtime change).

## Constraint + validation
- `sqlglot>=26.0,<27.0` → `>=30.0,<31.0` (lock 30.12.0). The code now depends on the v30 arg names, so the floor is raised deliberately.
- **2621 tests pass**, ruff + mypy clean.

Closes #212.