### PR TITLE
fix(ui): render the results table once per run instead of twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to OrionBelt Semantic Layer are documented here.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The results table rendered twice on every run and every sort click.** `execute_query` returned a bare frame for the table, and the caller revealed the table in a chained `.then` that sent a *second* update to the same component purely to set `visible`. Gradio renders each update, so a sort click, whose data barely changes, visibly repainted the table. Visibility now rides along with the value in one update and the table is one output of one call, so it renders once. The same chain served the Run Query path, which had the same double render.
+
+- **The sort icons disappeared and popped back on every re-render.** The post-render JS removed each header's `▲▼✕` span and rebuilt it from scratch, only to recolour the active direction. It now updates the active class in place and keeps the nodes, so nothing is torn down, and the click listeners survive rather than being rebound. It also ran on a `setInterval(..., 150)`, which does not fire until after its first delay, so an already-rendered table waited 150ms for its icons; the injection is attempted immediately and only falls back to polling when the headers are not there yet. A header whose column changed underneath it is still rebuilt, since its controls would otherwise carry the previous column's label.
+
 ## [2.24.1] - 2026-08-05
 
 ### Added

--- a/src/orionbelt/ui/app.py
+++ b/src/orionbelt/ui/app.py
@@ -629,45 +629,83 @@ _ALIGN_HEADERS_JS = """
     // Inject per-column sort controls (up / down / clear) into each header. They
     // write a hidden signal textbox that triggers a server-side re-query. Value-
     // less selects the injection may cause are now harmless (handlers use EventData).
-    var tries = 0;
-    var iv = setInterval(function () {
-        var root = document.querySelector('.result-table');
-        var ths = root ? root.querySelectorAll('th') : [];
-        if (!ths.length) { if (++tries > 25) clearInterval(iv); return; }
-        clearInterval(iv);
-        // Active orderBy ("field|dir" per line) -> colour the matching ▲/▼ orange.
+    // Active orderBy ("field|dir" per line) -> colour the matching ▲/▼ orange.
+    function readSortMap() {
         var sortState = (document.querySelector('#ob-sort-state textarea') || {}).value || '';
         var sortMap = {};
         sortState.split('\\n').forEach(function (s) {
             var kv = s.split('|');
             if (kv[0]) sortMap[kv[0]] = kv[1];
         });
+        return sortMap;
+    }
+    function buildControls(label, sortMap) {
+        var wrap = document.createElement('span');
+        wrap.className = 'ob-sort';
+        wrap.dataset.label = label;                    // label, free of the glyphs
+        [['\\u25B2', 'asc'], ['\\u25BC', 'desc'], ['\\u2715', 'clear']].forEach(function (p) {
+            var b = document.createElement('span');
+            b.textContent = p[0];
+            b.dataset.dir = p[1];
+            b.className = 'ob-sort-btn' + (sortMap[label] === p[1] ? ' ob-active' : '');
+            b.title = (p[1] === 'clear' ? 'Clear sort on ' : 'Sort ' + p[1] + ' by ') + label;
+            b.addEventListener('click', function (e) {
+                e.stopPropagation();
+                e.preventDefault();
+                var signal = document.querySelector('#ob-sort-signal textarea');
+                if (!signal) return;
+                signal.value = label + '|' + p[1] + '|' + Date.now();
+                signal.dispatchEvent(new Event('input', { bubbles: true }));
+            });
+            wrap.appendChild(b);
+        });
+        return wrap;
+    }
+    // Inject per-column sort controls (up / down / clear) into each header. They
+    // write a hidden signal textbox that triggers a server-side re-query. Value-
+    // less selects the injection may cause are now harmless (handlers use EventData).
+    //
+    // Controls already present are recoloured in place rather than removed and
+    // rebuilt: tearing them down made the icons disappear and pop back on every
+    // re-render, which read as a flicker on each sort click. Keeping the nodes
+    // also keeps their click listeners, so no rebinding is needed.
+    function injectSortControls() {
+        var root = document.querySelector('.result-table');
+        var ths = root ? root.querySelectorAll('th') : [];
+        if (!ths.length) return false;
+        var sortMap = readSortMap();
         ths.forEach(function (th) {
-            var existing = th.querySelector('.ob-sort');
-            if (existing) existing.remove();           // re-inject to refresh active colour
             var btn = th.querySelector('button');
+            var existing = th.querySelector('.ob-sort');
+            if (existing) {
+                // The header text with the glyphs stripped back out. If Gradio
+                // reused this node for a different column, the controls carry
+                // the wrong label and must be rebuilt rather than recoloured.
+                var current = ((btn || th).textContent || '')
+                    .replace(existing.textContent, '').trim();
+                if (current === existing.dataset.label) {
+                    var known = existing.dataset.label;
+                    existing.querySelectorAll('.ob-sort-btn').forEach(function (b) {
+                        b.classList.toggle('ob-active', sortMap[known] === b.dataset.dir);
+                    });
+                    return;
+                }
+                existing.remove();
+            }
             var label = ((btn || th).textContent || '').trim();
             if (!label || label === '#') return;       // skip the index + empty columns
-            var wrap = document.createElement('span');
-            wrap.className = 'ob-sort';
-            [['\\u25B2', 'asc'], ['\\u25BC', 'desc'], ['\\u2715', 'clear']].forEach(function (p) {
-                var b = document.createElement('span');
-                b.textContent = p[0];
-                b.className = 'ob-sort-btn' + (sortMap[label] === p[1] ? ' ob-active' : '');
-                b.title = (p[1] === 'clear' ? 'Clear sort on ' : 'Sort ' + p[1] + ' by ') + label;
-                b.addEventListener('click', function (e) {
-                    e.stopPropagation();
-                    e.preventDefault();
-                    var signal = document.querySelector('#ob-sort-signal textarea');
-                    if (!signal) return;
-                    signal.value = label + '|' + p[1] + '|' + Date.now();
-                    signal.dispatchEvent(new Event('input', { bubbles: true }));
-                });
-                wrap.appendChild(b);
-            });
-            (btn || th).appendChild(wrap);             // inline, next to the label
+            (btn || th).appendChild(buildControls(label, sortMap));
         });
-    }, 150);
+        return true;
+    }
+    // Try immediately: setInterval does not fire until after its first delay, so
+    // polling first made an already-rendered table wait 150ms for its icons.
+    if (!injectSortControls()) {
+        var tries = 0;
+        var iv = setInterval(function () {
+            if (injectSortControls() || ++tries > 25) clearInterval(iv);
+        }, 150);
+    }
 }
 """
 
