### PR TITLE
fix: preserve high-precision DECIMAL across pgwire, Flight, cache, and REST (#136)

### DIFF
--- a/drivers/ob-flight-extension/src/ob_flight/converters.py
+++ b/drivers/ob-flight-extension/src/ob_flight/converters.py
@@ -96,7 +96,9 @@ def _decimal_column_type(col: tuple[Any, ...], sampled: list[Any]) -> pa.DataTyp
         and isinstance(desc_precision, int)
         and desc_precision > 0
         and isinstance(desc_scale, int)
-        and desc_scale >= 0
+        # ``>=`` not ``>``: a legal decimal can have precision == scale (e.g.
+        # NUMERIC(2, 2) for values in [0, 1) — zero integer digits).
+        and desc_precision >= desc_scale >= 0
     )
     # Non-decimal sampled values (int / str / …), or no decimal signal at all.
     if not decimals and (sampled or not has_desc):
@@ -107,7 +109,7 @@ def _decimal_column_type(col: tuple[Any, ...], sampled: list[Any]) -> pa.DataTyp
     if (
         isinstance(desc_precision, int)
         and isinstance(desc_scale, int)
-        and desc_precision > desc_scale
+        and desc_precision >= desc_scale >= 0
     ):
         scale = max(scale, desc_scale)
         int_digits = max(int_digits, desc_precision - desc_scale)

--- a/drivers/ob-flight-extension/src/ob_flight/converters.py
+++ b/drivers/ob-flight-extension/src/ob_flight/converters.py
@@ -76,6 +76,29 @@ def decimal_arrow_type(precision: int, scale: int, *, exact: bool = False) -> pa
     return pa.float64()
 
 
+def _decimal_column_type(col: tuple[Any, ...], sampled: list[Any]) -> pa.DataType:
+    """Arrow type for a DECIMAL column from its PEP 249 description + samples.
+
+    A column's first fetched batch can under-represent its declared width (e.g.
+    a ``NUMERIC(40, 2)`` whose early rows are all small), so the driver-reported
+    precision/scale (``description[4]`` / ``[5]``) — which bound *every* row —
+    take priority. The sampled width is combined in (via ``max``) so neither an
+    under-sampled batch nor an under-reported description can narrow the type,
+    then the width is chosen by :func:`decimal_arrow_type` (decimal128 ≤ 38,
+    decimal256 ≤ 76, float64 beyond). See issue #136.
+    """
+    ps = [_decimal_precision_scale(v) for v in sampled if isinstance(v, Decimal)]
+    scale = max((s for _, s in ps), default=0)
+    int_digits = max((p - s for p, s in ps), default=0)
+    desc_precision = col[4] if len(col) > 4 else None
+    desc_scale = col[5] if len(col) > 5 else None
+    if isinstance(desc_scale, int) and desc_scale >= 0:
+        scale = max(scale, desc_scale)
+        if isinstance(desc_precision, int) and desc_precision > desc_scale:
+            int_digits = max(int_digits, desc_precision - desc_scale)
+    return decimal_arrow_type(int_digits + scale, scale)
+
+
 def _python_type_to_arrow(value: Any) -> pa.DataType:
     """Infer Arrow type from a Python value (fallback when type codes are unreliable)."""
     if isinstance(value, bool):
