### PR TITLE
OBML: remove dead authorable `label` on dimension/measure/metric (#221)

### DIFF
--- a/docs/guide/model-format.md
+++ b/docs/guide/model-format.md
@@ -282,7 +282,6 @@ dimensions:
 | `dataObject` | string | Yes | Source data object name |
 | `column` | string | Yes | Column name in the data object |
 | `resultType` | enum | Yes | Data type of the result (informative only, not used for SQL generation) |
-| `label` | string | No | Display label |
 | `timeGrain` | enum | No | Time grain: `year`, `quarter`, `month`, `week`, `day`, `hour`, `minute`, `second`. The underlying column's `abstractType` must be `date`, `timestamp`, or `timestamp_tz` — validation rejects `timeGrain` on string/numeric columns (error code `TIME_GRAIN_ON_NON_TEMPORAL`). For text columns that encode dates (e.g. `'2024-03'`), define a computed column with `to_date()` first and point the dimension at that. |
 | `via` | string | No | Force join path through this intermediate data object (role-playing dimensions) |
 | `format` | string | No | Display format pattern (e.g. `#,##0.00`, `0.00%`) |
@@ -742,7 +741,6 @@ Window metrics compose freely with derived metrics — `expression: '{[Revenue]}
 | `orderDirection` | `"asc"` \| `"desc"` | `"desc"` | Window `ORDER BY` direction |
 | `defaultValue` | scalar | — | Default value for `lag` / `lead` when the offset row is absent |
 | `dataType` | string | — | OBML data type (e.g. `decimal(18, 4)`). Overrides automatic type inference for CAST wrapping. |
-| `label` | string | — | Display label |
 | `description` | string | — | Business description |
 | `format` | string | — | Display format pattern (e.g. `#,##0.00`, `0.00%`) |
 | `synonyms` | list | — | Alternative names or terms (LLM hints) |

--- a/docs/guide/trend-analysis.md
+++ b/docs/guide/trend-analysis.md
@@ -111,9 +111,21 @@ The killer feature is composing window metrics through `DERIVED`:
 
 ```yaml
 metrics:
-  - { label: Revenue MA3,  type: cumulative, measure: Revenue, timeDimension: order_month, cumulativeType: avg, window: 3,  partitionBy: [Country] }
-  - { label: Revenue MA12, type: cumulative, measure: Revenue, timeDimension: order_month, cumulativeType: avg, window: 12, partitionBy: [Country] }
-  - label: MA Crossover Signal
+  Revenue MA3:
+    type: cumulative
+    measure: Revenue
+    timeDimension: order_month
+    cumulativeType: avg
+    window: 3
+    partitionBy: [Country]
+  Revenue MA12:
+    type: cumulative
+    measure: Revenue
+    timeDimension: order_month
+    cumulativeType: avg
+    window: 12
+    partitionBy: [Country]
+  MA Crossover Signal:
     type: derived
     expression: "CASE WHEN {[Revenue MA3]} > {[Revenue MA12]} THEN 1 ELSE -1 END"
 ```

--- a/packages/osi-orionbelt/src/osi_orionbelt/schemas/obml-schema.json
+++ b/packages/osi-orionbelt/src/osi_orionbelt/schemas/obml-schema.json
@@ -492,9 +492,6 @@
           "$ref": "#/definitions/dataType",
           "description": "Data type of the result (informative only, not used for SQL generation)"
         },
-        "label": {
-          "type": "string"
-        },
         "timeGrain": {
           "$ref": "#/definitions/timeGrain"
         },
@@ -646,9 +643,6 @@
           "items": {
             "$ref": "#/definitions/queryColumn"
           }
