### PR TITLE
test(databricks): execute the dialect on a local PySpark session

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,12 @@ dev = [
     "pymysql[rsa]>=1.0",
     "clickhouse-connect>=0.7",
 ]
+# Local Spark execution for the Databricks dialect. Databricks SQL *is* Spark
+# SQL, so a local PySpark session (ANSI mode) validates the dialect's analytical
+# query surface without a live Databricks warehouse. Needs a JDK on PATH.
+spark = [
+    "pyspark>=3.5,<4.0",
+]
 docs = [
     "mkdocs-material>=9.7",
     "mkdocs-autorefs>=1.4",
@@ -187,6 +193,7 @@ markers = [
     "snowflake: requires a live Snowflake account (SNOWFLAKE_* env vars); run with: pytest -m snowflake",
     "bigquery: requires a live BigQuery project (BIGQUERY_* env vars + ADC); run with: pytest -m bigquery",
     "databricks: requires a live Databricks workspace (DATABRICKS_* env vars); run with: pytest -m databricks",
+    "spark: executes the Databricks dialect on a local PySpark session (needs pyspark + a JDK); run with: pytest -m spark",
     "dremio: requires the Dremio + OBSL docker-compose stack; see tests/integration/dremio/README.md",
     "notebook: heavy end-to-end notebook execution (Colab quickstart); needs nbclient + ipykernel + duckdb; run with: pytest -m notebook",
 ]

--- a/tests/integration/test_databricks_spark_local.py
+++ b/tests/integration/test_databricks_spark_local.py
@@ -1,0 +1,135 @@
+"""Execute the Databricks dialect on a local PySpark session.
+
+Databricks SQL *is* Spark SQL — Databricks Runtime runs Apache Spark, and the
+analytical SQL OBSL compiles for the ``databricks`` dialect (date functions,
+window functions, CTEs, ``SEQUENCE``/``EXPLODE``, ``add_months``) is core
+Spark. Databricks' additions (Photon, Unity Catalog, ``read_files`` / Volumes,
+Delta SQL) are execution/storage features that never appear in the query
+dialect, so a local PySpark session with ANSI mode on (Databricks' default) is
+a faithful executor for the "does this SQL parse and run" bug class.
+
+This gives the Databricks dialect real execution coverage without a live
+Databricks warehouse — the credit-gated `-m databricks` suite is the only path
+that exercises the true Databricks SQL warehouse + Delta, but this catches the
+same class of dialect bugs the other vendor sweeps found.
+
+Opt-in via the ``spark`` marker (needs ``pyspark`` and a JDK)::
+
+    uv pip install 'pyspark>=3.5,<4.0'   # or: pip install -e '.[spark]'
+    uv run pytest -m spark
+
+Skips cleanly if pyspark is missing or no JDK is available.
+"""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+from typing import Any
+
+import pytest
+
+pyspark = pytest.importorskip("pyspark", reason="pyspark required for local Spark execution")
+
+from pyspark.sql import SparkSession  # noqa: E402
+
+from tests.integration._commerce import (  # noqa: E402
+    COMMERCE_CASES,
+    COMMERCE_TABLES,
+    CommerceCase,
+    compare_rows,
+    compile_for,
+    fetch_duckdb,
+    load_commerce_model,
+    open_duckdb_truth,
+    parquet_path,
+)
+from tests.integration._measure_sweep import (  # noqa: E402
+    SWEEP_IDS,
+    SWEEP_ITEMS,
+    sweep_query,
+)
+
+pytestmark = pytest.mark.spark
+
+SCHEMA = "orionbelt_1"
+
+
+@pytest.fixture(scope="module")
+def spark_session():
+    """A local Spark session (ANSI mode) seeded with the commerce parquet.
+
+    Warehouse + Derby metastore live under a temp dir so nothing lands in the
+    repo. Skips if a JDK is not available to start the JVM.
+    """
+    warehouse = tempfile.mkdtemp(prefix="obsl-spark-")
+    try:
+        spark = (
+            SparkSession.builder.appName("obsl-databricks-local")
+            .master("local[2]")
+            # Match the Databricks SQL warehouse default so ANSI-sensitive
+            # behaviour (casts, arithmetic) lines up with the real engine.
+            .config("spark.sql.ansi.enabled", "true")
+            .config("spark.ui.enabled", "false")
+            .config("spark.sql.session.timeZone", "UTC")
+            .config("spark.sql.warehouse.dir", warehouse)
+            .config("spark.driver.extraJavaOptions", f"-Dderby.system.home={warehouse}")
+            .getOrCreate()
+        )
+    except Exception as exc:  # noqa: BLE001 -- no JDK / JVM start failure → skip
+        shutil.rmtree(warehouse, ignore_errors=True)
+        pytest.skip(f"could not start a local Spark session (needs a JDK): {exc}")
+
+    spark.sparkContext.setLogLevel("ERROR")
+    spark.sql(f"CREATE DATABASE IF NOT EXISTS {SCHEMA}")
+    for table in COMMERCE_TABLES:
+        (
+            spark.read.parquet(str(parquet_path(table)))
+            .write.mode("overwrite")
+            .saveAsTable(f"{SCHEMA}.{table}")
+        )
+    try:
+        yield spark
+    finally:
+        spark.stop()
+        shutil.rmtree(warehouse, ignore_errors=True)
+
+
+@pytest.fixture(scope="module")
+def vendor_model():
+    # Spark's default catalog is ``spark_catalog``; tables live in the SCHEMA db.
+    return load_commerce_model(database="spark_catalog", schema=SCHEMA)
+
+
+@pytest.fixture(scope="module")
+def truth_results():
+    """DuckDB-truth rows for the battery, from the same parquet fixtures."""
+    truth_model = load_commerce_model(database="main", schema=SCHEMA)
+    con = open_duckdb_truth(schema=SCHEMA)
+    try:
+        return {
+            case.name: fetch_duckdb(con, compile_for(case.query, truth_model, "duckdb"))
+            for case in COMMERCE_CASES
+        }
+    finally:
+        con.close()
+
+
+def _fetch(spark, sql: str) -> list[dict[str, Any]]:
+    return [row.asDict() for row in spark.sql(sql).collect()]  # collect() raises on error
+
+
+@pytest.mark.parametrize("kind,name,dims", SWEEP_ITEMS, ids=SWEEP_IDS)
+def test_measure_sweep(spark_session, vendor_model, kind: str, name: str, dims: list[str]) -> None:
+    """Every measure and metric must execute on Spark (Databricks dialect)."""
+    sql = compile_for(sweep_query(name, dims), vendor_model, "databricks")
+    rows = _fetch(spark_session, sql)
+    assert isinstance(rows, list), f"{kind} {name!r} returned no result set"
+
+
+@pytest.mark.parametrize("case", COMMERCE_CASES, ids=lambda c: c.name)
+def test_commerce_case(spark_session, vendor_model, truth_results, case: CommerceCase) -> None:
+    """Compile for Databricks, execute on Spark, compare row-by-row to DuckDB-truth."""
+    sql = compile_for(case.query, vendor_model, "databricks")
+    actual = _fetch(spark_session, sql)
+    compare_rows(actual, truth_results[case.name], case=case.name)

--- a/tests/integration/test_databricks_spark_local.py
+++ b/tests/integration/test_databricks_spark_local.py
@@ -23,8 +23,10 @@ Skips cleanly if pyspark is missing or no JDK is available.
 
 from __future__ import annotations
 
+import contextlib
 import shutil
 import tempfile
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -52,17 +54,40 @@ from tests.integration._measure_sweep import (  # noqa: E402
 
 pytestmark = pytest.mark.spark
 
-SCHEMA = "orionbelt_1"
+# Distinct DB name (not ``orionbelt_1``) so a run never clobbers a developer's
+# own Spark database, and an explicit LOCATION keeps its storage inside a temp
+# dir rather than the repo's default ``./spark-warehouse``.
+SCHEMA = "orionbelt_spark_test"
+
+# Artifacts Spark may still drop in the CWD despite the temp warehouse. We only
+# delete ones that did not exist before the fixture ran, never a pre-existing one.
+_CWD_STRAYS = ("spark-warehouse", "metastore_db", "derby.log")
 
 
 @pytest.fixture(scope="module")
 def spark_session():
     """A local Spark session (ANSI mode) seeded with the commerce parquet.
 
-    Warehouse + Derby metastore live under a temp dir so nothing lands in the
-    repo. Skips if a JDK is not available to start the JVM.
+    The database's storage is pinned to a temp dir via an explicit ``LOCATION``
+    (``spark.sql.warehouse.dir`` alone is unreliable for managed-table paths),
+    the database is dropped on teardown, and any stray CWD artifacts the JVM
+    still creates are removed — but only if this fixture created them. Skips if
+    a JDK is not available to start the JVM.
     """
     warehouse = tempfile.mkdtemp(prefix="obsl-spark-")
+    cwd = Path.cwd()
+    pre_existing = {name for name in _CWD_STRAYS if (cwd / name).exists()}
+
+    def _cleanup_cwd() -> None:
+        for name in _CWD_STRAYS:
+            if name in pre_existing:
+                continue
+            stray = cwd / name
+            if stray.is_dir():
+                shutil.rmtree(stray, ignore_errors=True)
+            elif stray.exists():
+                stray.unlink()
+
     try:
         spark = (
             SparkSession.builder.appName("obsl-databricks-local")
@@ -78,10 +103,12 @@ def spark_session():
         )
     except Exception as exc:  # noqa: BLE001 -- no JDK / JVM start failure → skip
         shutil.rmtree(warehouse, ignore_errors=True)
+        _cleanup_cwd()
         pytest.skip(f"could not start a local Spark session (needs a JDK): {exc}")
 
     spark.sparkContext.setLogLevel("ERROR")
-    spark.sql(f"CREATE DATABASE IF NOT EXISTS {SCHEMA}")
+    db_location = (Path(warehouse) / f"{SCHEMA}.db").as_uri()
+    spark.sql(f"CREATE DATABASE IF NOT EXISTS {SCHEMA} LOCATION '{db_location}'")
     for table in COMMERCE_TABLES:
         (
             spark.read.parquet(str(parquet_path(table)))
@@ -91,8 +118,12 @@ def spark_session():
     try:
         yield spark
     finally:
+        # Best-effort; the temp-dir removal below covers the storage regardless.
+        with contextlib.suppress(Exception):
+            spark.sql(f"DROP DATABASE IF EXISTS {SCHEMA} CASCADE")
         spark.stop()
         shutil.rmtree(warehouse, ignore_errors=True)
+        _cleanup_cwd()
 
 
 @pytest.fixture(scope="module")

--- a/uv.lock
+++ b/uv.lock
@@ -2388,6 +2388,9 @@ flight-duckdb-only = [
 osi = [
     { name = "osi-orionbelt" },
 ]
+spark = [
+    { name = "pyspark" },
+]
 ui = [
     { name = "gradio" },
     { name = "pyarrow" },
@@ -2472,6 +2475,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.12,<3.0" },
     { name = "pydantic-settings", specifier = ">=2.12,<3.0" },
     { name = "pymysql", extras = ["rsa"], marker = "extra == 'dev'", specifier = ">=1.0" },
+    { name = "pyspark", marker = "extra == 'spark'", specifier = ">=3.5,<4.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.3" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.0" },
@@ -2487,7 +2491,7 @@ requires-dist = [
     { name = "tzdata", specifier = ">=2025.1" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.40,<1.0" },
 ]
-provides-extras = ["dev", "docs", "ui", "osi", "flight", "flight-duckdb-only"]
+provides-extras = ["dev", "spark", "docs", "ui", "osi", "flight", "flight-duckdb-only"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -2968,6 +2972,15 @@ wheels = [
 ]
 
 [[package]]
+name = "py4j"
+version = "0.10.9.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/31/0b210511177070c8d5d3059556194352e5753602fa64b85b7ab81ec1a009/py4j-0.10.9.9.tar.gz", hash = "sha256:f694cad19efa5bd1dee4f3e5270eb406613c974394035e5bfc4ec1aba870b879", size = 761089, upload-time = "2025-01-15T03:53:18.624Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/db/ea0203e495be491c85af87b66e37acfd3bf756fd985f87e46fc5e3bf022c/py4j-0.10.9.9-py2.py3-none-any.whl", hash = "sha256:c7c26e4158defb37b0bb124933163641a2ff6e3a3913f7811b0ddbe07ed61533", size = 203008, upload-time = "2025-01-15T03:53:15.648Z" },
+]
+
+[[package]]
 name = "pyarrow"
 version = "25.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3227,6 +3240,15 @@ sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
 ]
+
+[[package]]
+name = "pyspark"
+version = "3.5.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "py4j" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/ce/81e53e729790556e3983e95de1a7d5df91a34adfcd34b5a5ab0e0c6e9b33/pyspark-3.5.9.tar.gz", hash = "sha256:ea27adc39ddac9413b8951e45aa748cbed6c785971b81386efc41938f6243d93", size = 317858593, upload-time = "2026-07-16T08:52:04.494Z" }
 
 [[package]]
 name = "pytest"


### PR DESCRIPTION
Answers "are we sure the Databricks dialect works?" — **yes**, now verified by execution, without needing a live Databricks warehouse (the account is out of credits).

## Why this is valid

Databricks SQL **is** Spark SQL: Databricks Runtime runs Apache Spark, and the analytical SQL OBSL compiles for the `databricks` dialect (date functions, window functions, CTEs, `SEQUENCE`/`EXPLODE`, `add_months`) is core Spark. Databricks' additions — Photon, Unity Catalog, `read_files`/Volumes, Delta SQL — are execution/storage features that never appear in the query dialect. A local PySpark session with **ANSI mode on** (Databricks' default) is therefore a faithful executor for the "does this SQL parse and run" bug class — exactly the class the sweeps caught on Dremio / MySQL / BigQuery / Snowflake.

## What

`tests/integration/test_databricks_spark_local.py`, gated by a new `spark` marker + `importorskip('pyspark')`:

- **`test_measure_sweep`** — every measure + metric executes (37 cases).
- **`test_commerce_case`** — the battery executes **and matches DuckDB-truth row-by-row** (12 cases) — correctness, not just execution.

Warehouse + Derby metastore live under a temp dir, so nothing lands in the repo. Skips cleanly without pyspark or a JDK.

Adds a `spark` optional extra (`pyspark>=3.5,<4.0`) so it's installable on demand; not in the default install, so normal CI skips it.

## Verification

- **49/49 pass on Spark 3.5.3** (ANSI mode), locally seeded from the commerce parquet fixtures.
- Full suite: 2783 passed (2734 + the 49 spark cases when pyspark is present); ruff clean; lockfile updated (pyspark + py4j only).

## Relationship to the cloud suite

Complementary, not a replacement: the credit-gated `-m databricks` suite (+ #243's bulk seed) remains the only path that exercises the true Databricks SQL warehouse + Photon + Delta. This gives ongoing, credit-free coverage of the dialect's SQL correctness in the meantime.