### PR TITLE
OBML internals: rename the identity field `label` -> `name` (#224)

### DIFF
--- a/schema/obml-contract.yml
+++ b/schema/obml-contract.yml
@@ -95,8 +95,8 @@ classes:
     json_schema_def: dataObject
     ontology_class: DataObject
     fields:
-      label:
-        alias: label
+      name:
+        alias: name
         type: "str"
         json_schema: false
         ontology_property: null
@@ -184,8 +184,8 @@ classes:
     json_schema_def: column
     ontology_class: Column
     fields:
-      label:
-        alias: label
+      name:
+        alias: name
         type: "str"
         json_schema: false
         ontology_property: null
@@ -314,11 +314,11 @@ classes:
     json_schema_def: dimension
     ontology_class: Dimension
     fields:
-      label:
-        alias: label
+      name:
+        alias: name
         type: "str"
         # Not authorable: the dimension's identity is its mapping key, which the
-        # resolver copies into `label`. Same treatment as DataObject/Column.
+        # resolver copies into `name`. Same treatment as DataObject/Column.
         json_schema: false
         ontology_property: null
         osi_roundtrip: false
@@ -515,11 +515,11 @@ classes:
     json_schema_def: measure
     ontology_class: Measure
     fields:
-      label:
-        alias: label
+      name:
+        alias: name
         type: "str"
         # Not authorable: the measure's identity is its mapping key, which the
-        # resolver copies into `label`. Same treatment as DataObject/Column.
+        # resolver copies into `name`. Same treatment as DataObject/Column.
         json_schema: false
         ontology_property: null
         osi_roundtrip: false
@@ -682,11 +682,11 @@ classes:
     json_schema_def: metric
     ontology_class: Metric
     fields:
-      label:
-        alias: label
+      name:
+        alias: name
         type: "str"
         # Not authorable: the metric's identity is its mapping key, which the
-        # resolver copies into `label`. Same treatment as DataObject/Column.
+        # resolver copies into `name`. Same treatment as DataObject/Column.
         json_schema: false
         ontology_property: null
         osi_roundtrip: false

--- a/src/orionbelt/compiler/expr_parser.py
+++ b/src/orionbelt/compiler/expr_parser.py
@@ -257,7 +257,7 @@ def tokenize_measure_expression(
                         name = match.group(1).strip()
                         cols = getattr(_obj, "columns", None) if _obj is not None else None
                         if cols is not None and name in cols:
-                            label = getattr(_obj, "label", _default_label) or _default_label
+                            label = getattr(_obj, "name", _default_label) or _default_label
                             return f"{{[{label}].[{name}]}}"
                         return match.group(0)
 

--- a/src/orionbelt/compiler/resolution.py
+++ b/src/orionbelt/compiler/resolution.py
@@ -67,7 +67,7 @@ def _build_computed_column_expr(
 ) -> Expr:
     """Parse a computed column's ``expression`` into an AST.
 
-    ``{name}`` placeholders are substituted with ``{[obj.label].[name]}`` so
+    ``{name}`` placeholders are substituted with ``{[obj.name].[name]}`` so
     the existing measure-expression tokenizer resolves them to physical
     table-qualified column refs. Falls back to a column ref to the column's
     own ``code`` if parsing fails — defensive: never block compilation on
@@ -78,7 +78,7 @@ def _build_computed_column_expr(
     def _sub(match: re.Match[str]) -> str:
         name = match.group(1).strip()
         if name in obj.columns:
-            return f"{{[{obj.label}].[{name}]}}"
+            return f"{{[{obj.name}].[{name}]}}"
         return match.group(0)
 
     rewritten = _COMPUTED_PLACEHOLDER.sub(_sub, expr_str)
@@ -86,7 +86,7 @@ def _build_computed_column_expr(
         tokens = tokenize_measure_expression(rewritten, model)
         return parse_expression(tokens)
     except Exception:  # noqa: BLE001 — preserve previous behaviour on bad expression
-        return ColumnRef(name=column.code or column.label, table=obj.label)
+        return ColumnRef(name=column.code or column.name, table=obj.name)
 
 
 def make_column_expr(model: SemanticModel, object_name: str, column_label: str) -> Expr:
@@ -755,7 +755,7 @@ class QueryResolver:
         if measure.aggregation == AggregationType.MEASURE:
             return FunctionCall(
                 name="MEASURE",
-                args=[ColumnRef(name=measure.label, table=None)],
+                args=[ColumnRef(name=measure.name, table=None)],
             )
         if measure.expression:
             return self._expand_expression(ctx, measure)

--- a/src/orionbelt/compiler/sql_translator.py
+++ b/src/orionbelt/compiler/sql_translator.py
@@ -825,7 +825,7 @@ def _try_translate_raw_mode(ast: exp.Select, model: SemanticModel) -> list[str] 
     known_objects: set[str] = set()
     for obj_name, obj in model.data_objects.items():
         known_objects.add(obj_name.lower())
-        label = getattr(obj, "label", obj_name) or obj_name
+        label = getattr(obj, "name", obj_name) or obj_name
         known_objects.add(str(label).lower())
 
     bare_aggregate_labels: set[str] = set()
@@ -850,7 +850,7 @@ def _try_translate_raw_mode(ast: exp.Select, model: SemanticModel) -> list[str] 
                 # Find the canonical (case-preserved) data-object label.
                 canonical_obj = None
                 for obj_name, obj in model.data_objects.items():
-                    label = getattr(obj, "label", obj_name) or obj_name
+                    label = getattr(obj, "name", obj_name) or obj_name
                     if obj_name.lower() == table_lc or str(label).lower() == table_lc:
                         canonical_obj = str(label) if label else obj_name
                         break

--- a/src/orionbelt/models/semantic.py
+++ b/src/orionbelt/models/semantic.py
@@ -261,7 +261,7 @@ class DataObjectColumn(BaseModel):
     syntax (``regexp_replace``, ``btrim``, etc.).
     """
 
-    label: str
+    name: str
     code: str = ""
     abstract_type: DataType = Field(alias="abstractType")
     sql_type: str | None = Field(None, alias="sqlType")
@@ -335,7 +335,7 @@ class RefreshPolicy(BaseModel):
 class DataObject(BaseModel):
     """A database table or view with its columns and joins."""
 
-    label: str
+    name: str
     code: str
     database: str
     schema_name: str = Field(alias="schema")
@@ -388,7 +388,7 @@ class DataObject(BaseModel):
             import warnings
 
             warnings.warn(
-                f"Data object '{self.label}' sets 'countLabel' but 'countable' is false; "
+                f"Data object '{self.name}' sets 'countLabel' but 'countable' is false; "
                 "the label is ignored because no count measure is synthesized.",
                 stacklevel=2,
             )
@@ -400,7 +400,7 @@ class DataObject(BaseModel):
 class Dimension(BaseModel):
     """A named dimension referencing a data object column."""
 
-    label: str
+    name: str
     view: str = Field(alias="dataObject")
     column: str = ""
     result_type: DataType = Field(DataType.STRING, alias="resultType")
@@ -488,7 +488,7 @@ class PeriodOverPeriod(BaseModel):
 class Measure(BaseModel):
     """An aggregation measure with optional expression template."""
 
-    label: str
+    name: str
     columns: list[DataColumnRef] = []
     result_type: DataType = Field(DataType.FLOAT, alias="resultType")
     aggregation: AggregationType
@@ -633,7 +633,7 @@ class Metric(BaseModel):
     a synthetical date spine.  Supports ratio, difference, previous value, and percent change.
     """
 
-    label: str
+    name: str
     type: MetricType = MetricType.DERIVED
     # Derived metrics
     expression: str | None = None

--- a/src/orionbelt/models/synthesis.py
+++ b/src/orionbelt/models/synthesis.py
@@ -78,7 +78,7 @@ def count_label(object_key: str, obj: DataObject, pattern: str | None = None) ->
     The returned string is BOTH the measure's queryable id and its display label.
     """
     template = obj.count_label or pattern or DEFAULT_COUNT_PATTERN
-    display = obj.label or object_key
+    display = obj.name or object_key
     return template.replace("{object}", display)
 
 
@@ -97,12 +97,12 @@ def synthesize_count_measure(object_key: str, obj: DataObject, name: str) -> Mea
     ``COUNT(*)`` because the ref carries no column.
     """
     return Measure(
-        label=name,
+        name=name,
         columns=[DataColumnRef(view=object_key)],
         aggregation=AggregationType.COUNT,
         result_type=DataType.INT,
         data_type="integer",
-        description=f"Row count of {obj.label or object_key}.",
+        description=f"Row count of {obj.name or object_key}.",
     )
 
 

--- a/src/orionbelt/obsl/metadata_rows.py
+++ b/src/orionbelt/obsl/metadata_rows.py
@@ -74,7 +74,7 @@ def build_dimension_rows(
     if not getattr(model, "dimensions", None):
         return rows
     for dim_name, dim in model.dimensions.items():
-        name = getattr(dim, "label", dim_name) or dim_name
+        name = getattr(dim, "name", dim_name) or dim_name
         data_object = getattr(dim, "view", "") or ""
         column = getattr(dim, "column", "") or ""
         type_ = _enum_value(getattr(dim, "result_type", None), default="string") or "string"
@@ -96,7 +96,7 @@ def build_measure_rows(
     if not effective:
         return rows
     for meas_name, meas in effective.items():
-        name = getattr(meas, "label", meas_name) or meas_name
+        name = getattr(meas, "name", meas_name) or meas_name
         aggregation = _enum_value(getattr(meas, "aggregation", None), default="") or ""
         expression = getattr(meas, "expression", None)
         type_ = _enum_value(getattr(meas, "result_type", None), default="float") or "float"
@@ -144,7 +144,7 @@ def build_metric_rows(
     if not getattr(model, "metrics", None):
         return rows
     for met_name, met in model.metrics.items():
-        name = getattr(met, "label", met_name) or met_name
+        name = getattr(met, "name", met_name) or met_name
         metric_type = _enum_value(getattr(met, "type", None), default="derived") or "derived"
         expression = getattr(met, "expression", None)
         measure = getattr(met, "measure", None)

--- a/src/orionbelt/parser/resolver.py
+++ b/src/orionbelt/parser/resolver.py
@@ -37,13 +37,23 @@ from orionbelt.models.synthesis import DEFAULT_COUNT_PATTERN, count_label, count
 from orionbelt.parser.loader import SourceMap
 
 
-def _allowed_keys(*model_classes: type[BaseModel], extra: tuple[str, ...] = ()) -> frozenset[str]:
+def _allowed_keys(
+    *model_classes: type[BaseModel],
+    extra: tuple[str, ...] = (),
+    exclude: tuple[str, ...] = (),
+) -> frozenset[str]:
     """Return the set of YAML keys accepted at a parse site.
 
     Includes every field name and alias for the given Pydantic model classes,
     plus any extra keys (used for legacy / internal markers like
     ``_extends_sources`` or the ``filter`` (singular) backward-compat key on
     measures).
+
+    ``exclude`` drops resolved-only fields that exist on the model but are not
+    authorable in YAML — notably ``name``, the identity that the resolver
+    always derives from the mapping key. Excluding it keeps authoring ``name:``
+    an ``UNKNOWN_PROPERTY`` error, consistent with its ``json_schema: false``
+    status, rather than being silently accepted and dropped.
     """
     keys: set[str] = set(extra)
     for cls in model_classes:
@@ -51,7 +61,7 @@ def _allowed_keys(*model_classes: type[BaseModel], extra: tuple[str, ...] = ()) 
             keys.add(name)
             if fdef.alias:
                 keys.add(fdef.alias)
-    return frozenset(keys)
+    return frozenset(keys - set(exclude))
 
 
 def _check_unknown_keys(
@@ -100,12 +110,12 @@ _TOP_LEVEL_KEYS = _allowed_keys(
         # — leave the existing check to flag them as unknown.
     ),
 )
-_DATA_OBJECT_KEYS = _allowed_keys(DataObject, extra=("schema",))
-_DATA_OBJECT_COLUMN_KEYS = _allowed_keys(DataObjectColumn)
+_DATA_OBJECT_KEYS = _allowed_keys(DataObject, extra=("schema",), exclude=("name",))
+_DATA_OBJECT_COLUMN_KEYS = _allowed_keys(DataObjectColumn, exclude=("name",))
 _DATA_OBJECT_JOIN_KEYS = _allowed_keys(DataObjectJoin)
 _REFRESH_KEYS = _allowed_keys(RefreshPolicy, extra=("maxStaleness",))
-_DIMENSION_KEYS = _allowed_keys(Dimension)
-_MEASURE_KEYS = _allowed_keys(Measure, extra=("filter",))
+_DIMENSION_KEYS = _allowed_keys(Dimension, exclude=("name",))
+_MEASURE_KEYS = _allowed_keys(Measure, extra=("filter",), exclude=("name",))
 _GRAIN_OVERRIDE_KEYS = _allowed_keys(GrainOverride)
 _FILTER_CONTEXT_KEYS = _allowed_keys(FilterContext)
 _FILTER_CONTEXT_FILTER_KEYS = _allowed_keys(FilterContextFilter)
@@ -120,7 +130,7 @@ _CUSTOM_EXTENSION_KEYS = _allowed_keys(CustomExtension)
 # Period-over-period / Window / Cumulative metric blocks share the Metric
 # field set, but the inner periodOverPeriod block has its own shape.
 _PERIOD_OVER_PERIOD_KEYS = _allowed_keys(PeriodOverPeriod)
-_METRIC_KEYS = _allowed_keys(Metric)
+_METRIC_KEYS = _allowed_keys(Metric, exclude=("name",))
 
 
 def _parse_extensions(

--- a/src/orionbelt/parser/resolver.py
+++ b/src/orionbelt/parser/resolver.py
@@ -364,7 +364,7 @@ class ReferenceResolver:
                         source_map,
                     )
                     obj_columns[fname] = DataObjectColumn(
-                        label=fname,
+                        name=fname,
                         code=fdata.get("code", fname if not fdata.get("expression") else ""),
                         abstract_type=fdata.get("abstractType", "string"),
                         sql_type=fdata.get("sqlType"),
@@ -401,7 +401,7 @@ class ReferenceResolver:
                     )
 
                 data_objects[name] = DataObject(
-                    label=name,
+                    name=name,
                     code=raw_obj.get("code", ""),
                     database=raw_obj.get("database", ""),
                     schema_name=raw_obj.get("schema", ""),
@@ -501,7 +501,7 @@ class ReferenceResolver:
                     )
 
                 dimensions[name] = Dimension(
-                    label=name,
+                    name=name,
                     view=data_object or "",
                     column=column or "",
                     result_type=raw_dim.get("resultType", "string"),
@@ -701,7 +701,7 @@ class ReferenceResolver:
                             )
 
                 measures[name] = Measure(
-                    label=name,
+                    name=name,
                     columns=measure_columns,
                     result_type=raw_meas.get("resultType", "float"),
                     aggregation=raw_meas.get("aggregation", "sum"),
@@ -846,7 +846,7 @@ class ReferenceResolver:
                         )
 
                     metrics[name] = Metric(
-                        label=name,
+                        name=name,
                         type=MetricType.CUMULATIVE,
                         measure=raw_metric.get("measure"),
                         time_dimension=raw_metric.get("timeDimension"),
@@ -920,7 +920,7 @@ class ReferenceResolver:
                     )
 
                     metrics[name] = Metric(
-                        label=name,
+                        name=name,
                         type=MetricType.PERIOD_OVER_PERIOD,
                         expression=expression,
                         period_over_period=pop_config,
@@ -971,7 +971,7 @@ class ReferenceResolver:
                         )
 
                     metrics[name] = Metric(
-                        label=name,
+                        name=name,
                         type=MetricType.WINDOW,
                         measure=ref_measure,
                         time_dimension=raw_metric.get("timeDimension"),
@@ -1002,7 +1002,7 @@ class ReferenceResolver:
                     )
 
                     metrics[name] = Metric(
-                        label=name,
+                        name=name,
                         expression=expression,
                         data_type=raw_metric.get("dataType"),
                         description=raw_metric.get("description"),

--- a/src/orionbelt/service/model_store.py
+++ b/src/orionbelt/service/model_store.py
@@ -805,7 +805,7 @@ class ModelStore:
 
         data_objects = [
             DataObjectInfo(
-                label=obj.label,
+                label=obj.name,
                 code=obj.qualified_code,
                 columns=list(obj.columns.keys()),
                 join_targets=[j.join_to for j in obj.joins],
@@ -817,7 +817,7 @@ class ModelStore:
 
         dimensions = [
             DimensionInfo(
-                name=dim.label,
+                name=dim.name,
                 result_type=dim.result_type.value,
                 data_object=dim.view,
                 column=dim.column,
@@ -830,7 +830,7 @@ class ModelStore:
 
         measures = [
             MeasureInfo(
-                name=m.label,
+                name=m.name,
                 result_type=m.result_type.value,
                 aggregation=m.aggregation,
                 expression=m.expression,
@@ -842,7 +842,7 @@ class ModelStore:
 
         metrics = [
             MetricInfo(
-                name=met.label,
+                name=met.name,
                 expression=met.expression,
                 synonyms=met.synonyms,
                 type=met.type.value,

--- a/tests/unit/test_aggregation_measure.py
+++ b/tests/unit/test_aggregation_measure.py
@@ -85,7 +85,7 @@ def test_measure_alias_normalizes_to_canonical_enum(alias: str) -> None:
     """``agg`` / ``aggregate`` are accepted as aliases for ``measure`` so OBML
     reads naturally regardless of which vendor convention the user is used to.
     """
-    m = Measure(label="X", aggregation=alias)
+    m = Measure(name="X", aggregation=alias)
     assert m.aggregation == AggregationType.MEASURE
 
 
@@ -100,7 +100,7 @@ def test_measure_aggregation_rejects_columns() -> None:
     """
     with pytest.raises(ValueError, match="columns:"):
         Measure(
-            label="Revenue",
+            name="Revenue",
             aggregation="measure",
             columns=[{"dataObject": "Sales", "column": "Amount"}],  # type: ignore[arg-type]
         )
@@ -109,7 +109,7 @@ def test_measure_aggregation_rejects_columns() -> None:
 def test_measure_aggregation_rejects_expression() -> None:
     with pytest.raises(ValueError, match="expression:"):
         Measure(
-            label="Revenue",
+            name="Revenue",
             aggregation="measure",
             expression="{[Sales].[Amount]} * 1.1",
         )
@@ -118,7 +118,7 @@ def test_measure_aggregation_rejects_expression() -> None:
 def test_measure_aggregation_rejects_filters() -> None:
     with pytest.raises(ValueError, match="filters:"):
         Measure(
-            label="Revenue",
+            name="Revenue",
             aggregation="measure",
             filters=[
                 {
@@ -132,14 +132,14 @@ def test_measure_aggregation_rejects_filters() -> None:
 
 def test_measure_aggregation_rejects_total() -> None:
     with pytest.raises(ValueError, match="total"):
-        Measure(label="Revenue", aggregation="measure", total=True)
+        Measure(name="Revenue", aggregation="measure", total=True)
 
 
 def test_measure_aggregation_allows_minimal_form() -> None:
     """Bare label + ``aggregation: measure`` must parse cleanly — that's
     the entire intended surface (the engine knows the rest).
     """
-    m = Measure(label="Total Revenue", aggregation="measure")
+    m = Measure(name="Total Revenue", aggregation="measure")
     assert m.aggregation == AggregationType.MEASURE
     assert m.columns == []
     assert m.expression is None

--- a/tests/unit/test_aggregation_validation.py
+++ b/tests/unit/test_aggregation_validation.py
@@ -92,19 +92,19 @@ class TestMeasureDirectConstruction:
 
         with pytest.raises(ValidationError):
             Measure(
-                label="M",
+                name="M",
                 aggregation="ssum",  # type: ignore[arg-type]
                 result_type="float",
             )
 
     def test_direct_construction_accepts_enum(self) -> None:
         m = Measure(
-            label="M",
+            name="M",
             aggregation=AggregationType.SUM,
             result_type="float",
         )
         assert m.aggregation == AggregationType.SUM
 
     def test_direct_construction_normalizes_case(self) -> None:
-        m = Measure(label="M", aggregation="Sum", result_type="float")  # type: ignore[arg-type]
+        m = Measure(name="M", aggregation="Sum", result_type="float")  # type: ignore[arg-type]
         assert m.aggregation == AggregationType.SUM

--- a/tests/unit/test_cumulative.py
+++ b/tests/unit/test_cumulative.py
@@ -179,12 +179,12 @@ class TestMetricModel:
 class TestMetricValidation:
     def test_derived_requires_expression(self) -> None:
         with pytest.raises(ValueError, match="expression"):
-            Metric(label="Bad", type=MetricType.DERIVED)
+            Metric(name="Bad", type=MetricType.DERIVED)
 
     def test_cumulative_requires_measure(self) -> None:
         with pytest.raises(ValueError, match="measure"):
             Metric(
-                label="Bad",
+                name="Bad",
                 type=MetricType.CUMULATIVE,
                 time_dimension="Order Date",
             )
@@ -192,7 +192,7 @@ class TestMetricValidation:
     def test_cumulative_requires_time_dimension(self) -> None:
         with pytest.raises(ValueError, match="timeDimension"):
             Metric(
-                label="Bad",
+                name="Bad",
                 type=MetricType.CUMULATIVE,
                 measure="Revenue",
             )
@@ -200,7 +200,7 @@ class TestMetricValidation:
     def test_cumulative_rejects_expression(self) -> None:
         with pytest.raises(ValueError, match="must not have"):
             Metric(
-                label="Bad",
+                name="Bad",
                 type=MetricType.CUMULATIVE,
                 measure="Revenue",
                 time_dimension="Order Date",
@@ -210,7 +210,7 @@ class TestMetricValidation:
     def test_window_and_grain_to_date_mutually_exclusive(self) -> None:
         with pytest.raises(ValueError, match="mutually exclusive"):
             Metric(
-                label="Bad",
+                name="Bad",
                 type=MetricType.CUMULATIVE,
                 measure="Revenue",
                 time_dimension="Order Date",
@@ -221,7 +221,7 @@ class TestMetricValidation:
     def test_window_must_be_positive(self) -> None:
         with pytest.raises(ValueError, match="window"):
             Metric(
-                label="Bad",
+                name="Bad",
                 type=MetricType.CUMULATIVE,
                 measure="Revenue",
                 time_dimension="Order Date",

--- a/tests/unit/test_data_types.py
+++ b/tests/unit/test_data_types.py
@@ -80,23 +80,23 @@ class TestParseDataType:
 
 class TestResolveMeasureDataType:
     def test_explicit_wins(self) -> None:
-        m = Measure(label="Revenue", aggregation="sum", data_type="decimal(38, 8)")
+        m = Measure(name="Revenue", aggregation="sum", data_type="decimal(38, 8)")
         result = resolve_measure_data_type(m, None)
         assert result == DecimalType(38, 8)
 
     def test_count_infers_bigint(self) -> None:
-        m = Measure(label="Order Count", aggregation="count")
+        m = Measure(name="Order Count", aggregation="count")
         result = resolve_measure_data_type(m, None)
         assert result == SimpleType("bigint")
 
     def test_count_distinct_infers_bigint(self) -> None:
-        m = Measure(label="Unique Customers", aggregation="count_distinct")
+        m = Measure(name="Unique Customers", aggregation="count_distinct")
         result = resolve_measure_data_type(m, None)
         assert result == SimpleType("bigint")
 
     def test_division_infers_decimal_18_6(self) -> None:
         m = Measure(
-            label="Rate",
+            name="Rate",
             aggregation="sum",
             expression="{[Orders].[Amount]} / {[Orders].[Count]}",
         )
@@ -104,33 +104,33 @@ class TestResolveMeasureDataType:
         assert result == DIVISION_DEFAULT
 
     def test_sum_uses_builtin_default(self) -> None:
-        m = Measure(label="Revenue", aggregation="sum")
+        m = Measure(name="Revenue", aggregation="sum")
         result = resolve_measure_data_type(m, None)
         assert result == BUILTIN_DEFAULT
 
     def test_avg_uses_builtin_default(self) -> None:
-        m = Measure(label="Average", aggregation="avg")
+        m = Measure(name="Average", aggregation="avg")
         result = resolve_measure_data_type(m, None)
         assert result == BUILTIN_DEFAULT
 
     def test_model_settings_override(self) -> None:
-        m = Measure(label="Revenue", aggregation="sum")
+        m = Measure(name="Revenue", aggregation="sum")
         settings = ModelSettings(default_numeric_data_type="decimal(18, 4)")
         result = resolve_measure_data_type(m, settings)
         assert result == DecimalType(18, 4)
 
     def test_min_passthrough(self) -> None:
-        m = Measure(label="Min Price", aggregation="min")
+        m = Measure(name="Min Price", aggregation="min")
         result = resolve_measure_data_type(m, None)
         assert result is None
 
     def test_max_passthrough(self) -> None:
-        m = Measure(label="Max Price", aggregation="max")
+        m = Measure(name="Max Price", aggregation="max")
         result = resolve_measure_data_type(m, None)
         assert result is None
 
     def test_listagg_passthrough(self) -> None:
-        m = Measure(label="Names", aggregation="listagg")
+        m = Measure(name="Names", aggregation="listagg")
         result = resolve_measure_data_type(m, None)
         assert result is None
 
@@ -138,7 +138,7 @@ class TestResolveMeasureDataType:
 class TestResolveMetricDataType:
     def test_explicit_wins(self) -> None:
         m = Metric(
-            label="Rate",
+            name="Rate",
             expression="{[Revenue]} / {[Count]}",
             data_type="decimal(18, 4)",
         )
@@ -146,12 +146,12 @@ class TestResolveMetricDataType:
         assert result == DecimalType(18, 4)
 
     def test_division_infers_decimal_18_6(self) -> None:
-        m = Metric(label="Rate", expression="{[Revenue]} / {[Count]}")
+        m = Metric(name="Rate", expression="{[Revenue]} / {[Count]}")
         result = resolve_metric_data_type(m, None)
         assert result == DIVISION_DEFAULT
 
     def test_simple_expression_uses_default(self) -> None:
-        m = Metric(label="Total", expression="{[Revenue]} + {[Tax]}")
+        m = Metric(name="Total", expression="{[Revenue]} + {[Tax]}")
         result = resolve_metric_data_type(m, None)
         assert result == BUILTIN_DEFAULT
 
@@ -201,20 +201,20 @@ class TestDialectRendering:
 
 class TestModelValidation:
     def test_valid_data_type_on_measure(self) -> None:
-        m = Measure(label="Rev", aggregation="sum", data_type="decimal(18, 2)")
+        m = Measure(name="Rev", aggregation="sum", data_type="decimal(18, 2)")
         assert m.data_type == "decimal(18, 2)"
 
     def test_invalid_data_type_on_measure(self) -> None:
         with pytest.raises(ValueError):
-            Measure(label="Rev", aggregation="sum", data_type="varchar(255)")
+            Measure(name="Rev", aggregation="sum", data_type="varchar(255)")
 
     def test_valid_data_type_on_metric(self) -> None:
-        m = Metric(label="Rate", expression="{[A]} / {[B]}", data_type="decimal(18, 6)")
+        m = Metric(name="Rate", expression="{[A]} / {[B]}", data_type="decimal(18, 6)")
         assert m.data_type == "decimal(18, 6)"
 
     def test_invalid_data_type_on_metric(self) -> None:
         with pytest.raises(ValueError):
-            Metric(label="Rate", expression="{[A]} / {[B]}", data_type="number(18, 2)")
+            Metric(name="Rate", expression="{[A]} / {[B]}", data_type="number(18, 2)")
 
     def test_valid_model_settings(self) -> None:
         s = ModelSettings(default_numeric_data_type="decimal(18, 4)")

--- a/tests/unit/test_diagram.py
+++ b/tests/unit/test_diagram.py
@@ -19,19 +19,19 @@ def _sample_model() -> SemanticModel:
     return SemanticModel(
         data_objects={
             "Orders": DataObject(
-                label="Orders",
+                name="Orders",
                 code="orders",
                 database="DB",
                 schema_name="PUBLIC",
                 columns={
                     "Order ID": DataObjectColumn(
-                        label="Order ID", code="order_id", abstract_type=DataType.STRING
+                        name="Order ID", code="order_id", abstract_type=DataType.STRING
                     ),
                     "Customer ID": DataObjectColumn(
-                        label="Customer ID", code="customer_id", abstract_type=DataType.STRING
+                        name="Customer ID", code="customer_id", abstract_type=DataType.STRING
                     ),
                     "Amount": DataObjectColumn(
-                        label="Amount", code="amount", abstract_type=DataType.FLOAT
+                        name="Amount", code="amount", abstract_type=DataType.FLOAT
                     ),
                 },
                 joins=[
@@ -44,23 +44,23 @@ def _sample_model() -> SemanticModel:
                 ],
             ),
             "Customers": DataObject(
-                label="Customers",
+                name="Customers",
                 code="customers",
                 database="DB",
                 schema_name="PUBLIC",
                 columns={
                     "Cust ID": DataObjectColumn(
-                        label="Cust ID", code="cust_id", abstract_type=DataType.STRING
+                        name="Cust ID", code="cust_id", abstract_type=DataType.STRING
                     ),
                     "Name": DataObjectColumn(
-                        label="Name", code="name", abstract_type=DataType.STRING
+                        name="Name", code="name", abstract_type=DataType.STRING
                     ),
                 },
             ),
         },
         dimensions={
             "Customer Name": Dimension(
-                label="Customer Name",
+                name="Customer Name",
                 view="Customers",
                 column="Name",
                 result_type=DataType.STRING,
@@ -168,13 +168,13 @@ class TestGenerateMermaidER:
         model = SemanticModel(
             data_objects={
                 "Sales": DataObject(
-                    label="Sales",
+                    name="Sales",
                     code="sales",
                     database="DB",
                     schema_name="PUBLIC",
                     columns={
                         "Date": DataObjectColumn(
-                            label="Date", code="dt", abstract_type=DataType.DATE
+                            name="Date", code="dt", abstract_type=DataType.DATE
                         ),
                     },
                     joins=[
@@ -189,13 +189,13 @@ class TestGenerateMermaidER:
                     ],
                 ),
                 "Calendar": DataObject(
-                    label="Calendar",
+                    name="Calendar",
                     code="calendar",
                     database="DB",
                     schema_name="PUBLIC",
                     columns={
                         "Cal Date": DataObjectColumn(
-                            label="Cal Date", code="cal_date", abstract_type=DataType.DATE
+                            name="Cal Date", code="cal_date", abstract_type=DataType.DATE
                         ),
                     },
                 ),
@@ -209,7 +209,7 @@ class TestGenerateMermaidER:
         model = SemanticModel(
             data_objects={
                 "A": DataObject(
-                    label="A",
+                    name="A",
                     code="a",
                     database="DB",
                     schema_name="PUBLIC",
@@ -222,7 +222,7 @@ class TestGenerateMermaidER:
                         ),
                     ],
                 ),
-                "B": DataObject(label="B", code="b", database="DB", schema_name="PUBLIC"),
+                "B": DataObject(name="B", code="b", database="DB", schema_name="PUBLIC"),
             },
         )
         result = generate_mermaid_er(model)
@@ -235,13 +235,13 @@ class TestGenerateMermaidER:
         model = SemanticModel(
             data_objects={
                 "Account Balances": DataObject(
-                    label="Account Balances",
+                    name="Account Balances",
                     code="acct_bal",
                     database="DB",
                     schema_name="PUBLIC",
                     columns={
                         "Account ID": DataObjectColumn(
-                            label="Account ID",
+                            name="Account ID",
                             code="account_id",
                             abstract_type=DataType.STRING,
                         ),

--- a/tests/unit/test_fanout.py
+++ b/tests/unit/test_fanout.py
@@ -44,18 +44,18 @@ def _make_model(
     instead of Orders, simulating a reversed-traversal fanout scenario.
     """
     orders = DataObject(
-        label="Orders",
+        name="Orders",
         code="ORDERS",
         database="WH",
         schema_name="PUBLIC",
         columns={
             "Order ID": DataObjectColumn(
-                label="Order ID", code="ORDER_ID", abstract_type=DataType.STRING
+                name="Order ID", code="ORDER_ID", abstract_type=DataType.STRING
             ),
             "Customer ID": DataObjectColumn(
-                label="Customer ID", code="CUSTOMER_ID", abstract_type=DataType.STRING
+                name="Customer ID", code="CUSTOMER_ID", abstract_type=DataType.STRING
             ),
-            "Amount": DataObjectColumn(label="Amount", code="AMOUNT", abstract_type=DataType.FLOAT),
+            "Amount": DataObjectColumn(name="Amount", code="AMOUNT", abstract_type=DataType.FLOAT),
         },
         joins=[
             DataObjectJoin(
@@ -67,19 +67,19 @@ def _make_model(
         ],
     )
     customers = DataObject(
-        label="Customers",
+        name="Customers",
         code="CUSTOMERS",
         database="WH",
         schema_name="PUBLIC",
         columns={
             "Cust ID": DataObjectColumn(
-                label="Cust ID", code="CUST_ID", abstract_type=DataType.STRING
+                name="Cust ID", code="CUST_ID", abstract_type=DataType.STRING
             ),
             "Country": DataObjectColumn(
-                label="Country", code="COUNTRY", abstract_type=DataType.STRING
+                name="Country", code="COUNTRY", abstract_type=DataType.STRING
             ),
             "Revenue": DataObjectColumn(
-                label="Revenue", code="REVENUE", abstract_type=DataType.FLOAT
+                name="Revenue", code="REVENUE", abstract_type=DataType.FLOAT
             ),
         },
     )
@@ -91,7 +91,7 @@ def _make_model(
 
     measures: dict[str, Measure] = {
         "Total Revenue": Measure(
-            label="Total Revenue",
+            name="Total Revenue",
             columns=[{"dataObject": measure_obj, "column": measure_col}],
             result_type=DataType.FLOAT,
             aggregation="sum",
@@ -101,13 +101,13 @@ def _make_model(
     metrics: dict[str, Metric] = {}
     if add_metric:
         measures["Order Count"] = Measure(
-            label="Order Count",
+            name="Order Count",
             columns=[{"dataObject": measure_obj, "column": measure_col}],
             result_type=DataType.INT,
             aggregation="count",
         )
         metrics["Revenue per Order"] = Metric(
-            label="Revenue per Order",
+            name="Revenue per Order",
             expression="{[Total Revenue]} / {[Order Count]}",
         )
 
@@ -115,7 +115,7 @@ def _make_model(
         data_objects={"Orders": orders, "Customers": customers},
         dimensions={
             "Customer Country": Dimension(
-                label="Customer Country",
+                name="Customer Country",
                 view="Customers",
                 column="Country",
                 result_type=DataType.STRING,
@@ -517,7 +517,7 @@ class TestJunctionTableFanout:
         model = self._make_movies_model()
         # Override measure to use MAX
         model.measures["Movies Cnt"] = Measure(
-            label="Movies Cnt",
+            name="Movies Cnt",
             columns=[{"dataObject": "Movies", "column": "Movie ID"}],
             result_type=DataType.INT,
             aggregation="max",
@@ -601,16 +601,16 @@ class TestPipelineFanout:
         silently-wrong SQL.
         """
         orders = DataObject(
-            label="Orders",
+            name="Orders",
             code="ORDERS",
             database="WH",
             schema_name="PUBLIC",
             columns={
                 "Order ID": DataObjectColumn(
-                    label="Order ID", code="ORDER_ID", abstract_type=DataType.STRING
+                    name="Order ID", code="ORDER_ID", abstract_type=DataType.STRING
                 ),
                 "Customer ID": DataObjectColumn(
-                    label="Customer ID", code="CUSTOMER_ID", abstract_type=DataType.STRING
+                    name="Customer ID", code="CUSTOMER_ID", abstract_type=DataType.STRING
                 ),
             },
             joins=[
@@ -623,16 +623,16 @@ class TestPipelineFanout:
             ],
         )
         customers = DataObject(
-            label="Customers",
+            name="Customers",
             code="CUSTOMERS",
             database="WH",
             schema_name="PUBLIC",
             columns={
                 "Cust ID": DataObjectColumn(
-                    label="Cust ID", code="CUST_ID", abstract_type=DataType.STRING
+                    name="Cust ID", code="CUST_ID", abstract_type=DataType.STRING
                 ),
                 "Revenue": DataObjectColumn(
-                    label="Revenue", code="REVENUE", abstract_type=DataType.FLOAT
+                    name="Revenue", code="REVENUE", abstract_type=DataType.FLOAT
                 ),
             },
         )
@@ -641,7 +641,7 @@ class TestPipelineFanout:
             data_objects={"Orders": orders, "Customers": customers},
             dimensions={
                 "Order ID": Dimension(
-                    label="Order ID",
+                    name="Order ID",
                     view="Orders",
                     column="Order ID",
                     result_type=DataType.STRING,
@@ -649,7 +649,7 @@ class TestPipelineFanout:
             },
             measures={
                 "Cust Revenue": Measure(
-                    label="Cust Revenue",
+                    name="Cust Revenue",
                     columns=[{"dataObject": "Customers", "column": "Revenue"}],
                     result_type=DataType.FLOAT,
                     aggregation="sum",

--- a/tests/unit/test_filter_context.py
+++ b/tests/unit/test_filter_context.py
@@ -188,7 +188,7 @@ class TestFilterContextModel:
 
     def test_measure_filter_context_field(self):
         m = Measure(
-            label="test",
+            name="test",
             aggregation="sum",
             filter_context=FilterContext(mode=FilterContextMode.FIXED),
         )
@@ -196,7 +196,7 @@ class TestFilterContextModel:
         assert m.filter_context.mode == FilterContextMode.FIXED
 
     def test_measure_filter_context_none_by_default(self):
-        m = Measure(label="test", aggregation="sum")
+        m = Measure(name="test", aggregation="sum")
         assert m.filter_context is None
 
 

--- a/tests/unit/test_grain_override.py
+++ b/tests/unit/test_grain_override.py
@@ -193,7 +193,7 @@ class TestGrainOverrideModel:
     def test_total_and_grain_mutual_exclusion(self) -> None:
         with pytest.raises(ValueError, match="mutually exclusive"):
             Measure(
-                label="Bad",
+                name="Bad",
                 aggregation="sum",
                 total=True,
                 grain=GrainOverride(mode=GrainMode.FIXED),

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -62,26 +62,26 @@ class TestDataColumnRef:
 
 class TestDataObjectColumn:
     def test_data_object_column_creation(self) -> None:
-        col = DataObjectColumn(label="Amount", code="AMOUNT", abstractType="float")
-        assert col.label == "Amount"
+        col = DataObjectColumn(name="Amount", code="AMOUNT", abstractType="float")
+        assert col.name == "Amount"
         assert col.code == "AMOUNT"
         assert col.abstract_type == DataType.FLOAT
 
     def test_data_object_column_with_num_class(self) -> None:
         col = DataObjectColumn(
-            label="Amount", code="AMOUNT", abstractType="float", numClass="additive"
+            name="Amount", code="AMOUNT", abstractType="float", numClass="additive"
         )
         assert col.num_class == NumClass.ADDITIVE
 
     def test_data_object_column_num_class_defaults_to_none(self) -> None:
-        col = DataObjectColumn(label="Amount", code="AMOUNT", abstractType="float")
+        col = DataObjectColumn(name="Amount", code="AMOUNT", abstractType="float")
         assert col.num_class is None
 
 
 class TestDataObject:
     def test_data_object_qualified_code(self) -> None:
         obj = DataObject(
-            label="Orders",
+            name="Orders",
             code="ORDERS",
             database="WAREHOUSE",
             schema="PUBLIC",
@@ -91,7 +91,7 @@ class TestDataObject:
 
 class TestDimension:
     def test_dimension_with_data_object_column(self) -> None:
-        dim = Dimension(label="Country", view="Customers", column="Country", resultType="string")
+        dim = Dimension(name="Country", view="Customers", column="Country", resultType="string")
         assert dim.view == "Customers"
         assert dim.column == "Country"
 
@@ -99,7 +99,7 @@ class TestDimension:
 class TestMeasure:
     def test_simple_measure(self) -> None:
         m = Measure(
-            label="Revenue",
+            name="Revenue",
             columns=[DataColumnRef(view="Orders", column="Amount")],
             resultType="float",
             aggregation="sum",
@@ -109,7 +109,7 @@ class TestMeasure:
 
     def test_measure_with_expression(self) -> None:
         m = Measure(
-            label="Profit",
+            name="Profit",
             columns=[
                 DataColumnRef(view="Sales", column="Amount"),
                 DataColumnRef(view="Sales", column="Cost"),

--- a/tests/unit/test_pop.py
+++ b/tests/unit/test_pop.py
@@ -192,7 +192,7 @@ class TestPoPValidation:
     def test_pop_requires_expression(self) -> None:
         with pytest.raises(ValueError, match="expression"):
             Metric(
-                label="Bad",
+                name="Bad",
                 type=MetricType.PERIOD_OVER_PERIOD,
                 period_over_period=PeriodOverPeriod(
                     time_dimension="D",
@@ -204,7 +204,7 @@ class TestPoPValidation:
     def test_pop_requires_period_over_period(self) -> None:
         with pytest.raises(ValueError, match="periodOverPeriod"):
             Metric(
-                label="Bad",
+                name="Bad",
                 type=MetricType.PERIOD_OVER_PERIOD,
                 expression="{[Revenue]}",
             )
@@ -212,7 +212,7 @@ class TestPoPValidation:
     def test_pop_rejects_cumulative_fields(self) -> None:
         with pytest.raises(ValueError, match="must not have"):
             Metric(
-                label="Bad",
+                name="Bad",
                 type=MetricType.PERIOD_OVER_PERIOD,
                 expression="{[Revenue]}",
                 period_over_period=PeriodOverPeriod(

--- a/tests/unit/test_strict_property_parsing.py
+++ b/tests/unit/test_strict_property_parsing.py
@@ -77,6 +77,25 @@ class TestOBMLStrictParsing:
         assert "UNKNOWN_PROPERTY" in codes
         assert any("dataObjects.Orders" in p for p in paths)
 
+    @pytest.mark.parametrize(
+        ("anchor", "path"),
+        [
+            ("    code: ORDERS", "dataObjects.Orders"),
+            ("    resultType: string", "dimensions.Order ID"),
+            ("    aggregation: sum", "measures.Revenue"),
+        ],
+    )
+    def test_label_is_not_an_authorable_key(self, anchor: str, path: str) -> None:
+        """``label`` was renamed to the resolved-only ``name`` field (#224), so
+        an authored ``label:`` on an analytical type is now a strict-parse error
+        rather than a silently-dropped key. The identity comes from the mapping
+        key, never an authored property.
+        """
+        yaml = _BASE.replace(anchor, f"{anchor}\n    label: Nope", 1)
+        codes, paths = _resolve(yaml)
+        assert "UNKNOWN_PROPERTY" in codes
+        assert any(path in p for p in paths)
+
     def test_unknown_column_key(self) -> None:
         yaml = _BASE.replace(
             "      ID:\n        code: ID\n        abstractType: string",

--- a/tests/unit/test_strict_property_parsing.py
+++ b/tests/unit/test_strict_property_parsing.py
@@ -77,21 +77,32 @@ class TestOBMLStrictParsing:
         assert "UNKNOWN_PROPERTY" in codes
         assert any("dataObjects.Orders" in p for p in paths)
 
+    @pytest.mark.parametrize("key", ["label", "name"])
     @pytest.mark.parametrize(
-        ("anchor", "path"),
+        ("source", "anchor", "path"),
         [
-            ("    code: ORDERS", "dataObjects.Orders"),
-            ("    resultType: string", "dimensions.Order ID"),
-            ("    aggregation: sum", "measures.Revenue"),
+            (_BASE, "    code: ORDERS", "dataObjects.Orders"),
+            (_BASE, "        code: ID", "dataObjects.Orders.columns.ID"),
+            (_BASE, "    resultType: string", "dimensions.Order ID"),
+            (_BASE, "    aggregation: sum", "measures.Revenue"),
+            (
+                _BASE + 'metrics:\n  Margin:\n    expression: "{[Revenue]}"\n',
+                "    expression:",
+                "metrics.Margin",
+            ),
         ],
     )
-    def test_label_is_not_an_authorable_key(self, anchor: str, path: str) -> None:
-        """``label`` was renamed to the resolved-only ``name`` field (#224), so
-        an authored ``label:`` on an analytical type is now a strict-parse error
-        rather than a silently-dropped key. The identity comes from the mapping
-        key, never an authored property.
+    def test_identity_field_is_not_authorable(
+        self, key: str, source: str, anchor: str, path: str
+    ) -> None:
+        """Neither ``label`` (the old field name) nor ``name`` (the resolved-only
+        identity field, #224) is authorable on any OBML type. Identity comes only
+        from the mapping key, so authoring either is a strict-parse
+        ``UNKNOWN_PROPERTY`` error, not a silently-dropped key. Guards against the
+        rename re-introducing a silently-accepted authored key.
         """
-        yaml = _BASE.replace(anchor, f"{anchor}\n    label: Nope", 1)
+        indent = anchor[: len(anchor) - len(anchor.lstrip())]
+        yaml = source.replace(anchor, f"{anchor}\n{indent}{key}: Nope", 1)
         codes, paths = _resolve(yaml)
         assert "UNKNOWN_PROPERTY" in codes
         assert any(path in p for p in paths)

--- a/tests/unit/test_synthesized_counts.py
+++ b/tests/unit/test_synthesized_counts.py
@@ -36,7 +36,6 @@ version: 1.0
 
 dataObjects:
   Sales:
-    label: Sales
     code: SALES
     database: WAREHOUSE
     schema: PUBLIC
@@ -58,7 +57,6 @@ dataObjects:
         columnsTo: [Region Code]
 
   Region:
-    label: Region
     code: REGIONS
     database: WAREHOUSE
     schema: PUBLIC
@@ -163,7 +161,7 @@ def test_count_by_many_to_one_dim_no_fanout(
 
 def test_declared_override_wins(model: SemanticModel, pipeline: CompilationPipeline) -> None:
     declared = Measure(
-        label="Sales Count",
+        name="Sales Count",
         columns=[DataColumnRef(view="Sales", column="Sale ID")],
         aggregation=AggregationType.COUNT_DISTINCT,
         result_type=DataType.INT,
@@ -185,13 +183,13 @@ def test_declared_override_wins(model: SemanticModel, pipeline: CompilationPipel
 
 def test_per_object_opt_out() -> None:
     obj = DataObject(
-        label="Sales",
+        name="Sales",
         code="SALES",
         database="W",
         schema="P",
         countable=False,
         columns={
-            "Amount": DataObjectColumn(label="Amount", code="AMT", abstract_type=DataType.FLOAT)
+            "Amount": DataObjectColumn(name="Amount", code="AMT", abstract_type=DataType.FLOAT)
         },
     )
     m = SemanticModel(data_objects={"Sales": obj})
@@ -200,12 +198,12 @@ def test_per_object_opt_out() -> None:
 
 def test_model_expose_counts_false() -> None:
     obj = DataObject(
-        label="Sales",
+        name="Sales",
         code="SALES",
         database="W",
         schema="P",
         columns={
-            "Amount": DataObjectColumn(label="Amount", code="AMT", abstract_type=DataType.FLOAT)
+            "Amount": DataObjectColumn(name="Amount", code="AMT", abstract_type=DataType.FLOAT)
         },
     )
     m = SemanticModel(data_objects={"Sales": obj}, expose_counts=False)
@@ -213,57 +211,57 @@ def test_model_expose_counts_false() -> None:
 
 
 def test_label_default_pattern(model: SemanticModel) -> None:
-    assert model.effective_measures["Sales Count"].label == "Sales Count"
+    assert model.effective_measures["Sales Count"].name == "Sales Count"
 
 
 def test_label_model_pattern() -> None:
     obj = DataObject(
-        label="Sales",
+        name="Sales",
         code="SALES",
         database="W",
         schema="P",
         columns={
-            "Amount": DataObjectColumn(label="Amount", code="AMT", abstract_type=DataType.FLOAT)
+            "Amount": DataObjectColumn(name="Amount", code="AMT", abstract_type=DataType.FLOAT)
         },
     )
     m = SemanticModel(data_objects={"Sales": obj}, count_label_pattern="# {object}")
     # Name == label, so the pattern sets both the key and the label.
     assert "# Sales" in m.effective_measures
-    assert m.effective_measures["# Sales"].label == "# Sales"
+    assert m.effective_measures["# Sales"].name == "# Sales"
 
 
 def test_label_per_object_override() -> None:
     obj = DataObject(
-        label="Sales",
+        name="Sales",
         code="SALES",
         database="W",
         schema="P",
         count_label="Sales headcount",
         columns={
-            "Amount": DataObjectColumn(label="Amount", code="AMT", abstract_type=DataType.FLOAT)
+            "Amount": DataObjectColumn(name="Amount", code="AMT", abstract_type=DataType.FLOAT)
         },
     )
     m = SemanticModel(data_objects={"Sales": obj}, count_label_pattern="# {object}")
     # Per-object override beats the model pattern (and is the name too).
     assert "Sales headcount" in m.effective_measures
-    assert m.effective_measures["Sales headcount"].label == "Sales headcount"
+    assert m.effective_measures["Sales headcount"].name == "Sales headcount"
 
 
 def test_label_interpolates_display_label_not_key() -> None:
     """``{object}`` fills from the object's display label, not the reference key."""
     obj = DataObject(
-        label="Sales",
+        name="Sales",
         code="FACT_SALES",
         database="W",
         schema="P",
         columns={
-            "Amount": DataObjectColumn(label="Amount", code="AMT", abstract_type=DataType.FLOAT)
+            "Amount": DataObjectColumn(name="Amount", code="AMT", abstract_type=DataType.FLOAT)
         },
     )
     m = SemanticModel(data_objects={"fact_sales": obj})
     # Name/label interpolate the display label ("Sales"), not the key.
     assert "Sales Count" in m.effective_measures
-    assert m.effective_measures["Sales Count"].label == "Sales Count"
+    assert m.effective_measures["Sales Count"].name == "Sales Count"
 
 
 def test_pattern_validation_rejects_other_tokens() -> None:
@@ -275,7 +273,7 @@ def test_count_label_ignored_when_not_countable_warns() -> None:
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
         DataObject(
-            label="Sales",
+            name="Sales",
             code="SALES",
             database="W",
             schema="P",
@@ -349,7 +347,6 @@ def test_resolver_honors_count_label() -> None:
 version: 1.0
 dataObjects:
   Sales:
-    label: Sales
     code: SALES
     database: W
     schema: P
@@ -360,7 +357,7 @@ dataObjects:
     )
     # countLabel sets both the name and the label.
     assert "Deals" in m.effective_measures
-    assert m.effective_measures["Deals"].label == "Deals"
+    assert m.effective_measures["Deals"].name == "Deals"
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit/test_trend_analysis.py
+++ b/tests/unit/test_trend_analysis.py
@@ -142,11 +142,11 @@ def _load_model(yaml: str = TREND_MODEL_YAML) -> SemanticModel:
 class TestMetricPartitionByValidation:
     def test_derived_rejects_partition_by(self) -> None:
         with pytest.raises(ValueError, match="partitionBy"):
-            Metric(label="Bad", type=MetricType.DERIVED, expression="{[X]}", partition_by=["Dim"])
+            Metric(name="Bad", type=MetricType.DERIVED, expression="{[X]}", partition_by=["Dim"])
 
     def test_cumulative_accepts_partition_by(self) -> None:
         m = Metric(
-            label="OK",
+            name="OK",
             type=MetricType.CUMULATIVE,
             measure="Revenue",
             time_dimension="Order Date",
@@ -156,12 +156,12 @@ class TestMetricPartitionByValidation:
 
     def test_window_metric_requires_window_function(self) -> None:
         with pytest.raises(ValueError, match="windowFunction"):
-            Metric(label="Bad", type=MetricType.WINDOW, measure="Revenue")
+            Metric(name="Bad", type=MetricType.WINDOW, measure="Revenue")
 
     def test_window_lag_requires_offset(self) -> None:
         with pytest.raises(ValueError, match="offset"):
             Metric(
-                label="Bad",
+                name="Bad",
                 type=MetricType.WINDOW,
                 window_function=WindowFunctionKind.LAG,
                 measure="Revenue",
@@ -171,7 +171,7 @@ class TestMetricPartitionByValidation:
     def test_window_lag_requires_time_dimension(self) -> None:
         with pytest.raises(ValueError, match="timeDimension"):
             Metric(
-                label="Bad",
+                name="Bad",
                 type=MetricType.WINDOW,
                 window_function=WindowFunctionKind.LAG,
                 measure="Revenue",
@@ -181,7 +181,7 @@ class TestMetricPartitionByValidation:
     def test_window_ntile_requires_buckets(self) -> None:
         with pytest.raises(ValueError, match="buckets"):
             Metric(
-                label="Bad",
+                name="Bad",
                 type=MetricType.WINDOW,
                 window_function=WindowFunctionKind.NTILE,
                 measure="Revenue",
@@ -190,7 +190,7 @@ class TestMetricPartitionByValidation:
     def test_window_row_number_no_measure_ok(self) -> None:
         # ROW_NUMBER can rank without an explicit measure
         m = Metric(
-            label="RN",
+            name="RN",
             type=MetricType.WINDOW,
             window_function=WindowFunctionKind.ROW_NUMBER,
             time_dimension="Order Date",
@@ -200,7 +200,7 @@ class TestMetricPartitionByValidation:
     def test_window_rejects_expression(self) -> None:
         with pytest.raises(ValueError, match="must not have 'expression'"):
             Metric(
-                label="Bad",
+                name="Bad",
                 type=MetricType.WINDOW,
                 window_function=WindowFunctionKind.RANK,
                 measure="Revenue",
@@ -210,7 +210,7 @@ class TestMetricPartitionByValidation:
     def test_window_invalid_order_direction(self) -> None:
         with pytest.raises(ValueError, match="orderDirection"):
             Metric(
-                label="Bad",
+                name="Bad",
                 type=MetricType.WINDOW,
                 window_function=WindowFunctionKind.RANK,
                 measure="Revenue",
@@ -222,7 +222,7 @@ class TestStatisticalAggregationArity:
     def test_corr_requires_two_columns(self) -> None:
         with pytest.raises(ValueError, match="2 columns"):
             Measure(
-                label="Bad",
+                name="Bad",
                 aggregation="corr",
                 columns=[{"dataObject": "Orders", "column": "Amount"}],
             )
@@ -235,7 +235,7 @@ class TestStatisticalAggregationArity:
         at load time, not at compile time."""
         with pytest.raises(ValueError, match=r"corr.*expression"):
             Measure(
-                label="Bad",
+                name="Bad",
                 aggregation="corr",
                 expression="{[Orders].[Amount]} + {[Orders].[Spend]}",
             )
@@ -243,7 +243,7 @@ class TestStatisticalAggregationArity:
     def test_covar_pop_rejects_expression_form(self) -> None:
         with pytest.raises(ValueError, match=r"covar_pop.*expression"):
             Measure(
-                label="Bad",
+                name="Bad",
                 aggregation="covar_pop",
                 expression="{[Orders].[Amount]} + {[Orders].[Spend]}",
             )
@@ -251,7 +251,7 @@ class TestStatisticalAggregationArity:
     def test_regr_slope_rejects_expression_form(self) -> None:
         with pytest.raises(ValueError, match=r"regr_slope.*expression"):
             Measure(
-                label="Bad",
+                name="Bad",
                 aggregation="regr_slope",
                 expression="{[Orders].[Amount]} + {[Orders].[Spend]}",
             )
@@ -262,7 +262,7 @@ class TestStatisticalAggregationArity:
         columns restriction only applies to TWO-column aggregates,
         where collapsing two args into one scalar would break the call."""
         m = Measure(
-            label="OK",
+            name="OK",
             aggregation="stddev",
             expression="{[Orders].[Amount]} + 100",
         )
@@ -271,7 +271,7 @@ class TestStatisticalAggregationArity:
     def test_stddev_requires_one_column(self) -> None:
         with pytest.raises(ValueError, match="1 column"):
             Measure(
-                label="Bad",
+                name="Bad",
                 aggregation="stddev",
                 columns=[
                     {"dataObject": "Orders", "column": "Amount"},
@@ -281,7 +281,7 @@ class TestStatisticalAggregationArity:
 
     def test_stddev_accepts_one_column(self) -> None:
         m = Measure(
-            label="OK",
+            name="OK",
             aggregation="stddev",
             columns=[{"dataObject": "Orders", "column": "Amount"}],
         )
@@ -289,7 +289,7 @@ class TestStatisticalAggregationArity:
 
     def test_corr_accepts_two_columns(self) -> None:
         m = Measure(
-            label="OK",
+            name="OK",
             aggregation="corr",
             columns=[
                 {"dataObject": "Orders", "column": "Amount"},
@@ -310,7 +310,7 @@ class TestStatisticalAggregationArity:
         """
         # Non-statistical aggregation + expression: still allowed.
         m = Measure(
-            label="OK",
+            name="OK",
             aggregation="sum",
             expression="{[Orders].[Amount]} + {[Orders].[Spend]}",
         )
@@ -318,7 +318,7 @@ class TestStatisticalAggregationArity:
         # Statistical aggregation + expression: rejected.
         with pytest.raises(ValueError, match=r"corr.*expression"):
             Measure(
-                label="Bad",
+                name="Bad",
                 aggregation="corr",
                 expression="{[Orders].[Amount]} + {[Orders].[Spend]}",
             )


### PR DESCRIPTION
Closes #224. Internal-consistency follow-up to #221.

## What

The `label` field on the five resolved model types (`DataObject`, `DataObjectColumn`, `Dimension`, `Measure`, `Metric`) holds the object's **identity**, not a display label: the resolver denormalizes the mapping key into it, and every read consumes it as the name. The name is a leftover from the old list-keyed-by-`label` format. This renames it to `name` so the field says what it is, and frees the word `label` for a genuine display label later (the OSI field-label surfacing).

## Changes

- **`models/semantic.py`**: rename the field on all five types (`name: str`). None of the five had a `name` field; the top-level `SemanticModel.name` is unrelated.
- **Construction + read sites**: resolver/synthesis constructors and the reads in `resolution.py`, `model_store.py`, `synthesis.py`, `semantic.py`. mypy's attr-defined checking found every direct read; the **six `getattr(obj, "label", ...)` string-based reads** (`metadata_rows.py`, `sql_translator.py`, `expr_parser.py`) were updated by hand since mypy cannot see them.
- **`schema/obml-contract.yml`**: the five field entries become `name` (alias `name`), still `json_schema: false` / `osi_roundtrip: false`.

## No external surface change

The field is non-authorable (absent from the JSON schema, verified), the response models (`DataObjectInfo` etc.) keep their own `label`, and `_model_to_raw` / the OSI converter work off mapping keys, not this field.

## Incidental tightening

Because the resolver's property allowlist is derived from the Pydantic fields, an authored `label:` in YAML is now an `UNKNOWN_PROPERTY` strict-parse error - closing the resolver-level gap #221 left (the schema rejected it, the pure-resolver path silently dropped it). Covered by a new parametrized test in `test_strict_property_parsing.py`.

## Tests

All tests updated for the rename (`label=` -> `name=`; `.label` -> `.name` where reading the five types). `DataObjectInfo.label` reads and `RDFS.label` left unchanged. Full unit suite (2097), contract, integration, and OSI package all pass; ruff + mypy clean.

Refs #221, #220.