-        },
-        "label": {
-          "type": "string"
         },
         "resultType": {
           "$ref": "#/definitions/dataType",
@@ -857,9 +851,6 @@
       "type": "object",
       "description": "Metric definition. A derived metric (expression referencing measures), a cumulative metric (window function over a measure), or a period-over-period metric (comparing a measure across time periods).",
       "properties": {
-        "label": {
-          "type": "string"
-        },
         "type": {
           "description": "Metric category: derived (expression-based), cumulative (windowed aggregation over a measure), period_over_period (time comparison), or window (rank/lag/lead/ntile/first_value/last_value).",
           "enum": [

--- a/schema/obml-contract.yml
+++ b/schema/obml-contract.yml
@@ -317,9 +317,11 @@ classes:
       label:
         alias: label
         type: "str"
-        json_schema: true
+        # Not authorable: the dimension's identity is its mapping key, which the
+        # resolver copies into `label`. Same treatment as DataObject/Column.
+        json_schema: false
         ontology_property: null
-        osi_roundtrip: true
+        osi_roundtrip: false
       view:
         alias: dataObject
         type: "str"
@@ -516,9 +518,11 @@ classes:
       label:
         alias: label
         type: "str"
-        json_schema: true
+        # Not authorable: the measure's identity is its mapping key, which the
+        # resolver copies into `label`. Same treatment as DataObject/Column.
+        json_schema: false
         ontology_property: null
-        osi_roundtrip: true
+        osi_roundtrip: false
       columns:
         alias: columns
         type: "list[DataColumnRef]"
@@ -681,9 +685,11 @@ classes:
       label:
         alias: label
         type: "str"
-        json_schema: true
+        # Not authorable: the metric's identity is its mapping key, which the
+        # resolver copies into `label`. Same treatment as DataObject/Column.
+        json_schema: false
         ontology_property: null
-        osi_roundtrip: true
+        osi_roundtrip: false
       type:
         alias: type
         type: "MetricType"

--- a/schema/obml-schema.json
+++ b/schema/obml-schema.json
@@ -492,9 +492,6 @@
           "$ref": "#/definitions/dataType",
           "description": "Data type of the result (informative only, not used for SQL generation)"
         },
-        "label": {
-          "type": "string"
-        },
         "timeGrain": {
           "$ref": "#/definitions/timeGrain"
         },
@@ -646,9 +643,6 @@
           "items": {
             "$ref": "#/definitions/queryColumn"
           }
-        },
-        "label": {
-          "type": "string"
         },
         "resultType": {
           "$ref": "#/definitions/dataType",
@@ -857,9 +851,6 @@
       "type": "object",
       "description": "Metric definition. A derived metric (expression referencing measures), a cumulative metric (window function over a measure), or a period-over-period metric (comparing a measure across time periods).",
       "properties": {
-        "label": {
-          "type": "string"
-        },
         "type": {
           "description": "Metric category: derived (expression-based), cumulative (windowed aggregation over a measure), period_over_period (time comparison), or window (rank/lag/lead/ntile/first_value/last_value).",
           "enum": [

--- a/src/orionbelt/api/routers/convert.py
+++ b/src/orionbelt/api/routers/convert.py
@@ -71,6 +71,12 @@ async def obml_to_osi(body: OBMLtoOSIRequest) -> ConvertResponse:
     data = parse_yaml(body.input_yaml)
     mod = get_converter_module()
 
+    # Validate the OBML input against the schema before converting. Advisory —
+    # surfaced in ``input_validation`` so an authored ``label:`` (or any other
+    # schema violation) is reported rather than silently coerced away, matching
+    # the osi-to-obml direction.
+    input_validation = run_validation(mod.validate_obml, data)
+
     try:
         converter = mod.OBMLtoOSI(
             data,
@@ -116,6 +122,7 @@ async def obml_to_osi(body: OBMLtoOSIRequest) -> ConvertResponse:
         output_yaml=output_yaml,
         warnings=warnings,
         validation=validation,
+        input_validation=input_validation,
         ontology_yaml=ontology_yaml,
         ontology_validation=ontology_validation,
     )

--- a/src/orionbelt/cli/_local.py
+++ b/src/orionbelt/cli/_local.py
@@ -285,6 +285,13 @@ def convert_obml_to_osi(
     data = yaml.safe_load(input_yaml)
     if not isinstance(data, dict):
         raise CliError("OBML input must be a YAML/JSON mapping (object)")
+    # The CLI is an external boundary: surface OBML input schema issues (e.g. an
+    # authored ``label:``) instead of silently coercing them away. Advisory,
+    # matching the REST convert endpoints — conversion still runs.
+    input_warnings = [
+        f"OBML input schema: {msg}"
+        for msg in _validation_dict(mod.validate_obml, data).get("schema_errors", [])
+    ]
     converter = mod.OBMLtoOSI(
         data,
         model_name=model_name,
@@ -295,7 +302,7 @@ def convert_obml_to_osi(
         result: dict[str, Any] = converter.convert()
     except Exception as exc:  # noqa: BLE001
         raise CliError(f"OBML -> OSI conversion failed: {exc}") from None
-    warnings = list(converter.warnings)
+    warnings = input_warnings + list(converter.warnings)
 
     ontology: dict[str, Any] | None = None
     if include_ontology:

--- a/src/orionbelt/cli/_local.py
+++ b/src/orionbelt/cli/_local.py
@@ -83,9 +83,25 @@ def validate(model_yaml: str) -> ValidationSummary:
 def _load(model_yaml: str) -> tuple[ModelStore, str, SemanticModel]:
     """Load a model into a fresh store, returning the store, id and model.
 
-    Raises ``ModelValidationError`` (from the store) when the model is invalid;
-    the caller maps that to a clean CLI failure.
+    The CLI is an external ingestion boundary, so it enforces the published
+    JSON Schema here the same way the REST API does via its request guards
+    (``api/schema_guards.py``). ``ModelStore.load_model`` itself stays
+    coercion-tolerant for internal callers; the strictness lives at the
+    boundary. Without this, a schema violation the API rejects with 422
+    (e.g. an authored ``label:`` on a dimension) would be silently coerced
+    away by the CLI.
+
+    Raises ``CliError`` on a JSON Schema violation, and ``ModelValidationError``
+    (from the store) on a semantic error; the caller maps both to a clean CLI
+    failure.
     """
+    from orionbelt.parser.schema_validation import validate_obml_yaml
+
+    schema_errors = validate_obml_yaml(model_yaml)
+    if schema_errors:
+        details = "; ".join(f"[{e.code}] {e.message}" for e in schema_errors)
+        raise CliError(f"Model failed schema validation: {details}")
+
     store = ModelStore()
     result = store.load_model(model_yaml, dedup=False)
     return store, result.model_id, store.get_model(result.model_id)

--- a/tests/integration/test_api_convert.py
+++ b/tests/integration/test_api_convert.py
@@ -188,45 +188,62 @@ class TestOsiToObmlInputValidation:
         assert body["validation"]["schema_valid"] is True
 
 
-class TestObmlToOsiBackwardCompat:
-    """The reverse endpoint must NOT regress — input_validation should be
-    None when no input-side check runs (the obml-to-osi endpoint doesn't
-    validate input yet)."""
+class TestObmlToOsiInputValidation:
+    """The obml-to-osi endpoint validates its OBML input against the schema
+    (advisory), mirroring osi-to-obml — a violation is surfaced in
+    ``input_validation`` rather than silently coerced away."""
 
-    async def test_obml_to_osi_input_validation_absent(self, client: AsyncClient) -> None:
-        obml = {
-            "version": 1.0,
-            "dataObjects": {
-                "Orders": {
-                    "code": "orders",
-                    "database": "WAREHOUSE",
-                    "schema": "PUBLIC",
-                    "columns": {
-                        "Amount": {"code": "amount", "abstractType": "float"},
-                    },
-                }
-            },
-            "measures": {
-                "Revenue": {
-                    "columns": [{"dataObject": "Orders", "column": "Amount"}],
-                    "resultType": "float",
-                    "aggregation": "sum",
-                }
-            },
-        }
+    _VALID_OBML = {
+        "version": 1.0,
+        "dataObjects": {
+            "Orders": {
+                "code": "orders",
+                "database": "WAREHOUSE",
+                "schema": "PUBLIC",
+                "columns": {
+                    "Amount": {"code": "amount", "abstractType": "float"},
+                },
+            }
+        },
+        "measures": {
+            "Revenue": {
+                "columns": [{"dataObject": "Orders", "column": "Amount"}],
+                "resultType": "float",
+                "aggregation": "sum",
+            }
+        },
+    }
+
+    async def test_valid_input_reports_schema_valid(self, client: AsyncClient) -> None:
+        response = await client.post(
+            "/v1/convert/obml-to-osi",
+            json={"input_yaml": yaml.safe_dump(self._VALID_OBML)},
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["input_validation"] is not None
+        assert body["input_validation"]["schema_valid"] is True
+        # No ontology unless explicitly requested.
+        assert body["ontology_yaml"] is None
+        assert body["ontology_validation"] is None
+
+    async def test_authored_label_surfaced_but_conversion_runs(self, client: AsyncClient) -> None:
+        obml = json.loads(json.dumps(self._VALID_OBML))
+        obml["measures"]["Revenue"]["label"] = "Authored"
         response = await client.post(
             "/v1/convert/obml-to-osi",
             json={"input_yaml": yaml.safe_dump(obml)},
         )
+        # Advisory: conversion still succeeds (200), but the schema violation
+        # is surfaced rather than silently dropped.
         assert response.status_code == 200
         body = response.json()
-        # input_validation field exists but is None — the obml-to-osi endpoint
-        # doesn't currently run input-side schema validation.
-        assert "input_validation" in body
-        assert body["input_validation"] is None
-        # No ontology unless explicitly requested.
-        assert body["ontology_yaml"] is None
-        assert body["ontology_validation"] is None
+        iv = body["input_validation"]
+        assert iv is not None
+        assert iv["schema_valid"] is False
+        assert any("label" in e for e in iv["schema_errors"]), iv["schema_errors"]
+        # The conversion still produced OSI output.
+        assert body["output_yaml"]
 
 
 class TestObmlToOsiOntology:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -215,6 +215,25 @@ def test_convert_obml_to_osi(model_file):
     assert "semantic_model" in result.stdout
 
 
+def test_convert_obml_to_osi_surfaces_authored_label(tmp_path):
+    """An authored ``label:`` in the OBML input is surfaced as a schema warning
+    (advisory) instead of being silently coerced away. Conversion still runs.
+    See #221.
+    """
+    import yaml
+
+    raw = yaml.safe_load(SAMPLE_MODEL_YAML)
+    mkey = next(iter(raw["measures"]))
+    raw["measures"][mkey]["label"] = "Authored"
+    bad = tmp_path / "model.yaml"
+    bad.write_text(yaml.safe_dump(raw), encoding="utf-8")
+
+    result = runner.invoke(app, ["convert", "obml-to-osi", str(bad)])
+    assert result.exit_code == 0  # advisory: conversion still succeeds
+    assert "semantic_model" in result.stdout  # output still produced
+    assert "label" in result.output.lower()  # the violation is surfaced
+
+
 def test_convert_roundtrip_osi_to_obml(model_file, tmp_path):
     osi = runner.invoke(app, ["convert", "obml-to-osi", model_file])
     assert osi.exit_code == 0

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -113,6 +113,25 @@ def test_compile_unknown_measure_clean_error(model_file, tmp_path):
     assert "Traceback" not in result.output
 
 
+def test_compile_rejects_authored_label(tmp_path, query_file):
+    """The CLI is an external boundary: an authored ``label:`` on a dimension
+    fails schema validation with a clean error (no traceback), matching the
+    REST API's 422 guard rather than being silently coerced. See #221.
+    """
+    import yaml
+
+    raw = yaml.safe_load(SAMPLE_MODEL_YAML)
+    dim_key = next(iter(raw["dimensions"]))
+    raw["dimensions"][dim_key]["label"] = "Authored"
+    bad = tmp_path / "model.yaml"
+    bad.write_text(yaml.safe_dump(raw), encoding="utf-8")
+
+    result = runner.invoke(app, ["compile", str(bad), "-q", query_file])
+    assert result.exit_code == 1
+    assert "Traceback" not in result.output
+    assert "schema validation" in result.output.lower()
+
+
 def test_compile_explain(model_file, query_file):
     result = runner.invoke(
         app, ["compile", model_file, "-q", query_file, "-d", "postgres", "--explain"]

--- a/tests/unit/test_json_schema_contract.py
+++ b/tests/unit/test_json_schema_contract.py
@@ -30,6 +30,7 @@ import json
 from pathlib import Path
 
 import pytest
+import yaml
 
 jsonschema = pytest.importorskip("jsonschema", reason="jsonschema required for contract test")
 
@@ -102,7 +103,16 @@ def test_timegrain_enum_matches_python_enum(obml_schema) -> None:
 
 @pytest.mark.parametrize(
     "removed_field",
-    ["dimension.group", "measure.reduceToRelationDimensionality"],
+    [
+        "dimension.group",
+        "measure.reduceToRelationDimensionality",
+        # `label` is not authorable on the analytical types: the identity is the
+        # mapping key, which the resolver copies into `label` (like DataObject /
+        # Column). Same treatment must hold in the schema. See #221.
+        "dimension.label",
+        "measure.label",
+        "metric.label",
+    ],
 )
 def test_removed_fields_absent_from_schema(obml_schema, removed_field) -> None:
     """Strict parser (v2.7.2) rejects unknown keys; schema must not
@@ -116,6 +126,48 @@ def test_removed_fields_absent_from_schema(obml_schema, removed_field) -> None:
         f"``{removed_field}`` is no longer a model field but the JSON "
         f"Schema still advertises it. Users following the schema get "
         f"``UNKNOWN_PROPERTY`` from the runtime parser. See #85."
+    )
+
+
+@pytest.mark.parametrize("parent", ["dimensions", "measures", "metrics"])
+def test_authored_label_fails_schema_validation(parent) -> None:
+    """An authored ``label:`` on an analytical type is rejected by schema
+    validation rather than silently coerced away. See #221.
+    """
+    from orionbelt.parser.schema_validation import validate_obml_yaml
+
+    base = {
+        "dimensions": {
+            "Region": {"dataObject": "Sales", "column": "Region", "resultType": "string"}
+        },
+        "measures": {
+            "Revenue": {
+                "columns": [{"dataObject": "Sales", "column": "Amount"}],
+                "aggregation": "sum",
+            }
+        },
+        "metrics": {"Margin": {"type": "derived", "expression": "{[Revenue]} * 0.1"}},
+    }
+    entry = next(iter(base[parent].values()))
+    entry["label"] = "Authored Label"
+    doc = {
+        "version": 1.0,
+        "dataObjects": {
+            "Sales": {
+                "code": "SALES",
+                "database": "WH",
+                "schema": "PUBLIC",
+                "columns": {
+                    "Region": {"code": "REGION", "abstractType": "string"},
+                    "Amount": {"code": "AMOUNT", "abstractType": "float"},
+                },
+            }
+        },
+        **base,
+    }
+    errors = validate_obml_yaml(yaml.safe_dump(doc))
+    assert any(e.code == "SCHEMA_VALIDATION" and "label" in e.message for e in errors), (
+        f"authored label on {parent} should fail schema validation, got {errors}"
     )
 
 


### PR DESCRIPTION
Closes #221.

## What

`label` on `dimension` / `measure` / `metric` was a leftover from the old list-keyed-by-label OBML format. Since the refactor to name-keyed maps, the resolver sets `label` from the mapping key and never reads an authored `label:`, so the property has been silently ignored: declared in the JSON schema, but dead since the initial commit and undocumented.

`DataObject` and `DataObjectColumn` already treat `label` as non-authorable (`json_schema: false`; the key *is* the label). This brings the three analytical types in line, so the whole model surface is consistent.

## Changes

- **`schema/obml-schema.json`**: drop `label` from the `dimension`/`measure`/`metric` definitions. With `additionalProperties: false`, an authored `label:` now fails schema validation loudly instead of being silently ignored, matching how `dataObject` already behaves.
- **`schema/obml-contract.yml`**: mark `Dimension`/`Measure`/`Metric` `label` as `json_schema: false`, `osi_roundtrip: false`. The Pydantic field stays (codegen reads the resolved `.label`); it is populated from the key by the resolver.
- **Vendored OSI schema snapshot** resynced (`test_osi_orionbelt_schema_sync` drift guard).
- **`docs/guide/trend-analysis.md`**: the moving-average example used the stale `list`-with-`label` form, which the resolver already rejects (`'metrics' must be a YAML mapping`). Converted it to the name-keyed map form the rest of the page uses.

## Behavior change

The only user-visible change: a model that authored a redundant `label:` under a dimension/measure/metric now gets a `SCHEMA_VALIDATION` error at load time instead of having it silently dropped. No shipped or fixture model does this. Names are display-grade in OBML (`Country Name`, `Total Sales`), so a separate label added nothing; `description` and `synonyms` cover the adjacent needs.

## Why remove rather than wire it up

Wiring `label` would mean auditing the four codegen sites that currently conflate `label` with the identifier (table alias in `resolution.py`, measure `ColumnRef`, `sql_translator.py`, `expr_parser.py`) plus a name-vs-label rendering split across the API / RDF / BI surfaces, for a payoff that only appears on foreign-OSI import. If that need materializes later, it can be wired deliberately with those sites fixed. See #221 for the full rationale.

## Tests

Full unit + integration suite green (`549 passed` integration, contract/schema-sync/OSI converter suites pass). `ruff check` + `ruff format` clean. No Python source changed.

Refs #201, #202. Background review context: apache/ossie#206.