@@ -1716,15 +1754,17 @@ def create_blocks(
                     meta_code,
                 ],
             ).then(
+                # ``result_table`` is deliberately absent: ``execute_query``
+                # already returns its visibility with its value, and sending a
+                # second update to the same component re-rendered the Dataframe.
                 fn=lambda info: (
                     gr.Tabs(selected=1) if info else gr.Tabs(),
                     gr.update(visible=bool(info)),
                     gr.update(visible=bool(info)),
                     gr.update(visible=bool(info)),
-                    gr.update(visible=bool(info)),
                 ),
                 inputs=[result_info],
-                outputs=[tabs, tsv_download, copy_data_btn, meta_acc, result_table],
+                outputs=[tabs, tsv_download, copy_data_btn, meta_acc],
             ).then(
                 fn=filter_chip_update,
                 inputs=[query_input],
@@ -1767,14 +1807,16 @@ def create_blocks(
             ]
 
             def _wire_post(trigger: Any) -> Any:
+                # As above, ``result_table`` is not an output here: its
+                # visibility rides along with its value from the handler, so a
+                # filter or sort click renders the table once instead of twice.
                 return trigger.then(
                     fn=lambda info: (
                         gr.update(visible=bool(info)),
                         gr.update(visible=bool(info)),
-                        gr.update(visible=bool(info)),
                     ),
                     inputs=[result_info],
-                    outputs=[tsv_download, copy_data_btn, result_table],
+                    outputs=[tsv_download, copy_data_btn],
                 ).then(fn=None, inputs=[num_cols_box], js=_ALIGN_HEADERS_JS)
 
             # Click a dimension value -> add/toggle its filter and re-run in one shot.

--- a/src/orionbelt/ui/handlers.py
+++ b/src/orionbelt/ui/handlers.py
@@ -624,15 +624,7 @@ def _decode_arrow_execute_response(resp: Any) -> Any:
     return data
 
 
-def execute_query(
-    model_yaml: str,
-    query_yaml: str,
-    dialect: str,
-    api_url: str,
-    session_state: dict[str, str] | None,
-    model_state: dict[str, str] | None,
-    request: gr.Request | None = None,
-) -> tuple[
+_ExecuteResult = tuple[
     str,
     str,
     dict[str, str] | None,
@@ -643,7 +635,43 @@ def execute_query(
     str | None,
     str,
     str,
-]:
+]
+
+
+def execute_query(
+    model_yaml: str,
+    query_yaml: str,
+    dialect: str,
+    api_url: str,
+    session_state: dict[str, str] | None,
+    model_state: dict[str, str] | None,
+    request: gr.Request | None = None,
+) -> _ExecuteResult:
+    """Execute a query and return the results with the table ready to show.
+
+    Same tuple as :func:`_execute_query`, except the ``display_df`` slot is a
+    ``gr.update`` carrying the table's visibility alongside its value. The
+    caller used to reveal the table in a chained ``.then``, which sent a second
+    update to the same component and re-rendered the Dataframe on every run and
+    every sort click - visible as a flicker. One update renders once.
+    """
+    result = _execute_query(
+        model_yaml, query_yaml, dialect, api_url, session_state, model_state, request
+    )
+    # result[6] is result_info: empty on every error path, set on success.
+    table = gr.update(value=result[4], visible=bool(result[6]))
+    return (*result[:4], table, *result[5:])
+
+
+def _execute_query(
+    model_yaml: str,
+    query_yaml: str,
+    dialect: str,
+    api_url: str,
+    session_state: dict[str, str] | None,
+    model_state: dict[str, str] | None,
+    request: gr.Request | None = None,
+) -> _ExecuteResult:
     """Execute query via the REST API and return results as a table.
 
     Returns ``(sql_output, explain_yaml, session_state, model_state,

--- a/tests/unit/test_ui_result_table_single_render.py
+++ b/tests/unit/test_ui_result_table_single_render.py
@@ -1,0 +1,55 @@
+"""The result table is written once per run, not twice.
+
+``execute_query`` used to return a bare DataFrame for the result table, and
+the caller revealed the table in a chained ``.then`` that sent a second update
+to the same component. Gradio renders each update, so every run and every sort
+click painted the Dataframe twice, which read as a flicker. The visibility now
+rides along with the value, so the table is one output of one call.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("gradio", reason="gradio required by the UI handlers")
+
+from orionbelt.ui.handlers import execute_query  # noqa: E402
+
+# Index of the result-table slot in the execute_query tuple.
+_TABLE = 4
+# Index of result_info, the emptiness of which decides the table's visibility.
+_INFO = 6
+
+
+def _run(query_yaml: str) -> tuple:
+    return execute_query("version: 1.0", query_yaml, "duckdb", "http://unused", None, None)
+
+
+def test_a_failed_run_hides_the_table_in_its_own_update() -> None:
+    """No second round-trip is needed to hide it: the value update carries it."""
+    result = _run("this: [is not valid yaml")
+
+    assert result[_INFO] == ""
+    table = result[_TABLE]
+    assert isinstance(table, dict), "the table slot must be a gr.update, not a bare frame"
+    assert table["visible"] is False
+
+
+def test_the_table_update_still_carries_the_value() -> None:
+    """Folding visibility in must not drop the data the table renders."""
+    table = _run("this: [is not valid yaml")[_TABLE]
+
+    assert "value" in table, "the update must carry the frame, or the table renders empty"
+
+
+def test_visibility_tracks_result_info() -> None:
+    """The rule the removed .then applied (`visible=bool(info)`) is preserved.
+
+    Asserted against the same handler output rather than restated, so the two
+    cannot drift apart the way the value and its visibility did. Driven off an
+    error path on purpose: the success path needs a live API, and this
+    invariant holds either way.
+    """
+    result = _run("version: 1.0")  # a mapping, but not a query
+
+    assert result[_TABLE]["visible"] is bool(result[_INFO])


### PR DESCRIPTION
## Problem

Sorting the results table by a header arrow works, but flickers: the table visibly re-renders twice. Two independent causes, both of which also affect the Run Query path (less noticeable there, because the data actually changes).

**1. `result_table` was written twice per click.** The handler returned the new frame into `result_table`, then a chained `.then` sent a *second* update to the same component purely to set `visible`:

```python
# before
outputs=[tsv_download, copy_data_btn, result_table],   # <- result_table again
```

Gradio renders each update, so that is two round-trips and two paints.

**2. The sort icons were torn down and rebuilt after each paint.** The post-render JS removed each header's `▲▼✕` span and recreated it from scratch, only to recolour the active direction. It also ran on `setInterval(..., 150)`, which does not fire until after its first delay, so even an already-rendered table waited 150ms before its icons appeared.

## Change

- Visibility rides along with the value: `execute_query` returns `gr.update(value=df, visible=bool(info))` for the table slot, and `result_table` is dropped from both post-execute steps. One call, one render. The composite handlers (`filter_and_execute`, `clear_filters_and_execute`, `sort_and_execute`) splat `execute_query`'s tuple, so they inherit this with no change.
- The icons are recoloured in place via `classList.toggle`, keeping the nodes and their click listeners instead of rebinding. A header whose column changed underneath it is still rebuilt, detected by comparing the header text with the glyphs stripped back out against the label stored when the controls were built.
- The injection is attempted immediately and only falls back to polling when the headers are not in the DOM yet.

`execute_query` keeps its name and signature. Gradio injects `gr.Request` by annotation, so wrapping it with `*args` would silently break that; the previous body is now `_execute_query`.

## Verification

- 3 new tests pin the handler contract (`tests/unit/test_ui_result_table_single_render.py`): the table slot is a `gr.update`, it still carries the value, and its visibility tracks `result_info`, asserted against the same output rather than restated so the two cannot drift.
- Full suite 2989 passed, 499 skipped. `ruff check`, `ruff format`, `mypy` clean.
- The JS passes `node --check` and was exercised against a DOM stub: a re-render reuses the same nodes, updates the active direction (`desc` to `asc`), keeps exactly 3 buttons, and a column swap rebuilds with the new label and no duplicate wrapper.

**Needs a human eye:** the Gradio Dataframe does not render in my headless browser, so I could verify the logic but not the flicker. Please confirm sorting looks clean before merging.