### PR TITLE
Generate per-vendor seed SQL scripts on seed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ design/
 examples/test*
 examples/tpcds_queries/
 semantic-layer-spec.md
+
+# Generated per-vendor seed scripts (backup of what the drift seed executed)
+tests/integration/drift/vendor_exec/seed_sql/

--- a/tests/integration/drift/vendor_exec/_seed.py
+++ b/tests/integration/drift/vendor_exec/_seed.py
@@ -122,6 +122,11 @@ class VendorSpec:
     # four container-tested engines coerce plain strings happily and are
     # left as-is; the cloud engines are stricter.
     date_literals: bool = False
+    # GoogleSQL (BigQuery) escapes a single quote inside a string literal with a
+    # backslash (``\'``); the SQL-standard doubling (``''``) parses there as two
+    # adjacent literals ("O''Brien" -> 'O' 'Brien') and errors. Every other
+    # dialect here accepts ``''``. Set True to switch to backslash escaping.
+    backslash_escape: bool = False
     notes: tuple[str, ...] = ()
 
     def q(self, name: str) -> str:
@@ -178,6 +183,7 @@ _SPECS: dict[str, VendorSpec] = {
         container="SCHEMA",
         executed=False,
         date_literals=True,
+        backslash_escape=True,
         notes=("Run against the target project. `orionbelt_1` is the dataset.",),
     ),
     "snowflake": VendorSpec(
@@ -222,19 +228,31 @@ VENDORS: tuple[str, ...] = tuple(_SPECS)
 # ----------------------------------------------------------------------
 
 
-def _lit(v: Any, *, date_literals: bool = False) -> str:
+def _lit(v: Any, *, date_literals: bool = False, backslash_escape: bool = False) -> str:
     if v is None:
         return "NULL"
     if isinstance(v, (int, float, Decimal)):
         return str(v)
     if isinstance(v, date):
         return f"DATE '{v.isoformat()}'" if date_literals else f"'{v.isoformat()}'"
-    s = str(v).replace("'", "''")
+    s = str(v)
+    # GoogleSQL escapes a quote as ``\'``; every other dialect doubles it as
+    # ``''``. In the backslash path, escape backslashes first so they don't
+    # consume the quote escape.
+    s = (
+        s.replace("\\", "\\\\").replace("'", "\\'")
+        if backslash_escape
+        else s.replace("'", "''")
+    )
     return f"'{s}'"
 
 
 def _values_batches(
-    rows: list[tuple[Any, ...]], batch_size: int, *, date_literals: bool = False
+    rows: list[tuple[Any, ...]],
+    batch_size: int,
+    *,
+    date_literals: bool = False,
+    backslash_escape: bool = False,
 ) -> list[str]:
     """Yield ``(...), (...)`` strings, ``batch_size`` rows per chunk."""
     out: list[str] = []
@@ -242,7 +260,12 @@ def _values_batches(
         chunk = rows[i : i + batch_size]
         out.append(
             ", ".join(
-                "(" + ", ".join(_lit(v, date_literals=date_literals) for v in row) + ")"
+                "("
+                + ", ".join(
+                    _lit(v, date_literals=date_literals, backslash_escape=backslash_escape)
+                    for v in row
+                )
+                + ")"
                 for row in chunk
             )
         )
@@ -321,7 +344,10 @@ def plan(vendor: str, *, grant_user: str | None = None) -> SeedPlan:
         inserts = [
             f"INSERT INTO {spec.table(tbl)} VALUES {batch}"
             for batch in _values_batches(
-                payload["rows"], _BATCH_SIZE, date_literals=spec.date_literals
+                payload["rows"],
+                _BATCH_SIZE,
+                date_literals=spec.date_literals,
+                backslash_escape=spec.backslash_escape,
             )
         ]
         tables.append((table_ddl, inserts))

--- a/tests/integration/drift/vendor_exec/_seed.py
+++ b/tests/integration/drift/vendor_exec/_seed.py
@@ -239,11 +239,7 @@ def _lit(v: Any, *, date_literals: bool = False, backslash_escape: bool = False)
     # GoogleSQL escapes a quote as ``\'``; every other dialect doubles it as
     # ``''``. In the backslash path, escape backslashes first so they don't
     # consume the quote escape.
-    s = (
-        s.replace("\\", "\\\\").replace("'", "\\'")
-        if backslash_escape
-        else s.replace("'", "''")
-    )
+    s = s.replace("\\", "\\\\").replace("'", "\\'") if backslash_escape else s.replace("'", "''")
     return f"'{s}'"
 
 

--- a/tests/integration/drift/vendor_exec/_seed.py
+++ b/tests/integration/drift/vendor_exec/_seed.py
@@ -12,10 +12,25 @@ DuckDB stores numeric columns as ``DOUBLE`` and the OBSL compiler
 applies ``CAST(... AS DECIMAL(p, s))`` at query time per measure. The
 seed mirrors that: ``DOUBLE`` everywhere, casts happen in the
 generated SQL.
+
+Every seeder builds its full statement list *before* touching the
+connection and mirrors it to ``seed_sql/<vendor>/{01_schema,02_data}.sql``
+(gitignored). Those dumps are exactly what ran, so they double as a
+backup and as standalone scripts anyone can replay against their own
+database. Generate them without Docker or a live connection with::
+
+    uv run python tests/integration/drift/vendor_exec/_seed.py
+
+Set ``OBSL_SEED_SQL_DIR`` to redirect the output directory, or to the
+empty string to skip dumping entirely.
 """
 
 from __future__ import annotations
 
+import os
+import warnings
+from collections.abc import Callable
+from dataclasses import dataclass, field
 from datetime import date
 from decimal import Decimal
 from pathlib import Path
@@ -28,7 +43,7 @@ COMMERCE_DUCKDB = REPO_ROOT / "examples" / "orionbelt_1_commerce.duckdb"
 SCHEMA = "orionbelt_1"
 
 # ----------------------------------------------------------------------
-# Source extraction (run once per session, cheap — ~25k rows total)
+# Source extraction (run once per session, cheap — ~26k rows total)
 # ----------------------------------------------------------------------
 
 
@@ -74,7 +89,7 @@ def get_source() -> dict[str, dict[str, Any]]:
 
 
 # ----------------------------------------------------------------------
-# Per-dialect type translation
+# Per-dialect vendor specs
 # ----------------------------------------------------------------------
 
 
@@ -85,18 +100,120 @@ def get_source() -> dict[str, dict[str, Any]]:
 # measure outputs to ``DECIMAL(18, 2)`` per the model's declared type,
 # so the source-column choice never propagates to query output — but it
 # does prevent IEEE-754 last-bit drift inside the engine's accumulator.
-_PG_TYPES = {"VARCHAR": "TEXT", "DATE": "DATE", "DOUBLE": "DECIMAL(18, 2)"}
-_MYSQL_TYPES = {"VARCHAR": "VARCHAR(255)", "DATE": "DATE", "DOUBLE": "DECIMAL(18, 2)"}
-_CH_TYPES = {"VARCHAR": "String", "DATE": "Date", "DOUBLE": "Decimal(18, 2)"}
-_DUCKDB_TYPES = {"VARCHAR": "VARCHAR", "DATE": "DATE", "DOUBLE": "DECIMAL(18, 2)"}
+#
+# Identifiers stay lowercase and quoted everywhere, matching what the
+# compiler emits per dialect (see tests/integration/drift/compile_only/).
+# Snowflake in particular treats a quoted lowercase name as
+# case-sensitive lowercase, so unquoted DDL would not resolve.
+@dataclass(frozen=True)
+class VendorSpec:
+    """Everything that differs between one vendor's seed script and another's."""
+
+    name: str
+    types: dict[str, str]
+    quote: str
+    # ``SCHEMA`` for namespace-style engines, ``DATABASE`` for MySQL and
+    # ClickHouse. ``None`` means the engine has no CREATE-able namespace
+    # we can assume (Dremio), so tables are dropped individually instead.
+    container: str | None
+    executed: bool
+    table_opts: Callable[[list[tuple[str, str]]], str] = lambda _cols: ""
+    # ANSI ``DATE 'yyyy-mm-dd'`` literals instead of bare strings. The
+    # four container-tested engines coerce plain strings happily and are
+    # left as-is; the cloud engines are stricter.
+    date_literals: bool = False
+    notes: tuple[str, ...] = ()
+
+    def q(self, name: str) -> str:
+        return f"{self.quote}{name}{self.quote}"
+
+    def table(self, tbl: str) -> str:
+        return f"{self.q(SCHEMA)}.{self.q(tbl)}"
+
+    def columns_clause(self, columns: list[tuple[str, str]]) -> str:
+        return ", ".join(f"{self.q(name)} {self.types[dtype]}" for name, dtype in columns)
 
 
-def _columns_clause(columns: list[tuple[str, str]], type_map: dict[str, str]) -> str:
-    return ", ".join(f'"{name}" {type_map[dtype]}' for name, dtype in columns)
+def _merge_tree(columns: list[tuple[str, str]]) -> str:
+    # Pick the first column as the ORDER BY key — IDs are first by
+    # convention in this schema, and any column suffices for our query
+    # workload (no real-world ordering matters here).
+    return f" ENGINE = MergeTree() ORDER BY `{columns[0][0]}`"
 
 
-def _ch_columns_clause(columns: list[tuple[str, str]]) -> str:
-    return ", ".join(f"`{name}` {_CH_TYPES[dtype]}" for name, dtype in columns)
+_SPECS: dict[str, VendorSpec] = {
+    "postgres": VendorSpec(
+        name="postgres",
+        types={"VARCHAR": "TEXT", "DATE": "DATE", "DOUBLE": "DECIMAL(18, 2)"},
+        quote='"',
+        container="SCHEMA",
+        executed=True,
+    ),
+    "mysql": VendorSpec(
+        name="mysql",
+        types={"VARCHAR": "VARCHAR(255)", "DATE": "DATE", "DOUBLE": "DECIMAL(18, 2)"},
+        quote="`",
+        container="DATABASE",
+        executed=True,
+    ),
+    "clickhouse": VendorSpec(
+        name="clickhouse",
+        types={"VARCHAR": "String", "DATE": "Date", "DOUBLE": "Decimal(18, 2)"},
+        quote="`",
+        container="DATABASE",
+        executed=True,
+        table_opts=_merge_tree,
+    ),
+    "duckdb": VendorSpec(
+        name="duckdb",
+        types={"VARCHAR": "VARCHAR", "DATE": "DATE", "DOUBLE": "DECIMAL(18, 2)"},
+        quote='"',
+        container="SCHEMA",
+        executed=True,
+    ),
+    "bigquery": VendorSpec(
+        name="bigquery",
+        types={"VARCHAR": "STRING", "DATE": "DATE", "DOUBLE": "NUMERIC(18, 2)"},
+        quote="`",
+        container="SCHEMA",
+        executed=False,
+        date_literals=True,
+        notes=("Run against the target project. `orionbelt_1` is the dataset.",),
+    ),
+    "snowflake": VendorSpec(
+        name="snowflake",
+        types={"VARCHAR": "VARCHAR", "DATE": "DATE", "DOUBLE": "NUMBER(18, 2)"},
+        quote='"',
+        container="SCHEMA",
+        executed=False,
+        date_literals=True,
+        notes=("USE DATABASE <db> first. Quoted lowercase names are case-sensitive.",),
+    ),
+    "databricks": VendorSpec(
+        name="databricks",
+        types={"VARCHAR": "STRING", "DATE": "DATE", "DOUBLE": "DECIMAL(18, 2)"},
+        quote="`",
+        container="SCHEMA",
+        executed=False,
+        table_opts=lambda _cols: " USING DELTA",
+        date_literals=True,
+        notes=("USE CATALOG <catalog> first. `orionbelt_1` is the schema.",),
+    ),
+    "dremio": VendorSpec(
+        name="dremio",
+        types={"VARCHAR": "VARCHAR", "DATE": "DATE", "DOUBLE": "DECIMAL(18, 2)"},
+        quote='"',
+        container=None,
+        executed=False,
+        date_literals=True,
+        notes=(
+            "Dremio has no CREATE SCHEMA: prefix every table with a writable",
+            '(Iceberg-capable) source, e.g. "nas"."orionbelt_1"."sales".',
+        ),
+    ),
+}
+
+VENDORS: tuple[str, ...] = tuple(_SPECS)
 
 
 # ----------------------------------------------------------------------
@@ -105,23 +222,183 @@ def _ch_columns_clause(columns: list[tuple[str, str]]) -> str:
 # ----------------------------------------------------------------------
 
 
-def _lit(v: Any) -> str:
+def _lit(v: Any, *, date_literals: bool = False) -> str:
     if v is None:
         return "NULL"
     if isinstance(v, (int, float, Decimal)):
         return str(v)
     if isinstance(v, date):
-        return f"'{v.isoformat()}'"
+        return f"DATE '{v.isoformat()}'" if date_literals else f"'{v.isoformat()}'"
     s = str(v).replace("'", "''")
     return f"'{s}'"
 
 
-def _values_batches(rows: list[tuple[Any, ...]], batch_size: int) -> list[str]:
+def _values_batches(
+    rows: list[tuple[Any, ...]], batch_size: int, *, date_literals: bool = False
+) -> list[str]:
     """Yield ``(...), (...)`` strings, ``batch_size`` rows per chunk."""
     out: list[str] = []
     for i in range(0, len(rows), batch_size):
         chunk = rows[i : i + batch_size]
-        out.append(", ".join("(" + ", ".join(_lit(v) for v in row) + ")" for row in chunk))
+        out.append(
+            ", ".join(
+                "(" + ", ".join(_lit(v, date_literals=date_literals) for v in row) + ")"
+                for row in chunk
+            )
+        )
+    return out
+
+
+_BATCH_SIZE = 500
+
+
+# ----------------------------------------------------------------------
+# Statement builders
+#
+# One spec-driven builder covers all eight dialects. The four
+# container-tested vendors get exactly the statements their seeder runs;
+# the four cloud/remote ones are script-only (their tests bulk-load
+# parquet through a native loader instead — see ``VendorSpec.executed``).
+# ----------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SeedPlan:
+    """Statements for one vendor, grouped so they can be replayed two ways.
+
+    ``setup`` is the namespace preamble; ``tables`` pairs each table's DDL
+    with its INSERTs. Seeders walk it table-by-table (create, then load,
+    exactly as they always have); the dumper flattens it into a DDL file
+    and a DML file. One source, so the scripts and the seed never diverge.
+
+    ``grants`` is kept apart because it is testcontainer plumbing: it has
+    to run, but a grant to a throwaway test user is noise in a script
+    someone else is meant to run, so the dump leaves it out.
+    """
+
+    setup: list[str]
+    tables: list[tuple[list[str], list[str]]]
+    grants: list[str] = field(default_factory=list)
+
+    @property
+    def ddl(self) -> list[str]:
+        return self.setup + [stmt for table_ddl, _ in self.tables for stmt in table_ddl]
+
+    @property
+    def dml(self) -> list[str]:
+        return [stmt for _, inserts in self.tables for stmt in inserts]
+
+
+def plan(vendor: str, *, grant_user: str | None = None) -> SeedPlan:
+    """Build the full statement plan for ``vendor``.
+
+    ``grant_user`` appends the MySQL grant the testcontainer needs; it is
+    omitted from the shareable dumps, where it would be noise.
+    """
+    spec = _SPECS[vendor]
+    setup: list[str] = []
+    if spec.container:
+        # CASCADE is a SCHEMA-only clause: MySQL and ClickHouse reject it
+        # on DROP DATABASE, which drops its contents unconditionally.
+        cascade = " CASCADE" if spec.container == "SCHEMA" else ""
+        setup.append(f"DROP {spec.container} IF EXISTS {spec.q(SCHEMA)}{cascade}")
+        setup.append(f"CREATE {spec.container} {spec.q(SCHEMA)}")
+    grants: list[str] = []
+    if grant_user and vendor == "mysql":
+        grants.append(f"GRANT ALL PRIVILEGES ON {spec.q(SCHEMA)}.* TO '{grant_user}'@'%'")
+        grants.append("FLUSH PRIVILEGES")
+
+    tables: list[tuple[list[str], list[str]]] = []
+    for tbl, payload in get_source().items():
+        table_ddl: list[str] = []
+        if not spec.container:
+            # No CREATE-able namespace to drop wholesale (Dremio).
+            table_ddl.append(f"DROP TABLE IF EXISTS {spec.table(tbl)}")
+        table_ddl.append(
+            f"CREATE TABLE {spec.table(tbl)} ({spec.columns_clause(payload['columns'])})"
+            f"{spec.table_opts(payload['columns'])}"
+        )
+        inserts = [
+            f"INSERT INTO {spec.table(tbl)} VALUES {batch}"
+            for batch in _values_batches(
+                payload["rows"], _BATCH_SIZE, date_literals=spec.date_literals
+            )
+        ]
+        tables.append((table_ddl, inserts))
+    return SeedPlan(setup=setup, tables=tables, grants=grants)
+
+
+def _run(seed_plan: SeedPlan, execute: Callable[[str], Any]) -> None:
+    """Replay a plan in seed order: preamble, grants, then per table create + load."""
+    for stmt in (*seed_plan.setup, *seed_plan.grants):
+        execute(stmt)
+    for table_ddl, inserts in seed_plan.tables:
+        for stmt in (*table_ddl, *inserts):
+            execute(stmt)
+
+
+# ----------------------------------------------------------------------
+# Script dumping — gitignored per-vendor scripts, generated on seed
+# ----------------------------------------------------------------------
+
+_DEFAULT_SEED_SQL_DIR = Path(__file__).resolve().parent / "seed_sql"
+
+
+def seed_sql_dir() -> Path | None:
+    """Destination for the dumped scripts, or ``None`` when disabled.
+
+    ``OBSL_SEED_SQL_DIR`` overrides the location; setting it to the
+    empty string turns dumping off (useful in CI, where the artefacts
+    are thrown away anyway).
+    """
+    override = os.environ.get("OBSL_SEED_SQL_DIR")
+    if override is None:
+        return _DEFAULT_SEED_SQL_DIR
+    return Path(override) if override.strip() else None
+
+
+def _render(vendor: str, kind: str, statements: list[str]) -> str:
+    """Join statements into a runnable script with a provenance header.
+
+    No timestamp: the output is a pure function of the bundled seed, so
+    identical data yields byte-identical files and a diff means the data
+    actually changed.
+    """
+    spec = _SPECS[vendor]
+    provenance = (
+        "Mirrors exactly what the vendor_exec seed executes."
+        if spec.executed
+        else "Generated only — this vendor's tests bulk-load parquet natively."
+    )
+    lines = [
+        f"OrionBelt commerce seed ({SCHEMA}) — {vendor} {kind}",
+        "Generated from examples/orionbelt_1_commerce.duckdb by",
+        "tests/integration/drift/vendor_exec/_seed.py. Do not edit by hand.",
+        provenance,
+        "Run 01_schema.sql before 02_data.sql.",
+        *spec.notes,
+    ]
+    header = "".join(f"-- {line}\n" for line in lines)
+    return header + "\n" + "".join(f"{stmt};\n" for stmt in statements)
+
+
+def dump_scripts(vendor: str, seed_plan: SeedPlan) -> Path | None:
+    """Write ``<dir>/<vendor>/{01_schema,02_data}.sql``; return the folder.
+
+    Dumping is a convenience, never a reason to fail a test run, so a
+    read-only or full filesystem downgrades to a warning.
+    """
+    base = seed_sql_dir()
+    if base is None:
+        return None
+    out = base / vendor
+    try:
+        out.mkdir(parents=True, exist_ok=True)
+        (out / "01_schema.sql").write_text(_render(vendor, "schema", seed_plan.ddl))
+        (out / "02_data.sql").write_text(_render(vendor, "data", seed_plan.dml))
+    except OSError as exc:
+        warnings.warn(f"Could not write seed SQL scripts to {out}: {exc}", stacklevel=2)
+        return None
     return out
 
 
@@ -132,16 +409,10 @@ def _values_batches(rows: list[tuple[Any, ...]], batch_size: int) -> list[str]:
 
 def seed_postgres(conn: Any) -> None:
     """Create ``orionbelt_1`` schema + tables and bulk-load all rows."""
-    src = get_source()
+    seed_plan = plan("postgres")
+    dump_scripts("postgres", seed_plan)
     cur = conn.cursor()
-    cur.execute(f'DROP SCHEMA IF EXISTS "{SCHEMA}" CASCADE')
-    cur.execute(f'CREATE SCHEMA "{SCHEMA}"')
-    for tbl, payload in src.items():
-        cur.execute(
-            f'CREATE TABLE "{SCHEMA}"."{tbl}" ({_columns_clause(payload["columns"], _PG_TYPES)})'
-        )
-        for batch in _values_batches(payload["rows"], batch_size=500):
-            cur.execute(f'INSERT INTO "{SCHEMA}"."{tbl}" VALUES {batch}')
+    _run(seed_plan, cur.execute)
     conn.commit()
 
 
@@ -154,39 +425,18 @@ def seed_mysql(conn: Any, *, grant_user: str | None = None) -> None:
     be the connection's MySQL user — set to ``None`` to skip grant
     (e.g. when seeding as ``root``).
     """
-    src = get_source()
+    seed_plan = plan("mysql", grant_user=grant_user)
+    dump_scripts("mysql", seed_plan)
     cur = conn.cursor()
-    cur.execute(f"DROP DATABASE IF EXISTS `{SCHEMA}`")
-    cur.execute(f"CREATE DATABASE `{SCHEMA}`")
-    if grant_user:
-        cur.execute(f"GRANT ALL PRIVILEGES ON `{SCHEMA}`.* TO '{grant_user}'@'%'")
-        cur.execute("FLUSH PRIVILEGES")
-    for tbl, payload in src.items():
-        cols_sql = ", ".join(
-            f"`{name}` {_MYSQL_TYPES[dtype]}" for name, dtype in payload["columns"]
-        )
-        cur.execute(f"CREATE TABLE `{SCHEMA}`.`{tbl}` ({cols_sql})")
-        for batch in _values_batches(payload["rows"], batch_size=500):
-            cur.execute(f"INSERT INTO `{SCHEMA}`.`{tbl}` VALUES {batch}")
+    _run(seed_plan, cur.execute)
     conn.commit()
 
 
 def seed_clickhouse(client: Any) -> None:
     """ClickHouse: CREATE DATABASE + MergeTree tables; INSERT in chunks."""
-    src = get_source()
-    client.command(f"DROP DATABASE IF EXISTS `{SCHEMA}`")
-    client.command(f"CREATE DATABASE `{SCHEMA}`")
-    for tbl, payload in src.items():
-        # Pick the first column as the ORDER BY key — IDs are first by
-        # convention in this schema, and any column suffices for our
-        # query workload (no real-world ordering matters here).
-        order_key = payload["columns"][0][0]
-        client.command(
-            f"CREATE TABLE `{SCHEMA}`.`{tbl}` ({_ch_columns_clause(payload['columns'])}) "
-            f"ENGINE = MergeTree() ORDER BY `{order_key}`"
-        )
-        for batch in _values_batches(payload["rows"], batch_size=500):
-            client.command(f"INSERT INTO `{SCHEMA}`.`{tbl}` VALUES {batch}")
+    seed_plan = plan("clickhouse")
+    dump_scripts("clickhouse", seed_plan)
+    _run(seed_plan, client.command)
 
 
 def seed_duckdb(conn: Any) -> None:
@@ -197,11 +447,26 @@ def seed_duckdb(conn: Any) -> None:
     rows is unambiguously attributable to that engine, not to the
     seed loader.
     """
-    src = get_source()
-    conn.execute(f'DROP SCHEMA IF EXISTS "{SCHEMA}" CASCADE')
-    conn.execute(f'CREATE SCHEMA "{SCHEMA}"')
-    for tbl, payload in src.items():
-        cols_sql = _columns_clause(payload["columns"], _DUCKDB_TYPES)
-        conn.execute(f'CREATE TABLE "{SCHEMA}"."{tbl}" ({cols_sql})')
-        for batch in _values_batches(payload["rows"], batch_size=500):
-            conn.execute(f'INSERT INTO "{SCHEMA}"."{tbl}" VALUES {batch}')
+    seed_plan = plan("duckdb")
+    dump_scripts("duckdb", seed_plan)
+    _run(seed_plan, conn.execute)
+
+
+# ----------------------------------------------------------------------
+# Standalone generation — no container, no live connection
+# ----------------------------------------------------------------------
+
+
+def dump_all() -> list[Path]:
+    """Write every vendor's scripts and return the folders written."""
+    written: list[Path] = []
+    for vendor in VENDORS:
+        out = dump_scripts(vendor, plan(vendor))
+        if out is not None:
+            written.append(out)
+    return written
+
+
+if __name__ == "__main__":
+    for folder in dump_all():
+        print(folder)  # noqa: T201


### PR DESCRIPTION
## Why

The commerce dataset (`orionbelt_1`, 15 tables) had no standalone DDL/DML anywhere in the repo. The only literal `CREATE TABLE` statements lived inside `scripts/build_demo_duckdb.py` (DuckDB only), and the drift seed loader built its statements on the fly and threw them away. That makes the dataset awkward to hand to anyone who is not running the test suite.

## What

Each seeder now mirrors its statements to a gitignored per-vendor folder:

```
tests/integration/drift/vendor_exec/seed_sql/<vendor>/01_schema.sql   # DDL
tests/integration/drift/vendor_exec/seed_sql/<vendor>/02_data.sql     # DML
```

They double as a backup of what the seed ran and as standalone scripts that replay against any target database. ~2 MB per vendor, 26,325 rows.

All 8 dialects are covered:

| Vendor | Namespace | String / Numeric | Table option | Provenance |
|---|---|---|---|---|
| postgres | `SCHEMA` | `TEXT` / `DECIMAL(18,2)` | | mirrors the seed |
| mysql | `DATABASE` | `VARCHAR(255)` / `DECIMAL(18,2)` | | mirrors the seed |
| clickhouse | `DATABASE` | `String` / `Decimal(18,2)` | `ENGINE = MergeTree() ORDER BY` | mirrors the seed |
| duckdb | `SCHEMA` | `VARCHAR` / `DECIMAL(18,2)` | | mirrors the seed |
| bigquery | `SCHEMA` (dataset) | `STRING` / `NUMERIC(18,2)` | | generated only |
| snowflake | `SCHEMA` | `VARCHAR` / `NUMBER(18,2)` | | generated only |
| databricks | `SCHEMA` | `STRING` / `DECIMAL(18,2)` | `USING DELTA` | generated only |
| dremio | none, per-table `DROP TABLE` | `VARCHAR` / `DECIMAL(18,2)` | | generated only |

The four cloud/remote vendors bulk-load parquet through native loaders (`load_table_from_file`, `write_pandas`, `PUT` + `read_files`), so there are no SQL statements to mirror. Their scripts are generated-only and the file header says so.

Generate without Docker or a live connection:

```
uv run python tests/integration/drift/vendor_exec/_seed.py
```

`OBSL_SEED_SQL_DIR` redirects the output directory, or set it empty to skip dumping.

## Seed mechanics are unchanged

A `SeedPlan` holds `setup`, per-table `(ddl, inserts)` and `grants`, so the seeders still walk it table-by-table, create then load, in exactly the original order. The dumper flattens the same plan into the two files, so the scripts and the seed cannot diverge. Four near-identical builders collapse into one spec-driven builder.

Details worth a reviewer's eye:

- identifiers stay quoted lowercase to match compiler output per dialect. Load-bearing on Snowflake, where a quoted lowercase name is case-sensitive, so unquoted DDL would not resolve against the generated SQL
- `CASCADE` only on `DROP SCHEMA`. MySQL and ClickHouse reject it on `DROP DATABASE`
- ANSI `DATE 'yyyy-mm-dd'` literals for the cloud engines, bare strings kept for the four that already accepted them
- the MySQL testcontainer `GRANT` runs but is left out of the dump, where a grant to a throwaway test user is noise
- no timestamp in the header, so identical data gives byte-identical files and a diff means the data actually changed
- write failures warn rather than fail a test run

## Testing

- `uv run pytest -m docker tests/integration/drift/vendor_exec/`: 208 passed against live Postgres/MySQL/ClickHouse/DuckDB containers
- regenerated DuckDB scripts replayed into a fresh database: 15 tables, 26,325 rows, `sum(salesamount)` = 42,458,509.61, matching source exactly
- all 8 schema files and INSERT samples parse under sqlglot in their own dialect (Dremio read as Postgres, sqlglot has no Dremio dialect)
- `ruff check`, `ruff format`, `mypy` clean
- `seed_sql/` confirmed gitignored

## Caveats

- the four generated-only vendors are not executed by any test, so nothing catches it if a future dialect change makes them wrong. Inherent to covering engines that never run SQL DDL; the header states it
- the Dremio script assumes each table is prefixed with a writable Iceberg-capable source, so it will not run as-is against a plain instance