### PR TITLE
CLI: surface OSI input validation on convert osi-to-obml (#225)

### DIFF
--- a/src/orionbelt/cli/_local.py
+++ b/src/orionbelt/cli/_local.py
@@ -259,12 +259,25 @@ def convert_osi_to_obml(input_yaml: str) -> tuple[dict[str, Any], list[str], dic
     data = yaml.safe_load(input_yaml)
     if not isinstance(data, dict):
         raise CliError("OSI input must be a YAML/JSON mapping (object)")
+    # The CLI is an external boundary: surface OSI input schema issues instead of
+    # silently converting a malformed document. Advisory, matching the REST
+    # osi-to-obml endpoint — conversion still runs. (v0.1.x inputs run through a
+    # legacy shim inside convert(), so a schema warning here can be spurious for
+    # legacy docs; the conversion still succeeds regardless.)
+    input_warnings = [
+        f"OSI input schema: {msg}"
+        for msg in _validation_dict(mod.validate_osi, data).get("schema_errors", [])
+    ]
     converter = mod.OSItoOBML(data)
     try:
         result: dict[str, Any] = converter.convert()
     except Exception as exc:  # noqa: BLE001 — surface converter failures cleanly
         raise CliError(f"OSI -> OBML conversion failed: {exc}") from None
-    return result, list(converter.warnings), _validation_dict(mod.validate_obml, result)
+    return (
+        result,
+        input_warnings + list(converter.warnings),
+        _validation_dict(mod.validate_obml, result),
+    )
 
 
 def convert_obml_to_osi(

--- a/src/orionbelt/cli/main.py
+++ b/src/orionbelt/cli/main.py
@@ -137,6 +137,18 @@ def _emit_warnings(warnings: list[Any]) -> None:
             _render.warn(str(w))
 
 
+def _remote_input_schema_warnings(data: dict[str, Any], label: str) -> list[str]:
+    """Input-schema issues from a convert response, as warning strings.
+
+    The REST convert endpoints surface input schema violations under
+    ``input_validation.schema_errors`` rather than ``warnings``. The local
+    conversion paths fold the same issues into their warnings, so mirror that
+    for ``--server`` users to keep both paths symmetric (see #225).
+    """
+    iv = data.get("input_validation") or {}
+    return [f"{label} input schema: {msg}" for msg in (iv.get("schema_errors") or [])]
+
+
 # --------------------------------------------------------------------------
 # Commands
 # --------------------------------------------------------------------------
@@ -501,7 +513,8 @@ def convert(
                 data = RemoteClient(server, api_key).convert_osi_to_obml(input_yaml)
             except CliError as exc:
                 raise _fail(str(exc)) from None
-            output, warnings = data.get("output_yaml", ""), data.get("warnings") or []
+            output = data.get("output_yaml", "")
+            warnings = _remote_input_schema_warnings(data, "OSI") + (data.get("warnings") or [])
         else:
             import yaml
 
@@ -526,7 +539,8 @@ def convert(
             )
         except CliError as exc:
             raise _fail(str(exc)) from None
-        output, warnings = data.get("output_yaml", ""), data.get("warnings") or []
+        output = data.get("output_yaml", "")
+        warnings = _remote_input_schema_warnings(data, "OBML") + (data.get("warnings") or [])
         onto_yaml = data.get("ontology_yaml")
     else:
         import yaml

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -244,6 +244,28 @@ def test_convert_roundtrip_osi_to_obml(model_file, tmp_path):
     assert "dataObjects" in back.stdout
 
 
+def test_convert_osi_to_obml_surfaces_input_schema_issue(model_file, tmp_path):
+    """A schema violation in the OSI input is surfaced as a warning (advisory),
+    mirroring the REST endpoint and the obml-to-osi CLI path. Conversion still
+    runs. See #225.
+    """
+    import yaml
+
+    # Generate a genuinely valid OSI document, then inject an unexpected field
+    # property the OSI schema forbids (but the converter tolerates).
+    osi = runner.invoke(app, ["convert", "obml-to-osi", model_file])
+    assert osi.exit_code == 0
+    doc = yaml.safe_load(osi.stdout)
+    doc["semantic_model"][0]["datasets"][0]["fields"][0]["bogusProp"] = "x"
+    osi_file = tmp_path / "bad.osi.yaml"
+    osi_file.write_text(yaml.safe_dump(doc), encoding="utf-8")
+
+    back = runner.invoke(app, ["convert", "osi-to-obml", str(osi_file)])
+    assert back.exit_code == 0  # advisory: conversion still succeeds
+    assert "dataObjects" in back.stdout  # output still produced
+    assert "bogusprop" in back.output.lower()  # the violation is surfaced
+
+
 # -- dialects ---------------------------------------------------------------
 
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -244,6 +244,54 @@ def test_convert_roundtrip_osi_to_obml(model_file, tmp_path):
     assert "dataObjects" in back.stdout
 
 
+def test_convert_osi_to_obml_remote_surfaces_input_schema(monkeypatch, tmp_path):
+    """The --server path surfaces input schema issues the REST endpoint returns
+    under input_validation.schema_errors (not warnings). See #225."""
+    from orionbelt.cli import _remote
+
+    def fake(self, input_yaml):
+        return {
+            "output_yaml": "dataObjects: {}\n",
+            "warnings": [],
+            "input_validation": {
+                "schema_valid": False,
+                "schema_errors": ["[semantic_model.0.datasets.0] bad OSI input"],
+            },
+        }
+
+    monkeypatch.setattr(_remote.RemoteClient, "convert_osi_to_obml", fake)
+    osi_file = tmp_path / "in.osi.yaml"
+    osi_file.write_text("version: '0.2.0.dev0'\n", encoding="utf-8")
+    result = runner.invoke(app, ["convert", "osi-to-obml", str(osi_file), "-s", "http://example"])
+    assert result.exit_code == 0
+    assert "dataObjects" in result.stdout
+    assert "bad osi input" in result.output.lower()
+
+
+def test_convert_obml_to_osi_remote_surfaces_input_schema(monkeypatch, tmp_path):
+    """The --server obml-to-osi path likewise surfaces input_validation
+    schema errors (latent gap from #223's REST change)."""
+    from orionbelt.cli import _remote
+
+    def fake(self, input_yaml, *, model_name="semantic_model", include_ontology=False):
+        return {
+            "output_yaml": "semantic_model: []\n",
+            "warnings": [],
+            "input_validation": {
+                "schema_valid": False,
+                "schema_errors": ["[measures.Revenue] 'label' was unexpected"],
+            },
+        }
+
+    monkeypatch.setattr(_remote.RemoteClient, "convert_obml_to_osi", fake)
+    obml_file = tmp_path / "in.yaml"
+    obml_file.write_text("version: 1.0\n", encoding="utf-8")
+    result = runner.invoke(app, ["convert", "obml-to-osi", str(obml_file), "-s", "http://example"])
+    assert result.exit_code == 0
+    assert "semantic_model" in result.stdout
+    assert "label" in result.output.lower()
+
+
 def test_convert_osi_to_obml_surfaces_input_schema_issue(model_file, tmp_path):
     """A schema violation in the OSI input is surfaced as a warning (advisory),
     mirroring the REST endpoint and the obml-to-osi CLI path. Conversion still


### PR DESCRIPTION
Closes #225.

## What

Boundary-symmetry follow-up to #223. The convert paths validate their input against the schema (advisory - conversion still runs, issues surfaced not blocked). Three of the four surfaces already did; the CLI `osi-to-obml` path was the last one that did not - it validated the OBML *output* but not the OSI *input*, so a malformed OSI document converted with no warning about the input.

| Surface | Validates its input? |
|---|---|
| REST `osi-to-obml` | Yes |
| REST `obml-to-osi` | Yes (#223) |
| CLI `obml-to-osi` | Yes (#223) |
| CLI `osi-to-obml` | **Yes (this PR)** |

## Change

`convert_osi_to_obml` now runs advisory OSI input validation (`mod.validate_osi`) and prepends any schema issues to the returned warnings, mirroring what #223 did for `convert_obml_to_osi`. Conversion still runs; exit stays 0.

As on the REST endpoint, a v0.1.x input can produce a spurious schema warning (the legacy shim runs inside `convert()`); the conversion succeeds regardless. The comment notes this.

## Tests

- A valid v0.2 OSI input produces no schema warnings (no spurious noise).
- An unexpected field property is surfaced as a warning, with the conversion still succeeding (exit 0, output produced).

Full `test_cli.py` green; ruff + mypy clean.

Refs #223.