### PR TITLE
feat(demo): add one-side measures that exercise grain deduplication

### DIFF
--- a/examples/orionbelt_1_commerce.yaml
+++ b/examples/orionbelt_1_commerce.yaml
@@ -788,10 +788,17 @@ measures:
     columns:
       - dataObject: Products
         column: Units In Stock
-  Catalogue Units In Stock:
-    # The same column at no grain: every product counted once across the whole
-    # query, so it can sit beside the per-group figure above and legitimately
-    # differ from the sum of it.
+  Grand Total Units In Stock:
+    # The same column with the grouping collapsed: each product counted once
+    # across the query, so it sits beside the per-group figure above and
+    # legitimately differs from the sum of it.
+    #
+    # Scoped to the query, NOT to the whole Products table. `total: true`
+    # removes the grouping, not the joins -- so asked alongside a Sales measure
+    # this is the stock of products that were *sold*, and alongside a Purchases
+    # measure the stock of products that were *purchased*. Those differ whenever
+    # a product appears on one path and not the other. Do not read it as a
+    # catalogue-wide figure; for that, query the measure on its own.
     aggregation: sum
     total: true
     dataType: "decimal(18, 2)"

--- a/examples/orionbelt_1_commerce.yaml
+++ b/examples/orionbelt_1_commerce.yaml
@@ -776,12 +776,39 @@ measures:
       - dataObject: Account Balances
         column: Balance Amount
   Total Units In Stock:
+    # Sourced from Products, the *one* side of Sales -> Products. Grouped by a
+    # Sales dimension the join repeats each product once per sale, so this is
+    # aggregated over rows deduplicated on the product key rather than over the
+    # flattened join. Per-group values are correct, but a product sold through
+    # two channels is counted in both, so the columns does not add up to the
+    # catalogue total -- see "Catalogue Units In Stock" for that.
     aggregation: sum
     dataType: "decimal(18, 2)"
     format: "#,##0"
     columns:
       - dataObject: Products
         column: Units In Stock
+  Catalogue Units In Stock:
+    # The same column at no grain: every product counted once across the whole
+    # query, so it can sit beside the per-group figure above and legitimately
+    # differ from the sum of it.
+    aggregation: sum
+    total: true
+    dataType: "decimal(18, 2)"
+    format: "#,##0"
+    columns:
+      - dataObject: Products
+        column: Units In Stock
+  Avg Unit Price:
+    # AVG over the one side is the quiet case: without deduplication a product
+    # sold a hundred times would drag the average towards its own price, which
+    # answers "average price per sale" rather than "average price per product".
+    aggregation: avg
+    dataType: "decimal(18, 2)"
+    format: "#,##0.00"
+    columns:
+      - dataObject: Products
+        column: Unit Price
 
 metrics:
   # ── Derived metrics — algebra over base measures ──

--- a/tests/integration/_commerce.py
+++ b/tests/integration/_commerce.py
@@ -257,6 +257,42 @@ COMMERCE_CASES: tuple[CommerceCase, ...] = (
             grouping=Grouping.CUBE,
         ),
     ),
+    # --- Grain deduplication (measures sourced from the *one* side) ---
+    # Products sits on the one side of Sales -> Products, so the join repeats
+    # each product once per sale. These aggregate over rows deduplicated on the
+    # product key instead; without that they are inflated by the sale count.
+    CommerceCase(
+        "dedup_stock_by_channel",
+        QueryObject(
+            select=QuerySelect(
+                dimensions=["Channel Name"],
+                measures=["Total Sales", "Total Units In Stock"],
+            ),
+        ),
+    ),
+    # AVG is the quiet case: weighted by sale count it answers "average price
+    # per sale" rather than "per product", and the two are close enough that
+    # only a vendor-to-vendor comparison would catch a regression.
+    CommerceCase(
+        "dedup_avg_unit_price_by_category",
+        QueryObject(
+            select=QuerySelect(
+                dimensions=["Product Category"],
+                measures=["Total Sales", "Avg Unit Price"],
+            ),
+        ),
+    ),
+    # total: true on a deduplicated measure takes a separate path again -- its
+    # own CTE at no grain, cross joined in.
+    CommerceCase(
+        "dedup_grand_total_stock_by_channel",
+        QueryObject(
+            select=QuerySelect(
+                dimensions=["Channel Name"],
+                measures=["Total Sales", "Grand Total Units In Stock"],
+            ),
+        ),
+    ),
 )
 
 


### PR DESCRIPTION
## The demo already had one, and it was wrong

`Total Units In Stock` is sourced from `Products` - the *one* side of `Sales -> Products` - so it is exactly the shape the grain-dedup work fixes. Executed against the real `orionbelt_1_commerce.duckdb`, grouped by channel:

| Channel | Before | After |
|---|---|---|
| Wholesale | 1,267,641 | 87,441 |
| Online | 4,325,669 | 91,618 |
| B2B | 453,000 | 68,963 |
| Retail | 2,502,274 | 90,935 |

The whole catalogue holds **91,618** units. The old figures were ~93x inflated. Every new value is at or below the catalogue total, and Online reaching it exactly means every product has sold through that channel at least once.

**The deployed demo still serves the old numbers** until it is redeployed - that is independent of this PR.

## What this adds

Two measures on the same object, showing what the existing one cannot.

**`Catalogue Units In Stock`** (`total: true`) - the same column at no grain, 91,618 on every row. It sits beside the per-channel figure and shows the two legitimately differ: a product sold through two channels counts in both, so the per-group column does not add up to the catalogue total.

**`Avg Unit Price`** - the quiet case, and the better teaching example:

| | Value |
|---|---|
| sale-weighted (the old behaviour) | **712.95** |
| deduplicated, per channel | 802.35 - 822.38 |
| true catalogue average | **820.29** |

A product sold a hundred times drags the weighted mean towards its own price. Wrong in a way nobody would notice, unlike an inflated SUM.

Together:

| Channel | Total Sales | Units In Stock | Catalogue | Avg Price |
|---|---|---|---|---|
| Wholesale | 4,384,649 | 87,441 | 91,618 | 812.67 |
| Online | 23,009,276 | 91,618 | 91,618 | 820.29 |
| Retail | 13,269,028 | 90,935 | 91,618 | 822.38 |
| B2B | 1,795,556 | 68,963 | 91,618 | 802.35 |

## No seed or source change

Both use existing columns (`Units In Stock`, `Unit Price`), so the DuckDB seed and the Dremio source are untouched. Verified on all eight dialects - the rewrite uses only a plain `SELECT DISTINCT` in a derived table plus CTEs, nothing dialect-specific.

## One thing worth knowing when querying these

Ask for these measures with **no fact measure alongside** and nothing pins which fact table to anchor on. `Products` reaches neither `Channels` nor the sales grain by itself, so resolution re-anchors on a common root - and both `Sales` and `Purchases` qualify, so it picks one deterministically. The query then silently answers "stock of products *purchased* per channel" rather than *sold*.

That is pre-existing behaviour of common-root selection, not something this PR introduces, and it is only reachable when the query is genuinely ambiguous about which fact it means. Adding any fact measure (`Total Sales`) resolves it. Flagging it because these new measures make it easy to hit.

## Testing

Full suite: 2783 passed, 0 failed. `ruff check` clean. Model validates.