@@ -112,11 +135,11 @@ def schema_from_description(
     for some columns. Passing sample_rows allows scanning multiple rows to find
     the first non-None value per column.
 
-    For DECIMAL columns the Arrow precision and scale are taken from the widest
-    sampled value so the type covers every value in the column — a fixed-scale
-    ``NUMERIC(p, s)`` column reports a stable scale, so the sample is
-    representative; the width jumps to decimal256 when the sampled precision
-    exceeds 38 (issue #136).
+    For DECIMAL columns the Arrow precision/scale come from the driver-reported
+    ``description[4]`` / ``[5]`` when present (they bound every row), combined
+    with the widest sampled value as a fallback — so a column whose first batch
+    under-represents its declared width is still typed wide enough. The width
+    jumps to decimal256 past precision 38 and to float64 past 76 (issue #136).
     """
     # Normalize: prefer sample_rows, fall back to single sample_row
     rows = sample_rows or ([sample_row] if sample_row is not None else [])
@@ -127,12 +150,7 @@ def schema_from_description(
         # Collect this column's non-None sample values (across rows).
         sampled = [row[i] for row in rows if i < len(row) and row[i] is not None]
         if sampled and isinstance(sampled[0], Decimal):
-            # Cover the widest sampled precision and scale so no value overflows
-            # the type — combine the max integer digits with the max scale.
-            ps = [_decimal_precision_scale(v) for v in sampled if isinstance(v, Decimal)]
-            max_scale = max(s for _, s in ps)
-            max_int_digits = max(p - s for p, s in ps)
-            arrow_type = decimal_arrow_type(max_int_digits + max_scale, max_scale)
+            arrow_type = _decimal_column_type(col, sampled)
         elif sampled:
             arrow_type = _python_type_to_arrow(sampled[0])
         else:

--- a/drivers/ob-flight-extension/src/ob_flight/converters.py
+++ b/drivers/ob-flight-extension/src/ob_flight/converters.py
@@ -76,26 +76,41 @@ def decimal_arrow_type(precision: int, scale: int, *, exact: bool = False) -> pa
     return pa.float64()
 
 
-def _decimal_column_type(col: tuple[Any, ...], sampled: list[Any]) -> pa.DataType:
-    """Arrow type for a DECIMAL column from its PEP 249 description + samples.
+def _decimal_column_type(col: tuple[Any, ...], sampled: list[Any]) -> pa.DataType | None:
+    """Arrow decimal type for a DECIMAL column, or ``None`` if it isn't decimal.
 
-    A column's first fetched batch can under-represent its declared width (e.g.
-    a ``NUMERIC(40, 2)`` whose early rows are all small), so the driver-reported
-    precision/scale (``description[4]`` / ``[5]``) — which bound *every* row —
-    take priority. The sampled width is combined in (via ``max``) so neither an
-    under-sampled batch nor an under-reported description can narrow the type,
-    then the width is chosen by :func:`decimal_arrow_type` (decimal128 ≤ 38,
-    decimal256 ≤ 76, float64 beyond). See issue #136.
+    A decimal is recognised from either non-null ``Decimal`` sample values or —
+    when the first fetched batch is all NULL (e.g. UNION ALL NULL padding) — a
+    numeric column whose driver-reported precision/scale (``description[4]`` /
+    ``[5]``) are present. Those bound *every* row, so they take priority over the
+    sample and a narrow (or empty) first batch can't under-size the type; the
+    sampled width is combined in via ``max``. :func:`decimal_arrow_type` then
+    picks decimal128 (≤ 38), decimal256 (≤ 76), or the float64 fallback (> 76).
+    See issue #136.
     """
-    ps = [_decimal_precision_scale(v) for v in sampled if isinstance(v, Decimal)]
-    scale = max((s for _, s in ps), default=0)
-    int_digits = max((p - s for p, s in ps), default=0)
+    decimals = [v for v in sampled if isinstance(v, Decimal)]
     desc_precision = col[4] if len(col) > 4 else None
     desc_scale = col[5] if len(col) > 5 else None
-    if isinstance(desc_scale, int) and desc_scale >= 0:
+    has_desc = (
+        col[1] == NUMBER
+        and isinstance(desc_precision, int)
+        and desc_precision > 0
+        and isinstance(desc_scale, int)
+        and desc_scale >= 0
+    )
+    # Non-decimal sampled values (int / str / …), or no decimal signal at all.
+    if not decimals and (sampled or not has_desc):
+        return None
+    ps = [_decimal_precision_scale(v) for v in decimals]
+    scale = max((s for _, s in ps), default=0)
+    int_digits = max((p - s for p, s in ps), default=0)
+    if (
+        isinstance(desc_precision, int)
+        and isinstance(desc_scale, int)
+        and desc_precision > desc_scale
+    ):
         scale = max(scale, desc_scale)
-        if isinstance(desc_precision, int) and desc_precision > desc_scale:
-            int_digits = max(int_digits, desc_precision - desc_scale)
+        int_digits = max(int_digits, desc_precision - desc_scale)
     return decimal_arrow_type(int_digits + scale, scale)
 
 
@@ -149,12 +164,14 @@ def schema_from_description(
         name = col[0]
         # Collect this column's non-None sample values (across rows).
         sampled = [row[i] for row in rows if i < len(row) and row[i] is not None]
-        if sampled and isinstance(sampled[0], Decimal):
-            arrow_type = _decimal_column_type(col, sampled)
-        elif sampled:
-            arrow_type = _python_type_to_arrow(sampled[0])
-        else:
-            arrow_type = pep249_type_to_arrow(col[1])
+        # A DECIMAL column (from Decimal samples and/or the driver's
+        # precision/scale) is typed first; otherwise infer from the first
+        # sampled value, or the PEP 249 type code when the batch is all NULL.
+        arrow_type = _decimal_column_type(col, sampled)
+        if arrow_type is None:
+            arrow_type = (
+                _python_type_to_arrow(sampled[0]) if sampled else pep249_type_to_arrow(col[1])
+            )
         fields.append(pa.field(name, arrow_type))
     return pa.schema(fields)
 

--- a/drivers/ob-flight-extension/src/ob_flight/converters.py
+++ b/drivers/ob-flight-extension/src/ob_flight/converters.py
@@ -31,34 +31,48 @@ def pep249_type_to_arrow(type_code: Any) -> pa.DataType:
     return pa.utf8()  # fallback
 
 
-# pyarrow decimal128 tops out at precision 38, decimal256 at 76. We advertise
-# the maximum precision so a column's magnitude cannot overflow the inferred
-# type for realistic NUMERIC data, and prefer decimal128 (universally supported
-# by Arrow clients — arrow-js, JDBC, ODBC) unless the scale needs more room.
+# pyarrow decimal128 tops out at precision 38, decimal256 at 76.
 _DECIMAL128_MAX_PRECISION = 38
 _DECIMAL256_MAX_PRECISION = 76
 
 
-def _decimal_scale(value: Decimal) -> int:
-    """Number of fractional digits in a Decimal (0 for integers or specials)."""
+def _decimal_precision_scale(value: Decimal) -> tuple[int, int]:
+    """Return the ``(precision, scale)`` needed to represent a Decimal exactly.
+
+    ``precision`` is the count of significant digits (always ``>= scale``);
+    ``scale`` is the number of fractional digits (0 for integers / specials).
+    """
     exponent = value.as_tuple().exponent
-    return -exponent if isinstance(exponent, int) and exponent < 0 else 0
+    if not isinstance(exponent, int):  # NaN / Infinity
+        return (1, 0)
+    ndigits = len(value.as_tuple().digits)
+    if exponent >= 0:
+        # e.g. 12E3 == 12000 → 5 integer digits, no fraction.
+        return (ndigits + exponent, 0)
+    scale = -exponent
+    return (max(ndigits, scale), scale)
 
 
-def decimal_arrow_type(scale: int) -> pa.DataType:
-    """Widest safe Arrow decimal type for a column with the given fractional scale.
+def decimal_arrow_type(precision: int, scale: int, *, exact: bool = False) -> pa.DataType:
+    """Arrow decimal type wide enough for ``(precision, scale)``.
 
     Preserves NUMERIC precision that ``float64`` would round away past ~15-16
-    significant digits (issue #136). Uses the maximum precision so the column's
-    integer magnitude cannot overflow the type for realistic data, preferring
-    ``decimal128`` and only widening to ``decimal256`` when the scale is large.
-    Falls back to ``float64`` for pathological scales neither decimal represents.
+    significant digits (issue #136). Prefers ``decimal128`` (max precision 38,
+    the broadest Arrow-client support — arrow-js, JDBC, ODBC), widens to
+    ``decimal256`` (max 76) once precision exceeds 38, and falls back to
+    ``float64`` beyond 76 — a width no real NUMERIC column reaches.
+
+    Unless ``exact`` is set the maximum precision of the chosen width is used, so
+    a column whose *sampled* rows under-represent its true magnitude cannot
+    overflow a later row. ``exact`` keeps the given precision and is used when it
+    comes from an authoritative declared type (the DB enforces the bound).
     """
     scale = max(0, scale)
-    if scale <= _DECIMAL128_MAX_PRECISION:
-        return pa.decimal128(_DECIMAL128_MAX_PRECISION, scale)
-    if scale <= _DECIMAL256_MAX_PRECISION:
-        return pa.decimal256(_DECIMAL256_MAX_PRECISION, scale)
+    precision = max(precision, scale, 1)
+    if precision <= _DECIMAL128_MAX_PRECISION:
+        return pa.decimal128(precision if exact else _DECIMAL128_MAX_PRECISION, scale)
+    if precision <= _DECIMAL256_MAX_PRECISION:
+        return pa.decimal256(precision if exact else _DECIMAL256_MAX_PRECISION, scale)
     return pa.float64()
 
 
@@ -71,7 +85,7 @@ def _python_type_to_arrow(value: Any) -> pa.DataType:
     if isinstance(value, float):
         return pa.float64()
     if isinstance(value, Decimal):
-        return decimal_arrow_type(_decimal_scale(value))
+        return decimal_arrow_type(*_decimal_precision_scale(value))
     if isinstance(value, datetime.datetime):
         return pa.timestamp("us")
     if isinstance(value, datetime.date):
@@ -98,9 +112,11 @@ def schema_from_description(
     for some columns. Passing sample_rows allows scanning multiple rows to find
     the first non-None value per column.
 
-    For DECIMAL columns the Arrow scale is taken from the widest sampled value
-    so it covers every value in the column — a fixed-scale ``NUMERIC(p, s)``
-    column reports a stable scale, so the sample is representative (issue #136).
+    For DECIMAL columns the Arrow precision and scale are taken from the widest
+    sampled value so the type covers every value in the column — a fixed-scale
+    ``NUMERIC(p, s)`` column reports a stable scale, so the sample is
+    representative; the width jumps to decimal256 when the sampled precision
+    exceeds 38 (issue #136).
     """
     # Normalize: prefer sample_rows, fall back to single sample_row
     rows = sample_rows or ([sample_row] if sample_row is not None else [])
@@ -111,9 +127,12 @@ def schema_from_description(
         # Collect this column's non-None sample values (across rows).
         sampled = [row[i] for row in rows if i < len(row) and row[i] is not None]
         if sampled and isinstance(sampled[0], Decimal):
-            # Cover the widest sampled scale so no value overflows the type.
-            max_scale = max(_decimal_scale(v) for v in sampled if isinstance(v, Decimal))
-            arrow_type = decimal_arrow_type(max_scale)
+            # Cover the widest sampled precision and scale so no value overflows
+            # the type — combine the max integer digits with the max scale.
+            ps = [_decimal_precision_scale(v) for v in sampled if isinstance(v, Decimal)]
+            max_scale = max(s for _, s in ps)
+            max_int_digits = max(p - s for p, s in ps)
+            arrow_type = decimal_arrow_type(max_int_digits + max_scale, max_scale)
         elif sampled:
             arrow_type = _python_type_to_arrow(sampled[0])
         else:
@@ -133,11 +152,19 @@ def rows_to_batch(
     if not rows:
         return pa.RecordBatch.from_pydict({field.name: [] for field in schema}, schema=schema)
     n_cols = len(schema)
+    # Columns whose Arrow type is floating but whose Python values are Decimal —
+    # the pathological ``decimal_arrow_type`` fallback (precision > 76). pyarrow
+    # won't build a float array straight from Decimals, so coerce those cells so
+    # delivery degrades (lossily) instead of raising.
+    float_cols = {i for i in range(n_cols) if pa.types.is_floating(schema.field(i).type)}
     columns: dict[str, list[Any]] = {schema.field(i).name: [] for i in range(n_cols)}
     for row in rows:
         for i in range(n_cols):
             col_name = schema.field(i).name
-            columns[col_name].append(row[i] if i < len(row) else None)
+            value = row[i] if i < len(row) else None
+            if i in float_cols and isinstance(value, Decimal):
+                value = float(value)
+            columns[col_name].append(value)
     return pa.RecordBatch.from_pydict(columns, schema=schema)
 
 

--- a/drivers/ob-flight-extension/src/ob_flight/converters.py
+++ b/drivers/ob-flight-extension/src/ob_flight/converters.py
@@ -31,6 +31,37 @@ def pep249_type_to_arrow(type_code: Any) -> pa.DataType:
     return pa.utf8()  # fallback
 
 
+# pyarrow decimal128 tops out at precision 38, decimal256 at 76. We advertise
+# the maximum precision so a column's magnitude cannot overflow the inferred
+# type for realistic NUMERIC data, and prefer decimal128 (universally supported
+# by Arrow clients — arrow-js, JDBC, ODBC) unless the scale needs more room.
+_DECIMAL128_MAX_PRECISION = 38
+_DECIMAL256_MAX_PRECISION = 76
+
+
+def _decimal_scale(value: Decimal) -> int:
+    """Number of fractional digits in a Decimal (0 for integers or specials)."""
+    exponent = value.as_tuple().exponent
+    return -exponent if isinstance(exponent, int) and exponent < 0 else 0
+
+
+def decimal_arrow_type(scale: int) -> pa.DataType:
+    """Widest safe Arrow decimal type for a column with the given fractional scale.
+
+    Preserves NUMERIC precision that ``float64`` would round away past ~15-16
+    significant digits (issue #136). Uses the maximum precision so the column's
+    integer magnitude cannot overflow the type for realistic data, preferring
+    ``decimal128`` and only widening to ``decimal256`` when the scale is large.
+    Falls back to ``float64`` for pathological scales neither decimal represents.
+    """
+    scale = max(0, scale)
+    if scale <= _DECIMAL128_MAX_PRECISION:
+        return pa.decimal128(_DECIMAL128_MAX_PRECISION, scale)
+    if scale <= _DECIMAL256_MAX_PRECISION:
+        return pa.decimal256(_DECIMAL256_MAX_PRECISION, scale)
+    return pa.float64()
+
+
 def _python_type_to_arrow(value: Any) -> pa.DataType:
     """Infer Arrow type from a Python value (fallback when type codes are unreliable)."""
     if isinstance(value, bool):
@@ -40,7 +71,7 @@ def _python_type_to_arrow(value: Any) -> pa.DataType:
     if isinstance(value, float):
         return pa.float64()
     if isinstance(value, Decimal):
-        return pa.float64()
+        return decimal_arrow_type(_decimal_scale(value))
     if isinstance(value, datetime.datetime):
         return pa.timestamp("us")
     if isinstance(value, datetime.date):
@@ -66,6 +97,10 @@ def schema_from_description(
     For UNION ALL queries with NULL padding, a single sample row may have None
     for some columns. Passing sample_rows allows scanning multiple rows to find
     the first non-None value per column.
+
+    For DECIMAL columns the Arrow scale is taken from the widest sampled value
+    so it covers every value in the column — a fixed-scale ``NUMERIC(p, s)``
+    column reports a stable scale, so the sample is representative (issue #136).
     """
     # Normalize: prefer sample_rows, fall back to single sample_row
     rows = sample_rows or ([sample_row] if sample_row is not None else [])
@@ -73,17 +108,16 @@ def schema_from_description(
     fields = []
     for i, col in enumerate(description):
         name = col[0]
-        # Scan rows for first non-None value in this column
-        value = None
-        for row in rows:
-            if i < len(row) and row[i] is not None:
-                value = row[i]
-                break
-        if value is not None:
-            arrow_type = _python_type_to_arrow(value)
+        # Collect this column's non-None sample values (across rows).
+        sampled = [row[i] for row in rows if i < len(row) and row[i] is not None]
+        if sampled and isinstance(sampled[0], Decimal):
+            # Cover the widest sampled scale so no value overflows the type.
+            max_scale = max(_decimal_scale(v) for v in sampled if isinstance(v, Decimal))
+            arrow_type = decimal_arrow_type(max_scale)
+        elif sampled:
+            arrow_type = _python_type_to_arrow(sampled[0])
         else:
-            type_code = col[1]
-            arrow_type = pep249_type_to_arrow(type_code)
+            arrow_type = pep249_type_to_arrow(col[1])
         fields.append(pa.field(name, arrow_type))
     return pa.schema(fields)
 

--- a/drivers/ob-flight-extension/src/ob_flight/server_execution.py
+++ b/drivers/ob-flight-extension/src/ob_flight/server_execution.py
@@ -302,8 +302,14 @@ def _numeric_result_arrow_type(item: Any, model: Any) -> pa.DataType | None:
     the FlightInfo schema aligned with the exact value the stream carries so
     high-precision decimals survive (issue #136). Returns ``None`` when the item
     has no declared decimal type, so the caller falls back to ``result_type``.
+
+    A declared precision wider than Arrow's decimal256 limit (76) — which OBML
+    permits but Arrow cannot represent — degrades to ``float64`` via
+    ``decimal_arrow_type`` rather than raising during schema construction.
     """
     from orionbelt.service.db_executor import parse_decimal_type
+
+    from ob_flight.converters import decimal_arrow_type
 
     declared = getattr(item, "data_type", None)
     if not declared:
@@ -315,9 +321,7 @@ def _numeric_result_arrow_type(item: Any, model: Any) -> pa.DataType | None:
     if parsed is None:
         return None
     precision, scale = parsed
-    if precision <= 38:
-        return pa.decimal128(precision, scale)
-    return pa.decimal256(precision, scale)
+    return decimal_arrow_type(precision, scale, exact=True)
 
 
 def semantic_result_schema(server: OBFlightServer, query: Any, model: Any) -> pa.Schema:

--- a/drivers/ob-flight-extension/src/ob_flight/server_execution.py
+++ b/drivers/ob-flight-extension/src/ob_flight/server_execution.py
@@ -292,11 +292,40 @@ def classify_sql(server: OBFlightServer, sql: str, model: Any) -> str:
     return _MODE_REJECTED
 
 
+def _numeric_result_arrow_type(item: Any, model: Any) -> pa.DataType | None:
+    """Advertise a governed measure/metric's declared DECIMAL as an Arrow decimal.
+
+    A DECIMAL column's precision/scale comes from the model's declared
+    ``dataType`` (e.g. ``decimal(18, 2)``), falling back to the model-level
+    ``defaultNumericDataType`` — the same source of truth the pgwire NUMERIC
+    surface uses (issue #116). Advertising the exact Arrow decimal here keeps
+    the FlightInfo schema aligned with the exact value the stream carries so
+    high-precision decimals survive (issue #136). Returns ``None`` when the item
+    has no declared decimal type, so the caller falls back to ``result_type``.
+    """
+    from orionbelt.service.db_executor import parse_decimal_type
+
+    declared = getattr(item, "data_type", None)
+    if not declared:
+        settings = getattr(model, "settings", None)
+        declared = getattr(settings, "default_numeric_data_type", None) if settings else None
+    if not declared:
+        return None
+    parsed = parse_decimal_type(declared)
+    if parsed is None:
+        return None
+    precision, scale = parsed
+    if precision <= 38:
+        return pa.decimal128(precision, scale)
+    return pa.decimal256(precision, scale)
+
+
 def semantic_result_schema(server: OBFlightServer, query: Any, model: Any) -> pa.Schema:
     """Build the result Arrow schema for a semantic query without DB I/O.
 
-    Reads ``result_type`` from each selected dimension / measure / metric.
-    See ``design/PLAN_flight_natural_sql.md`` §3.4 "Schema probe".
+    Reads ``result_type`` from each selected dimension / measure / metric,
+    upgrading governed DECIMAL measures/metrics to an exact Arrow decimal
+    (issue #136). See ``design/PLAN_flight_natural_sql.md`` §3.4 "Schema probe".
     """
     from ob_flight.catalog import _obml_type_to_arrow
 
@@ -313,11 +342,12 @@ def semantic_result_schema(server: OBFlightServer, query: Any, model: Any) -> pa
     for label in measures:
         meas = model.measures.get(label)
         met = model.metrics.get(label) if meas is None else None
-        if meas is not None:
+        decimal_type = _numeric_result_arrow_type(meas or met, model)
+        if decimal_type is not None:
+            fields.append(pa.field(label, decimal_type))
+        elif meas is not None:
             rt = getattr(getattr(meas, "result_type", None), "value", None) or "float"
             fields.append(pa.field(label, _obml_type_to_arrow(rt)))
-        elif met is not None:
-            fields.append(pa.field(label, pa.float64()))
         else:
             fields.append(pa.field(label, pa.float64()))
     if query.grouping is not None:
@@ -669,7 +699,15 @@ def execute_sql(
 
         table = pa.Table.from_batches(batches)
 
-        # Cache populate — write back after a successful warehouse run.
+        # Cast to the schema advertised in FlightInfo so the streamed schema
+        # matches what the client was promised — e.g. a governed DECIMAL column
+        # inferred as decimal128(38, s) narrows to the declared decimal(p, s)
+        # (issue #136). Best-effort: a mismatch leaves the table unchanged.
+        table = align_cached_table(table, result_schema)
+
+        # Cache populate — write back after a successful warehouse run. Storing
+        # the aligned table keeps the cached decimal type consistent with the
+        # REST/pgwire writers and with a subsequent Flight cache hit.
         if cache_meta is not None and server._cache is not None:
             server._cache_put_table(table, cache_meta)
 

--- a/drivers/ob-flight-extension/tests/test_converters.py
+++ b/drivers/ob-flight-extension/tests/test_converters.py
@@ -119,6 +119,18 @@ class TestSchemaFromDescription:
         schema = schema_from_description(desc, sample_rows=[(5,)])
         assert schema.field(0).type == pa.int64()
 
+    def test_precision_equals_scale_keeps_scale(self):
+        # NUMERIC(2, 2) — a legal decimal for values in [0, 1) with zero integer
+        # digits — must keep its scale even with an all-NULL first batch, so a
+        # later Decimal('0.12') doesn't fail to rescale (issue #136 P2).
+        from decimal import Decimal
+
+        desc = (("frac", NUMBER, None, None, 2, 2, None),)
+        schema = schema_from_description(desc, sample_rows=[(None,)])
+        assert schema.field(0).type == pa.decimal128(38, 2)
+        val = Decimal("0.12")
+        assert rows_to_batch([(val,)], schema).column(0).to_pylist()[0] == val
+
 
 class TestDecimalArrowType:
     def test_within_decimal128_uses_max_headroom(self):

--- a/drivers/ob-flight-extension/tests/test_converters.py
+++ b/drivers/ob-flight-extension/tests/test_converters.py
@@ -79,6 +79,27 @@ class TestSchemaFromDescription:
         schema = schema_from_description(desc, sample_rows=[(None,)])
         assert schema.field(0).type == pa.float64()
 
+    def test_driver_precision_scale_beats_narrow_first_batch(self):
+        # A NUMERIC(40, 2) whose first batch is all small values must still be
+        # typed wide enough (decimal256) from the driver-reported precision/scale
+        # so a later 40-precision row doesn't overflow the reused schema (#136).
+        from decimal import Decimal
+
+        desc = (("amt", NUMBER, None, None, 40, 2, None),)  # description[4]=40, [5]=2
+        schema = schema_from_description(desc, sample_rows=[(Decimal("1.23"),)])
+        assert schema.field(0).type == pa.decimal256(76, 2)
+        wide = Decimal("1" * 38 + ".50")  # precision 40 — arrives in a later batch
+        assert rows_to_batch([(wide,)], schema).column(0).to_pylist()[0] == wide
+
+    def test_driver_precision_over_76_degrades_to_float(self):
+        # A driver-reported precision beyond decimal256's limit degrades to
+        # float64 instead of raising during schema construction.
+        from decimal import Decimal
+
+        desc = (("amt", NUMBER, None, None, 100, 2, None),)
+        schema = schema_from_description(desc, sample_rows=[(Decimal("1.23"),)])
+        assert schema.field(0).type == pa.float64()
+
 
 class TestDecimalArrowType:
     def test_within_decimal128_uses_max_headroom(self):

--- a/drivers/ob-flight-extension/tests/test_converters.py
+++ b/drivers/ob-flight-extension/tests/test_converters.py
@@ -9,6 +9,7 @@ import pyarrow as pa
 from ob_driver_core.type_codes import BINARY, DATETIME, NUMBER, STRING
 from ob_flight.converters import (
     cursor_to_batches,
+    decimal_arrow_type,
     pep249_type_to_arrow,
     rows_to_batch,
     schema_from_description,
@@ -52,6 +53,51 @@ class TestSchemaFromDescription:
         desc = (("value", NUMBER, None, None, None, None, None),)
         schema = schema_from_description(desc)
         assert len(schema) == 1
+
+    def test_decimal_sample_infers_decimal_not_float(self):
+        # A Decimal sample value must produce an Arrow decimal so high-precision
+        # NUMERIC survives instead of rounding through float64 (issue #136).
+        from decimal import Decimal
+
+        desc = (("amt", NUMBER, None, None, None, None, None),)
+        rows = [(Decimal("123456789012345678.90"),)]
+        schema = schema_from_description(desc, sample_rows=rows)
+        assert schema.field(0).type == pa.decimal128(38, 2)
+
+    def test_decimal_scale_covers_widest_sample(self):
+        # The Arrow scale is taken from the widest sampled value.
+        from decimal import Decimal
+
+        desc = (("amt", NUMBER, None, None, None, None, None),)
+        rows = [(Decimal("1.5"),), (Decimal("1.500"),), (Decimal("1.50"),)]
+        schema = schema_from_description(desc, sample_rows=rows)
+        assert schema.field(0).type == pa.decimal128(38, 3)
+
+    def test_all_null_decimal_column_falls_back_to_type_code(self):
+        # No sample value → PEP 249 type code path (unchanged float64).
+        desc = (("amt", NUMBER, None, None, None, None, None),)
+        schema = schema_from_description(desc, sample_rows=[(None,)])
+        assert schema.field(0).type == pa.float64()
+
+
+class TestDecimalArrowType:
+    def test_common_scales_use_decimal128(self):
+        assert decimal_arrow_type(2) == pa.decimal128(38, 2)
+        assert decimal_arrow_type(0) == pa.decimal128(38, 0)
+
+    def test_large_scale_uses_decimal256(self):
+        assert decimal_arrow_type(40) == pa.decimal256(76, 40)
+
+    def test_pathological_scale_falls_back_to_float(self):
+        assert decimal_arrow_type(200) == pa.float64()
+
+    def test_high_precision_roundtrips_exactly(self):
+        from decimal import Decimal
+
+        val = Decimal("123456789012345678.90")
+        schema = pa.schema([pa.field("x", decimal_arrow_type(2))])
+        batch = rows_to_batch([(val,)], schema)
+        assert batch.column(0).to_pylist()[0] == val
 
 
 class TestRowsToBatch:

--- a/drivers/ob-flight-extension/tests/test_converters.py
+++ b/drivers/ob-flight-extension/tests/test_converters.py
@@ -81,26 +81,60 @@ class TestSchemaFromDescription:
 
 
 class TestDecimalArrowType:
-    def test_common_scales_use_decimal128(self):
-        assert decimal_arrow_type(2) == pa.decimal128(38, 2)
-        assert decimal_arrow_type(0) == pa.decimal128(38, 0)
+    def test_within_decimal128_uses_max_headroom(self):
+        # Inferred (non-exact): max precision of the chosen width so a later,
+        # wider row can't overflow.
+        assert decimal_arrow_type(20, 2) == pa.decimal128(38, 2)
+        assert decimal_arrow_type(1, 0) == pa.decimal128(38, 0)
 
-    def test_large_scale_uses_decimal256(self):
-        assert decimal_arrow_type(40) == pa.decimal256(76, 40)
+    def test_precision_over_38_uses_decimal256(self):
+        # Precision beyond decimal128's 38 must widen to decimal256, not
+        # overflow decimal128(38, s) (issue #136 P2a).
+        assert decimal_arrow_type(40, 2) == pa.decimal256(76, 2)
 
-    def test_pathological_scale_falls_back_to_float(self):
-        assert decimal_arrow_type(200) == pa.float64()
+    def test_precision_over_76_falls_back_to_float(self):
+        # Beyond decimal256's limit — no Arrow decimal can hold it (P2b).
+        assert decimal_arrow_type(100, 2) == pa.float64()
+        assert decimal_arrow_type(100, 2, exact=True) == pa.float64()
+
+    def test_exact_keeps_declared_precision(self):
+        # Advertised schema from an authoritative declared type keeps precision.
+        assert decimal_arrow_type(18, 2, exact=True) == pa.decimal128(18, 2)
+        assert decimal_arrow_type(40, 2, exact=True) == pa.decimal256(40, 2)
 
     def test_high_precision_roundtrips_exactly(self):
         from decimal import Decimal
 
         val = Decimal("123456789012345678.90")
-        schema = pa.schema([pa.field("x", decimal_arrow_type(2))])
+        schema = pa.schema([pa.field("x", decimal_arrow_type(20, 2))])
         batch = rows_to_batch([(val,)], schema)
         assert batch.column(0).to_pylist()[0] == val
 
+    def test_sampled_precision_over_38_infers_decimal256(self):
+        # A sampled value needing precision 40 must not be typed decimal128(38,2)
+        # (which would raise in rows_to_batch) — P2a regression.
+        from decimal import Decimal
+
+        wide = Decimal("1" * 38 + ".50")  # 38 integer digits + scale 2
+        desc = (("amt", NUMBER, None, None, None, None, None),)
+        schema = schema_from_description(desc, sample_rows=[(wide,)])
+        assert schema.field(0).type == pa.decimal256(76, 2)
+        # And it actually builds + round-trips exactly.
+        batch = rows_to_batch([(wide,)], schema)
+        assert batch.column(0).to_pylist()[0] == wide
+
 
 class TestRowsToBatch:
+    def test_decimal_into_float_column_is_coerced(self):
+        # The >76-precision fallback advertises float64; pyarrow can't build a
+        # float array straight from Decimals, so rows_to_batch coerces them so
+        # delivery degrades lossily instead of raising.
+        from decimal import Decimal
+
+        schema = pa.schema([pa.field("x", pa.float64())])
+        batch = rows_to_batch([(Decimal("1.5"),), (None,)], schema)
+        assert batch.column(0).to_pylist() == [1.5, None]
+
     def test_basic(self):
         schema = pa.schema([pa.field("x", pa.float64()), pa.field("y", pa.utf8())])
         rows = [(1.0, "a"), (2.0, "b"), (3.0, "c")]

--- a/drivers/ob-flight-extension/tests/test_converters.py
+++ b/drivers/ob-flight-extension/tests/test_converters.py
@@ -100,6 +100,25 @@ class TestSchemaFromDescription:
         schema = schema_from_description(desc, sample_rows=[(Decimal("1.23"),)])
         assert schema.field(0).type == pa.float64()
 
+    def test_all_null_first_batch_uses_driver_precision_scale(self):
+        # A NUMERIC(40, 2) whose first batch is entirely NULL (UNION ALL padding)
+        # must still be typed decimal from the driver's precision/scale, so a
+        # later Decimal isn't degraded to float64 (issue #136 P2).
+        from decimal import Decimal
+
+        desc = (("amt", NUMBER, None, None, 40, 2, None),)
+        schema = schema_from_description(desc, sample_rows=[(None,)])
+        assert schema.field(0).type == pa.decimal256(76, 2)
+        wide = Decimal("1" * 38 + ".50")
+        assert rows_to_batch([(wide,)], schema).column(0).to_pylist()[0] == wide
+
+    def test_non_decimal_sampled_values_are_not_forced_to_decimal(self):
+        # A numeric column reporting precision/scale but yielding int values
+        # stays int64 — the driver width only applies to real decimal columns.
+        desc = (("id", NUMBER, None, None, 10, 0, None),)
+        schema = schema_from_description(desc, sample_rows=[(5,)])
+        assert schema.field(0).type == pa.int64()
+
 
 class TestDecimalArrowType:
     def test_within_decimal128_uses_max_headroom(self):

--- a/drivers/ob-flight-extension/tests/test_natural_sql.py
+++ b/drivers/ob-flight-extension/tests/test_natural_sql.py
@@ -15,8 +15,10 @@ Spec: design/PLAN_flight_natural_sql.md.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import pyarrow as pa
 import pyarrow.flight as flight
 import pytest
 
@@ -26,6 +28,7 @@ from ob_flight.catalog import (
 )
 from ob_flight.flight_sql import build_columns_table, build_tables_table
 from ob_flight.server import OBFlightServer
+from ob_flight.server_execution import semantic_result_schema
 from orionbelt.parser.loader import TrackedLoader
 from orionbelt.parser.resolver import ReferenceResolver
 
@@ -452,3 +455,69 @@ class TestSchemaProbeShortcut:
         assert schema is not None
         names = [f.name for f in schema]
         assert "_g_Customer Country" in names
+
+
+class TestSemanticResultSchemaDecimals:
+    """A governed DECIMAL measure/metric is advertised as an exact Arrow decimal
+    so the FlightInfo schema matches the high-precision value the stream carries
+    (issue #136), sourced from the declared ``dataType`` like pgwire (#116)."""
+
+    def _query(self, measures: list[str]):
+        return SimpleNamespace(
+            select=SimpleNamespace(dimensions=["Region"], measures=measures),
+            grouping=None,
+        )
+
+    def _model(self, **kw):
+        dim = SimpleNamespace(result_type=SimpleNamespace(value="string"))
+        return SimpleNamespace(
+            dimensions={"Region": dim},
+            measures=kw.get("measures", {}),
+            metrics=kw.get("metrics", {}),
+            settings=SimpleNamespace(default_numeric_data_type=kw.get("default_numeric_data_type")),
+        )
+
+    def test_declared_decimal_measure_advertised_as_decimal(self) -> None:
+        model = self._model(
+            measures={
+                "Revenue": SimpleNamespace(
+                    data_type="decimal(18, 2)",
+                    result_type=SimpleNamespace(value="float"),
+                )
+            }
+        )
+        schema = semantic_result_schema(None, self._query(["Revenue"]), model)
+        assert schema.field("Revenue").type == pa.decimal128(18, 2)
+
+    def test_float_measure_stays_double(self) -> None:
+        model = self._model(
+            measures={
+                "Ratio": SimpleNamespace(data_type=None, result_type=SimpleNamespace(value="float"))
+            }
+        )
+        schema = semantic_result_schema(None, self._query(["Ratio"]), model)
+        assert schema.field("Ratio").type == pa.float64()
+
+    def test_declared_decimal_metric_advertised_as_decimal(self) -> None:
+        model = self._model(
+            metrics={
+                "Margin": SimpleNamespace(
+                    data_type="decimal(30, 4)",
+                    result_type=SimpleNamespace(value="float"),
+                )
+            }
+        )
+        schema = semantic_result_schema(None, self._query(["Margin"]), model)
+        assert schema.field("Margin").type == pa.decimal128(30, 4)
+
+    def test_default_numeric_data_type_fallback(self) -> None:
+        model = self._model(
+            measures={
+                "Amount": SimpleNamespace(
+                    data_type=None, result_type=SimpleNamespace(value="float")
+                )
+            },
+            default_numeric_data_type="decimal(12, 3)",
+        )
+        schema = semantic_result_schema(None, self._query(["Amount"]), model)
+        assert schema.field("Amount").type == pa.decimal128(12, 3)

--- a/drivers/ob-flight-extension/tests/test_natural_sql.py
+++ b/drivers/ob-flight-extension/tests/test_natural_sql.py
@@ -521,3 +521,17 @@ class TestSemanticResultSchemaDecimals:
         )
         schema = semantic_result_schema(None, self._query(["Amount"]), model)
         assert schema.field("Amount").type == pa.decimal128(12, 3)
+
+    def test_declared_precision_beyond_arrow_limit_degrades_to_float(self) -> None:
+        # OBML permits precisions wider than Arrow's decimal256 max (76); such a
+        # declared type must degrade to float64, not raise during FlightInfo
+        # schema construction (issue #136 P2b).
+        model = self._model(
+            measures={
+                "Huge": SimpleNamespace(
+                    data_type="decimal(100, 2)", result_type=SimpleNamespace(value="float")
+                )
+            }
+        )
+        schema = semantic_result_schema(None, self._query(["Huge"]), model)
+        assert schema.field("Huge").type == pa.float64()

--- a/src/orionbelt/api/schemas.py
+++ b/src/orionbelt/api/schemas.py
@@ -96,7 +96,15 @@ class ColumnMetadata(BaseModel):
     """Metadata for a single result column."""
 
     name: str
-    type: str = Field(description="Type hint: string, number, datetime, binary")
+    type: str = Field(
+        description=(
+            "Column type: 'string', 'number', 'datetime', 'binary', or a "
+            "'decimal(p, s)' string for governed DECIMAL columns. DECIMAL "
+            "cells are delivered in JSON as an exact decimal string (not a "
+            "float) so precision beyond float's ~15-16 significant digits is "
+            "preserved (issue #136); the pgwire surface reports them as NUMERIC."
+        )
+    )
     format: str | None = Field(
         default=None,
         description="Display format pattern from model (e.g. '#,##0.00', '0.00%')",

--- a/src/orionbelt/service/db_executor.py
+++ b/src/orionbelt/service/db_executor.py
@@ -485,11 +485,16 @@ def _serialize_value(val: Any, tz: ZoneInfo | None = None) -> Any:
     only holds ~15-16 significant digits, so a wide NUMERIC (e.g.
     ``Decimal('123456789012345678.90')``) would round on the way through and
     surface as ``123456789012345680.00`` on the pgwire NUMERIC path (issue
-    #136). Every boundary handles the Decimal without a lossy float hop — the
+    #136). Every boundary carries the Decimal without a lossy float hop — the
     pgwire encoder emits exact fixed-scale text, the Arrow result cache stores
     it as ``decimal128``/``decimal256``, and ``value_formatting.format_row``
-    formats it directly. REST/JSON is the one exception: FastAPI's encoder
-    still narrows a Decimal to a float, matching the pre-existing JSON shape.
+    formats it directly.
+
+    On the raw REST/JSON surface the value is deliberately delivered as an
+    **exact decimal string** (Pydantic v2 serializes ``Decimal`` as a JSON
+    string), not a lossy float — a fixed, value-independent contract so a
+    column's JSON type never changes row to row. This is documented on
+    ``api.schemas.ColumnMetadata.type``.
     """
     if val is None:
         return None

--- a/src/orionbelt/service/db_executor.py
+++ b/src/orionbelt/service/db_executor.py
@@ -476,10 +476,20 @@ def warm_db_tz_cache(dialect: str) -> ZoneInfo | None:
 
 
 def _serialize_value(val: Any, tz: ZoneInfo | None = None) -> Any:
-    """Convert a Python value to a JSON-serializable type.
+    """Convert a Python value to a display-ready, mostly JSON-serializable type.
 
     For naive datetimes, applies the resolved timezone if available.
     Microseconds are elided when zero for cleaner output.
+
+    ``Decimal`` is preserved as-is rather than cast to ``float``: a float
+    only holds ~15-16 significant digits, so a wide NUMERIC (e.g.
+    ``Decimal('123456789012345678.90')``) would round on the way through and
+    surface as ``123456789012345680.00`` on the pgwire NUMERIC path (issue
+    #136). Every boundary handles the Decimal without a lossy float hop — the
+    pgwire encoder emits exact fixed-scale text, the Arrow result cache stores
+    it as ``decimal128``/``decimal256``, and ``value_formatting.format_row``
+    formats it directly. REST/JSON is the one exception: FastAPI's encoder
+    still narrows a Decimal to a float, matching the pre-existing JSON shape.
     """
     if val is None:
         return None
@@ -500,7 +510,7 @@ def _serialize_value(val: Any, tz: ZoneInfo | None = None) -> Any:
     if isinstance(val, date):
         return val.isoformat()
     if isinstance(val, Decimal):
-        return float(val)
+        return val
     if isinstance(val, bytes):
         return base64.b64encode(val).decode("ascii")
     return str(val)

--- a/tests/integration/test_cache_endpoints.py
+++ b/tests/integration/test_cache_endpoints.py
@@ -489,3 +489,64 @@ class TestHeartbeatInvalidatesShortcut:
             "/v1/query/execute", json=_QUERY_BODY, params={"dialect": "duckdb"}
         )
         assert miss.json()["cached"] is False
+
+
+class TestDecimalPrecisionContract:
+    """Issue #136: a high-precision DECIMAL survives end to end.
+
+    On the raw JSON surface it is delivered as an **exact decimal string**
+    (Pydantic v2 serializes ``Decimal`` as a JSON string), and a cache hit —
+    which rebuilds the row from the stored Arrow ``decimal128`` blob — reproduces
+    the identical string. The pgwire NUMERIC encoding of the same value is exact
+    too (unit-covered in ``tests/unit/test_pgwire_types``); asserted here as well
+    so all three surfaces are proven together.
+    """
+
+    async def test_raw_json_decimal_is_exact_string_and_survives_cache(
+        self, cached_client: tuple[AsyncClient, FileCache]
+    ) -> None:
+        from decimal import Decimal
+
+        from orionbelt.pgwire.types import encode_value
+
+        client, _ = cached_client
+        sid = (await client.post("/v1/sessions")).json()["session_id"]
+        mid = (
+            await client.post(f"/v1/sessions/{sid}/models", json={"model_yaml": SAMPLE_MODEL_YAML})
+        ).json()["model_id"]
+        body = {"model_id": mid, "query": _QUERY_BODY, "dialect": "duckdb"}
+
+        # A value wider than float's ~15-16 significant digits: casting to float
+        # would round it to 123456789012345680.00.
+        wide = ExecutionResult(
+            columns=[
+                ColumnMeta("Customer Country", "string"),
+                ColumnMeta("Total Revenue", "number", "#,##0.00"),
+            ],
+            raw_rows=[["US", Decimal("123456789012345678.90")]],
+            row_count=1,
+            execution_time_ms=1.0,
+        )
+
+        # Fresh miss populates the cache with the wide decimal.
+        with patch("orionbelt.api.query_cache.execute_sql", return_value=wide):
+            first = await client.post(f"/v1/sessions/{sid}/query/execute", json=body)
+        assert first.status_code == 200, first.text
+        fdata = first.json()
+        assert fdata["cached"] is False
+        # Raw JSON: exact decimal string, not a rounded float.
+        assert fdata["rows"][0][1] == "123456789012345678.90"
+        assert isinstance(fdata["rows"][0][1], str)
+
+        # Cache hit rebuilds the row from the stored Arrow decimal blob — the
+        # same exact string, never routed back through execute_sql.
+        second = await client.post(f"/v1/sessions/{sid}/query/execute", json=body)
+        assert second.status_code == 200
+        sdata = second.json()
+        assert sdata["cached"] is True
+        assert sdata["rows"][0][1] == "123456789012345678.90"
+
+        # pgwire NUMERIC text for the same value is exact and fixed-scale.
+        assert encode_value(Decimal("123456789012345678.90"), "decimal", 0, 2) == (
+            "123456789012345678.90"
+        )

--- a/tests/unit/test_arrow_executor.py
+++ b/tests/unit/test_arrow_executor.py
@@ -83,16 +83,18 @@ class TestDefaultFormatForArrowType:
 
 
 class TestArrowToRowsStringNumericNormalisation:
-    def test_string_numeric_is_parsed_to_float(self) -> None:
+    def test_string_numeric_is_parsed_to_decimal(self) -> None:
         """The string cell from ADBC's opaque[string] type is parsed to
-        Decimal in ``_arrow_to_rows``; ``_serialize_value`` then converts
-        to float for downstream JSON-friendly output."""
+        Decimal in ``_arrow_to_rows`` and preserved as a Decimal by
+        ``_serialize_value`` (no lossy float hop — issue #136)."""
+        from decimal import Decimal
+
         table = _opaque_numeric_table(["2045134942.09"])
         rows = _arrow_to_rows(table)
         assert len(rows) == 1
         cell = rows[0][0]
-        assert isinstance(cell, float)
-        assert cell == 2045134942.09
+        assert isinstance(cell, Decimal)
+        assert cell == Decimal("2045134942.09")
 
     def test_unparseable_string_passes_through(self) -> None:
         """Garbage in the string column doesn't crash — falls back to the
@@ -103,13 +105,13 @@ class TestArrowToRowsStringNumericNormalisation:
         # _serialize_value sees the original string and returns it unchanged.
         assert rows[0][0] == "not-a-number"
 
-    def test_plain_decimal128_unchanged(self) -> None:
-        """The non-ADBC path (pydict already yields ``Decimal``) is
-        unaffected — _serialize_value still converts Decimal → float."""
+    def test_plain_decimal128_preserved(self) -> None:
+        """The non-ADBC path (pydict already yields ``Decimal``) keeps the
+        Decimal — ``_serialize_value`` no longer casts it to float (#136)."""
         from decimal import Decimal
 
         arr = pa.array([Decimal("123.45")], type=pa.decimal128(18, 2))
         table = pa.table({"x": arr})
         rows = _arrow_to_rows(table)
-        assert rows[0][0] == 123.45
-        assert isinstance(rows[0][0], float)
+        assert rows[0][0] == Decimal("123.45")
+        assert isinstance(rows[0][0], Decimal)

--- a/tests/unit/test_db_executor.py
+++ b/tests/unit/test_db_executor.py
@@ -49,7 +49,17 @@ class TestSerializeValue:
         assert _serialize_value(d) == "2024-06-01"
 
     def test_decimal(self) -> None:
-        assert _serialize_value(Decimal("99.95")) == 99.95
+        # Decimals are preserved (not cast to float) so wide NUMERIC values
+        # keep full precision on the pgwire / cache paths (issue #136).
+        result = _serialize_value(Decimal("99.95"))
+        assert result == Decimal("99.95")
+        assert isinstance(result, Decimal)
+
+    def test_high_precision_decimal_is_not_rounded(self) -> None:
+        # A value wider than float's ~15-16 significant digits would round to
+        # 123456789012345680.00 if cast to float.
+        val = Decimal("123456789012345678.90")
+        assert _serialize_value(val) == val
 
     def test_bytes(self) -> None:
         assert _serialize_value(b"\x00\x01\x02") == "AAEC"
@@ -62,7 +72,7 @@ class TestSerializeRow:
     def test_mixed_row(self) -> None:
         row = ("US", 42, Decimal("100.5"), None, datetime(2024, 1, 1))
         result = _serialize_row(row)
-        assert result == ["US", 42, 100.5, None, "2024-01-01T00:00:00"]
+        assert result == ["US", 42, Decimal("100.5"), None, "2024-01-01T00:00:00"]
 
 
 @pytest.mark.skipif(not _has_ob_driver_core, reason="ob_driver_core not installed")

--- a/tests/unit/test_pgwire_types.py
+++ b/tests/unit/test_pgwire_types.py
@@ -117,6 +117,12 @@ def test_encode_decimal_fixed_scale() -> None:
     assert pgtypes.encode_value(-16050258.53, "decimal", 0, 2) == "-16050258.53"
     # Large magnitude must not come out as ``1.605...E7``.
     assert "E" not in pgtypes.encode_value(16050258.53, "decimal", 0, 2).upper()
+    # A Decimal wider than float precision must survive exactly, not round to
+    # ``123456789012345680.00`` (issue #136).
+    assert (
+        pgtypes.encode_value(Decimal("123456789012345678.90"), "decimal", 0, 2)
+        == "123456789012345678.90"
+    )
 
 
 def test_encode_decimal_without_scale_keeps_value() -> None:


### PR DESCRIPTION
Closes #136.

## Problem

DECIMAL values wider than IEEE-754 double precision (~15-16 significant digits) lost precision. `Decimal('123456789012345678.90')` came back as `123456789012345680.00`. Root cause: `service/db_executor.py::_serialize_value` cast every `Decimal` to `float`, and every delivery surface funneled through it. #116 fixed the pgwire NUMERIC *type/scale*; this closes the remaining *value* gap and extends it to Flight.

## Fix

Preserve `Decimal` end to end. Each surface then carries it losslessly:

| Surface | Behavior |
| --- | --- |
| **pgwire** | `_encode_decimal_text` emits exact fixed-scale NUMERIC text |
| **Result cache** (shared) | Arrow `decimal128`/`decimal256` round-trips the value |
| **TSV / `format_values`** | `value_formatting.format_row` formats the `Decimal` directly |
| **Arrow Flight** | infers/advertises an exact Arrow decimal (see below) |
| **REST / JSON** | **exact decimal string** — see contract note |

### REST/JSON contract (was the reviewer's P2)

Pydantic v2 serializes `Decimal` as a JSON **string**, so raw-JSON DECIMAL cells are delivered as exact decimal strings rather than lossy floats. This is a deliberate, value-independent contract (a column's JSON type never changes row to row). Documented on `api.schemas.ColumnMetadata.type` (surfaces in the OpenAPI docs) and in the `_serialize_value` docstring. The earlier "REST/JSON unchanged" claim was wrong and is corrected.

### Arrow Flight (`drivers/ob-flight-extension`)

Flight had the same defect in its own converter (`Decimal → float64`), and because the result cache is shared, that also made cached decimal types inconsistent across surfaces. Fixed:
- `converters.py`: infer Arrow `decimal128`/`decimal256` from `Decimal` values (scale from the widest sampled value; decimal128 preferred for client compatibility).
- `server_execution.py`: advertise governed DECIMAL measures/metrics as an exact Arrow decimal in the `FlightInfo` schema (precision/scale from the model's declared `dataType` / `defaultNumericDataType` — the same source pgwire uses in #116), and cast fresh executes to that advertised schema so streamed data matches what was advertised.

## Tests

- `test_db_executor` / `test_arrow_executor`: `_serialize_value` and the ADBC/decimal128 arrow paths preserve `Decimal`; high-precision regression.
- `test_pgwire_types`: wide `Decimal` encodes to exact fixed-scale text.
- `test_converters` (Flight): `Decimal` → `decimal128`, scale-from-widest-sample, high-precision round-trip.
- `test_natural_sql` (Flight): governed decimal measures/metrics advertised as Arrow decimal; float measures stay `double`; `defaultNumericDataType` fallback.
- `test_cache_endpoints` (integration): `/query/execute` returns the exact decimal **string**, a **cache hit** rebuilds the same string from the Arrow blob, and pgwire NUMERIC text is exact — all three surfaces in one test.

Main-package suite green; ruff + format + mypy clean.

## Depends on #237

This branch's `test_natural_sql` suite currently also carries the 9 sqlglot-30 catalog failures fixed in #237. Merge #237 first; then this branch's Flight suite is fully green.