### PR TITLE
fix: reject a DISTINCT listagg ordered by a column it does not aggregate

### DIFF
--- a/docs/guide/model-format.md
+++ b/docs/guide/model-format.md
@@ -423,7 +423,7 @@ measures:
 | `grain` | object | No | [Grain override](grain-filter-context.md#grain-override) -- controls aggregation grain independently from query dimensions |
 | `filterContext` | object | No | [Filter context override](grain-filter-context.md#filter-context) -- controls which query WHERE filters apply |
 | `delimiter` | string | No | Separator for `listagg` aggregation (default: `","`) |
-| `withinGroup` | object | No | Ordering clause for `listagg` — specifies `column` and `order` (`ASC`/`DESC`) |
+| `withinGroup` | object | No | Ordering clause for `listagg` — specifies `column` and `order` (`ASC`/`DESC`). With `distinct: true` the column must be the one being aggregated (error code `WITHIN_GROUP_NOT_IN_DISTINCT_ARGS`). |
 | `dataType` | string | No | OBML data type (e.g. `decimal(18, 4)`, `bigint`). Overrides automatic type inference for CAST wrapping. |
 | `format` | string | No | Display format pattern (e.g. `#,##0.00`, `0.00%`) |
 | `description` | string | No | Business description |
@@ -571,6 +571,13 @@ measures:
 ```
 
 The `delimiter` defaults to `","` if omitted. The `withinGroup` clause is optional and specifies ordering of the concatenated values.
+
+With `distinct: true`, `withinGroup.column` must be the column the measure aggregates. SQL restricts a DISTINCT
+aggregate's `ORDER BY` to expressions in its argument list — the engine sorts values it has already deduplicated,
+so it cannot order them by something it collapsed away. Postgres, DuckDB and BigQuery all reject it (*"In a
+DISTINCT aggregate, ORDER BY expressions must appear in the argument list"*). Model validation catches this up
+front (`WITHIN_GROUP_NOT_IN_DISTINCT_ARGS`) rather than letting every query on the measure fail at execution
+time. Order by the aggregated column, or drop `distinct: true` if the ordering matters more.
 
 ## Metrics
 

--- a/src/orionbelt/parser/validator.py
+++ b/src/orionbelt/parser/validator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from collections import deque
 
 import networkx as nx
@@ -9,12 +10,16 @@ import networkx as nx
 from orionbelt.models.errors import SemanticError
 from orionbelt.models.semantic import (
     DataType,
+    Measure,
     MeasureFilter,
     MeasureFilterGroup,
     MeasureFilterItem,
     SemanticModel,
 )
 from orionbelt.models.synthesis import count_label, model_count_pattern
+
+# ``{[Data Object].[Column]}`` reference inside a measure expression.
+_MEASURE_COLUMN_REF = re.compile(r"\{\[([^\]]+)\]\.\[([^\]]+)\]\}")
 
 
 class SemanticValidator:
@@ -33,6 +38,7 @@ class SemanticValidator:
         errors.extend(self._check_num_class_on_numeric_columns(model))
         errors.extend(self._check_time_grain_on_temporal_columns(model))
         errors.extend(self._check_measure_filter_refs(model))
+        errors.extend(self._check_distinct_within_group(model))
         errors.extend(self._check_via_reachability(model))
         errors.extend(self._check_missing_via(model))
         return errors
@@ -478,6 +484,77 @@ class SemanticValidator:
                         )
                     )
         return errors
+
+    def _check_distinct_within_group(self, model: SemanticModel) -> list[SemanticError]:
+        """Reject ``distinct: true`` + a ``withinGroup`` that is not the aggregated column.
+
+        SQL restricts a DISTINCT aggregate's ORDER BY to expressions that appear
+        in its argument list: the engine sorts the deduplicated values, so it
+        cannot order them by something it has just collapsed away. Postgres,
+        DuckDB and BigQuery all reject it outright ("In a DISTINCT aggregate,
+        ORDER BY expressions must appear in the argument list").
+
+        Without this check the model loads happily and every query touching the
+        measure fails at execution time with a driver-level binder error, which
+        points at generated SQL rather than at the two lines of OBML that caused
+        it.
+        """
+        errors: list[SemanticError] = []
+        for measure_name, measure in model.measures.items():
+            if not measure.distinct or measure.within_group is None:
+                continue
+
+            ordered = measure.within_group.column
+            ordered_ref = (ordered.view or "", ordered.column or "")
+            if ordered_ref in self._aggregated_column_refs(measure):
+                continue
+
+            aggregated = self._describe_aggregated_columns(measure)
+            errors.append(
+                SemanticError(
+                    code="WITHIN_GROUP_NOT_IN_DISTINCT_ARGS",
+                    message=(
+                        f"Measure '{measure_name}' is DISTINCT but orders by "
+                        f"'{ordered_ref[0]}.{ordered_ref[1]}', which is not among the "
+                        f"columns it aggregates ({aggregated}). A DISTINCT aggregate "
+                        f"can only be ordered by an expression in its argument list, "
+                        f"so this fails at execution time on Postgres, DuckDB and "
+                        f"BigQuery among others."
+                    ),
+                    path=f"measures.{measure_name}.withinGroup",
+                    hint=(
+                        "Order by the aggregated column itself, or drop "
+                        "`distinct: true` if the ordering matters more than "
+                        "deduplication."
+                    ),
+                )
+            )
+        return errors
+
+    @staticmethod
+    def _aggregated_column_refs(measure: Measure) -> set[tuple[str, str]]:
+        """The ``(dataObject, column)`` pairs that form a measure's aggregate argument.
+
+        Only a bare column reference can be matched against a ``withinGroup``
+        column. An ``expression`` that computes something (``a || b``) aggregates
+        that computed value, not its parts, so ordering by any single part is
+        still outside the argument list — hence the empty set.
+        """
+        if measure.columns:
+            return {(c.view or "", c.column or "") for c in measure.columns}
+        if measure.expression:
+            refs = _MEASURE_COLUMN_REF.findall(measure.expression.strip())
+            whole = _MEASURE_COLUMN_REF.fullmatch(measure.expression.strip())
+            if whole is not None and len(refs) == 1:
+                return {(refs[0][0], refs[0][1])}
+        return set()
+
+    @staticmethod
+    def _describe_aggregated_columns(measure: Measure) -> str:
+        refs = SemanticValidator._aggregated_column_refs(measure)
+        if refs:
+            return ", ".join(f"'{obj}.{col}'" for obj, col in sorted(refs))
+        return "a computed expression, which cannot be matched by column"
 
     def _check_measure_filter_refs(self, model: SemanticModel) -> list[SemanticError]:
         """Verify that measure filter columns reference existing data objects and columns."""

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -1263,6 +1263,30 @@ dataObjects:
         errors = validator.validate(model)
         assert any(e.code == "NUM_CLASS_ON_NON_NUMERIC" for e in errors)
 
+    def test_distinct_listagg_ordered_by_another_column_is_rejected(
+        self, resolver: ReferenceResolver
+    ) -> None:
+        """A DISTINCT aggregate can only be ordered by an expression in its argument list.
+
+        Without this the model loads and every query touching the measure dies
+        at execution time with a driver binder error against generated SQL.
+        """
+        codes = _listagg_errors(resolver, distinct=True, order_column="Stock On Hand")
+        assert "WITHIN_GROUP_NOT_IN_DISTINCT_ARGS" in codes
+
+    def test_distinct_listagg_ordered_by_the_aggregated_column_is_allowed(
+        self, resolver: ReferenceResolver
+    ) -> None:
+        codes = _listagg_errors(resolver, distinct=True, order_column="Product ID")
+        assert "WITHIN_GROUP_NOT_IN_DISTINCT_ARGS" not in codes
+
+    def test_non_distinct_listagg_may_order_by_any_column(
+        self, resolver: ReferenceResolver
+    ) -> None:
+        """The restriction is DISTINCT's; plain LISTAGG can order by anything."""
+        codes = _listagg_errors(resolver, distinct=False, order_column="Stock On Hand")
+        assert "WITHIN_GROUP_NOT_IN_DISTINCT_ARGS" not in codes
+
     def test_num_class_on_numeric_column_ok(self, resolver: ReferenceResolver) -> None:
         """numClass on int/float columns should not produce errors."""
         yaml_content = """\
@@ -1625,3 +1649,42 @@ class TestMalformedMeasureExpressionRefs:
         errs = self._get_malformed(resolver, "{[Orders].Amount]}")
         assert len(errs) == 1
         assert "missing opening '[' on column" in errs[0].message  # type: ignore[union-attr]
+
+
+_LISTAGG_MODEL = """\
+version: 1.0
+dataObjects:
+  Products:
+    code: products
+    database: DB
+    schema: SCH
+    columns:
+      Product ID:
+        code: id
+        abstractType: string
+        primaryKey: true
+      Stock On Hand:
+        code: stock_on_hand
+        abstractType: int
+measures:
+  Product List:
+    resultType: string
+    aggregation: listagg
+    delimiter: ","
+{distinct}    columns:
+      - dataObject: Products
+        column: Product ID
+    withinGroup:
+      column: {{dataObject: Products, column: {order_column}}}
+      order: ASC
+"""
+
+
+def _listagg_errors(resolver: ReferenceResolver, *, distinct: bool, order_column: str):
+    yaml_content = _LISTAGG_MODEL.format(
+        distinct="    distinct: true\n" if distinct else "",
+        order_column=order_column,
+    )
+    raw, source_map = TrackedLoader().load_string(yaml_content)
+    model, _ = resolver.resolve(raw, source_map)
+    return [e.code for e in SemanticValidator().validate(model)]


### PR DESCRIPTION
Independent of #258 / #259 - branched off `main`, safe to merge in any order.

Found while re-reviewing #258. It surfaced through that feature but is not caused by it: the compiled SQL is **byte-identical on `origin/main`**, which I verified against a clean worktree.

## The problem

SQL restricts a DISTINCT aggregate's `ORDER BY` to expressions in its argument list. The engine sorts values it has already deduplicated, so it cannot order them by something it collapsed away. This OBML:

```yaml
Product List:
  aggregation: listagg
  distinct: true
  columns: [{dataObject: Products, column: Product ID}]
  withinGroup:
    column: {dataObject: Products, column: Stock On Hand}
```

loaded without complaint and compiled to:

```sql
LISTAGG(DISTINCT "Products"."id", ',' ORDER BY "Products"."stock_on_hand" ASC)
```

which every affected engine refuses at execution time:

```
Binder Error: In a DISTINCT aggregate, ORDER BY expressions must appear in the argument list
```

So the error surfaced against generated SQL, at query time, pointing nowhere near the two lines of OBML responsible.

## The restriction is DISTINCT's, not the join graph's

Verified directly against DuckDB, all three shapes:

| `withinGroup` column | Result |
|---|---|
| Another table's column | ❌ Binder Error |
| The **same** object's non-argument column | ❌ Binder Error |
| The aggregated column itself | ✅ `p1,p2` |

It reproduces on a model with **one data object and no joins at all**. That is why this belongs in model validation rather than anywhere near the join/fanout machinery: a guard placed there would only fire when the measure also happened to sit on a replicated object, leaving the same bug live for the same-object and no-join cases while looking handled.

## The change

One rule in `SemanticValidator`, raising `WITHIN_GROUP_NOT_IN_DISTINCT_ARGS`:

```
Measure 'Product List' is DISTINCT but orders by 'Products.Stock On Hand', which is
not among the columns it aggregates ('Products.Product ID'). A DISTINCT aggregate can
only be ordered by an expression in its argument list, so this fails at execution time
on Postgres, DuckDB and BigQuery among others.
```

with a hint pointing at the two fixes: order by the aggregated column, or drop `distinct: true`.

## What stays valid

- `distinct: true` ordered by the **aggregated** column - the shape that works.
- Any `withinGroup` on a measure **without** `distinct: true`; the restriction is DISTINCT's alone.
- Multi-column aggregates: the ordering column need only be *in* the argument list.

An expression-bodied measure matches only when its whole expression is a single column reference. One that computes a value (`a || b`) aggregates the computed value, not its parts, so ordering by any single part is genuinely outside the argument list and is correctly rejected.

## Testing

Three tests in `tests/unit/test_parser.py` covering rejected / allowed-when-aggregated / allowed-without-distinct. Full suite: 2736 passed, 0 failed. `ruff check`, `ruff format`, `mypy` clean.

Docs: the `withinGroup` row in the model-format reference plus the LISTAGG section now state the constraint and the error code.