### PR TITLE
Update the local Spark test docstring for pyspark 4.x

### DIFF
--- a/tests/integration/test_databricks_spark_local.py
+++ b/tests/integration/test_databricks_spark_local.py
@@ -13,9 +13,10 @@ Databricks warehouse — the credit-gated `-m databricks` suite is the only path
 that exercises the true Databricks SQL warehouse + Delta, but this catches the
 same class of dialect bugs the other vendor sweeps found.
 
-Opt-in via the ``spark`` marker (needs ``pyspark`` and a JDK)::
+Opt-in via the ``spark`` marker (needs ``pyspark`` and a JDK; Spark 4 dropped
+Java 8/11, so 4.x needs a JDK 17 or newer)::
 
-    uv pip install 'pyspark>=3.5,<4.0'   # or: pip install -e '.[spark]'
+    uv pip install 'pyspark>=3.5,<5.0'   # or: pip install -e '.[spark]'
     uv run pytest -m spark
 
 Skips cleanly if pyspark is missing or no JDK is available.


### PR DESCRIPTION
## Summary

Follow-up to #255, which widened the `spark` extra to `pyspark>=3.5,<5.0` (resolving 4.2.0) but left `tests/integration/test_databricks_spark_local.py` telling readers to install `'pyspark>=3.5,<4.0'`. That install hint now contradicts `pyproject.toml`.

While updating it, this also records the JDK floor: Spark 4 dropped Java 8 and 11, so a 4.x run needs JDK 17 or newer. The old docstring said only "needs a JDK", which was accurate for 3.5 but is now a trap.

## Changes

- `<4.0` -> `<5.0` in the module docstring's install command
- Note the JDK 17+ requirement for Spark 4.x

Docstring only, no test behaviour change.

## Verification

The suite in this module is opt-in (`-m spark`). Ran it against pyspark 4.2.0 on OpenJDK 17.0.12 before merging #255: **49 passed**. `ruff check` and `ruff format --check` clean.