### PR TITLE
osi converter: restore OBML dimension name across the round-trip (#220)

### DIFF
--- a/packages/osi-orionbelt/src/osi_orionbelt/obml_to_osi.py
+++ b/packages/osi-orionbelt/src/osi_orionbelt/obml_to_osi.py
@@ -393,6 +393,11 @@ class OBMLtoOSI:
         for _dim_name, dim_obj in obml_dimensions.items():
             if dim_obj.get("dataObject") == do_name and dim_obj.get("column") == col_name:
                 matched_dim = dim_obj
+                # Preserve the dimension's OBML name explicitly. The OSI field
+                # name is the physical code, so without this the round-trip
+                # would rename the dimension to its column code. Authoritative
+                # (do not rely on synonyms, which mix names and user aliases).
+                ext_data["obml_dimension_name"] = _dim_name
                 if dim_obj.get("timeGrain"):
                     ext_data["obml_time_grain"] = dim_obj["timeGrain"]
                 if dim_obj.get("format"):

--- a/packages/osi-orionbelt/src/osi_orionbelt/osi_to_obml.py
+++ b/packages/osi-orionbelt/src/osi_orionbelt/osi_to_obml.py
@@ -565,10 +565,13 @@ class OSItoOBML:
                 if isinstance(ai_ctx, dict) and ai_ctx.get("synonyms"):
                     dim_def["synonyms"] = list(ai_ctx["synonyms"])
                 # Restore OBML-only dimension properties from custom_extensions
+                restored_name: str | None = None
                 for ext in field.get("custom_extensions", []):
                     if ext.get("vendor_name") in _OBML_VENDOR_READ:
                         try:
                             ext_data = json.loads(ext.get("data", "{}"))
+                            if ext_data.get("obml_dimension_name"):
+                                restored_name = ext_data["obml_dimension_name"]
                             if ext_data.get("obml_time_grain"):
                                 dim_def["timeGrain"] = ext_data["obml_time_grain"]
                             if ext_data.get("obml_dimension_format"):
@@ -584,20 +587,32 @@ class OSItoOBML:
                         except (json.JSONDecodeError, TypeError):
                             pass
                         break
+                # Prefer the dimension's restored OBML name (export stashes it on
+                # the field). The OSI field name is the physical code, so this is
+                # what keeps an OBML-origin round-trip from renaming dimensions to
+                # their code. Drop it from synonyms to avoid a self-referential
+                # alias.
+                if restored_name and dim_def.get("synonyms"):
+                    dim_def["synonyms"] = [s for s in dim_def["synonyms"] if s != restored_name]
+                    if not dim_def["synonyms"]:
+                        del dim_def["synonyms"]
+                base_name = restored_name or field_name
                 # Dimension names must be unique across the model. When the same
-                # field name occurs in more than one data object (e.g. Orders.date
-                # and Invoices.date), qualify the later one with its data object
-                # instead of silently overwriting the earlier dimension.
-                key = field_name
+                # name occurs in more than one data object (e.g. foreign OSI where
+                # two datasets share a bare field name and no OBML-origin name was
+                # restored), qualify the later one with its data object instead of
+                # silently overwriting the earlier dimension. A restored OBML name
+                # is unique by construction, so this fallback is foreign-OSI only.
+                key = base_name
                 if key in dimensions and dimensions[key].get("dataObject") != ds_name:
-                    key = f"{ds_name} {field_name}"
+                    key = f"{ds_name} {base_name}"
                     suffix = 2
                     while key in dimensions:
-                        key = f"{ds_name} {field_name} {suffix}"
+                        key = f"{ds_name} {base_name} {suffix}"
                         suffix += 1
                     self.warnings.append(
-                        f"Dimension name '{field_name}' occurs in multiple data "
-                        f"objects; emitted '{ds_name}.{field_name}' as dimension "
+                        f"Dimension name '{base_name}' occurs in multiple data "
+                        f"objects; emitted '{ds_name}.{base_name}' as dimension "
                         f"'{key}' to avoid a collision."
                     )
                 dimensions[key] = dim_def

--- a/packages/osi-orionbelt/src/osi_orionbelt/osi_to_obml.py
+++ b/packages/osi-orionbelt/src/osi_orionbelt/osi_to_obml.py
@@ -570,8 +570,14 @@ class OSItoOBML:
                     if ext.get("vendor_name") in _OBML_VENDOR_READ:
                         try:
                             ext_data = json.loads(ext.get("data", "{}"))
-                            if ext_data.get("obml_dimension_name"):
-                                restored_name = ext_data["obml_dimension_name"]
+                            # Extension data is opaque to ``validate_osi``, so a
+                            # foreign payload may put any JSON here. Only accept a
+                            # non-empty string as the dimension name (it becomes a
+                            # dict key); otherwise ignore it and fall back to the
+                            # field name.
+                            _name = ext_data.get("obml_dimension_name")
+                            if isinstance(_name, str) and _name:
+                                restored_name = _name
                             if ext_data.get("obml_time_grain"):
                                 dim_def["timeGrain"] = ext_data["obml_time_grain"]
                             if ext_data.get("obml_dimension_format"):

--- a/packages/osi-orionbelt/tests/test_osi_converter_properties.py
+++ b/packages/osi-orionbelt/tests/test_osi_converter_properties.py
@@ -253,21 +253,28 @@ class TestDataObjectProperties:
 class TestDimensionProperties:
     """Dimension properties roundtrip.
 
-    Note: OSI uses column *code* as the field name, so after roundtrip the
-    dimension key becomes the physical code (ORDER_DATE).
+    The OSI field name is the physical column code, but the export stashes the
+    dimension's OBML name in an ``obml_dimension_name`` extension, so the
+    round-trip restores the original key (``Order Date``), not the code (#220).
     """
+
+    def test_dimension_name_roundtrip(self):
+        result = _roundtrip(_OBML_FULL)
+        # The OBML dimension name is restored, not renamed to the column code.
+        assert "Order Date" in result["dimensions"]
+        assert "ORDER_DATE" not in result["dimensions"]
 
     def test_dimension_result_type_roundtrip(self):
         result = _roundtrip(_OBML_FULL)
-        assert result["dimensions"]["ORDER_DATE"].get("resultType") == "date"
+        assert result["dimensions"]["Order Date"].get("resultType") == "date"
 
     def test_dimension_description_roundtrip(self):
         result = _roundtrip(_OBML_FULL)
-        assert result["dimensions"]["ORDER_DATE"].get("description") == "Order date dimension"
+        assert result["dimensions"]["Order Date"].get("description") == "Order date dimension"
 
     def test_dimension_owner_roundtrip(self):
         result = _roundtrip(_OBML_FULL)
-        assert result["dimensions"]["ORDER_DATE"].get("owner") == "analytics"
+        assert result["dimensions"]["Order Date"].get("owner") == "analytics"
 
 
 class TestCumulativeMetricDataType:

--- a/packages/osi-orionbelt/tests/test_osi_converter_roundtrip_robustness.py
+++ b/packages/osi-orionbelt/tests/test_osi_converter_roundtrip_robustness.py
@@ -254,6 +254,85 @@ class TestDimensionNameCollision:
 
 
 # ---------------------------------------------------------------------------
+# #220: OBML dimension name restored across the round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestDimensionNameRoundTrip:
+    """An OBML-origin round-trip restores each dimension's name (the OSI field
+    name is the physical code, so without the ``obml_dimension_name`` extension
+    the dimension would be renamed to its code) and never trips the collision
+    fallback, since the restored names are unique by construction."""
+
+    _OBML = {
+        "version": 1.0,
+        "dataObjects": {
+            "Orders": {
+                "code": "FACT_ORDERS",
+                "database": "WH",
+                "schema": "PUBLIC",
+                "columns": {
+                    "Order Date": {"code": "order_dt", "abstractType": "date"},
+                    "Region": {"code": "rgn", "abstractType": "string"},
+                    "Amount": {"code": "amt", "abstractType": "float"},
+                },
+            },
+            "Invoices": {
+                "code": "FACT_INV",
+                "database": "WH",
+                "schema": "PUBLIC",
+                "columns": {"Invoice Date": {"code": "inv_dt", "abstractType": "date"}},
+            },
+        },
+        # Names deliberately differ from their column codes; both date dims would
+        # collide on the code path if names were not restored.
+        "dimensions": {
+            "Order Placed On": {
+                "dataObject": "Orders",
+                "column": "Order Date",
+                "resultType": "date",
+            },
+            "Sales Region": {"dataObject": "Orders", "column": "Region", "resultType": "string"},
+            "Invoice Raised On": {
+                "dataObject": "Invoices",
+                "column": "Invoice Date",
+                "resultType": "date",
+            },
+        },
+        "measures": {
+            "Revenue": {
+                "columns": [{"dataObject": "Orders", "column": "Amount"}],
+                "aggregation": "sum",
+                "resultType": "float",
+            }
+        },
+    }
+
+    def _roundtrip(self) -> tuple[dict[str, Any], list[str]]:
+        osi = conv.OBMLtoOSI(self._OBML, model_name="sales").convert()
+        c = conv.OSItoOBML(osi)
+        return c.convert(), c.warnings
+
+    def test_names_restored_not_renamed_to_code(self) -> None:
+        obml, _ = self._roundtrip()
+        assert set(obml["dimensions"]) == {
+            "Order Placed On",
+            "Sales Region",
+            "Invoice Raised On",
+        }
+
+    def test_no_collision_fallback_for_obml_origin(self) -> None:
+        _, warnings = self._roundtrip()
+        assert not any("collision" in w.lower() for w in warnings), warnings
+
+    def test_restored_name_not_left_as_a_synonym(self) -> None:
+        obml, _ = self._roundtrip()
+        # The dimension must not carry its own restored name as a synonym.
+        for name, dim in obml["dimensions"].items():
+            assert name not in dim.get("synonyms", [])
+
+
+# ---------------------------------------------------------------------------
 # P2: validate_osi robustness on malformed input
 # ---------------------------------------------------------------------------
 

--- a/packages/osi-orionbelt/tests/test_osi_converter_roundtrip_robustness.py
+++ b/packages/osi-orionbelt/tests/test_osi_converter_roundtrip_robustness.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 import json
 from typing import Any
 
+import pytest
+
 import osi_orionbelt.converter as conv
 
 # ---------------------------------------------------------------------------
@@ -330,6 +332,43 @@ class TestDimensionNameRoundTrip:
         # The dimension must not carry its own restored name as a synonym.
         for name, dim in obml["dimensions"].items():
             assert name not in dim.get("synonyms", [])
+
+    @pytest.mark.parametrize("bad", [["x"], 5, "", {}, None])
+    def test_non_string_restored_name_is_ignored(self, bad: Any) -> None:
+        # obml_dimension_name is opaque to validate_osi, so a foreign payload may
+        # put any JSON there. A non-string (would be an unhashable dict key) must
+        # be ignored and fall back to the field name, never crash the converter.
+        osi = {
+            "version": "0.2.0.dev0",
+            "semantic_model": [
+                {
+                    "name": "s",
+                    "datasets": [
+                        {
+                            "name": "Orders",
+                            "source": "WH.PUBLIC.orders",
+                            "fields": [
+                                {
+                                    "name": "dt",
+                                    "expression": {
+                                        "dialects": [{"dialect": "ANSI_SQL", "expression": "dt"}]
+                                    },
+                                    "dimension": {},
+                                    "custom_extensions": [
+                                        {
+                                            "vendor_name": "ORIONBELT",
+                                            "data": json.dumps({"obml_dimension_name": bad}),
+                                        }
+                                    ],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ],
+        }
+        obml = conv.OSItoOBML(osi).convert()
+        assert list(obml["dimensions"]) == ["dt"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #220.

## Problem

The OSI field name is the physical column **code**, so `OBML -> OSI -> OBML` renamed every dimension to its code (e.g. `Order Placed On` came back as `order_dt`) and could then trip the space-qualified collision fallback for names that were unique in the source. The dimension name only survived as one entry in the field's `ai_context` synonyms, mixed with the column display name and user aliases, so it could not be recovered reliably.

## Fix

- **Export** (`obml_to_osi`): stash the dimension's OBML name in an explicit `obml_dimension_name` OBSL-vendor extension on the field, alongside the other `obml_dimension_*` keys. Authoritative, not synonym-derived.
- **Import** (`osi_to_obml`): read it and use it as the dimension key. Precedence: **restored OBML name -> field name (the code) -> space-qualified collision fallback.** Because restored names are unique by construction, the fallback is now genuinely foreign-OSI only. The restored name is also dropped from the dimension's synonyms so it is not left as a self-referential alias.

## Verified

- OBML-origin round-trip restores the names, resolves clean, and fires **no** collision warning.
- Foreign OSI (two datasets sharing a bare field name, no restored name) still triggers the space-qualified collision fallback - unchanged.

## Tests

- New `TestDimensionNameRoundTrip`: names restored, no collision fallback for OBML-origin, no self-referential synonym.
- Updated `TestDimensionProperties`, which had codified the old code-keyed behavior (`ORDER_DATE`), to expect the restored name (`Order Date`).

158 package tests pass; convert integration green; ruff clean; no new mypy errors (the package's pre-existing typing debt is unchanged and outside CI's `mypy src/` scope).

## Note

Per the issue, the same extension hook is where #222 (N dimensions per column) would carry a **list** of dimension descriptors. This PR keeps a single `obml_dimension_name` since the converter is one-dimension-per-column today; #222 will generalize it.

Refs #201, #202.