### PR TITLE
chore: ignore .playwright-mcp/ scratch output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,10 @@ htmlcov/
 *.log
 .DS_Store
 .claude/
+# Playwright MCP scratch output: accessibility snapshots and console logs
+# written per browser session. The console logs were already caught by
+# *.log above, which left only the .yml page dumps showing as untracked.
+.playwright-mcp/
 /cache/
 /usage/
 security/


### PR DESCRIPTION
Independent of #265 / #266 - one line plus a comment, mergeable any time.

## What it is

The Playwright MCP server writes its scratch output into `.playwright-mcp/`: an accessibility snapshot per page plus a console log, once per browser session. The directory has been sitting untracked in `git status` since 2026-07-21, holding 172K from a session against the public demo UI:

```
console-2026-07-21T11-41-56-071Z.log     404s for manifest.json / favicon.ico
page-2026-07-21T11-41-57-315Z.yml        (empty)
page-2026-07-21T11-42-19-451Z.yml        56K DOM accessibility tree
page-2026-07-21T11-42-28-803Z.yml        56K
page-2026-07-21T11-42-32-940Z.yml        56K
```

Regenerable tool output, nothing to do with the project.

## Why it is worth a rule

`*.log` already caught the console log, which is why only the `.yml` dumps showed. Four permanently-dirty entries is enough noise to hide a genuinely untracked file, and enough to get swept into a stray `git add -A`.

Ignored as a directory, placed next to `.claude/` since it is the same kind of agent-tooling output.

## Note

This only stops git tracking it. The existing 172K is still on disk locally - delete it or leave it, it will be rewritten on the next browser session either way.