### PR TITLE
ci: run the driver-package test suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,25 @@ jobs:
         working-directory: packages/osi-orionbelt
         run: uv run pytest --tb=short -q
 
+      # Driver workspace members (drivers/*) also sit outside the root
+      # testpaths and carry duplicate test-module basenames across packages
+      # (e.g. several test_driver.py), so a root-level collection errors on the
+      # name clashes. Run each package's suite from its own directory instead,
+      # same as osi-orionbelt. Exit code 5 = "no tests collected" is treated as
+      # success so a driver without tests (e.g. ob-bigquery) doesn't fail CI.
+      - name: Run driver test suites
+        run: |
+          rc=0
+          for d in drivers/*/; do
+            [ -d "${d}tests" ] || continue
+            echo "::group::${d}"
+            (cd "$d" && uv run pytest --tb=short -q)
+            code=$?
+            echo "::endgroup::"
+            if [ "$code" -ne 0 ] && [ "$code" -ne 5 ]; then rc=1; fi
+          done
+          exit $rc
+
   coverage:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Why

The root pytest config is `testpaths = ["tests"]`, and `ci.yml` only runs the root suite plus `osi-orionbelt` explicitly. **Nothing under `drivers/*` has ever been executed by CI.** That gap let two suites rot unnoticed:

- `ob-flight-extension` catalog tests broke under the `sqlglot` 30 bump (fixed in #237)
- `ob-clickhouse` tests drifted from the driver's `query_arrow()` migration (fixed in #238)

## What

Adds a **Run driver test suites** step to the `test` job (runs on Python 3.12 / 3.13 / 3.14). It iterates `drivers/*/` and runs each package's suite **from its own directory**.

Why per-directory rather than `pytest drivers/` from the root: the driver packages carry their own pytest configs and duplicate test-module basenames across packages (several `test_driver.py`, `test_yaml_detection.py`), so a root-level collection **errors** on the name clashes (verified: 12 collection errors, partial collection). This mirrors why `osi-orionbelt` already runs as its own step.

Exit code `5` ("no tests collected") is treated as success so a driver without a `tests/` dir (e.g. `ob-bigquery`) doesn't fail the job.

Local run of the loop (current `main`):

| Package | Result |
|---|---|
| ob-driver-core | 38 passed |
| ob-duckdb | 44 passed |
| ob-postgres | 46 passed |
| ob-mysql | 47 passed |
| ob-snowflake | 44 passed |
| ob-databricks | 56 passed |
| ob-dremio | 63 passed |
| ob-clickhouse | fixed by #238 |
| ob-flight-extension | fixed by #237 |
| ob-bigquery | skipped (no tests) |

## Merge order

**Depends on #237 and #238.** Until both land on `main`, this job is red (by design - it's surfacing the exact breakage it's meant to catch). Merge #237 and #238 first, then this.