### PR TITLE
test: pin the pgwire port the suite binds to 5532

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
@@ -10,6 +11,24 @@ from orionbelt.models.semantic import SemanticModel
 from orionbelt.parser.loader import TrackedLoader
 from orionbelt.parser.resolver import ReferenceResolver
 from orionbelt.service.session_manager import SessionManager
+
+# ``Settings`` reads the developer's ``.env``, so a machine that runs the pgwire
+# server for real (``PGWIRE_ENABLED=true``) makes the tests that start a full
+# app lifespan bind its port for real too. That collides with whatever already
+# holds it -- a local Postgres, a Docker port forward -- and the test dies with
+# "address already in use", on a machine-dependent port, for reasons unrelated
+# to what it is testing.
+#
+# Pin a port the suite owns and nothing else is expected to use. Set as a real
+# environment variable so it outranks ``.env`` (pydantic-settings resolves env
+# vars ahead of dotenv), via ``setdefault`` so an explicit export still wins.
+#
+# This is deliberately narrow: it fixes the one setting that binds a socket. The
+# broader problem -- that the whole suite inherits ``.env``, including
+# ``AUTH_MODE``, ``MODEL_FILES`` and datasource credentials -- is not addressed
+# here.
+TEST_PGWIRE_PORT = "5532"
+os.environ.setdefault("PGWIRE_PORT", TEST_PGWIRE_PORT)
 
 
 def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:


### PR DESCRIPTION
Independent of #258 / #259 - branched off `main`, safe to merge in any order.

## The problem

`Settings` reads the developer's `.env`. On a machine that runs pgwire for real (`PGWIRE_ENABLED=true`), the tests that start a full app lifespan start a real listener on that port, and `test_model_files_preload_accepts_valid_model` dies with:

```
OSError: [Errno 48] error while attempting to bind on address ('0.0.0.0', 5433):
         address already in use
```

That has nothing to do with what the test checks, which is `MODEL_FILES` preload validation. It just needs the lifespan to run. The failure is machine-dependent: it hits anyone whose port is taken by a local Postgres or a Docker port forward, and is invisible to everyone else.

## The change

Pin a port the suite owns, in `tests/conftest.py`:

```python
TEST_PGWIRE_PORT = "5532"
os.environ.setdefault("PGWIRE_PORT", TEST_PGWIRE_PORT)
```

Set as a real environment variable so it outranks `.env` - pydantic-settings resolves env vars ahead of dotenv - and via `setdefault` so an explicit export still wins.

CI is unaffected: with no `.env` present, `PGWIRE_ENABLED` defaults to `false` and no listener starts either way.

## Verification

On a machine whose `.env` sets `PGWIRE_ENABLED=true` and `PGWIRE_PORT=5433`, with that port held:

| | Result |
|---|---|
| Before | 1 failed, 2732 passed |
| After | **2733 passed, 0 failed** |

Run with no override flags and `.env` untouched.

## Scope

Deliberately narrow: this fixes the one setting that binds a socket. It does not address the broader issue that the suite inherits `.env` at all - `AUTH_MODE`, `MODEL_FILES` and datasource credentials leak in the same way, so the suite can behave differently on every machine. That is worth its own PR; this one just stops the port collision.