### PR TITLE
test+fix: cloud-vendor sweeps + BigQuery/Snowflake execution fixes

### DIFF
--- a/src/orionbelt/compiler/pop_wrap.py
+++ b/src/orionbelt/compiler/pop_wrap.py
@@ -155,9 +155,12 @@ def wrap_with_pop(
     # --- CTE 2: date_spine ---
     # Use scalar subqueries so every dialect can resolve date_range references
     # without needing date_range in their FROM clause (universally compatible).
+    # Quote the CTE name so it matches the quoted declaration on case-folding
+    # dialects (Snowflake folds a bare ``date_range`` to ``DATE_RANGE``).
+    date_range_ref = dialect.quote_identifier("date_range")
     spine_sql = dialect.render_date_spine_cte_sql(
-        min_date="(SELECT min_date FROM date_range)",
-        max_date="(SELECT max_date FROM date_range)",
+        min_date=f"(SELECT min_date FROM {date_range_ref})",
+        max_date=f"(SELECT max_date FROM {date_range_ref})",
         grain=grain,
         offset=offset,
         offset_grain=offset_grain,
@@ -339,6 +342,11 @@ def _build_pop_base_sql(
     FROM date_spine, LEFT JOIN fact tables and dimension tables,
     GROUP BY spine_date + non-time dimensions.
     """
+    # Quote the spine CTE name so references match the quoted declaration on
+    # case-folding dialects (Snowflake); ``spine_date`` etc. stay bare, matching
+    # the spine's own bare column aliases.
+    spine_cte = dialect.quote_identifier("date_spine")
+
     # Dimension aliases: d1 = time dim (spine_date), d2..dN = others
     dim_selects: list[str] = []
     dim_groups: list[str] = []
@@ -346,7 +354,7 @@ def _build_pop_base_sql(
     for d_idx, dim in enumerate(resolved.dimensions, 1):
         pop_measure = next((m for m in resolved.measures if m.is_pop), None)
         if pop_measure and dim.name == pop_measure.pop_time_dimension:
-            dim_selects.append(f"date_spine.spine_date AS {dialect.quote_identifier(dim.name)}")
+            dim_selects.append(f"{spine_cte}.spine_date AS {dialect.quote_identifier(dim.name)}")
         else:
             obj_alias = dialect.quote_identifier(dim.object_name)
             col = dialect.quote_identifier(dim.source_column)
@@ -382,7 +390,7 @@ def _build_pop_base_sql(
     select_clause = ",\n       ".join(all_selects)
 
     # FROM date_spine
-    from_clause = "date_spine"
+    from_clause = spine_cte
     base_obj_name = resolved.base_object or time_obj_name
 
     # ── Build LEFT JOINs ──
@@ -401,7 +409,7 @@ def _build_pop_base_sql(
     time_col = f"{time_alias_q}.{dialect.quote_identifier(time_source_col)}"
     trunc_col = dialect.render_date_trunc_sql(time_col, grain)
     join_clauses.append(
-        f"\n  LEFT JOIN {time_table} AS {time_alias_q}\n    ON {trunc_col} = date_spine.spine_date"
+        f"\n  LEFT JOIN {time_table} AS {time_alias_q}\n    ON {trunc_col} = {spine_cte}.spine_date"
     )
     joined_objects.add(time_obj_name)
 
@@ -472,9 +480,15 @@ def _build_pop_compare_sql(
     time_q = dialect.quote_identifier(pop_time_dim or "")
     non_time_dims = [d for d in resolved.dimensions if d.name != pop_time_dim]
 
+    # Quote the CTE names so references match the quoted declarations on
+    # case-folding dialects (Snowflake). The self-join aliases (``pop_prev``)
+    # stay bare — they are declared and referenced bare, so they already agree.
+    base_cte = dialect.quote_identifier("pop_base")
+    spine_cte = dialect.quote_identifier("date_spine")
+
     def _dim_match(alias: str) -> str:
         parts = [
-            f"pop_base.{dialect.quote_identifier(d.name)} = "
+            f"{base_cte}.{dialect.quote_identifier(d.name)} = "
             f"{alias}.{dialect.quote_identifier(d.name)}"
             for d in non_time_dims
         ]
@@ -493,20 +507,20 @@ def _build_pop_compare_sql(
         if key == spine_key and "pop_prev" not in alias_by_key.values():
             alias = "pop_prev"
             join_clauses.append(
-                f"  LEFT JOIN date_spine ON pop_base.{time_q} = date_spine.spine_date"
+                f"  LEFT JOIN {spine_cte} ON {base_cte}.{time_q} = {spine_cte}.spine_date"
             )
             # NB: alias is ``pop_prev`` (not ``prev``) — ``prev`` is a reserved
             # word in Dremio and rejects as an unquoted table alias.
             join_clauses.append(
-                f"  LEFT JOIN pop_base AS {alias}\n"
-                f"    ON date_spine.spine_date_prev = {alias}.{time_q}{_dim_match(alias)}"
+                f"  LEFT JOIN {base_cte} AS {alias}\n"
+                f"    ON {spine_cte}.spine_date_prev = {alias}.{time_q}{_dim_match(alias)}"
             )
         else:
             alias = f"pop_prev_{len(alias_by_key)}"
             grain_val = m.pop_offset_grain.value if m.pop_offset_grain else "month"
-            prev_date = dialect.date_add_sql(f"pop_base.{time_q}", grain_val, m.pop_offset or 0)
+            prev_date = dialect.date_add_sql(f"{base_cte}.{time_q}", grain_val, m.pop_offset or 0)
             join_clauses.append(
-                f"  LEFT JOIN pop_base AS {alias}\n"
+                f"  LEFT JOIN {base_cte} AS {alias}\n"
                 f"    ON {alias}.{time_q} = {prev_date}{_dim_match(alias)}"
             )
         alias_by_key[key] = alias
@@ -515,11 +529,11 @@ def _build_pop_compare_sql(
     selects: list[str] = []
     for dim in resolved.dimensions:
         q = dialect.quote_identifier(dim.name)
-        selects.append(f"pop_base.{q} AS {q}")
+        selects.append(f"{base_cte}.{q} AS {q}")
     for m in resolved.measures:
         if not m.is_pop:
             q = dialect.quote_identifier(m.name)
-            selects.append(f"pop_base.{q} AS {q}")
+            selects.append(f"{base_cte}.{q} AS {q}")
     for m in pop_measures:
         if m.pop_comparison is None:
             raise ResolutionError(
@@ -535,7 +549,7 @@ def _build_pop_compare_sql(
         q_base = dialect.quote_identifier(base_name)
         q_metric = dialect.quote_identifier(m.name)
         alias = alias_by_key[(m.pop_offset, m.pop_offset_grain)]
-        current = f"pop_base.{q_base}"
+        current = f"{base_cte}.{q_base}"
         prev = f"{alias}.{q_base}"
         nullif_prev = f"NULLIF({prev}, 0)"
 
@@ -560,7 +574,7 @@ def _build_pop_compare_sql(
         selects.append(f"{expr} AS {q_metric}")
 
     select_clause = ",\n       ".join(selects)
-    return f"SELECT {select_clause}\n  FROM pop_base\n" + "\n".join(join_clauses)
+    return f"SELECT {select_clause}\n  FROM {base_cte}\n" + "\n".join(join_clauses)
 
 
 def _build_outer_order_by(resolved: ResolvedQuery) -> list[OrderByItem]:

--- a/src/orionbelt/dialect/bigquery.py
+++ b/src/orionbelt/dialect/bigquery.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from orionbelt.ast.nodes import Cast, Expr, FunctionCall, Literal, OrderByItem
+from orionbelt.ast.nodes import Cast, Expr, FunctionCall, Literal, OrderByItem, RawSQL
 from orionbelt.dialect.base import Dialect, DialectCapabilities
 from orionbelt.dialect.registry import DialectRegistry
 from orionbelt.models.semantic import TimeGrain
@@ -94,9 +94,11 @@ class BigQueryDialect(Dialect):
         )
 
     def render_time_grain(self, column: Expr, grain: TimeGrain) -> Expr:
-        if grain == TimeGrain.WEEK:
-            return FunctionCall(name="DATE_TRUNC", args=[column, Literal.string("ISOWEEK")])
-        return FunctionCall(name="DATE_TRUNC", args=[column, Literal.string(grain.value)])
+        # BigQuery DATE_TRUNC takes a date-part *keyword* (MONTH, ISOWEEK), not a
+        # string literal: DATE_TRUNC(col, 'month') raises "A valid date part name
+        # is required". RawSQL: emit the bare keyword (matches render_date_trunc_sql).
+        part = "ISOWEEK" if grain == TimeGrain.WEEK else grain.value.upper()
+        return FunctionCall(name="DATE_TRUNC", args=[column, RawSQL(sql=part)])
 
     def render_cast(self, expr: Expr, target_type: str) -> Expr:
         return Cast(expr=expr, type_name=target_type)

--- a/src/orionbelt/dialect/snowflake.py
+++ b/src/orionbelt/dialect/snowflake.py
@@ -83,15 +83,19 @@ class SnowflakeDialect(Dialect):
     ) -> str:
         spine = f"DATEADD('{grain}', rn - 1, {min_date})::date"
         prev = f"DATEADD('{offset_grain}', {offset}, {spine})::date"
+        # GENERATOR(ROWCOUNT => n) requires a *constant* n; the row count is only
+        # known at run time (it depends on the date_range scalar subqueries), so
+        # generate a fixed upper bound and filter to the range — 100000 rows
+        # covers ~270 years at daily grain, far beyond any practical spine.
         return (
             f"SELECT {spine} AS spine_date,\n"
             f"       CASE WHEN {prev} >= {min_date}\n"
             f"            THEN {prev} END AS spine_date_prev\n"
             f"FROM (\n"
             f"  SELECT ROW_NUMBER() OVER (ORDER BY SEQ4()) AS rn\n"
-            f"  FROM TABLE(GENERATOR(ROWCOUNT => "
-            f"DATEDIFF('{grain}', {min_date}, {max_date}) + 1))\n"
-            f") AS t"
+            f"  FROM TABLE(GENERATOR(ROWCOUNT => 100000))\n"
+            f") AS t\n"
+            f"WHERE {spine} <= {max_date}"
         )
 
     def _compile_multi_field_count(self, args: list[Expr], distinct: bool) -> str:

--- a/tests/architecture/test_rawsql_guard.py
+++ b/tests/architecture/test_rawsql_guard.py
@@ -27,6 +27,8 @@ APPROVED_RAWSQL: dict[str, int] = {
     "src/orionbelt/compiler/pop_wrap.py": 4,
     # MySQL quarter truncation (nested DATE_ADD/MAKEDATE/QUARTER).
     "src/orionbelt/dialect/mysql.py": 1,
+    # BigQuery DATE_TRUNC date-part keyword (MONTH/ISOWEEK, not a quoted string).
+    "src/orionbelt/dialect/bigquery.py": 1,
 }
 
 

--- a/tests/integration/_measure_sweep.py
+++ b/tests/integration/_measure_sweep.py
@@ -1,0 +1,59 @@
+"""Shared measure/metric execution-sweep helpers.
+
+The sweep runs *one query per measure and per metric* of the commerce model and
+asserts it executes on a given engine. Its job is breadth — catching dialect
+SQL that compiles cleanly but the engine rejects at runtime — so it asserts
+execution only; row-level correctness stays the ``COMMERCE_CASES`` battery's
+job (:mod:`tests.integration._commerce`).
+
+The item list is derived from the resolved model so it stays in sync as the
+model grows, and uses ``effective_measures`` so *synthesised* row-count
+measures (``Sales Count`` etc.) are swept too, not just declared measures.
+
+Vendor sweep tests parametrise over :data:`SWEEP_ITEMS` and compile each item
+with the vendor-specific model fixture, so the same battery covers every
+dialect from one definition.
+"""
+
+from __future__ import annotations
+
+from orionbelt.models.query import QueryObject
+from orionbelt.models.semantic import Metric, SemanticModel
+from tests.integration._commerce import load_commerce_model
+
+
+def _metric_time_dimension(metric: Metric) -> str | None:
+    """The dimension a cumulative / period-over-period metric requires in SELECT."""
+    if metric.time_dimension:
+        return metric.time_dimension
+    pop = metric.period_over_period
+    return pop.time_dimension if pop is not None else None
+
+
+def build_sweep_items(model: SemanticModel) -> list[tuple[str, str, list[str]]]:
+    """Return ``(kind, name, dimensions)`` for every measure and metric.
+
+    Measures are swept as grand totals (always resolvable, exercises the
+    aggregation). Cumulative / period-over-period metrics carry their required
+    time dimension; derived metrics are grouped by a plain dimension.
+    """
+    items: list[tuple[str, str, list[str]]] = [
+        ("measure", name, []) for name in model.effective_measures
+    ]
+    for name, metric in model.metrics.items():
+        time_dim = _metric_time_dimension(metric)
+        items.append(("metric", name, [time_dim] if time_dim else ["Product Category"]))
+    return items
+
+
+def sweep_query(name: str, dims: list[str]) -> QueryObject:
+    """A single-item query: the measure/metric grouped by ``dims``."""
+    return QueryObject.model_validate({"select": {"dimensions": dims, "measures": [name]}})
+
+
+# Item names/dimensions are independent of the physical database/schema, so a
+# throwaway model load is enough to enumerate them once for parametrisation.
+SWEEP_ITEMS: list[tuple[str, str, list[str]]] = build_sweep_items(
+    load_commerce_model(database="orionbelt")
+)
+SWEEP_IDS: list[str] = [f"{kind}:{name}" for kind, name, _ in SWEEP_ITEMS]

--- a/tests/integration/drift/compile_only/bigquery/03_total_sales_by_year_month.sql
+++ b/tests/integration/drift/compile_only/bigquery/03_total_sales_by_year_month.sql
@@ -1,3 +1,3 @@
-SELECT DATE_TRUNC(`Sales`.`salesdate`, 'year') AS `Sales Year`, DATE_TRUNC(`Sales`.`salesdate`, 'month') AS `Sales Month`, ROUND(CAST(SUM(`Sales`.`salesamount`) AS NUMERIC), 2) AS `Total Sales`
+SELECT DATE_TRUNC(`Sales`.`salesdate`, YEAR) AS `Sales Year`, DATE_TRUNC(`Sales`.`salesdate`, MONTH) AS `Sales Month`, ROUND(CAST(SUM(`Sales`.`salesamount`) AS NUMERIC), 2) AS `Total Sales`
 FROM ``.`orionbelt_1`.`sales` AS `Sales`
 GROUP BY ALL

--- a/tests/integration/drift/compile_only/bigquery/10_cumulative_sales_by_month.sql
+++ b/tests/integration/drift/compile_only/bigquery/10_cumulative_sales_by_month.sql
@@ -1,5 +1,5 @@
 WITH `cumulative_base` AS (
-SELECT DATE_TRUNC(`Sales`.`salesdate`, 'month') AS `Sales Month`, ROUND(CAST(SUM(`Sales`.`salesamount`) AS NUMERIC), 2) AS `Total Sales`
+SELECT DATE_TRUNC(`Sales`.`salesdate`, MONTH) AS `Sales Month`, ROUND(CAST(SUM(`Sales`.`salesamount`) AS NUMERIC), 2) AS `Total Sales`
 FROM ``.`orionbelt_1`.`sales` AS `Sales`
 GROUP BY ALL
 )

--- a/tests/integration/drift/compile_only/bigquery/11_rolling_30_day_sales.sql
+++ b/tests/integration/drift/compile_only/bigquery/11_rolling_30_day_sales.sql
@@ -1,5 +1,5 @@
 WITH `cumulative_base` AS (
-SELECT DATE_TRUNC(`Sales`.`salesdate`, 'day') AS `Sales Date`, ROUND(CAST(SUM(`Sales`.`salesamount`) AS NUMERIC), 2) AS `Total Sales`
+SELECT DATE_TRUNC(`Sales`.`salesdate`, DAY) AS `Sales Date`, ROUND(CAST(SUM(`Sales`.`salesamount`) AS NUMERIC), 2) AS `Total Sales`
 FROM ``.`orionbelt_1`.`sales` AS `Sales`
 GROUP BY ALL
 )

--- a/tests/integration/drift/compile_only/bigquery/13_sales_yoy_growth.sql
+++ b/tests/integration/drift/compile_only/bigquery/13_sales_yoy_growth.sql
@@ -5,25 +5,25 @@ SELECT DATE_TRUNC(MIN(`Sales`.`salesdate`), MONTH) AS min_date,
 ),
 `date_spine` AS (
 SELECT d AS spine_date,
-       CASE WHEN DATE_ADD(d, INTERVAL -1 YEAR) >= (SELECT min_date FROM date_range)
+       CASE WHEN DATE_ADD(d, INTERVAL -1 YEAR) >= (SELECT min_date FROM `date_range`)
             THEN DATE_ADD(d, INTERVAL -1 YEAR) END AS spine_date_prev
-FROM UNNEST(GENERATE_DATE_ARRAY((SELECT min_date FROM date_range), (SELECT max_date FROM date_range), INTERVAL 1 MONTH)) AS d
+FROM UNNEST(GENERATE_DATE_ARRAY((SELECT min_date FROM `date_range`), (SELECT max_date FROM `date_range`), INTERVAL 1 MONTH)) AS d
 ),
 `pop_base` AS (
-SELECT date_spine.spine_date AS `Sales Month`,
+SELECT `date_spine`.spine_date AS `Sales Month`,
        SUM(`Sales`.`salesamount`) AS `Total Sales`
-  FROM date_spine
+  FROM `date_spine`
   LEFT JOIN ``.`orionbelt_1`.`sales` AS `Sales`
-    ON DATE_TRUNC(`Sales`.`salesdate`, MONTH) = date_spine.spine_date
+    ON DATE_TRUNC(`Sales`.`salesdate`, MONTH) = `date_spine`.spine_date
   GROUP BY 1
 ),
 `pop_compare` AS (
-SELECT pop_base.`Sales Month` AS `Sales Month`,
-       pop_base.`Total Sales` / NULLIF(pop_prev.`Total Sales`, 0) - 1 AS `Sales YoY Growth`
-  FROM pop_base
-  LEFT JOIN date_spine ON pop_base.`Sales Month` = date_spine.spine_date
-  LEFT JOIN pop_base AS pop_prev
-    ON date_spine.spine_date_prev = pop_prev.`Sales Month`
+SELECT `pop_base`.`Sales Month` AS `Sales Month`,
+       `pop_base`.`Total Sales` / NULLIF(pop_prev.`Total Sales`, 0) - 1 AS `Sales YoY Growth`
+  FROM `pop_base`
+  LEFT JOIN `date_spine` ON `pop_base`.`Sales Month` = `date_spine`.spine_date
+  LEFT JOIN `pop_base` AS pop_prev
+    ON `date_spine`.spine_date_prev = pop_prev.`Sales Month`
 )
 SELECT `Sales Month` AS `Sales Month`, `Sales YoY Growth` AS `Sales YoY Growth`
 FROM `pop_compare` AS `pop_compare`

--- a/tests/integration/drift/compile_only/clickhouse/13_sales_yoy_growth.sql
+++ b/tests/integration/drift/compile_only/clickhouse/13_sales_yoy_growth.sql
@@ -4,26 +4,26 @@ SELECT toStartOfMonth(MIN("Sales"."salesdate")) AS min_date,
   FROM "orionbelt_1"."sales" AS "Sales"
 ),
 "date_spine" AS (
-SELECT addMonths((SELECT min_date FROM date_range), n) AS spine_date,
-       CASE WHEN addYears(addMonths((SELECT min_date FROM date_range), n), -1) >= (SELECT min_date FROM date_range)
-            THEN addYears(addMonths((SELECT min_date FROM date_range), n), -1) END AS spine_date_prev
-FROM (SELECT arrayJoin(range(0, toUInt32(dateDiff('month', (SELECT min_date FROM date_range), (SELECT max_date FROM date_range))) + 1)) AS n)
+SELECT addMonths((SELECT min_date FROM "date_range"), n) AS spine_date,
+       CASE WHEN addYears(addMonths((SELECT min_date FROM "date_range"), n), -1) >= (SELECT min_date FROM "date_range")
+            THEN addYears(addMonths((SELECT min_date FROM "date_range"), n), -1) END AS spine_date_prev
+FROM (SELECT arrayJoin(range(0, toUInt32(dateDiff('month', (SELECT min_date FROM "date_range"), (SELECT max_date FROM "date_range"))) + 1)) AS n)
 ),
 "pop_base" AS (
-SELECT date_spine.spine_date AS "Sales Month",
+SELECT "date_spine".spine_date AS "Sales Month",
        SUM("Sales"."salesamount") AS "Total Sales"
-  FROM date_spine
+  FROM "date_spine"
   LEFT JOIN "orionbelt_1"."sales" AS "Sales"
-    ON toStartOfMonth("Sales"."salesdate") = date_spine.spine_date
+    ON toStartOfMonth("Sales"."salesdate") = "date_spine".spine_date
   GROUP BY 1
 ),
 "pop_compare" AS (
-SELECT pop_base."Sales Month" AS "Sales Month",
-       CAST(pop_base."Total Sales" AS Nullable(Decimal(38, 14))) / CAST(NULLIF(pop_prev."Total Sales", 0) AS Nullable(Decimal(38, 14))) - 1 AS "Sales YoY Growth"
-  FROM pop_base
-  LEFT JOIN date_spine ON pop_base."Sales Month" = date_spine.spine_date
-  LEFT JOIN pop_base AS pop_prev
-    ON date_spine.spine_date_prev = pop_prev."Sales Month"
+SELECT "pop_base"."Sales Month" AS "Sales Month",
+       CAST("pop_base"."Total Sales" AS Nullable(Decimal(38, 14))) / CAST(NULLIF(pop_prev."Total Sales", 0) AS Nullable(Decimal(38, 14))) - 1 AS "Sales YoY Growth"
+  FROM "pop_base"
+  LEFT JOIN "date_spine" ON "pop_base"."Sales Month" = "date_spine".spine_date
+  LEFT JOIN "pop_base" AS pop_prev
+    ON "date_spine".spine_date_prev = pop_prev."Sales Month"
 )
 SELECT "Sales Month" AS "Sales Month", "Sales YoY Growth" AS "Sales YoY Growth"
 FROM "pop_compare" AS "pop_compare"

--- a/tests/integration/drift/compile_only/databricks/13_sales_yoy_growth.sql
+++ b/tests/integration/drift/compile_only/databricks/13_sales_yoy_growth.sql
@@ -5,25 +5,25 @@ SELECT date_trunc('month', MIN(`Sales`.`salesdate`)) AS min_date,
 ),
 `date_spine` AS (
 SELECT d AS spine_date,
-       CASE WHEN add_months(d, -12) >= (SELECT min_date FROM date_range)
+       CASE WHEN add_months(d, -12) >= (SELECT min_date FROM `date_range`)
             THEN add_months(d, -12) END AS spine_date_prev
-FROM (SELECT EXPLODE(SEQUENCE((SELECT min_date FROM date_range), (SELECT max_date FROM date_range), INTERVAL 1 MONTH)) AS d)
+FROM (SELECT EXPLODE(SEQUENCE((SELECT min_date FROM `date_range`), (SELECT max_date FROM `date_range`), INTERVAL 1 MONTH)) AS d)
 ),
 `pop_base` AS (
-SELECT date_spine.spine_date AS `Sales Month`,
+SELECT `date_spine`.spine_date AS `Sales Month`,
        SUM(`Sales`.`salesamount`) AS `Total Sales`
-  FROM date_spine
+  FROM `date_spine`
   LEFT JOIN ``.`orionbelt_1`.`sales` AS `Sales`
-    ON date_trunc('month', `Sales`.`salesdate`) = date_spine.spine_date
+    ON date_trunc('month', `Sales`.`salesdate`) = `date_spine`.spine_date
   GROUP BY 1
 ),
 `pop_compare` AS (
-SELECT pop_base.`Sales Month` AS `Sales Month`,
-       pop_base.`Total Sales` / NULLIF(pop_prev.`Total Sales`, 0) - 1 AS `Sales YoY Growth`
-  FROM pop_base
-  LEFT JOIN date_spine ON pop_base.`Sales Month` = date_spine.spine_date
-  LEFT JOIN pop_base AS pop_prev
-    ON date_spine.spine_date_prev = pop_prev.`Sales Month`
+SELECT `pop_base`.`Sales Month` AS `Sales Month`,
+       `pop_base`.`Total Sales` / NULLIF(pop_prev.`Total Sales`, 0) - 1 AS `Sales YoY Growth`
+  FROM `pop_base`
+  LEFT JOIN `date_spine` ON `pop_base`.`Sales Month` = `date_spine`.spine_date
+  LEFT JOIN `pop_base` AS pop_prev
+    ON `date_spine`.spine_date_prev = pop_prev.`Sales Month`
 )
 SELECT `Sales Month` AS `Sales Month`, `Sales YoY Growth` AS `Sales YoY Growth`
 FROM `pop_compare` AS `pop_compare`

--- a/tests/integration/drift/compile_only/dremio/13_sales_yoy_growth.sql
+++ b/tests/integration/drift/compile_only/dremio/13_sales_yoy_growth.sql
@@ -5,34 +5,34 @@ SELECT DATE_TRUNC('month', MIN("Sales"."salesdate")) AS min_date,
 ),
 "date_spine" AS (
 SELECT d AS spine_date,
-       CASE WHEN CAST(TIMESTAMPADD(YEAR, -1, d) AS DATE) >= (SELECT min_date FROM date_range)
+       CASE WHEN CAST(TIMESTAMPADD(YEAR, -1, d) AS DATE) >= (SELECT min_date FROM "date_range")
             THEN CAST(TIMESTAMPADD(YEAR, -1, d) AS DATE) END AS spine_date_prev
 FROM (
-  SELECT CAST(TIMESTAMPADD(MONTH, n, (SELECT min_date FROM date_range)) AS DATE) AS d
+  SELECT CAST(TIMESTAMPADD(MONTH, n, (SELECT min_date FROM "date_range")) AS DATE) AS d
   FROM (
     SELECT a.n + b.n * 10 + c.n * 100 AS n
     FROM (VALUES(0),(1),(2),(3),(4),(5),(6),(7),(8),(9)) a(n)
     CROSS JOIN (VALUES(0),(1),(2),(3),(4),(5),(6),(7),(8),(9)) b(n)
     CROSS JOIN (VALUES(0),(1),(2),(3),(4),(5),(6),(7),(8),(9)) c(n)
   ) AS nums
-  WHERE TIMESTAMPADD(MONTH, n, (SELECT min_date FROM date_range)) <= (SELECT max_date FROM date_range)
+  WHERE TIMESTAMPADD(MONTH, n, (SELECT min_date FROM "date_range")) <= (SELECT max_date FROM "date_range")
 ) AS spine
 ),
 "pop_base" AS (
-SELECT date_spine.spine_date AS "Sales Month",
+SELECT "date_spine".spine_date AS "Sales Month",
        SUM("Sales"."salesamount") AS "Total Sales"
-  FROM date_spine
+  FROM "date_spine"
   LEFT JOIN "orionbelt_1"."sales" AS "Sales"
-    ON DATE_TRUNC('month', "Sales"."salesdate") = date_spine.spine_date
+    ON DATE_TRUNC('month', "Sales"."salesdate") = "date_spine".spine_date
   GROUP BY 1
 ),
 "pop_compare" AS (
-SELECT pop_base."Sales Month" AS "Sales Month",
-       pop_base."Total Sales" / NULLIF(pop_prev."Total Sales", 0) - 1 AS "Sales YoY Growth"
-  FROM pop_base
-  LEFT JOIN date_spine ON pop_base."Sales Month" = date_spine.spine_date
-  LEFT JOIN pop_base AS pop_prev
-    ON date_spine.spine_date_prev = pop_prev."Sales Month"
+SELECT "pop_base"."Sales Month" AS "Sales Month",
+       "pop_base"."Total Sales" / NULLIF(pop_prev."Total Sales", 0) - 1 AS "Sales YoY Growth"
+  FROM "pop_base"
+  LEFT JOIN "date_spine" ON "pop_base"."Sales Month" = "date_spine".spine_date
+  LEFT JOIN "pop_base" AS pop_prev
+    ON "date_spine".spine_date_prev = pop_prev."Sales Month"
 )
 SELECT "Sales Month" AS "Sales Month", "Sales YoY Growth" AS "Sales YoY Growth"
 FROM "pop_compare" AS "pop_compare"

--- a/tests/integration/drift/compile_only/duckdb/13_sales_yoy_growth.sql
+++ b/tests/integration/drift/compile_only/duckdb/13_sales_yoy_growth.sql
@@ -5,25 +5,25 @@ SELECT date_trunc('month', MIN("Sales"."salesdate")) AS min_date,
 ),
 "date_spine" AS (
 SELECT d::date AS spine_date,
-       CASE WHEN (d + INTERVAL '-1 year')::date >= (SELECT min_date FROM date_range)
+       CASE WHEN (d + INTERVAL '-1 year')::date >= (SELECT min_date FROM "date_range")
             THEN (d + INTERVAL '-1 year')::date END AS spine_date_prev
-FROM generate_series((SELECT min_date FROM date_range)::timestamp, (SELECT max_date FROM date_range)::timestamp, INTERVAL '1 month') AS t(d)
+FROM generate_series((SELECT min_date FROM "date_range")::timestamp, (SELECT max_date FROM "date_range")::timestamp, INTERVAL '1 month') AS t(d)
 ),
 "pop_base" AS (
-SELECT date_spine.spine_date AS "Sales Month",
+SELECT "date_spine".spine_date AS "Sales Month",
        SUM("Sales"."salesamount") AS "Total Sales"
-  FROM date_spine
+  FROM "date_spine"
   LEFT JOIN "orionbelt_1"."sales" AS "Sales"
-    ON date_trunc('month', "Sales"."salesdate") = date_spine.spine_date
+    ON date_trunc('month', "Sales"."salesdate") = "date_spine".spine_date
   GROUP BY 1
 ),
 "pop_compare" AS (
-SELECT pop_base."Sales Month" AS "Sales Month",
-       pop_base."Total Sales" / NULLIF(pop_prev."Total Sales", 0) - 1 AS "Sales YoY Growth"
-  FROM pop_base
-  LEFT JOIN date_spine ON pop_base."Sales Month" = date_spine.spine_date
-  LEFT JOIN pop_base AS pop_prev
-    ON date_spine.spine_date_prev = pop_prev."Sales Month"
+SELECT "pop_base"."Sales Month" AS "Sales Month",
+       "pop_base"."Total Sales" / NULLIF(pop_prev."Total Sales", 0) - 1 AS "Sales YoY Growth"
+  FROM "pop_base"
+  LEFT JOIN "date_spine" ON "pop_base"."Sales Month" = "date_spine".spine_date
+  LEFT JOIN "pop_base" AS pop_prev
+    ON "date_spine".spine_date_prev = pop_prev."Sales Month"
 )
 SELECT "Sales Month" AS "Sales Month", "Sales YoY Growth" AS "Sales YoY Growth"
 FROM "pop_compare" AS "pop_compare"

--- a/tests/integration/drift/compile_only/mysql/13_sales_yoy_growth.sql
+++ b/tests/integration/drift/compile_only/mysql/13_sales_yoy_growth.sql
@@ -5,33 +5,33 @@ SELECT DATE_FORMAT(MIN(`Sales`.`salesdate`), '%Y-%m-01') AS min_date,
 ),
 `date_spine` AS (
 SELECT spine_date,
-       CASE WHEN DATE_SUB(spine_date, INTERVAL 1 YEAR) >= (SELECT min_date FROM date_range)
+       CASE WHEN DATE_SUB(spine_date, INTERVAL 1 YEAR) >= (SELECT min_date FROM `date_range`)
             THEN DATE_SUB(spine_date, INTERVAL 1 YEAR) END AS spine_date_prev
 FROM (
   WITH RECURSIVE dates AS (
-    SELECT (SELECT min_date FROM date_range) AS spine_date
+    SELECT (SELECT min_date FROM `date_range`) AS spine_date
     UNION ALL
     SELECT DATE_ADD(spine_date, INTERVAL 1 MONTH)
-    FROM dates WHERE spine_date < (SELECT max_date FROM date_range)
+    FROM dates WHERE spine_date < (SELECT max_date FROM `date_range`)
   )
   SELECT spine_date FROM dates
 ) AS spine
 ),
 `pop_base` AS (
-SELECT date_spine.spine_date AS `Sales Month`,
+SELECT `date_spine`.spine_date AS `Sales Month`,
        SUM(`Sales`.`salesamount`) AS `Total Sales`
-  FROM date_spine
+  FROM `date_spine`
   LEFT JOIN `orionbelt_1`.`sales` AS `Sales`
-    ON DATE_FORMAT(`Sales`.`salesdate`, '%Y-%m-01') = date_spine.spine_date
+    ON DATE_FORMAT(`Sales`.`salesdate`, '%Y-%m-01') = `date_spine`.spine_date
   GROUP BY 1
 ),
 `pop_compare` AS (
-SELECT pop_base.`Sales Month` AS `Sales Month`,
-       CAST(pop_base.`Total Sales` AS DECIMAL(38, 14)) / CAST(NULLIF(pop_prev.`Total Sales`, 0) AS DECIMAL(38, 14)) - 1 AS `Sales YoY Growth`
-  FROM pop_base
-  LEFT JOIN date_spine ON pop_base.`Sales Month` = date_spine.spine_date
-  LEFT JOIN pop_base AS pop_prev
-    ON date_spine.spine_date_prev = pop_prev.`Sales Month`
+SELECT `pop_base`.`Sales Month` AS `Sales Month`,
+       CAST(`pop_base`.`Total Sales` AS DECIMAL(38, 14)) / CAST(NULLIF(pop_prev.`Total Sales`, 0) AS DECIMAL(38, 14)) - 1 AS `Sales YoY Growth`
+  FROM `pop_base`
+  LEFT JOIN `date_spine` ON `pop_base`.`Sales Month` = `date_spine`.spine_date
+  LEFT JOIN `pop_base` AS pop_prev
+    ON `date_spine`.spine_date_prev = pop_prev.`Sales Month`
 )
 SELECT `Sales Month` AS `Sales Month`, `Sales YoY Growth` AS `Sales YoY Growth`
 FROM `pop_compare` AS `pop_compare`

--- a/tests/integration/drift/compile_only/postgres/13_sales_yoy_growth.sql
+++ b/tests/integration/drift/compile_only/postgres/13_sales_yoy_growth.sql
@@ -5,25 +5,25 @@ SELECT date_trunc('month', MIN("Sales"."salesdate")) AS min_date,
 ),
 "date_spine" AS (
 SELECT d::date AS spine_date,
-       CASE WHEN (d + INTERVAL '-1 year')::date >= (SELECT min_date FROM date_range)
+       CASE WHEN (d + INTERVAL '-1 year')::date >= (SELECT min_date FROM "date_range")
             THEN (d + INTERVAL '-1 year')::date END AS spine_date_prev
-FROM generate_series((SELECT min_date FROM date_range)::timestamp, (SELECT max_date FROM date_range)::timestamp, INTERVAL '1 month') AS d
+FROM generate_series((SELECT min_date FROM "date_range")::timestamp, (SELECT max_date FROM "date_range")::timestamp, INTERVAL '1 month') AS d
 ),
 "pop_base" AS (
-SELECT date_spine.spine_date AS "Sales Month",
+SELECT "date_spine".spine_date AS "Sales Month",
        SUM("Sales"."salesamount") AS "Total Sales"
-  FROM date_spine
+  FROM "date_spine"
   LEFT JOIN "orionbelt_1"."sales" AS "Sales"
-    ON date_trunc('month', "Sales"."salesdate") = date_spine.spine_date
+    ON date_trunc('month', "Sales"."salesdate") = "date_spine".spine_date
   GROUP BY 1
 ),
 "pop_compare" AS (
-SELECT pop_base."Sales Month" AS "Sales Month",
-       pop_base."Total Sales" / NULLIF(pop_prev."Total Sales", 0) - 1 AS "Sales YoY Growth"
-  FROM pop_base
-  LEFT JOIN date_spine ON pop_base."Sales Month" = date_spine.spine_date
-  LEFT JOIN pop_base AS pop_prev
-    ON date_spine.spine_date_prev = pop_prev."Sales Month"
+SELECT "pop_base"."Sales Month" AS "Sales Month",
+       "pop_base"."Total Sales" / NULLIF(pop_prev."Total Sales", 0) - 1 AS "Sales YoY Growth"
+  FROM "pop_base"
+  LEFT JOIN "date_spine" ON "pop_base"."Sales Month" = "date_spine".spine_date
+  LEFT JOIN "pop_base" AS pop_prev
+    ON "date_spine".spine_date_prev = pop_prev."Sales Month"
 )
 SELECT "Sales Month" AS "Sales Month", "Sales YoY Growth" AS "Sales YoY Growth"
 FROM "pop_compare" AS "pop_compare"

--- a/tests/integration/drift/compile_only/snowflake/13_sales_yoy_growth.sql
+++ b/tests/integration/drift/compile_only/snowflake/13_sales_yoy_growth.sql
@@ -4,29 +4,30 @@ SELECT DATE_TRUNC('month', MIN("Sales"."salesdate")) AS min_date,
   FROM ""."orionbelt_1"."sales" AS "Sales"
 ),
 "date_spine" AS (
-SELECT DATEADD('month', rn - 1, (SELECT min_date FROM date_range))::date AS spine_date,
-       CASE WHEN DATEADD('year', -1, DATEADD('month', rn - 1, (SELECT min_date FROM date_range))::date)::date >= (SELECT min_date FROM date_range)
-            THEN DATEADD('year', -1, DATEADD('month', rn - 1, (SELECT min_date FROM date_range))::date)::date END AS spine_date_prev
+SELECT DATEADD('month', rn - 1, (SELECT min_date FROM "date_range"))::date AS spine_date,
+       CASE WHEN DATEADD('year', -1, DATEADD('month', rn - 1, (SELECT min_date FROM "date_range"))::date)::date >= (SELECT min_date FROM "date_range")
+            THEN DATEADD('year', -1, DATEADD('month', rn - 1, (SELECT min_date FROM "date_range"))::date)::date END AS spine_date_prev
 FROM (
   SELECT ROW_NUMBER() OVER (ORDER BY SEQ4()) AS rn
-  FROM TABLE(GENERATOR(ROWCOUNT => DATEDIFF('month', (SELECT min_date FROM date_range), (SELECT max_date FROM date_range)) + 1))
+  FROM TABLE(GENERATOR(ROWCOUNT => 100000))
 ) AS t
+WHERE DATEADD('month', rn - 1, (SELECT min_date FROM "date_range"))::date <= (SELECT max_date FROM "date_range")
 ),
 "pop_base" AS (
-SELECT date_spine.spine_date AS "Sales Month",
+SELECT "date_spine".spine_date AS "Sales Month",
        SUM("Sales"."salesamount") AS "Total Sales"
-  FROM date_spine
+  FROM "date_spine"
   LEFT JOIN ""."orionbelt_1"."sales" AS "Sales"
-    ON DATE_TRUNC('month', "Sales"."salesdate") = date_spine.spine_date
+    ON DATE_TRUNC('month', "Sales"."salesdate") = "date_spine".spine_date
   GROUP BY 1
 ),
 "pop_compare" AS (
-SELECT pop_base."Sales Month" AS "Sales Month",
-       pop_base."Total Sales" / NULLIF(pop_prev."Total Sales", 0) - 1 AS "Sales YoY Growth"
-  FROM pop_base
-  LEFT JOIN date_spine ON pop_base."Sales Month" = date_spine.spine_date
-  LEFT JOIN pop_base AS pop_prev
-    ON date_spine.spine_date_prev = pop_prev."Sales Month"
+SELECT "pop_base"."Sales Month" AS "Sales Month",
+       "pop_base"."Total Sales" / NULLIF(pop_prev."Total Sales", 0) - 1 AS "Sales YoY Growth"
+  FROM "pop_base"
+  LEFT JOIN "date_spine" ON "pop_base"."Sales Month" = "date_spine".spine_date
+  LEFT JOIN "pop_base" AS pop_prev
+    ON "date_spine".spine_date_prev = pop_prev."Sales Month"
 )
 SELECT "Sales Month" AS "Sales Month", "Sales YoY Growth" AS "Sales YoY Growth"
 FROM "pop_compare" AS "pop_compare"

--- a/tests/integration/drift/duckdb/13_sales_yoy_growth.yaml
+++ b/tests/integration/drift/duckdb/13_sales_yoy_growth.yaml
@@ -1,15 +1,16 @@
 last_verified_by: tests/integration/correctness/test_pandas_baseline.py::test_sales_yoy_growth
 sql: "WITH \"date_range\" AS (\nSELECT date_trunc('month', MIN(\"Sales\".\"salesdate\")) AS min_date,\n       date_trunc('month',\
   \ MAX(\"Sales\".\"salesdate\")) AS max_date\n  FROM \"orionbelt_1\".\"sales\" AS \"Sales\"\n),\n\"date_spine\" AS (\nSELECT\
-  \ d::date AS spine_date,\n       CASE WHEN (d + INTERVAL '-1 year')::date >= (SELECT min_date FROM date_range)\n       \
-  \     THEN (d + INTERVAL '-1 year')::date END AS spine_date_prev\nFROM generate_series((SELECT min_date FROM date_range)::timestamp,\
-  \ (SELECT max_date FROM date_range)::timestamp, INTERVAL '1 month') AS t(d)\n),\n\"pop_base\" AS (\nSELECT date_spine.spine_date\
-  \ AS \"Sales Month\",\n       SUM(\"Sales\".\"salesamount\") AS \"Total Sales\"\n  FROM date_spine\n  LEFT JOIN \"orionbelt_1\"\
-  .\"sales\" AS \"Sales\"\n    ON date_trunc('month', \"Sales\".\"salesdate\") = date_spine.spine_date\n  GROUP BY 1\n),\n\
-  \"pop_compare\" AS (\nSELECT pop_base.\"Sales Month\" AS \"Sales Month\",\n       pop_base.\"Total Sales\" / NULLIF(pop_prev.\"\
-  Total Sales\", 0) - 1 AS \"Sales YoY Growth\"\n  FROM pop_base\n  LEFT JOIN date_spine ON pop_base.\"Sales Month\" = date_spine.spine_date\n\
-  \  LEFT JOIN pop_base AS pop_prev\n    ON date_spine.spine_date_prev = pop_prev.\"Sales Month\"\n)\nSELECT \"Sales Month\"\
-  \ AS \"Sales Month\", \"Sales YoY Growth\" AS \"Sales YoY Growth\"\nFROM \"pop_compare\" AS \"pop_compare\"\n"
+  \ d::date AS spine_date,\n       CASE WHEN (d + INTERVAL '-1 year')::date >= (SELECT min_date FROM \"date_range\")\n   \
+  \         THEN (d + INTERVAL '-1 year')::date END AS spine_date_prev\nFROM generate_series((SELECT min_date FROM \"date_range\"\
+  )::timestamp, (SELECT max_date FROM \"date_range\")::timestamp, INTERVAL '1 month') AS t(d)\n),\n\"pop_base\" AS (\nSELECT\
+  \ \"date_spine\".spine_date AS \"Sales Month\",\n       SUM(\"Sales\".\"salesamount\") AS \"Total Sales\"\n  FROM \"date_spine\"\
+  \n  LEFT JOIN \"orionbelt_1\".\"sales\" AS \"Sales\"\n    ON date_trunc('month', \"Sales\".\"salesdate\") = \"date_spine\"\
+  .spine_date\n  GROUP BY 1\n),\n\"pop_compare\" AS (\nSELECT \"pop_base\".\"Sales Month\" AS \"Sales Month\",\n       \"\
+  pop_base\".\"Total Sales\" / NULLIF(pop_prev.\"Total Sales\", 0) - 1 AS \"Sales YoY Growth\"\n  FROM \"pop_base\"\n  LEFT\
+  \ JOIN \"date_spine\" ON \"pop_base\".\"Sales Month\" = \"date_spine\".spine_date\n  LEFT JOIN \"pop_base\" AS pop_prev\n\
+  \    ON \"date_spine\".spine_date_prev = pop_prev.\"Sales Month\"\n)\nSELECT \"Sales Month\" AS \"Sales Month\", \"Sales\
+  \ YoY Growth\" AS \"Sales YoY Growth\"\nFROM \"pop_compare\" AS \"pop_compare\"\n"
 rows:
 - - '2021-01-01'
   - null

--- a/tests/integration/test_bigquery_execution.py
+++ b/tests/integration/test_bigquery_execution.py
@@ -45,6 +45,11 @@ from tests.integration._commerce import (  # noqa: E402
     open_duckdb_truth,
     parquet_path,
 )
+from tests.integration._measure_sweep import (  # noqa: E402
+    SWEEP_IDS,
+    SWEEP_ITEMS,
+    sweep_query,
+)
 
 pytestmark = pytest.mark.bigquery
 
@@ -157,3 +162,18 @@ def test_commerce_case(bigquery_setup, vendor_model, truth_results, case: Commer
     sql = compile_for(case.query, vendor_model, "bigquery")
     actual = _fetch_bigquery(client, sql)
     compare_rows(actual, truth_results[case.name], case=case.name)
+
+
+@pytest.mark.parametrize("kind,name,dims", SWEEP_ITEMS, ids=SWEEP_IDS)
+def test_measure_sweep(bigquery_setup, vendor_model, kind: str, name: str, dims: list[str]) -> None:
+    """Every measure and metric must execute on BigQuery (execution only).
+
+    Breadth complement to ``test_commerce_case``: covers the full measure and
+    metric surface (incl. synthesised counts), asserting each runs rather than
+    comparing rows. Catches BigQuery SQL that compiles but the engine rejects
+    (e.g. a grain-to-date DATE_TRUNC date-part form).
+    """
+    client, _cfg = bigquery_setup
+    sql = compile_for(sweep_query(name, dims), vendor_model, "bigquery")
+    rows = _fetch_bigquery(client, sql)  # raises on a BigQuery execution error
+    assert isinstance(rows, list), f"{kind} {name!r} returned no result set"

--- a/tests/integration/test_databricks_execution.py
+++ b/tests/integration/test_databricks_execution.py
@@ -48,6 +48,11 @@ from tests.integration._commerce import (  # noqa: E402
     open_duckdb_truth,
     parquet_path,
 )
+from tests.integration._measure_sweep import (  # noqa: E402
+    SWEEP_IDS,
+    SWEEP_ITEMS,
+    sweep_query,
+)
 
 pytestmark = pytest.mark.databricks
 
@@ -226,3 +231,20 @@ def test_commerce_case(databricks_setup, vendor_model, truth_results, case: Comm
     sql = compile_for(case.query, vendor_model, "databricks")
     actual = _fetch_databricks(con, sql)
     compare_rows(actual, truth_results[case.name], case=case.name)
+
+
+@pytest.mark.parametrize("kind,name,dims", SWEEP_ITEMS, ids=SWEEP_IDS)
+def test_measure_sweep(
+    databricks_setup, vendor_model, kind: str, name: str, dims: list[str]
+) -> None:
+    """Every measure and metric must execute on Databricks (execution only).
+
+    Breadth complement to ``test_commerce_case``: covers the full measure and
+    metric surface (incl. synthesised counts), asserting each runs rather than
+    comparing rows. Catches Databricks SQL that compiles but the engine rejects
+    (e.g. quarter-grain date arithmetic).
+    """
+    con, _cfg = databricks_setup
+    sql = compile_for(sweep_query(name, dims), vendor_model, "databricks")
+    rows = _fetch_databricks(con, sql)  # raises on a Databricks execution error
+    assert isinstance(rows, list), f"{kind} {name!r} returned no result set"

--- a/tests/integration/test_snowflake_execution.py
+++ b/tests/integration/test_snowflake_execution.py
@@ -57,6 +57,11 @@ from tests.integration._commerce import (  # noqa: E402
     open_duckdb_truth,
     parquet_path,
 )
+from tests.integration._measure_sweep import (  # noqa: E402
+    SWEEP_IDS,
+    SWEEP_ITEMS,
+    sweep_query,
+)
 
 pytestmark = pytest.mark.snowflake
 
@@ -211,3 +216,19 @@ def test_commerce_case(snowflake_setup, vendor_model, truth_results, case: Comme
     sql = compile_for(case.query, vendor_model, "snowflake")
     actual = _fetch_snowflake(con, sql)
     compare_rows(actual, truth_results[case.name], case=case.name)
+
+
+@pytest.mark.parametrize("kind,name,dims", SWEEP_ITEMS, ids=SWEEP_IDS)
+def test_measure_sweep(
+    snowflake_setup, vendor_model, kind: str, name: str, dims: list[str]
+) -> None:
+    """Every measure and metric must execute on Snowflake (execution only).
+
+    Breadth complement to ``test_commerce_case``: covers the full measure and
+    metric surface (incl. synthesised counts), asserting each runs rather than
+    comparing rows. Catches Snowflake SQL that compiles but the engine rejects.
+    """
+    con, _cfg = snowflake_setup
+    sql = compile_for(sweep_query(name, dims), vendor_model, "snowflake")
+    rows = _fetch_snowflake(con, sql)  # raises on a Snowflake execution error
+    assert isinstance(rows, list), f"{kind} {name!r} returned no result set"


### PR DESCRIPTION
Completes per-vendor execution-sweep coverage by adding the cloud engines, and fixes **three real bugs** the sweeps surfaced against live projects.

## Sweeps added

- **`tests/integration/_measure_sweep.py`** — shared helper deriving the sweep list from the resolved model (`effective_measures` incl. the 14 synthesised counts + each metric's time dimension).
- **A `test_measure_sweep` in each cloud suite** (Snowflake / BigQuery / Databricks), reusing the existing seed / connection / vendor-cased-model fixtures. 37 cases each, execution-only, gated by the existing markers; skip without credentials.

## Bugs found + fixed (verified against live accounts)

1. **BigQuery `render_time_grain`** — emitted `DATE_TRUNC(col, 'month')` (quoted string); BigQuery requires the bare keyword `MONTH`/`ISOWEEK`. Affected every query grouped by a time-grain dimension (the battery too — the compile-only snapshots had enshrined the invalid form). Fixed via `RawSQL` keyword; snapshots regenerated.
2. **PoP CTE reference quoting (all dialects)** — the spine declared CTEs quoted (`WITH "date_range"`) but referenced them bare (`FROM date_range`). Snowflake folds bare → `DATE_RANGE` → `Object 'DATE_RANGE' does not exist`. Quote the CTE-name qualifiers to match declarations (consistent with `_render_source_string` for star/CFL).
3. **Snowflake constant-rowcount spine** — `GENERATOR(ROWCOUNT => DATEDIFF(...))` needs a compile-time constant. Generate a fixed upper bound + filter to the range (same pattern the other dialects use).

## Live-run status

| Vendor | Result |
|---|---|
| **BigQuery** | **37/37** after fix #1 (verified live) |
| **Snowflake** | **37/37** after fixes #2 + #3 (verified live) |
| Databricks | blocked: SQL warehouse auto-stopped during the slow row-by-row seed — infra, not a code bug (compile check passed for all 37) |

## Verification

- Full suite: 2734 passed; ruff / mypy / RawSQL gate clean.
- Local PoP execution on Postgres/MySQL/ClickHouse/DuckDB unchanged after the quoting change.
- Live BigQuery + Snowflake sweeps both 37/37.

## Follow-ups

- **Databricks live run** needs a persistent / longer-idle SQL warehouse or a faster bulk seed (`COPY INTO` staged Parquet instead of row-by-row `INSERT VALUES`) — the current seed outlives the warehouse's auto-stop.
- Wiring the cloud markers into CI needs cloud secrets (infra decision).