### PR TITLE
Warm the cache-get path at startup

### DIFF
--- a/src/orionbelt/api/app.py
+++ b/src/orionbelt/api/app.py
@@ -291,6 +291,13 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
             # warmed too, not just the (process-global) pyarrow import.
             await asyncio.to_thread(result_codec.warm)
             await cache.stats()  # exercises DuckDB meta read + pytz bind
+            # A hit's fetch path is a DuckDB metadata SELECT plus an off-loop
+            # blob read, none of which ``stats()`` touches. Fire a throwaway
+            # lookup (a miss is fine) so the ``cache_entries`` /
+            # ``cache_entry_tables`` prepared statements and the off-loop read
+            # path are warm before the first real hit — otherwise it lands on
+            # the caller inside the timed fetch and inflates the reported time.
+            await cache.get("__warmup__")
         except Exception:
             logger.exception("Cache warm-up failed (non-fatal)")
 

--- a/src/orionbelt/api/app.py
+++ b/src/orionbelt/api/app.py
@@ -292,12 +292,11 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
             await asyncio.to_thread(result_codec.warm)
             await cache.stats()  # exercises DuckDB meta read + pytz bind
             # A hit's fetch path is a DuckDB metadata SELECT plus an off-loop
-            # blob read, none of which ``stats()`` touches. Fire a throwaway
-            # lookup (a miss is fine) so the ``cache_entries`` /
-            # ``cache_entry_tables`` prepared statements and the off-loop read
-            # path are warm before the first real hit — otherwise it lands on
-            # the caller inside the timed fetch and inflates the reported time.
-            await cache.get("__warmup__")
+            # blob read, neither of which ``stats()`` (nor a plain miss) touches.
+            # ``warmup`` drives the full set -> read-back -> evict round-trip so
+            # those statements and the off-loop read are warm before the first
+            # real hit, without recording a synthetic miss or leaving an entry.
+            await cache.warmup()
         except Exception:
             logger.exception("Cache warm-up failed (non-fatal)")
 

--- a/src/orionbelt/cache/file.py
+++ b/src/orionbelt/cache/file.py
@@ -491,6 +491,47 @@ class FileCache(Cache):
         except Exception:
             return
 
+    async def warmup(self) -> None:
+        """Drive the full hit fetch path once so the first real hit isn't cold.
+
+        A plain ``get`` miss short-circuits at ``row is None`` before the
+        off-loop blob read and the ``cache_entry_tables`` lookup, so it warms
+        only the first metadata SELECT. Instead run a reserved-key
+        ``set`` -> read-back -> ``_evict`` round-trip, exercising the INSERT,
+        both hit-path SELECTs and the off-loop ``_read_bytes`` a real hit uses.
+        It bypasses the public hit/miss counters and evicts the entry before
+        returning, so ``stats()`` is untouched. Best-effort and idempotent.
+        """
+        key = "__obsl_warmup__"
+        file_path: str | None = None
+        try:
+            await self.set(
+                key,
+                b"warmup",
+                ttl_seconds=60,
+                physical_tables=["__obsl_warmup__"],
+                datasource="__obsl_warmup__",
+                model_id="__obsl_warmup__",
+                query_hash="__obsl_warmup__",
+                dialect="__obsl_warmup__",
+                row_count=0,
+            )
+            # Re-run the exact reads ``get`` does on a hit, minus the counters.
+            row = self._exec(
+                "SELECT file_path FROM cache_entries WHERE cache_key = ?", [key]
+            ).fetchone()
+            if row is not None:
+                file_path = row[0]
+                await asyncio.to_thread(_read_bytes, file_path)
+                self._exec(
+                    "SELECT table_ref FROM cache_entry_tables WHERE cache_key = ?", [key]
+                ).fetchall()
+        except Exception:
+            logger.debug("cache warmup failed", exc_info=True)
+        finally:
+            with contextlib.suppress(Exception):
+                await self._evict(key, file_path)
+
     async def record_heartbeat(self, table_ref: str, observed_at: datetime) -> None:
         """Record a heartbeat for a physical table (idempotent on regression)."""
         now = datetime.now(UTC)

