### PR TITLE
Warm the result-cache decode path at startup

### DIFF
--- a/src/orionbelt/api/app.py
+++ b/src/orionbelt/api/app.py
@@ -286,8 +286,10 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
 
             from orionbelt.cache import result_codec
 
-            warm_payload = result_codec.encode_data(["warm"], [["warm"]])
-            result_codec.decode_data(warm_payload)
+            # Run the encode → decode round-trip on the default threadpool so
+            # the same worker ``try_cache_get`` uses for its off-loop decode is
+            # warmed too, not just the (process-global) pyarrow import.
+            await asyncio.to_thread(result_codec.warm)
             await cache.stats()  # exercises DuckDB meta read + pytz bind
         except Exception:
             logger.exception("Cache warm-up failed (non-fatal)")
@@ -481,19 +483,6 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
             cache=cache,
             cache_config=cache_config,
         )
-
-    # Warm the result-cache decode path off the request hot path. pyarrow is
-    # imported lazily inside ``decode_data``, so without this the first cache
-    # HIT pays the ~100-250ms C-extension load inside the timed fetch and
-    # reports an inflated ``execution_time_ms``. Running it via ``to_thread``
-    # also warms the default threadpool worker that ``try_cache_get`` uses.
-    # Best-effort: never let a warmup failure block startup.
-    try:
-        from orionbelt.cache import result_codec
-
-        await asyncio.to_thread(result_codec.warm)
-    except Exception:
-        logger.debug("result-cache codec warmup failed", exc_info=True)
 
     try:
         yield

--- a/src/orionbelt/api/app.py
+++ b/src/orionbelt/api/app.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import importlib.util
 import logging
 import os
@@ -480,6 +481,19 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
             cache=cache,
             cache_config=cache_config,
         )
+
+    # Warm the result-cache decode path off the request hot path. pyarrow is
+    # imported lazily inside ``decode_data``, so without this the first cache
+    # HIT pays the ~100-250ms C-extension load inside the timed fetch and
+    # reports an inflated ``execution_time_ms``. Running it via ``to_thread``
+    # also warms the default threadpool worker that ``try_cache_get`` uses.
+    # Best-effort: never let a warmup failure block startup.
+    try:
+        from orionbelt.cache import result_codec
+
+        await asyncio.to_thread(result_codec.warm)
+    except Exception:
+        logger.debug("result-cache codec warmup failed", exc_info=True)
 
     try:
         yield

--- a/src/orionbelt/cache/result_codec.py
+++ b/src/orionbelt/cache/result_codec.py
@@ -128,3 +128,18 @@ def table_to_rows(table: Any) -> list[list[Any]]:
     """Return a decoded table's rows as list-of-lists in schema column order."""
     names = table.column_names
     return [[row.get(n) for n in names] for row in table.to_pylist()]
+
+
+def warm() -> None:
+    """Warm the encode/decode path so the first real cache hit isn't slow.
+
+    ``decode_data`` imports pyarrow lazily (the C-extension load alone is
+    ~100-250ms), so the first cache *hit* pays that one-time cost inside the
+    timed fetch and reports an inflated ``execution_time_ms`` (issue: first hit
+    on a freshly-started Cloud Run instance shows hundreds of ms, every
+    subsequent hit is single-digit). Running a tiny round-trip at startup loads
+    pyarrow and warms the decode path off the request hot path. Best-effort: a
+    failure here must never block startup.
+    """
+    encode_data(["_"], [[0]])
+    decode_data(encode_data(["_"], [[0]]))


### PR DESCRIPTION
## Problem

The very first result-cache **hit** on a freshly-started instance (e.g. Cloud Run after scale-up) was slow: hundreds of ms, while every subsequent hit was single-digit ms. The reported `execution_time_ms` on that first hit is misleading because it's the timed cache fetch (`fetch_elapsed_ms`), and the fetch calls `decode_data`, which imports pyarrow lazily. The pyarrow C-extension load alone is ~100-250ms and lands inside that timed window.

So the number wasn't the cache being slow structurally: it was a one-time import warmup surfacing on the first decode.

## Fix

- Add `result_codec.warm()`: a tiny encode/decode round-trip that forces the lazy pyarrow import and exercises the decode path.
- Call it via `asyncio.to_thread` at the end of the API lifespan, right before `yield`, so it also warms the default threadpool worker that `try_cache_get` uses. Best-effort: a warmup failure is logged at debug and never blocks startup.

## Measured

- Warmup pays ~430ms once at boot (off the request hot path).
- Post-warm `decode_data` drops to ~0.1ms.

## Tests

`uv run pytest -k "result_codec or cache or lifespan or app"` -> 151 passed. `ruff check`, `ruff format`, `mypy` all clean.