### PR TITLE
fix(validator): reject unresolvable column refs in withinGroup and computed columns

### DIFF
--- a/docs/guide/model-format.md
+++ b/docs/guide/model-format.md
@@ -185,7 +185,8 @@ ORDER BY (("Date"."d_year" * 100) + "Date"."d_moy") ASC
 - The expression is parsed and rendered through the dialect's `compile_expr` like any other AST node, so dialect-specific functions are dialect-portable only insofar as they appear in OBML's expression grammar (arithmetic, `CASE WHEN`, function calls).
 - Every `{Column}` placeholder must name a sibling column of the same data object. An unresolvable placeholder is rejected at validation time with `UNKNOWN_COLUMN_IN_EXPRESSION` — it is not silently dropped, so a typo cannot reach the database as a string literal. To reference a column of a *different* data object, use a measure expression's `{[DataObject].[Column]}` form.
 - A computed column may reference another computed column on the same data object; the referenced expression is inlined recursively (`{doubled} * 2` where `doubled` is `{amount} * 2` compiles to `amount * 2 * 2`). A reference cycle is rejected with `CYCLIC_COMPUTED_COLUMN`.
-- Braces inside string literals are left alone, so a regex quantifier such as `regexp_extract({Zip}, '[0-9]{5}')` is not mistaken for a placeholder.
+- Braces inside a single-quoted string literal are data, never placeholders. A regex quantifier such as `regexp_extract({Zip}, '[0-9]{5}')` keeps its `{5}`, and `'{Zip}'` stays the literal five characters rather than becoming a column reference. Validation and compilation apply the same rule.
+- Both halves of a column reference are required wherever one appears (`dimensions`, a measure's `columns`, `withinGroup`, measure filters). Omitting `dataObject` or `column` is rejected with `INCOMPLETE_COLUMN_REF`, because an omitted half would otherwise reach SQL as an empty identifier.
 - ORDER BY on a computed column works correctly — the planner emits the inlined expression, not the alias, in `ORDER BY` (the recent compiler fix in the [Compilation guide](compilation.md)).
 
 ### Joins

--- a/docs/guide/model-format.md
+++ b/docs/guide/model-format.md
@@ -183,7 +183,9 @@ ORDER BY (("Date"."d_year" * 100) + "Date"."d_moy") ASC
 
 - `expression` and `code` are mutually exclusive on a single column.
 - The expression is parsed and rendered through the dialect's `compile_expr` like any other AST node, so dialect-specific functions are dialect-portable only insofar as they appear in OBML's expression grammar (arithmetic, `CASE WHEN`, function calls).
-- A computed column may not reference another computed column on the same data object (no recursive resolution today).
+- Every `{Column}` placeholder must name a sibling column of the same data object. An unresolvable placeholder is rejected at validation time with `UNKNOWN_COLUMN_IN_EXPRESSION` — it is not silently dropped, so a typo cannot reach the database as a string literal. To reference a column of a *different* data object, use a measure expression's `{[DataObject].[Column]}` form.
+- A computed column may reference another computed column on the same data object; the referenced expression is inlined recursively (`{doubled} * 2` where `doubled` is `{amount} * 2` compiles to `amount * 2 * 2`). A reference cycle is rejected with `CYCLIC_COMPUTED_COLUMN`.
+- Braces inside string literals are left alone, so a regex quantifier such as `regexp_extract({Zip}, '[0-9]{5}')` is not mistaken for a placeholder.
 - ORDER BY on a computed column works correctly — the planner emits the inlined expression, not the alias, in `ORDER BY` (the recent compiler fix in the [Compilation guide](compilation.md)).
 
 ### Joins
@@ -424,7 +426,7 @@ measures:
 | `grain` | object | No | [Grain override](grain-filter-context.md#grain-override) -- controls aggregation grain independently from query dimensions |
 | `filterContext` | object | No | [Filter context override](grain-filter-context.md#filter-context) -- controls which query WHERE filters apply |
 | `delimiter` | string | No | Separator for `listagg` aggregation (default: `","`) |
-| `withinGroup` | object | No | Ordering clause for `listagg` — specifies `column` and `order` (`ASC`/`DESC`). With `distinct: true` the column must be the one being aggregated (error code `WITHIN_GROUP_NOT_IN_DISTINCT_ARGS`). |
+| `withinGroup` | object | No | Ordering clause for `listagg` — specifies `column` and `order` (`ASC`/`DESC`). The `column` must resolve to a real data object column (`UNKNOWN_DATA_OBJECT` / `UNKNOWN_COLUMN`). With `distinct: true` it must additionally be the one being aggregated (error code `WITHIN_GROUP_NOT_IN_DISTINCT_ARGS`). |
 | `dataType` | string | No | OBML data type (e.g. `decimal(18, 4)`, `bigint`). Overrides automatic type inference for CAST wrapping. |
 | `format` | string | No | Display format pattern (e.g. `#,##0.00`, `0.00%`) |
 | `description` | string | No | Business description |

--- a/src/orionbelt/compiler/expr_parser.py
+++ b/src/orionbelt/compiler/expr_parser.py
@@ -47,6 +47,7 @@ from orionbelt.ast.nodes import (
     Literal,
     UnaryOp,
 )
+from orionbelt.models.expressions import substitute_placeholders
 
 if TYPE_CHECKING:
     from orionbelt.models.semantic import SemanticModel
@@ -96,12 +97,8 @@ _LITERAL_KEYWORDS: dict[str, str | int | float | bool | None] = {
 
 _IDENT_RE = re.compile(r"[A-Za-z_][A-Za-z_0-9]*")
 
-# ``{ColumnName}`` placeholder inside a computed-column expression body.
-# Same shape as ``compiler.resolution._COMPUTED_PLACEHOLDER`` — kept here
-# to avoid a circular import; both must match the OBML spec rule
-# "computed-column expressions use ``{column}`` for sibling columns
-# and ``{[obj].[col]}`` for cross-object references".
-_COMPUTED_PLACEHOLDER = re.compile(r"\{(\w[^}]*)\}")
+# ``{ColumnName}`` placeholder handling lives in ``models.expressions`` so the
+# validator and both compiler call sites share one rule. See that module.
 
 
 # ---------------------------------------------------------------------------
@@ -261,7 +258,7 @@ def tokenize_measure_expression(
                             return f"{{[{label}].[{name}]}}"
                         return match.group(0)
 
-                    rewritten = _COMPUTED_PLACEHOLDER.sub(_sub, inner)
+                    rewritten = substitute_placeholders(inner, _sub)
                     inner_tokens = tokenize_measure_expression(
                         rewritten, model, _seen=_seen | {key}
                     )

--- a/src/orionbelt/compiler/resolution.py
+++ b/src/orionbelt/compiler/resolution.py
@@ -29,6 +29,7 @@ from orionbelt.compiler.filters import (
 )
 from orionbelt.compiler.graph import JoinGraph, JoinStep, path_overrides
 from orionbelt.models.errors import SemanticError
+from orionbelt.models.expressions import substitute_placeholders
 from orionbelt.models.query import (
     CoalesceDimension,
     DimensionRef,
@@ -60,8 +61,6 @@ from orionbelt.models.semantic import (
 )
 from orionbelt.models.warnings import WarningCode, warning
 
-_COMPUTED_PLACEHOLDER = re.compile(r"\{(\w[^}]*)\}")
-
 
 def _build_computed_column_expr(
     column: DataObjectColumn, obj: DataObject, model: SemanticModel
@@ -82,7 +81,7 @@ def _build_computed_column_expr(
             return f"{{[{obj.name}].[{name}]}}"
         return match.group(0)
 
-    rewritten = _COMPUTED_PLACEHOLDER.sub(_sub, expr_str)
+    rewritten = substitute_placeholders(expr_str, _sub)
     try:
         tokens = tokenize_measure_expression(rewritten, model)
         return parse_expression(tokens)

--- a/src/orionbelt/models/expressions.py
+++ b/src/orionbelt/models/expressions.py
@@ -1,0 +1,78 @@
+"""Placeholder scanning for computed-column expressions.
+
+A computed column's ``expression`` refers to sibling columns of the same data
+object with single-brace ``{Column}`` placeholders. Three call sites need to
+agree on exactly which braces count as a placeholder:
+
+* ``parser/validator.py`` reports a placeholder that names no sibling column.
+* ``compiler/resolution.py`` rewrites placeholders to the qualified
+  ``{[Object].[Column]}`` form before tokenizing.
+* ``compiler/expr_parser.py`` does the same when inlining a nested computed
+  column.
+
+They used to carry three private copies of the pattern, kept in sync by
+comment. The rule now lives here once, so the validator cannot accept a
+placeholder the compiler would resolve differently.
+
+``models`` is the shared layer: ``parser`` must not import from ``compiler``,
+and both already depend on ``models``.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable, Iterator
+
+COMPUTED_PLACEHOLDER = re.compile(r"\{(\w[^}]*)\}")
+"""``{ColumnName}`` placeholder inside a computed-column expression body."""
+
+SQL_STRING_LITERAL = re.compile(r"'(?:[^']|'')*'")
+"""A single-quoted SQL string literal, ``''`` being the escaped quote."""
+
+_REGEX_QUANTIFIER = re.compile(r"^\d+(?:,\d*)?$")
+"""``{4}``, ``{2,}``, ``{2,4}`` - a regex quantifier, never a column name."""
+
+
+def _segments(expression: str) -> Iterator[tuple[str, bool]]:
+    """Split *expression* into ``(text, is_string_literal)`` pairs, in order."""
+    pos = 0
+    for match in SQL_STRING_LITERAL.finditer(expression):
+        if match.start() > pos:
+            yield expression[pos : match.start()], False
+        yield match.group(0), True
+        pos = match.end()
+    if pos < len(expression):
+        yield expression[pos:], False
+
+
+def substitute_placeholders(expression: str, repl: Callable[[re.Match[str]], str]) -> str:
+    """Apply *repl* to every placeholder outside a string literal.
+
+    Braces inside a literal are data, not references: an expression such as
+    ``regexp_extract({Zip}, '[0-9]{5}')`` must keep its quantifier, and
+    ``'{Amount}'`` must stay the four characters the author typed rather than
+    becoming a column reference embedded in a quoted string.
+    """
+    return "".join(
+        text if is_literal else COMPUTED_PLACEHOLDER.sub(repl, text)
+        for text, is_literal in _segments(expression)
+    )
+
+
+def find_placeholders(expression: str) -> list[str]:
+    """The column names *expression* references, in order of appearance.
+
+    Skips string literals for the reason above, and skips a bare regex
+    quantifier even outside one - a dialect that quotes patterns with double
+    quotes puts ``{5}`` beyond the reach of :data:`SQL_STRING_LITERAL`, and
+    reporting a missing column named ``5`` would be worse than staying quiet.
+    """
+    names: list[str] = []
+    for text, is_literal in _segments(expression):
+        if is_literal:
+            continue
+        for raw in COMPUTED_PLACEHOLDER.findall(text):
+            name = raw.strip()
+            if not _REGEX_QUANTIFIER.match(name):
+                names.append(name)
+    return names

--- a/src/orionbelt/parser/validator.py
+++ b/src/orionbelt/parser/validator.py
@@ -8,7 +8,9 @@ from collections import deque
 import networkx as nx
 
 from orionbelt.models.errors import SemanticError
+from orionbelt.models.expressions import find_placeholders
 from orionbelt.models.semantic import (
+    DataColumnRef,
     DataObject,
     DataType,
     Measure,
@@ -21,19 +23,6 @@ from orionbelt.models.synthesis import count_label, model_count_pattern
 
 # ``{[Data Object].[Column]}`` reference inside a measure expression.
 _MEASURE_COLUMN_REF = re.compile(r"\{\[([^\]]+)\]\.\[([^\]]+)\]\}")
-
-# ``{name}`` placeholder inside a computed column's ``expression``. Mirrors
-# ``compiler/resolution.py::_COMPUTED_PLACEHOLDER`` — the two must agree, or
-# the validator would accept a placeholder the compiler cannot resolve.
-_COMPUTED_PLACEHOLDER = re.compile(r"\{(\w[^}]*)\}")
-
-# Single-quoted SQL string literal, stripped before scanning for placeholders
-# so a regex quantifier inside one (``regexp_extract(x, '[0-9]{4}')``) is not
-# mistaken for a column reference.
-_SQL_STRING_LITERAL = re.compile(r"'(?:[^']|'')*'")
-
-# A bare regex quantifier — ``{4}``, ``{2,}``, ``{2,4}``. Never a column name.
-_REGEX_QUANTIFIER = re.compile(r"^\d+(?:,\d*)?$")
 
 
 class SemanticValidator:
@@ -311,37 +300,77 @@ class SemanticValidator:
 
         return errors
 
+    def _check_column_ref(
+        self,
+        ref: DataColumnRef,
+        model: SemanticModel,
+        *,
+        subject: str,
+        path: str,
+    ) -> list[SemanticError]:
+        """Validate one ``DataColumnRef``: both halves present, and both resolving.
+
+        The JSON schema makes ``dataObject`` and ``column`` required, but the
+        Pydantic type leaves both optional so models can be built in Python,
+        and ``ModelStore.load_model`` does not run the schema. A missing half
+        is not inert: codegen renders it as an empty identifier, so a ref
+        without a column compiles to ``ORDER BY "Sales".""`` and one without a
+        data object to ``ORDER BY ""."Product Name"``.
+        """
+        obj_name, col_name = ref.view, ref.column
+
+        missing = [
+            field for field, value in (("dataObject", obj_name), ("column", col_name)) if not value
+        ]
+        if missing:
+            return [
+                SemanticError(
+                    code="INCOMPLETE_COLUMN_REF",
+                    message=(
+                        f"{subject} is missing {' and '.join(missing)}. A column "
+                        f"reference needs both dataObject and column; an omitted "
+                        f"one compiles to an empty SQL identifier."
+                    ),
+                    path=path,
+                )
+            ]
+
+        if obj_name not in model.data_objects:
+            return [
+                SemanticError(
+                    code="UNKNOWN_DATA_OBJECT",
+                    message=f"{subject} references unknown data object '{obj_name}'",
+                    path=path,
+                )
+            ]
+
+        if col_name not in model.data_objects[obj_name].columns:
+            return [
+                SemanticError(
+                    code="UNKNOWN_COLUMN",
+                    message=(
+                        f"{subject} references unknown column '{col_name}' "
+                        f"in data object '{obj_name}'"
+                    ),
+                    path=path,
+                )
+            ]
+
+        return []
+
     def _check_measures_resolve(self, model: SemanticModel) -> list[SemanticError]:
         """Ensure measure column references resolve to actual data object columns."""
         errors: list[SemanticError] = []
         for name, measure in model.measures.items():
             for i, col_ref in enumerate(measure.columns):
-                obj_name = col_ref.view
-                col_name = col_ref.column
-                if obj_name and obj_name not in model.data_objects:
-                    errors.append(
-                        SemanticError(
-                            code="UNKNOWN_DATA_OBJECT",
-                            message=(
-                                f"Measure '{name}' column[{i}] references "
-                                f"unknown data object '{obj_name}'"
-                            ),
-                            path=f"measures.{name}.columns[{i}]",
-                        )
+                errors.extend(
+                    self._check_column_ref(
+                        col_ref,
+                        model,
+                        subject=f"Measure '{name}' column[{i}]",
+                        path=f"measures.{name}.columns[{i}]",
                     )
-                elif obj_name and col_name:
-                    obj = model.data_objects[obj_name]
-                    if col_name not in obj.columns:
-                        errors.append(
-                            SemanticError(
-                                code="UNKNOWN_COLUMN",
-                                message=(
-                                    f"Measure '{name}' column[{i}] references "
-                                    f"unknown column '{col_name}' in data object '{obj_name}'"
-                                ),
-                                path=f"measures.{name}.columns[{i}]",
-                            )
-                        )
+                )
         return errors
 
     def _check_join_targets_exist(self, model: SemanticModel) -> list[SemanticError]:
@@ -417,29 +446,14 @@ class SemanticValidator:
         """Ensure dimension references resolve."""
         errors: list[SemanticError] = []
         for name, dim in model.dimensions.items():
-            obj_name = dim.view
-            col_name = dim.column
-            if obj_name and obj_name not in model.data_objects:
-                errors.append(
-                    SemanticError(
-                        code="UNKNOWN_DATA_OBJECT",
-                        message=f"Dimension '{name}' references unknown data object '{obj_name}'",
-                        path=f"dimensions.{name}",
-                    )
+            errors.extend(
+                self._check_column_ref(
+                    DataColumnRef(view=dim.view, column=dim.column),
+                    model,
+                    subject=f"Dimension '{name}'",
+                    path=f"dimensions.{name}",
                 )
-            elif obj_name and col_name:
-                obj = model.data_objects[obj_name]
-                if col_name not in obj.columns:
-                    errors.append(
-                        SemanticError(
-                            code="UNKNOWN_COLUMN",
-                            message=(
-                                f"Dimension '{name}' references unknown column "
-                                f"'{col_name}' in data object '{obj_name}'"
-                            ),
-                            path=f"dimensions.{name}",
-                        )
-                    )
+            )
         return errors
 
     _NUMERIC_TYPES = {DataType.INT, DataType.FLOAT}
@@ -591,28 +605,47 @@ class SemanticValidator:
     ) -> None:
         """Recursively validate a measure filter item."""
         if isinstance(item, MeasureFilter):
-            if not item.column or not item.column.view:
+            if item.column is None:
                 return
-            obj = model.data_objects.get(item.column.view)
-            if not obj:
+            view, column = item.column.view, item.column.column
+            # An omitted half reaches codegen as an empty identifier, the same
+            # way it does for a dimension or a withinGroup column.
+            missing = [
+                field for field, value in (("dataObject", view), ("column", column)) if not value
+            ]
+            if missing or not view or not column:
                 errors.append(
                     SemanticError(
-                        code="UNKNOWN_FILTER_DATA_OBJECT",
+                        code="INCOMPLETE_COLUMN_REF",
                         message=(
-                            f"Measure '{meas_name}' filter references unknown "
-                            f"data object '{item.column.view}'"
+                            f"Measure '{meas_name}' filter is missing "
+                            f"{' and '.join(missing)}. A column reference needs both "
+                            f"dataObject and column; an omitted one compiles to an "
+                            f"empty SQL identifier."
                         ),
                         path=f"measures.{meas_name}.filters",
                     )
                 )
                 return
-            if item.column.column and item.column.column not in obj.columns:
+            obj = model.data_objects.get(view)
+            if not obj:
+                errors.append(
+                    SemanticError(
+                        code="UNKNOWN_FILTER_DATA_OBJECT",
+                        message=(
+                            f"Measure '{meas_name}' filter references unknown data object '{view}'"
+                        ),
+                        path=f"measures.{meas_name}.filters",
+                    )
+                )
+                return
+            if column not in obj.columns:
                 errors.append(
                     SemanticError(
                         code="UNKNOWN_FILTER_COLUMN",
                         message=(
                             f"Measure '{meas_name}' filter references unknown "
-                            f"column '{item.column.column}' in '{item.column.view}'"
+                            f"column '{column}' in '{view}'"
                         ),
                         path=f"measures.{meas_name}.filters",
                     )
@@ -635,46 +668,15 @@ class SemanticValidator:
         for name, measure in model.measures.items():
             if measure.within_group is None:
                 continue
-            ref = measure.within_group.column
-            obj_name, col_name = ref.view, ref.column
-            if obj_name and obj_name not in model.data_objects:
-                errors.append(
-                    SemanticError(
-                        code="UNKNOWN_DATA_OBJECT",
-                        message=(
-                            f"Measure '{name}' withinGroup references unknown "
-                            f"data object '{obj_name}'"
-                        ),
-                        path=f"measures.{name}.withinGroup",
-                    )
+            errors.extend(
+                self._check_column_ref(
+                    measure.within_group.column,
+                    model,
+                    subject=f"Measure '{name}' withinGroup",
+                    path=f"measures.{name}.withinGroup",
                 )
-            elif obj_name and col_name and col_name not in model.data_objects[obj_name].columns:
-                errors.append(
-                    SemanticError(
-                        code="UNKNOWN_COLUMN",
-                        message=(
-                            f"Measure '{name}' withinGroup references unknown column "
-                            f"'{col_name}' in data object '{obj_name}'"
-                        ),
-                        path=f"measures.{name}.withinGroup",
-                    )
-                )
+            )
         return errors
-
-    @staticmethod
-    def _computed_placeholders(expression: str) -> list[str]:
-        """The ``{name}`` column placeholders in a computed column's expression.
-
-        String literals are stripped first and bare regex quantifiers skipped,
-        so ``regexp_extract({Zip}, '[0-9]{4}')`` yields ``["Zip"]`` rather than
-        also reporting ``4`` as a missing column.
-        """
-        body = _SQL_STRING_LITERAL.sub("''", expression)
-        return [
-            name.strip()
-            for name in _COMPUTED_PLACEHOLDER.findall(body)
-            if not _REGEX_QUANTIFIER.match(name.strip())
-        ]
 
     def _check_computed_column_refs(self, model: SemanticModel) -> list[SemanticError]:
         """Ensure a computed column's ``{name}`` placeholders name sibling columns.
@@ -690,7 +692,7 @@ class SemanticValidator:
             for col_name, col in obj.columns.items():
                 if not col.expression:
                     continue
-                for ref in self._computed_placeholders(col.expression):
+                for ref in find_placeholders(col.expression):
                     if ref in obj.columns:
                         continue
                     errors.append(
@@ -759,7 +761,7 @@ class SemanticValidator:
             g.add_node(name)
         for name in computed:
             expression = obj.columns[name].expression or ""
-            for ref in self._computed_placeholders(expression):
+            for ref in find_placeholders(expression):
                 if ref in computed:
                     g.add_edge(name, ref)
         return g

--- a/src/orionbelt/parser/validator.py
+++ b/src/orionbelt/parser/validator.py
@@ -9,6 +9,7 @@ import networkx as nx
 
 from orionbelt.models.errors import SemanticError
 from orionbelt.models.semantic import (
+    DataObject,
     DataType,
     Measure,
     MeasureFilter,
@@ -20,6 +21,19 @@ from orionbelt.models.synthesis import count_label, model_count_pattern
 
 # ``{[Data Object].[Column]}`` reference inside a measure expression.
 _MEASURE_COLUMN_REF = re.compile(r"\{\[([^\]]+)\]\.\[([^\]]+)\]\}")
+
+# ``{name}`` placeholder inside a computed column's ``expression``. Mirrors
+# ``compiler/resolution.py::_COMPUTED_PLACEHOLDER`` — the two must agree, or
+# the validator would accept a placeholder the compiler cannot resolve.
+_COMPUTED_PLACEHOLDER = re.compile(r"\{(\w[^}]*)\}")
+
+# Single-quoted SQL string literal, stripped before scanning for placeholders
+# so a regex quantifier inside one (``regexp_extract(x, '[0-9]{4}')``) is not
+# mistaken for a column reference.
+_SQL_STRING_LITERAL = re.compile(r"'(?:[^']|'')*'")
+
+# A bare regex quantifier — ``{4}``, ``{2,}``, ``{2,4}``. Never a column name.
+_REGEX_QUANTIFIER = re.compile(r"^\d+(?:,\d*)?$")
 
 
 class SemanticValidator:
@@ -38,6 +52,9 @@ class SemanticValidator:
         errors.extend(self._check_num_class_on_numeric_columns(model))
         errors.extend(self._check_time_grain_on_temporal_columns(model))
         errors.extend(self._check_measure_filter_refs(model))
+        errors.extend(self._check_within_group_refs(model))
+        errors.extend(self._check_computed_column_refs(model))
+        errors.extend(self._check_no_cyclic_computed_columns(model))
         errors.extend(self._check_distinct_within_group(model))
         errors.extend(self._check_via_reachability(model))
         errors.extend(self._check_missing_via(model))
@@ -603,6 +620,158 @@ class SemanticValidator:
         elif isinstance(item, MeasureFilterGroup):
             for child in item.filters:
                 self._validate_filter_item(child, model, meas_name, errors)
+
+    def _check_within_group_refs(self, model: SemanticModel) -> list[SemanticError]:
+        """Verify that a ``withinGroup`` ordering column exists.
+
+        ``withinGroup`` is the one ``DataColumnRef`` site on a measure that no
+        other check covers: ``columns:`` goes through
+        :meth:`_check_measures_resolve` and filter columns through
+        :meth:`_check_measure_filter_refs`. Left unchecked, a typo compiles
+        straight into ``ORDER BY "Sales"."no_such_col"`` inside the LISTAGG and
+        only fails at the database.
+        """
+        errors: list[SemanticError] = []
+        for name, measure in model.measures.items():
+            if measure.within_group is None:
+                continue
+            ref = measure.within_group.column
+            obj_name, col_name = ref.view, ref.column
+            if obj_name and obj_name not in model.data_objects:
+                errors.append(
+                    SemanticError(
+                        code="UNKNOWN_DATA_OBJECT",
+                        message=(
+                            f"Measure '{name}' withinGroup references unknown "
+                            f"data object '{obj_name}'"
+                        ),
+                        path=f"measures.{name}.withinGroup",
+                    )
+                )
+            elif obj_name and col_name and col_name not in model.data_objects[obj_name].columns:
+                errors.append(
+                    SemanticError(
+                        code="UNKNOWN_COLUMN",
+                        message=(
+                            f"Measure '{name}' withinGroup references unknown column "
+                            f"'{col_name}' in data object '{obj_name}'"
+                        ),
+                        path=f"measures.{name}.withinGroup",
+                    )
+                )
+        return errors
+
+    @staticmethod
+    def _computed_placeholders(expression: str) -> list[str]:
+        """The ``{name}`` column placeholders in a computed column's expression.
+
+        String literals are stripped first and bare regex quantifiers skipped,
+        so ``regexp_extract({Zip}, '[0-9]{4}')`` yields ``["Zip"]`` rather than
+        also reporting ``4`` as a missing column.
+        """
+        body = _SQL_STRING_LITERAL.sub("''", expression)
+        return [
+            name.strip()
+            for name in _COMPUTED_PLACEHOLDER.findall(body)
+            if not _REGEX_QUANTIFIER.match(name.strip())
+        ]
+
+    def _check_computed_column_refs(self, model: SemanticModel) -> list[SemanticError]:
+        """Ensure a computed column's ``{name}`` placeholders name sibling columns.
+
+        A placeholder the compiler cannot resolve is not dropped and not
+        reported — it survives into codegen as a *string literal*, so
+        ``{amount} * {no_such_col}`` emits ``"Sales"."amount" * 'no_such_col'``.
+        The model validates clean and the wrongness surfaces, at best, as a
+        type error from the database.
+        """
+        errors: list[SemanticError] = []
+        for obj_name, obj in model.data_objects.items():
+            for col_name, col in obj.columns.items():
+                if not col.expression:
+                    continue
+                for ref in self._computed_placeholders(col.expression):
+                    if ref in obj.columns:
+                        continue
+                    errors.append(
+                        SemanticError(
+                            code="UNKNOWN_COLUMN_IN_EXPRESSION",
+                            message=(
+                                f"Computed column '{col_name}' in data object "
+                                f"'{obj_name}' references unknown column '{ref}'"
+                            ),
+                            path=f"dataObjects.{obj_name}.columns.{col_name}.expression",
+                            hint=(
+                                "A computed column's {placeholder} must name another "
+                                f"column of '{obj_name}'. To reference a column of a "
+                                "different data object, use a measure expression's "
+                                "{[Data Object].[Column]} form instead."
+                            ),
+                        )
+                    )
+        return errors
+
+    def _check_no_cyclic_computed_columns(self, model: SemanticModel) -> list[SemanticError]:
+        """Detect computed columns whose expressions reference each other in a loop.
+
+        The compiler raises ``RecursionError`` on such a chain, but
+        ``_build_computed_column_expr`` catches every exception and falls back
+        to a plain reference to the column's own ``code`` — which for a computed
+        column is empty, so the *label* is emitted as a physical column name.
+        A cycle therefore compiles to SQL naming a column that does not exist.
+        """
+        errors: list[SemanticError] = []
+        for obj_name, obj in model.data_objects.items():
+            g = self._computed_column_graph(obj)
+            # Each strongly connected component that is not a single acyclic
+            # node is exactly one reference cycle. Using SCCs rather than
+            # walking from every column keeps this linear and reports each
+            # cycle once, however many columns sit on it.
+            for scc in nx.strongly_connected_components(g):
+                if len(scc) == 1:
+                    only = next(iter(scc))
+                    if not g.has_edge(only, only):
+                        continue
+                cycle = self._describe_cycle(g, scc)
+                start = cycle[0]
+                errors.append(
+                    SemanticError(
+                        code="CYCLIC_COMPUTED_COLUMN",
+                        message=(
+                            f"Cyclic computed-column reference in data object "
+                            f"'{obj_name}': {' -> '.join(cycle)}"
+                        ),
+                        path=f"dataObjects.{obj_name}.columns.{start}.expression",
+                    )
+                )
+        return errors
+
+    def _computed_column_graph(self, obj: DataObject) -> nx.DiGraph[str]:
+        """Dependency graph over a data object's computed columns.
+
+        An edge ``a -> b`` means computed column ``a``'s expression references
+        ``b``. Only computed columns become nodes: a placeholder naming a
+        physical column terminates the chain and cannot be part of a cycle.
+        """
+        g: nx.DiGraph[str] = nx.DiGraph()
+        computed = {name for name, col in obj.columns.items() if col.expression}
+        for name in computed:
+            g.add_node(name)
+        for name in computed:
+            expression = obj.columns[name].expression or ""
+            for ref in self._computed_placeholders(expression):
+                if ref in computed:
+                    g.add_edge(name, ref)
+        return g
+
+    @staticmethod
+    def _describe_cycle(g: nx.DiGraph[str], scc: set[str]) -> list[str]:
+        """A readable ``a -> b -> a`` walk through one cyclic component."""
+        try:
+            edges = nx.find_cycle(g.subgraph(scc))
+        except nx.NetworkXNoCycle:  # pragma: no cover - scc is cyclic by construction
+            return sorted(scc)
+        return [source for source, _target in edges] + [edges[0][0]]
 
     def _build_directed_graph(self, model: SemanticModel) -> nx.DiGraph[str]:
         """Build a directed graph from primary (non-secondary) joins."""

--- a/tests/unit/test_computed_columns.py
+++ b/tests/unit/test_computed_columns.py
@@ -201,3 +201,87 @@ class TestComputedColumnInOrderBy:
         assert '""' not in ob_clause
         assert "REPORTINGDATEYEAR" in ob_clause
         assert "REPORTINGDATEMONTH" in ob_clause
+
+
+_STRING_LITERAL_MODEL_YAML = """\
+version: 1.0
+dataObjects:
+  Orders:
+    code: ORDERS
+    columns:
+      Order ID:
+        code: ORDER_ID
+        abstractType: string
+      Zip:
+        code: ZIP
+        abstractType: string
+      Zip 5:
+        abstractType: string
+        expression: "regexp_extract({Zip}, '[0-9]{5}')"
+      Quoted:
+        abstractType: string
+        expression: "'{Zip}'"
+      Nested:
+        abstractType: string
+        expression: "concat({Quoted}, '{Zip}')"
+
+dimensions:
+  Zip 5:
+    dataObject: Orders
+    column: Zip 5
+    resultType: string
+  Quoted:
+    dataObject: Orders
+    column: Quoted
+    resultType: string
+  Nested:
+    dataObject: Orders
+    column: Nested
+    resultType: string
+
+measures:
+  Order Count:
+    columns: [{dataObject: Orders, column: Order ID}]
+    resultType: int
+    aggregation: count
+"""
+
+
+def _string_literal_model() -> SemanticModel:
+    raw, sm = TrackedLoader().load_string(_STRING_LITERAL_MODEL_YAML)
+    model, result = ReferenceResolver().resolve(raw, sm)
+    assert result.valid, result.errors
+    return model
+
+
+def _compile_dimension(dimension: str) -> str:
+    query = QueryObject(
+        select=QuerySelect(dimensions=[dimension], measures=["Order Count"]),
+    )
+    return CompilationPipeline().compile(query, _string_literal_model(), "duckdb").sql
+
+
+class TestComputedColumnStringLiterals:
+    """Braces inside a string literal are data, not column placeholders.
+
+    Substitution used to run over the whole expression, so a placeholder
+    naming a real column was rewritten inside quotes and emitted as the
+    literal text ``'{[Orders].[Zip]}'``.
+    """
+
+    def test_regex_quantifier_survives(self) -> None:
+        sql = _compile_dimension("Zip 5")
+        assert "'[0-9]{5}'" in sql
+        assert '"Orders"."ZIP"' in sql
+
+    def test_placeholder_inside_literal_is_not_substituted(self) -> None:
+        sql = _compile_dimension("Quoted")
+        assert "'{Zip}'" in sql
+        assert "[Orders]" not in sql
+
+    def test_nested_computed_column_keeps_its_literals(self) -> None:
+        """The inlining path in expr_parser applies the same rule."""
+        sql = _compile_dimension("Nested")
+        # The {Quoted} reference resolves and inlines; both literals survive.
+        assert sql.count("'{Zip}'") == 2
+        assert "[Orders]" not in sql

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -1799,3 +1799,173 @@ def _listagg_errors(resolver: ReferenceResolver, *, distinct: bool, order_column
     raw, source_map = TrackedLoader().load_string(yaml_content)
     model, _ = resolver.resolve(raw, source_map)
     return [e.code for e in SemanticValidator().validate(model)]
+
+
+_COMPUTED_COLUMN_MODEL = """\
+version: 1.0
+dataObjects:
+  Sales:
+    code: sales
+    database: db
+    schema: public
+    columns:
+      Amount:
+        code: amount
+        abstractType: float
+      Zip:
+        code: zip
+        abstractType: string
+{extra_columns}\
+dimensions:
+  Zip Code:
+    dataObject: Sales
+    column: Zip
+    resultType: string
+"""
+
+
+def _computed_column_errors(resolver: ReferenceResolver, extra_columns: str) -> list[str]:
+    yaml_content = _COMPUTED_COLUMN_MODEL.format(extra_columns=extra_columns)
+    raw, source_map = TrackedLoader().load_string(yaml_content)
+    model, _ = resolver.resolve(raw, source_map)
+    return [e.code for e in SemanticValidator().validate(model)]
+
+
+class TestComputedColumnRefs:
+    """A computed column's ``{name}`` placeholders must name sibling columns.
+
+    An unresolved placeholder is not dropped by the compiler — it survives into
+    codegen as a string literal (``"Sales"."amount" * 'no_such_col'``), so the
+    model has to be rejected at validation time.
+    """
+
+    def test_resolvable_placeholder_is_valid(self, resolver: ReferenceResolver) -> None:
+        codes = _computed_column_errors(
+            resolver,
+            """      Doubled:
+        abstractType: float
+        expression: "{Amount} * 2"
+""",
+        )
+        assert codes == []
+
+    def test_unknown_placeholder_rejected(self, resolver: ReferenceResolver) -> None:
+        codes = _computed_column_errors(
+            resolver,
+            """      Bad:
+        abstractType: float
+        expression: "{Amount} * {No Such Column}"
+""",
+        )
+        assert codes == ["UNKNOWN_COLUMN_IN_EXPRESSION"]
+
+    def test_regex_quantifier_is_not_a_column_ref(self, resolver: ReferenceResolver) -> None:
+        """``'[0-9]{5}'`` is a quantifier inside a string literal, not a placeholder."""
+        codes = _computed_column_errors(
+            resolver,
+            """      Zip5:
+        abstractType: string
+        expression: "regexp_extract({Zip}, '[0-9]{5}')"
+""",
+        )
+        assert codes == []
+
+    def test_chained_computed_columns_are_valid(self, resolver: ReferenceResolver) -> None:
+        codes = _computed_column_errors(
+            resolver,
+            """      Doubled:
+        abstractType: float
+        expression: "{Amount} * 2"
+      Quadrupled:
+        abstractType: float
+        expression: "{Doubled} * 2"
+""",
+        )
+        assert codes == []
+
+    def test_direct_cycle_rejected(self, resolver: ReferenceResolver) -> None:
+        codes = _computed_column_errors(
+            resolver,
+            """      Loop:
+        abstractType: float
+        expression: "{Loop} + 1"
+""",
+        )
+        assert codes == ["CYCLIC_COMPUTED_COLUMN"]
+
+    def test_mutual_cycle_reported_once(self, resolver: ReferenceResolver) -> None:
+        codes = _computed_column_errors(
+            resolver,
+            """      A:
+        abstractType: float
+        expression: "{B} + 1"
+      B:
+        abstractType: float
+        expression: "{A} + 2"
+""",
+        )
+        assert codes == ["CYCLIC_COMPUTED_COLUMN"]
+
+    def test_three_node_cycle_reported_once_with_full_path(
+        self, resolver: ReferenceResolver
+    ) -> None:
+        yaml_content = _COMPUTED_COLUMN_MODEL.format(
+            extra_columns="""      A:
+        abstractType: float
+        expression: "{B} + 1"
+      B:
+        abstractType: float
+        expression: "{C} + 2"
+      C:
+        abstractType: float
+        expression: "{A} + 3"
+"""
+        )
+        raw, source_map = TrackedLoader().load_string(yaml_content)
+        model, _ = resolver.resolve(raw, source_map)
+        errors = SemanticValidator().validate(model)
+        assert [e.code for e in errors] == ["CYCLIC_COMPUTED_COLUMN"]
+        # Every column on the cycle is named, and the walk closes on itself.
+        message = errors[0].message
+        assert "A" in message and "B" in message and "C" in message
+        walk = message.rsplit(": ", 1)[1].split(" -> ")
+        assert len(walk) == 4 and walk[0] == walk[-1]
+
+    def test_entering_a_cycle_from_outside_is_reported(self, resolver: ReferenceResolver) -> None:
+        """A column that *reaches* a cycle is unusable too, but the cycle is the defect."""
+        codes = _computed_column_errors(
+            resolver,
+            """      Entry:
+        abstractType: float
+        expression: "{A} * 2"
+      A:
+        abstractType: float
+        expression: "{B} + 1"
+      B:
+        abstractType: float
+        expression: "{A} + 2"
+""",
+        )
+        assert codes == ["CYCLIC_COMPUTED_COLUMN"]
+
+
+class TestWithinGroupRefs:
+    """``withinGroup.column`` is validated like any other DataColumnRef site."""
+
+    def test_valid_within_group_column(self, resolver: ReferenceResolver) -> None:
+        codes = _listagg_errors(resolver, distinct=False, order_column="Stock On Hand")
+        assert codes == []
+
+    def test_unknown_within_group_column(self, resolver: ReferenceResolver) -> None:
+        codes = _listagg_errors(resolver, distinct=False, order_column="No Such Column")
+        assert "UNKNOWN_COLUMN" in codes
+
+    def test_unknown_within_group_data_object(self, resolver: ReferenceResolver) -> None:
+        yaml_content = _LISTAGG_MODEL.format(distinct="", order_column="Product ID").replace(
+            "column: {dataObject: Products, column: Product ID}\n      order: ASC",
+            "column: {dataObject: No Such Object, column: Product ID}\n      order: ASC",
+        )
+        raw, source_map = TrackedLoader().load_string(yaml_content)
+        model, _ = resolver.resolve(raw, source_map)
+        codes = [e.code for e in SemanticValidator().validate(model)]
+        assert "UNKNOWN_DATA_OBJECT" in codes

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -3,6 +3,17 @@
 from __future__ import annotations
 
 from orionbelt.models.errors import SemanticError
+from orionbelt.models.semantic import (
+    AggregationType,
+    DataColumnRef,
+    DataType,
+    Dimension,
+    FilterValue,
+    Measure,
+    MeasureFilter,
+    SemanticModel,
+    WithinGroup,
+)
 from orionbelt.parser.loader import TrackedLoader
 from orionbelt.parser.resolver import ReferenceResolver
 from orionbelt.parser.validator import SemanticValidator
@@ -1969,3 +1980,99 @@ class TestWithinGroupRefs:
         model, _ = resolver.resolve(raw, source_map)
         codes = [e.code for e in SemanticValidator().validate(model)]
         assert "UNKNOWN_DATA_OBJECT" in codes
+
+
+class TestIncompleteColumnRefs:
+    """Both halves of a ``DataColumnRef`` are required.
+
+    The JSON schema enforces this, but ``ModelStore.load_model`` does not run
+    the schema, and the Pydantic type leaves both fields optional. An omitted
+    half is not inert: it reaches codegen as an empty SQL identifier
+    (``ORDER BY "Sales".""``), so the validator has to reject it too.
+    """
+
+    @staticmethod
+    def _validate(model: SemanticModel) -> list[str]:
+        return [e.code for e in SemanticValidator().validate(model)]
+
+    def _model(self) -> SemanticModel:
+        raw, source_map = TrackedLoader().load_string(
+            _COMPUTED_COLUMN_MODEL.format(extra_columns="")
+        )
+        model, result = ReferenceResolver().resolve(raw, source_map)
+        assert result.valid
+        return model
+
+    def test_within_group_missing_column(self) -> None:
+        model = self._model()
+        model.measures["Listagg"] = Measure(
+            name="Listagg",
+            aggregation=AggregationType.LISTAGG,
+            columns=[DataColumnRef(view="Sales", column="Zip")],
+            within_group=WithinGroup(column=DataColumnRef(view="Sales")),
+        )
+        assert self._validate(model) == ["INCOMPLETE_COLUMN_REF"]
+
+    def test_within_group_missing_data_object(self) -> None:
+        model = self._model()
+        model.measures["Listagg"] = Measure(
+            name="Listagg",
+            aggregation=AggregationType.LISTAGG,
+            columns=[DataColumnRef(view="Sales", column="Zip")],
+            within_group=WithinGroup(column=DataColumnRef(column="Zip")),
+        )
+        assert self._validate(model) == ["INCOMPLETE_COLUMN_REF"]
+
+    def test_within_group_missing_both(self) -> None:
+        model = self._model()
+        model.measures["Listagg"] = Measure(
+            name="Listagg",
+            aggregation=AggregationType.LISTAGG,
+            columns=[DataColumnRef(view="Sales", column="Zip")],
+            within_group=WithinGroup(column=DataColumnRef()),
+        )
+        errors = SemanticValidator().validate(model)
+        assert [e.code for e in errors] == ["INCOMPLETE_COLUMN_REF"]
+        assert "dataObject and column" in errors[0].message
+
+    def test_measure_column_missing_column(self) -> None:
+        model = self._model()
+        model.measures["Broken"] = Measure(
+            name="Broken",
+            aggregation=AggregationType.SUM,
+            columns=[DataColumnRef(view="Sales")],
+        )
+        assert self._validate(model) == ["INCOMPLETE_COLUMN_REF"]
+
+    def test_dimension_missing_column(self) -> None:
+        model = self._model()
+        model.dimensions["Broken"] = Dimension(name="Broken", view="Sales")
+        assert self._validate(model) == ["INCOMPLETE_COLUMN_REF"]
+
+    def test_measure_filter_missing_data_object(self) -> None:
+        """The filter site keeps its own UNKNOWN_FILTER_* codes for refs that resolve."""
+        model = self._model()
+        model.measures["Filtered"] = Measure(
+            name="Filtered",
+            aggregation=AggregationType.SUM,
+            columns=[DataColumnRef(view="Sales", column="Amount")],
+            filters=[
+                MeasureFilter(
+                    column=DataColumnRef(column="Amount"),
+                    operator="equals",
+                    values=[FilterValue(data_type=DataType.INT, value_int=1)],
+                )
+            ],
+        )
+        assert self._validate(model) == ["INCOMPLETE_COLUMN_REF"]
+
+    def test_complete_refs_stay_valid(self) -> None:
+        """The guard must not fire on a fully specified reference."""
+        model = self._model()
+        model.measures["Fine"] = Measure(
+            name="Fine",
+            aggregation=AggregationType.SUM,
+            columns=[DataColumnRef(view="Sales", column="Amount")],
+        )
+        model.dimensions["Fine Dim"] = Dimension(name="Fine Dim", view="Sales", column="Amount")
+        assert self._validate(model) == []


### PR DESCRIPTION
Phase 1 of the TPC-DS compiler findings plan (finding 2). Validator work only, behind the existing OBML surface.

## What the finding actually was

The plan claimed measure `columns:` refs were unvalidated. That turned out to be wrong: `_check_measures_resolve` covers them, and `obsl validate` rejects them correctly. The original evidence came from calling `ReferenceResolver.resolve()` directly, which never runs `SemanticValidator`.

Probing every `DataColumnRef` and placeholder site instead surfaced three that genuinely do validate clean and then produce SQL naming columns the database does not have.

## The three gaps

| # | Site | Symptom | Now |
|---|---|---|---|
| 1 | `withinGroup.column` | Unchecked, compiles to `ORDER BY "Sales"."no_such_col"` inside the LISTAGG | `UNKNOWN_DATA_OBJECT` / `UNKNOWN_COLUMN` |
| 2 | Computed column `{name}` placeholder | Unresolved token survives as a **string literal**: `{amount} * {no_such_col}` emits `"Sales"."amount" * 'no_such_col'` | `UNKNOWN_COLUMN_IN_EXPRESSION` |
| 3 | Cyclic computed columns | `RecursionError` is swallowed by `_build_computed_column_expr`, which falls back to the column's own `code`. That is empty for a computed column, so the label is emitted as a physical column name | `CYCLIC_COMPUTED_COLUMN` |

`withinGroup` was the one `DataColumnRef` site on a measure with no coverage: `columns:` goes through `_check_measures_resolve` and filter columns through `_check_measure_filter_refs`. Grain dimensions, filter contexts, anchors, `via`, metric refs and measure-expression refs were all already checked.

## Implementation notes

- Cycle detection uses strongly connected components over a per-data-object dependency graph. Linear, and it reports each cycle once however many columns sit on it, rather than once per column. networkx was already imported in this module.
- Placeholder scanning strips single-quoted string literals and skips bare regex quantifiers, so `regexp_extract({Zip}, '[0-9]{5}')` is not mistaken for a reference to a column named `5`. This matters because computed-column expressions are explicitly dialect-leaky and may carry `regexp_*` calls.
- Only computed columns become graph nodes: a placeholder naming a physical column terminates the chain and cannot be part of a cycle.

## Docs correction

`docs/guide/model-format.md` claimed a computed column may not reference another computed column ("no recursive resolution today"). It has in fact resolved them recursively for some time, verified against codegen:

```
doubled: "{amount} * 2"
quad:    "{doubled} * 2"     ->  CAST(SUM("Sales"."amount" * 2 * 2) AS DECIMAL(18,2))
```

That is exactly why gap 3 needs a check. The stale line is corrected and the new rules documented.

## Scope

No OBML field is added, so no JSON schema, contract manifest, OSI converter or ontology propagation is required. Error codes are free-form `str` and are not centrally enumerated.

## Verification

- `uv run pytest`: 3058 passed, 539 skipped
- `ruff check`, `ruff format`, `mypy src/`: clean
- All six shipped example models still validate
- TPC-DS sweep unchanged on both engines: DuckDB 29/30, ClickHouse 27/30 (the non-matches are the pre-existing documented reference-variant artifacts)