--- a/src/orionbelt/cache/noop.py
+++ b/src/orionbelt/cache/noop.py
@@ -54,5 +54,8 @@ class NoopCache(Cache):
     async def record_hit(self, key: str) -> None:
         return None
 
+    async def warmup(self) -> None:
+        return None
+
     async def shutdown(self) -> None:
         return None

--- a/src/orionbelt/cache/protocol.py
+++ b/src/orionbelt/cache/protocol.py
@@ -113,5 +113,14 @@ class Cache(Protocol):
     async def record_hit(self, key: str) -> None:
         """Increment hit counters. Fire-and-forget; cheap when noop."""
 
+    async def warmup(self) -> None:
+        """Exercise the read path once at startup so the first hit isn't cold.
+
+        Default no-op (inherited by backends that have no cold path). A
+        disk-backed cache overrides this to warm its metadata queries and
+        off-loop blob read. Implementations MUST NOT mutate the hit/miss
+        counters or leave a persisted entry, so ``stats()`` stays clean.
+        """
+
     async def shutdown(self) -> None:
         """Release resources (file handles, sweep tasks). Idempotent."""

--- a/tests/unit/test_cache_file.py
+++ b/tests/unit/test_cache_file.py
@@ -217,3 +217,28 @@ class TestDeferredCounters:
         # Drained after flush — no double counting on the next read.
         assert cache._pending_counters.get("hits", 0) == 0
         assert cache._pending_counters.get("misses", 0) == 0
+
+
+class TestWarmup:
+    """warmup() drives the full hit path without polluting stats or entries."""
+
+    async def test_warmup_leaves_stats_and_entries_clean(self, cache: FileCache) -> None:
+        await cache.warmup()
+
+        # No synthetic hit/miss recorded, no lingering entry or table dep.
+        assert cache._pending_counters.get("hits", 0) == 0
+        assert cache._pending_counters.get("misses", 0) == 0
+        stats = await cache.stats()
+        assert stats.hit_count_total == 0
+        assert stats.miss_count_total == 0
+        assert stats.entry_count == 0
+        assert stats.tracked_physical_tables == 0
+
+        # The reserved key is gone (evicted), so a later lookup is a normal miss.
+        assert await cache.get("__obsl_warmup__") is None
+
+    async def test_warmup_is_idempotent(self, cache: FileCache) -> None:
+        await cache.warmup()
+        await cache.warmup()
+        stats = await cache.stats()
+        assert stats.entry_count == 0


### PR DESCRIPTION
## Follow-up to #231

The pyarrow decode warmup in #231 cut the first cache hit from ~274ms to ~155ms on Cloud Run. The residual ~150ms is the rest of the hit's fetch path that the decode warmup does not touch: a hit runs a DuckDB `cache_entries` metadata `SELECT` plus an **off-loop `.arrow` blob read**, and only then decodes. `stats()` warms a different query shape, so the first real hit still parses those statements and spins the first off-loop read inside the timed fetch.

## Fix

After the decode warm, fire a throwaway `cache.get("__warmup__")` at startup (a miss is fine). This warms:
- the `cache_entries` / `cache_entry_tables` prepared statements, and
- the off-loop read code path.

Stays inside the existing `if cache.backend_name == "file"` guard, so `noop` deployments pay nothing. Runs before Flight/pgwire start, so every surface's first hit benefits.

## Notes

Won't fully erase Cloud Run's sandboxed-filesystem cold tax on the very first genuine blob read, but takes another chunk off the first-hit time. Local: first hit stays ~15ms above steady state purely in the file-read path even with pyarrow warmed; this targets that path.

## Checks

`uv run pytest -k "cache or lifespan or app"` -> 139 passed. `ruff check`, `ruff format`, `mypy` clean.