### PR TITLE
feat(vendor-exec): run the commerce corpus live on Snowflake, BigQuery and Databricks

### DIFF
--- a/scripts/seed_cloud_vendor.py
+++ b/scripts/seed_cloud_vendor.py
@@ -1,0 +1,114 @@
+"""Load the commerce seed into a cloud warehouse.
+
+The vendor-execution suite seeds Postgres, MySQL and ClickHouse into a
+throwaway testcontainer on every run. The cloud warehouses have no container,
+and re-loading 26k rows over the network per session would dominate the suite,
+so their seed is applied once, out of band, by this script. The data is static,
+so "once" is the right cadence; the fixtures assert the schema is present and
+current rather than creating it.
+
+The SQL executed is exactly the generated dump under
+``tests/integration/drift/vendor_exec/seed_sql/<vendor>/``, which
+``_seed.py`` writes from ``examples/orionbelt_1_commerce.duckdb``. Regenerate
+those with::
+
+    uv run python tests/integration/drift/vendor_exec/_seed.py
+
+Usage::
+
+    uv run python scripts/seed_cloud_vendor.py snowflake
+    uv run python scripts/seed_cloud_vendor.py --check snowflake
+
+Credentials come from the environment (``.env`` is not read automatically -
+``set -a && source .env && set +a`` first). This drops and recreates the
+``orionbelt_1`` schema, so point it only at a database you own.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from collections.abc import Callable, Iterator
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SEED_SQL = REPO_ROOT / "tests" / "integration" / "drift" / "vendor_exec" / "seed_sql"
+SCHEMA = "orionbelt_1"
+EXPECTED_SALES_ROWS = 10000
+
+
+def statements(vendor: str) -> Iterator[tuple[str, str]]:
+    """Yield ``(filename, statement)`` for a vendor's seed dump, comments stripped."""
+    for name in ("01_schema.sql", "02_data.sql"):
+        path = SEED_SQL / vendor / name
+        if not path.exists():
+            raise SystemExit(f"No seed dump at {path}. Generate it with _seed.py first.")
+        for chunk in path.read_text(encoding="utf-8").split(";\n"):
+            body = "\n".join(
+                line for line in chunk.splitlines() if not line.strip().startswith("--")
+            ).strip()
+            if body:
+                yield name, body
+
+
+def _snowflake() -> tuple[Callable[[str], None], Callable[[str], list[tuple]], Callable[[], None]]:
+    import snowflake.connector
+
+    required = ("SNOWFLAKE_ACCOUNT", "SNOWFLAKE_USER", "SNOWFLAKE_PASSWORD", "SNOWFLAKE_DATABASE")
+    if missing := [n for n in required if not os.environ.get(n)]:
+        raise SystemExit(f"Missing environment: {', '.join(missing)}")
+    conn = snowflake.connector.connect(
+        account=os.environ["SNOWFLAKE_ACCOUNT"],
+        user=os.environ["SNOWFLAKE_USER"],
+        password=os.environ["SNOWFLAKE_PASSWORD"],
+        warehouse=os.environ.get("SNOWFLAKE_WAREHOUSE"),
+        database=os.environ["SNOWFLAKE_DATABASE"],
+    )
+    cur = conn.cursor()
+    return (lambda sql: cur.execute(sql), lambda sql: cur.execute(sql).fetchall(), conn.close)
+
+
+VENDORS: dict[str, Callable[[], tuple]] = {"snowflake": _snowflake}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("vendor", choices=sorted(VENDORS))
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Only report whether the schema is loaded and current; change nothing.",
+    )
+    args = parser.parse_args(argv)
+
+    execute, query, close = VENDORS[args.vendor]()
+    try:
+        if args.check:
+            try:
+                rows = query(f'SELECT COUNT(*) FROM "{SCHEMA}"."sales"')[0][0]
+            except Exception as exc:  # noqa: BLE001 — any failure means "not loaded"
+                print(f"{args.vendor}: schema '{SCHEMA}' not loaded ({exc})")
+                return 1
+            ok = rows == EXPECTED_SALES_ROWS
+            print(f"{args.vendor}: sales has {rows} rows, expected {EXPECTED_SALES_ROWS}")
+            return 0 if ok else 1
+
+        counts: dict[str, int] = {}
+        for name, statement in statements(args.vendor):
+            execute(statement)
+            counts[name] = counts.get(name, 0) + 1
+        for name, n in counts.items():
+            print(f"{args.vendor}: {name} -> {n} statements")
+        rows = query(f'SELECT COUNT(*) FROM "{SCHEMA}"."sales"')[0][0]
+        print(f"{args.vendor}: sales has {rows} rows")
+        if rows != EXPECTED_SALES_ROWS:
+            print(f"WARNING: expected {EXPECTED_SALES_ROWS}")
+            return 1
+        return 0
+    finally:
+        close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/seed_cloud_vendor.py
+++ b/scripts/seed_cloud_vendor.py
@@ -69,7 +69,59 @@ def _snowflake() -> tuple[Callable[[str], None], Callable[[str], list[tuple]], C
     return (lambda sql: cur.execute(sql), lambda sql: cur.execute(sql).fetchall(), conn.close)
 
 
-VENDORS: dict[str, Callable[[], tuple]] = {"snowflake": _snowflake}
+def _bigquery() -> tuple[Callable[[str], None], Callable[[str], list[tuple]], Callable[[], None]]:
+    from google.cloud import bigquery
+
+    project = os.environ.get("BIGQUERY_PROJECT")
+    if not project:
+        raise SystemExit("Missing environment: BIGQUERY_PROJECT")
+    client = bigquery.Client(project=project, location=os.environ.get("BIGQUERY_LOCATION"))
+
+    def execute(sql: str) -> None:
+        client.query(sql).result()
+
+    def query(sql: str) -> list[tuple]:
+        return [tuple(row.values()) for row in client.query(sql).result()]
+
+    return execute, query, client.close
+
+
+def _databricks() -> tuple[Callable[[str], None], Callable[[str], list[tuple]], Callable[[], None]]:
+    from databricks import sql as dbsql
+
+    required = ("DATABRICKS_SERVER_HOSTNAME", "DATABRICKS_HTTP_PATH")
+    if missing := [n for n in required if not os.environ.get(n)]:
+        raise SystemExit(f"Missing environment: {', '.join(missing)}")
+    token = os.environ.get("DATABRICKS_TOKEN") or os.environ.get("DATABRICKS_ACCESS_TOKEN")
+    if not token:
+        raise SystemExit("Missing environment: DATABRICKS_TOKEN")
+    conn = dbsql.connect(
+        server_hostname=os.environ["DATABRICKS_SERVER_HOSTNAME"],
+        http_path=os.environ["DATABRICKS_HTTP_PATH"],
+        access_token=token,
+        catalog=os.environ.get("DATABRICKS_CATALOG", "main"),
+    )
+    cur = conn.cursor()
+
+    def execute(sql: str) -> None:
+        cur.execute(sql)
+
+    def query(sql: str) -> list[tuple]:
+        cur.execute(sql)
+        return list(cur.fetchall())
+
+    return execute, query, conn.close
+
+
+VENDORS: dict[str, Callable[[], tuple]] = {
+    "bigquery": _bigquery,
+    "databricks": _databricks,
+    "snowflake": _snowflake,
+}
+
+# Identifier quoting per vendor, for the row-count probe. The seed dumps
+# themselves already carry the right quoting.
+_QUOTE = {"bigquery": "`", "databricks": "`", "snowflake": '"'}
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -83,10 +135,12 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     execute, query, close = VENDORS[args.vendor]()
+    q = _QUOTE[args.vendor]
+    sales = f"{q}{SCHEMA}{q}.{q}sales{q}"
     try:
         if args.check:
             try:
-                rows = query(f'SELECT COUNT(*) FROM "{SCHEMA}"."sales"')[0][0]
+                rows = query(f"SELECT COUNT(*) FROM {sales}")[0][0]
             except Exception as exc:  # noqa: BLE001 — any failure means "not loaded"
                 print(f"{args.vendor}: schema '{SCHEMA}' not loaded ({exc})")
                 return 1
@@ -100,7 +154,7 @@ def main(argv: list[str] | None = None) -> int:
             counts[name] = counts.get(name, 0) + 1
         for name, n in counts.items():
             print(f"{args.vendor}: {name} -> {n} statements")
-        rows = query(f'SELECT COUNT(*) FROM "{SCHEMA}"."sales"')[0][0]
+        rows = query(f"SELECT COUNT(*) FROM {sales}")[0][0]
         print(f"{args.vendor}: sales has {rows} rows")
         if rows != EXPECTED_SALES_ROWS:
             print(f"WARNING: expected {EXPECTED_SALES_ROWS}")

--- a/src/orionbelt/api/routers/oneshot.py
+++ b/src/orionbelt/api/routers/oneshot.py
@@ -55,7 +55,11 @@ from orionbelt.cache.ttl import NoCacheReason, TtlResult
 from orionbelt.compiler.fanout import FanoutError
 from orionbelt.compiler.resolution import ResolutionError
 from orionbelt.compiler.validator import format_sql
-from orionbelt.dialect.base import UnsupportedAggregationError, UnsupportedGroupingError
+from orionbelt.dialect.base import (
+    AmbiguousTableReferenceError,
+    UnsupportedAggregationError,
+    UnsupportedGroupingError,
+)
 from orionbelt.dialect.registry import UnsupportedDialectError
 from orionbelt.service.db_executor import (
     ExecutionError,
@@ -200,6 +204,11 @@ def _compile(
     except UnsupportedGroupingError as exc:
         return OneshotBatchQueryError(
             code="UNSUPPORTED_GROUPING",
+            message=str(exc),
+        )
+    except AmbiguousTableReferenceError as exc:
+        return OneshotBatchQueryError(
+            code="AMBIGUOUS_TABLE_REFERENCE",
             message=str(exc),
         )
     return compile_result, dialect

--- a/src/orionbelt/api/routers/shortcuts.py
+++ b/src/orionbelt/api/routers/shortcuts.py
@@ -57,7 +57,11 @@ from orionbelt.api.warnings_adapter import error_info_to_detail, semantic_error_
 from orionbelt.compiler.fanout import FanoutError
 from orionbelt.compiler.resolution import ResolutionError
 from orionbelt.compiler.validator import format_sql
-from orionbelt.dialect.base import UnsupportedAggregationError, UnsupportedGroupingError
+from orionbelt.dialect.base import (
+    AmbiguousTableReferenceError,
+    UnsupportedAggregationError,
+    UnsupportedGroupingError,
+)
 from orionbelt.dialect.registry import UnsupportedDialectError
 from orionbelt.models.query import QueryObject
 from orionbelt.models.semantic import SemanticModel
@@ -484,6 +488,16 @@ async def shortcut_compile_query(
                 "grouping": exc.grouping,
             },
         ) from None
+    except AmbiguousTableReferenceError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "error": "Ambiguous table reference",
+                "message": str(exc),
+                "dialect": exc.dialect,
+                "database": exc.database,
+            },
+        ) from None
 
     explain_resp = None
     if result.explain:
@@ -637,6 +651,16 @@ async def shortcut_execute_query(
                 "message": str(exc),
                 "dialect": exc.dialect,
                 "grouping": exc.grouping,
+            },
+        ) from None
+    except AmbiguousTableReferenceError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "error": "Ambiguous table reference",
+                "message": str(exc),
+                "dialect": exc.dialect,
+                "database": exc.database,
             },
         ) from None
 

--- a/src/orionbelt/api/services/query_compilation.py
+++ b/src/orionbelt/api/services/query_compilation.py
@@ -22,7 +22,11 @@ from orionbelt.compiler.fanout import FanoutError
 from orionbelt.compiler.resolution import ResolutionError
 from orionbelt.compiler.sql_translator import SQLTranslationError
 from orionbelt.compiler.validator import format_sql
-from orionbelt.dialect.base import UnsupportedAggregationError, UnsupportedGroupingError
+from orionbelt.dialect.base import (
+    AmbiguousTableReferenceError,
+    UnsupportedAggregationError,
+    UnsupportedGroupingError,
+)
 from orionbelt.dialect.registry import UnsupportedDialectError
 from orionbelt.service.model_store import ModelStore
 
@@ -121,6 +125,16 @@ def compile_query_or_raise(*, store: ModelStore, model_id: str, query: Any, dial
                 "message": str(exc),
                 "dialect": exc.dialect,
                 "grouping": exc.grouping,
+            },
+        ) from None
+    except AmbiguousTableReferenceError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "error": "Ambiguous table reference",
+                "message": str(exc),
+                "dialect": exc.dialect,
+                "database": exc.database,
             },
         ) from None
 
@@ -226,6 +240,19 @@ def compile_query_for_plan(
                     severity="error",
                     message=str(exc),
                     context={"dialect": exc.dialect, "grouping": exc.grouping},
+                )
+            ],
+            would_compile=False,
+        )
+    except AmbiguousTableReferenceError as exc:
+        return None, QueryPlanResponse(
+            status="error",
+            warnings=[
+                StructuredWarning(
+                    code="AMBIGUOUS_TABLE_REFERENCE",
+                    severity="error",
+                    message=str(exc),
+                    context={"dialect": exc.dialect, "database": exc.database},
                 )
             ],
             would_compile=False,

--- a/src/orionbelt/cli/_local.py
+++ b/src/orionbelt/cli/_local.py
@@ -16,7 +16,11 @@ from orionbelt.compiler.fanout import FanoutError
 from orionbelt.compiler.pipeline import CompilationResult
 from orionbelt.compiler.resolution import ResolutionError
 from orionbelt.compiler.validator import format_sql
-from orionbelt.dialect.base import UnsupportedAggregationError, UnsupportedGroupingError
+from orionbelt.dialect.base import (
+    AmbiguousTableReferenceError,
+    UnsupportedAggregationError,
+    UnsupportedGroupingError,
+)
 from orionbelt.dialect.registry import DialectRegistry, UnsupportedDialectError
 from orionbelt.models.query import QueryObject
 from orionbelt.models.semantic import SemanticModel
@@ -71,7 +75,11 @@ def _compile(
         raise CliError(f"Query resolution failed: {details}") from None
     except FanoutError as exc:
         raise CliError(f"Query fanout detected: {exc.message}") from None
-    except (UnsupportedAggregationError, UnsupportedGroupingError) as exc:
+    except (
+        AmbiguousTableReferenceError,
+        UnsupportedAggregationError,
+        UnsupportedGroupingError,
+    ) as exc:
         raise CliError(str(exc)) from None
 
 

--- a/src/orionbelt/dialect/base.py
+++ b/src/orionbelt/dialect/base.py
@@ -169,12 +169,16 @@ class Dialect(ABC):
         Default: three-part ``database.schema.code`` (Snowflake/Databricks/Dremio).
         Postgres and ClickHouse override to two-part naming.
         All components are quoted to prevent SQL injection.
+
+        An omitted component is dropped rather than emitted as an empty
+        identifier. ``database`` is optional in OBML, and quoting it anyway
+        produced ``""."schema"."table"``, which Snowflake rejects with
+        ``Database '""' does not exist``. Leaving it out lets the reference
+        resolve against the connection's current database, which is how a
+        single model serves several deployments of the same schema.
         """
-        return (
-            f"{self.quote_identifier(database)}"
-            f".{self.quote_identifier(schema)}"
-            f".{self.quote_identifier(code)}"
-        )
+        parts = [database, schema, code]
+        return ".".join(self.quote_identifier(p) for p in parts if p)
 
     @property
     @abstractmethod

--- a/src/orionbelt/dialect/base.py
+++ b/src/orionbelt/dialect/base.py
@@ -80,6 +80,32 @@ class UnsupportedGroupingError(Exception):
         super().__init__(f"Dialect '{dialect}' does not support GROUP BY {grouping.upper()}")
 
 
+class AmbiguousTableReferenceError(Exception):
+    """Raised when a table reference cannot be qualified unambiguously.
+
+    On a three-part dialect a data object with a ``database`` but no ``schema``
+    has no correct rendering. Emitting two parts would be read as
+    ``schema.table`` (Snowflake, Databricks) or ``dataset.table`` (BigQuery),
+    silently pointing at a different namespace than the model names; emitting
+    three with an empty middle is not valid syntax. Only Snowflake offers
+    ``db..table`` for "the default schema", and that is not portable.
+
+    A domain error rather than a bare ``ValueError`` so routers surface a 422,
+    matching every other unsupported-model case, instead of a 500.
+    """
+
+    def __init__(self, dialect: str, database: str, code: str) -> None:
+        self.dialect = dialect
+        self.database = database
+        self.code = code
+        super().__init__(
+            f"Data object '{code}' sets database '{database}' but no schema, which "
+            f"dialect '{dialect}' cannot qualify: a two-part name would be read as "
+            f"schema.table, not database.table. Set 'schema' on the data object, or "
+            f"drop 'database' and let the connection's current database apply."
+        )
+
+
 @dataclass
 class DialectCapabilities:
     """Flags indicating what SQL features a dialect supports."""
@@ -177,6 +203,8 @@ class Dialect(ABC):
         resolve against the connection's current database, which is how a
         single model serves several deployments of the same schema.
         """
+        if database and not schema:
+            raise AmbiguousTableReferenceError(self.name, database, code)
         parts = [database, schema, code]
         return ".".join(self.quote_identifier(p) for p in parts if p)
 

--- a/src/orionbelt/dialect/bigquery.py
+++ b/src/orionbelt/dialect/bigquery.py
@@ -3,7 +3,11 @@
 from __future__ import annotations
 
 from orionbelt.ast.nodes import Cast, Expr, FunctionCall, Literal, OrderByItem, RawSQL
-from orionbelt.dialect.base import Dialect, DialectCapabilities
+from orionbelt.dialect.base import (
+    AmbiguousTableReferenceError,
+    Dialect,
+    DialectCapabilities,
+)
 from orionbelt.dialect.registry import DialectRegistry
 from orionbelt.models.semantic import TimeGrain
 from orionbelt.models.types import DecimalType, OBMLType
@@ -90,7 +94,11 @@ class BigQueryDialect(Dialect):
 
         An omitted project is dropped rather than backquoted empty, so
         ``dataset.table`` resolves against the connection's default project.
+        A project *with* no dataset is refused: ``project.table`` is read as
+        ``dataset.table``, which would silently query a different namespace.
         """
+        if database and not schema:
+            raise AmbiguousTableReferenceError(self.name, database, code)
         parts = [database, schema, code]
         return ".".join(self.quote_identifier(p) for p in parts if p)
 

--- a/src/orionbelt/dialect/bigquery.py
+++ b/src/orionbelt/dialect/bigquery.py
@@ -86,12 +86,13 @@ class BigQueryDialect(Dialect):
         return f"`{escaped}`"
 
     def format_table_ref(self, database: str, schema: str, code: str) -> str:
-        """BigQuery: three-part ``project.dataset.table``."""
-        return (
-            f"{self.quote_identifier(database)}"
-            f".{self.quote_identifier(schema)}"
-            f".{self.quote_identifier(code)}"
-        )
+        """BigQuery: three-part ``project.dataset.table``.
+
+        An omitted project is dropped rather than backquoted empty, so
+        ``dataset.table`` resolves against the connection's default project.
+        """
+        parts = [database, schema, code]
+        return ".".join(self.quote_identifier(p) for p in parts if p)
 
     def render_time_grain(self, column: Expr, grain: TimeGrain) -> Expr:
         # BigQuery DATE_TRUNC takes a date-part *keyword* (MONTH, ISOWEEK), not a

--- a/src/orionbelt/dialect/clickhouse.py
+++ b/src/orionbelt/dialect/clickhouse.py
@@ -58,7 +58,15 @@ class ClickHouseDialect(Dialect):
     }
 
     def format_table_ref(self, database: str, schema: str, code: str) -> str:
-        """ClickHouse: two-part ``schema.code`` (OBML schema maps to CH database)."""
+        """ClickHouse: two-part ``schema.code`` (OBML schema maps to CH database).
+
+        An omitted schema collapses to the bare table rather than an empty
+        quoted component, so the reference resolves against the connection's
+        search path. ``database`` is not part of the name on this dialect, so
+        setting it without a schema is not ambiguous here.
+        """
+        if not schema:
+            return self.quote_identifier(code)
         return f"{self.quote_identifier(schema)}.{self.quote_identifier(code)}"
 
     @property

--- a/src/orionbelt/dialect/dremio.py
+++ b/src/orionbelt/dialect/dremio.py
@@ -36,6 +36,13 @@ class DremioDialect(Dialect):
         path (user encodes the complete Dremio path in the OBML ``code`` field).
         Otherwise falls back to the standard 3-part format.
         All components are quoted to prevent SQL injection.
+
+        Unlike the other three-part dialects this does *not* refuse a
+        ``database`` with no ``schema``: a Dremio path has no fixed arity, so
+        ``"PROD"."sales"`` is a well-formed two-level path naming exactly what
+        the model named. Elsewhere the same pair would silently be read as
+        ``schema.table`` - see
+        :class:`~orionbelt.dialect.base.AmbiguousTableReferenceError`.
         """
         parts = [self.quote_identifier(p) for p in (database, schema) if p]
         if parts:

--- a/src/orionbelt/dialect/duckdb.py
+++ b/src/orionbelt/dialect/duckdb.py
@@ -31,7 +31,15 @@ class DuckDBDialect(Dialect):
         )
 
     def format_table_ref(self, database: str, schema: str, code: str) -> str:
-        """DuckDB: two-part ``schema.code`` (skip database for local mode)."""
+        """DuckDB: two-part ``schema.code`` (skip database for local mode).
+
+        An omitted schema collapses to the bare table rather than an empty
+        quoted component, so the reference resolves against the connection's
+        search path. ``database`` is not part of the name on this dialect, so
+        setting it without a schema is not ambiguous here.
+        """
+        if not schema:
+            return self.quote_identifier(code)
         return f"{self.quote_identifier(schema)}.{self.quote_identifier(code)}"
 
     def quote_identifier(self, name: str) -> str:

--- a/src/orionbelt/dialect/mysql.py
+++ b/src/orionbelt/dialect/mysql.py
@@ -153,7 +153,15 @@ class MySQLDialect(Dialect):
         )
 
     def format_table_ref(self, database: str, schema: str, code: str) -> str:
-        """MySQL: two-part ``schema.code`` (schema == database in MySQL terminology)."""
+        """MySQL: two-part ``schema.code`` (schema == database in MySQL terminology).
+
+        An omitted schema collapses to the bare table rather than an empty
+        quoted component, so the reference resolves against the connection's
+        search path. ``database`` is not part of the name on this dialect, so
+        setting it without a schema is not ambiguous here.
+        """
+        if not schema:
+            return self.quote_identifier(code)
         return f"{self.quote_identifier(schema)}.{self.quote_identifier(code)}"
 
     def quote_identifier(self, name: str) -> str:

--- a/src/orionbelt/dialect/postgres.py
+++ b/src/orionbelt/dialect/postgres.py
@@ -34,7 +34,15 @@ class PostgresDialect(Dialect):
         return self._OBML_SIMPLE_TYPE_MAP.get(obml_type.name, obml_type.name.upper())
 
     def format_table_ref(self, database: str, schema: str, code: str) -> str:
-        """PostgreSQL: two-part ``schema.code`` (skip database)."""
+        """PostgreSQL: two-part ``schema.code`` (skip database).
+
+        An omitted schema collapses to the bare table rather than an empty
+        quoted component, so the reference resolves against the connection's
+        search path. ``database`` is not part of the name on this dialect, so
+        setting it without a schema is not ambiguous here.
+        """
+        if not schema:
+            return self.quote_identifier(code)
         return f"{self.quote_identifier(schema)}.{self.quote_identifier(code)}"
 
     @property

--- a/src/orionbelt/pgwire/router.py
+++ b/src/orionbelt/pgwire/router.py
@@ -35,7 +35,11 @@ from orionbelt.api.query_cache import (
 from orionbelt.compiler.fanout import FanoutError
 from orionbelt.compiler.resolution import ResolutionError
 from orionbelt.compiler.sql_translator import SQLTranslationError, translate_sql_to_query
-from orionbelt.dialect.base import UnsupportedAggregationError, UnsupportedGroupingError
+from orionbelt.dialect.base import (
+    AmbiguousTableReferenceError,
+    UnsupportedAggregationError,
+    UnsupportedGroupingError,
+)
 from orionbelt.dialect.registry import UnsupportedDialectError
 from orionbelt.models.semantic import SemanticModel
 from orionbelt.pgwire import protocol
@@ -257,7 +261,11 @@ class SemanticRouter:
                 code=SQLSTATE_FEATURE_NOT_SUPPORTED,
                 message=exc.message,
             )
-        except (UnsupportedAggregationError, UnsupportedGroupingError) as exc:
+        except (
+            AmbiguousTableReferenceError,
+            UnsupportedAggregationError,
+            UnsupportedGroupingError,
+        ) as exc:
             return protocol.build_error_response(
                 severity="ERROR",
                 code=SQLSTATE_FEATURE_NOT_SUPPORTED,

--- a/tests/integration/drift/compile_only/bigquery/01_total_sales.sql
+++ b/tests/integration/drift/compile_only/bigquery/01_total_sales.sql
@@ -1,2 +1,2 @@
 SELECT ROUND(CAST(SUM(`Sales`.`salesamount`) AS NUMERIC), 2) AS `Total Sales`
-FROM ``.`orionbelt_1`.`sales` AS `Sales`
+FROM `orionbelt_1`.`sales` AS `Sales`

--- a/tests/integration/drift/compile_only/bigquery/02_total_sales_by_country.sql
+++ b/tests/integration/drift/compile_only/bigquery/02_total_sales_by_country.sql
@@ -1,5 +1,5 @@
 SELECT `Countries`.`countryname` AS `Sales Country Name`, ROUND(CAST(SUM(`Sales`.`salesamount`) AS NUMERIC), 2) AS `Total Sales`
-FROM ``.`orionbelt_1`.`sales` AS `Sales`
-LEFT JOIN ``.`orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`
-LEFT JOIN ``.`orionbelt_1`.`countries` AS `Countries` ON `Clients`.`clientcountryid` = `Countries`.`countryid`
+FROM `orionbelt_1`.`sales` AS `Sales`
+LEFT JOIN `orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`
+LEFT JOIN `orionbelt_1`.`countries` AS `Countries` ON `Clients`.`clientcountryid` = `Countries`.`countryid`
 GROUP BY ALL

--- a/tests/integration/drift/compile_only/bigquery/03_total_sales_by_year_month.sql
+++ b/tests/integration/drift/compile_only/bigquery/03_total_sales_by_year_month.sql
@@ -1,3 +1,3 @@
 SELECT DATE_TRUNC(`Sales`.`salesdate`, YEAR) AS `Sales Year`, DATE_TRUNC(`Sales`.`salesdate`, MONTH) AS `Sales Month`, ROUND(CAST(SUM(`Sales`.`salesamount`) AS NUMERIC), 2) AS `Total Sales`
-FROM ``.`orionbelt_1`.`sales` AS `Sales`
+FROM `orionbelt_1`.`sales` AS `Sales`
 GROUP BY ALL

--- a/tests/integration/drift/compile_only/bigquery/04_sales_returns_cfl_by_country.sql
+++ b/tests/integration/drift/compile_only/bigquery/04_sales_returns_cfl_by_country.sql
@@ -1,14 +1,14 @@
 WITH `composite_01` AS (
 SELECT `Countries`.`countryname` AS `Sales Country Name`, CAST(`Sales`.`salesamount` AS NUMERIC) AS `Total Sales`, CAST(NULL AS NUMERIC) AS `Total Returns`
-FROM ``.`orionbelt_1`.`sales` AS `Sales`
-LEFT JOIN ``.`orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`
-LEFT JOIN ``.`orionbelt_1`.`countries` AS `Countries` ON `Clients`.`clientcountryid` = `Countries`.`countryid`
+FROM `orionbelt_1`.`sales` AS `Sales`
+LEFT JOIN `orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`
+LEFT JOIN `orionbelt_1`.`countries` AS `Countries` ON `Clients`.`clientcountryid` = `Countries`.`countryid`
 UNION ALL
 SELECT `Countries`.`countryname` AS `Sales Country Name`, CAST(NULL AS NUMERIC) AS `Total Sales`, CAST(`Returns`.`returnamount` AS NUMERIC) AS `Total Returns`
-FROM ``.`orionbelt_1`.`returns` AS `Returns`
-LEFT JOIN ``.`orionbelt_1`.`sales` AS `Sales` ON `Returns`.`returnsalesid` = `Sales`.`salesid`
-LEFT JOIN ``.`orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`
-LEFT JOIN ``.`orionbelt_1`.`countries` AS `Countries` ON `Clients`.`clientcountryid` = `Countries`.`countryid`
+FROM `orionbelt_1`.`returns` AS `Returns`
+LEFT JOIN `orionbelt_1`.`sales` AS `Sales` ON `Returns`.`returnsalesid` = `Sales`.`salesid`
+LEFT JOIN `orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`
+LEFT JOIN `orionbelt_1`.`countries` AS `Countries` ON `Clients`.`clientcountryid` = `Countries`.`countryid`
 )
 SELECT `Sales Country Name` AS `Sales Country Name`, ROUND(CAST(SUM(`composite_01`.`Total Sales`) AS NUMERIC), 2) AS `Total Sales`, ROUND(CAST(SUM(`composite_01`.`Total Returns`) AS NUMERIC), 2) AS `Total Returns`
 FROM `composite_01` AS `composite_01`

--- a/tests/integration/drift/compile_only/bigquery/05_sales_purchases_cfl_ungrouped.sql
+++ b/tests/integration/drift/compile_only/bigquery/05_sales_purchases_cfl_ungrouped.sql
@@ -1,9 +1,9 @@
 WITH `composite_01` AS (
 SELECT CAST(`Sales`.`salesamount` AS NUMERIC) AS `Total Sales`, CAST(NULL AS NUMERIC) AS `Total Purchases`
-FROM ``.`orionbelt_1`.`sales` AS `Sales`
+FROM `orionbelt_1`.`sales` AS `Sales`
 UNION ALL
 SELECT CAST(NULL AS NUMERIC) AS `Total Sales`, CAST(`Purchases`.`purchaseamount` AS NUMERIC) AS `Total Purchases`
-FROM ``.`orionbelt_1`.`purchases` AS `Purchases`
+FROM `orionbelt_1`.`purchases` AS `Purchases`
 )
 SELECT ROUND(CAST(SUM(`composite_01`.`Total Sales`) AS NUMERIC), 2) AS `Total Sales`, ROUND(CAST(SUM(`composite_01`.`Total Purchases`) AS NUMERIC), 2) AS `Total Purchases`
 FROM `composite_01` AS `composite_01`

--- a/tests/integration/drift/compile_only/bigquery/06_total_sales_by_sales_client.sql
+++ b/tests/integration/drift/compile_only/bigquery/06_total_sales_by_sales_client.sql
@@ -1,4 +1,4 @@
 SELECT `Clients`.`clientname` AS `Sales Client Name`, ROUND(CAST(SUM(`Sales`.`salesamount`) AS NUMERIC), 2) AS `Total Sales`
-FROM ``.`orionbelt_1`.`sales` AS `Sales`
-LEFT JOIN ``.`orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`
+FROM `orionbelt_1`.`sales` AS `Sales`
+LEFT JOIN `orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`
 GROUP BY ALL

--- a/tests/integration/drift/compile_only/bigquery/07_total_sales_by_client_with_complaints.sql
+++ b/tests/integration/drift/compile_only/bigquery/07_total_sales_by_client_with_complaints.sql
@@ -1,11 +1,11 @@
 WITH `composite_01` AS (
 SELECT `Clients`.`clientname` AS `Sales Client Name`, CAST(NULL AS STRING) AS `Complaint Client Name`, CAST(`Sales`.`salesamount` AS NUMERIC) AS `Total Sales`, CAST(NULL AS INT64) AS `Client Complaints Count`
-FROM ``.`orionbelt_1`.`sales` AS `Sales`
-LEFT JOIN ``.`orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`
+FROM `orionbelt_1`.`sales` AS `Sales`
+LEFT JOIN `orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`
 UNION ALL
 SELECT CAST(NULL AS STRING) AS `Sales Client Name`, `Clients`.`clientname` AS `Complaint Client Name`, CAST(NULL AS NUMERIC) AS `Total Sales`, CAST(1 AS INT64) AS `Client Complaints Count`
-FROM ``.`orionbelt_1`.`clientcomplaints` AS `Client Complaints`
-LEFT JOIN ``.`orionbelt_1`.`clients` AS `Clients` ON `Client Complaints`.`complclientid` = `Clients`.`clientid`
+FROM `orionbelt_1`.`clientcomplaints` AS `Client Complaints`
+LEFT JOIN `orionbelt_1`.`clients` AS `Clients` ON `Client Complaints`.`complclientid` = `Clients`.`clientid`
 )
 SELECT COALESCE(`Sales Client Name`, `Complaint Client Name`) AS `Client`, ROUND(CAST(SUM(`composite_01`.`Total Sales`) AS NUMERIC), 2) AS `Total Sales`, CAST(COUNT(`composite_01`.`Client Complaints Count`) AS INT64) AS `Client Complaints Count`
 FROM `composite_01` AS `composite_01`

--- a/tests/integration/drift/compile_only/bigquery/08_average_sale.sql
+++ b/tests/integration/drift/compile_only/bigquery/08_average_sale.sql
@@ -1,2 +1,2 @@
 SELECT ROUND(CAST(SUM(`Sales`.`salesamount`) / NULLIF(COUNT(1), 0) AS NUMERIC), 2) AS `Average Sale`
-FROM ``.`orionbelt_1`.`sales` AS `Sales`
+FROM `orionbelt_1`.`sales` AS `Sales`

--- a/tests/integration/drift/compile_only/bigquery/09_return_rate.sql
+++ b/tests/integration/drift/compile_only/bigquery/09_return_rate.sql
@@ -1,9 +1,9 @@
 WITH `composite_01` AS (
 SELECT CAST(`Returns`.`returnamount` AS NUMERIC) AS `Total Returns`, CAST(NULL AS NUMERIC) AS `Total Sales`
-FROM ``.`orionbelt_1`.`returns` AS `Returns`
+FROM `orionbelt_1`.`returns` AS `Returns`
 UNION ALL
 SELECT CAST(NULL AS NUMERIC) AS `Total Returns`, CAST(`Sales`.`salesamount` AS NUMERIC) AS `Total Sales`
-FROM ``.`orionbelt_1`.`sales` AS `Sales`
+FROM `orionbelt_1`.`sales` AS `Sales`
 )
 SELECT ROUND(CAST(SUM(`composite_01`.`Total Returns`) / NULLIF(SUM(`composite_01`.`Total Sales`), 0) AS NUMERIC), 4) AS `Return Rate`
 FROM `composite_01` AS `composite_01`

--- a/tests/integration/drift/compile_only/bigquery/10_cumulative_sales_by_month.sql
+++ b/tests/integration/drift/compile_only/bigquery/10_cumulative_sales_by_month.sql
@@ -1,6 +1,6 @@
 WITH `cumulative_base` AS (
 SELECT DATE_TRUNC(`Sales`.`salesdate`, MONTH) AS `Sales Month`, ROUND(CAST(SUM(`Sales`.`salesamount`) AS NUMERIC), 2) AS `Total Sales`
-FROM ``.`orionbelt_1`.`sales` AS `Sales`
+FROM `orionbelt_1`.`sales` AS `Sales`
 GROUP BY ALL
 )
 SELECT `Sales Month` AS `Sales Month`, ROUND(CAST(SUM(`Total Sales`) OVER (ORDER BY `Sales Month` ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS NUMERIC), 2) AS `Cumulative Sales`

--- a/tests/integration/drift/compile_only/bigquery/11_rolling_30_day_sales.sql
+++ b/tests/integration/drift/compile_only/bigquery/11_rolling_30_day_sales.sql
@@ -1,6 +1,6 @@
 WITH `cumulative_base` AS (
 SELECT DATE_TRUNC(`Sales`.`salesdate`, DAY) AS `Sales Date`, ROUND(CAST(SUM(`Sales`.`salesamount`) AS NUMERIC), 2) AS `Total Sales`
-FROM ``.`orionbelt_1`.`sales` AS `Sales`
+FROM `orionbelt_1`.`sales` AS `Sales`
 GROUP BY ALL
 )
 SELECT `Sales Date` AS `Sales Date`, ROUND(CAST(AVG(`Total Sales`) OVER (ORDER BY `Sales Date` ASC ROWS BETWEEN 29 PRECEDING AND CURRENT ROW) AS NUMERIC), 0) AS `Rolling 30 Day Sales`

--- a/tests/integration/drift/compile_only/bigquery/12_total_sales_country_in_filter.sql
+++ b/tests/integration/drift/compile_only/bigquery/12_total_sales_country_in_filter.sql
@@ -1,5 +1,5 @@
 SELECT ROUND(CAST(SUM(`Sales`.`salesamount`) AS NUMERIC), 2) AS `Total Sales`
-FROM ``.`orionbelt_1`.`sales` AS `Sales`
-LEFT JOIN ``.`orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`
-LEFT JOIN ``.`orionbelt_1`.`countries` AS `Countries` ON `Clients`.`clientcountryid` = `Countries`.`countryid`
+FROM `orionbelt_1`.`sales` AS `Sales`
+LEFT JOIN `orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`
+LEFT JOIN `orionbelt_1`.`countries` AS `Countries` ON `Clients`.`clientcountryid` = `Countries`.`countryid`
 WHERE `Countries`.`countryname` IN ('Croatia', 'Austria')

--- a/tests/integration/drift/compile_only/bigquery/13_sales_yoy_growth.sql
+++ b/tests/integration/drift/compile_only/bigquery/13_sales_yoy_growth.sql
@@ -1,7 +1,7 @@
 WITH `date_range` AS (
 SELECT DATE_TRUNC(MIN(`Sales`.`salesdate`), MONTH) AS min_date,
        DATE_TRUNC(MAX(`Sales`.`salesdate`), MONTH) AS max_date
-  FROM ``.`orionbelt_1`.`sales` AS `Sales`
+  FROM `orionbelt_1`.`sales` AS `Sales`
 ),
 `date_spine` AS (
 SELECT d AS spine_date,
@@ -13,7 +13,7 @@ FROM UNNEST(GENERATE_DATE_ARRAY((SELECT min_date FROM `date_range`), (SELECT max
 SELECT `date_spine`.spine_date AS `Sales Month`,
        SUM(`Sales`.`salesamount`) AS `Total Sales`
   FROM `date_spine`
-  LEFT JOIN ``.`orionbelt_1`.`sales` AS `Sales`
+  LEFT JOIN `orionbelt_1`.`sales` AS `Sales`
     ON DATE_TRUNC(`Sales`.`salesdate`, MONTH) = `date_spine`.spine_date
   GROUP BY 1
 ),

--- a/tests/integration/drift/compile_only/bigquery/14_total_sales_year_filter.sql
+++ b/tests/integration/drift/compile_only/bigquery/14_total_sales_year_filter.sql
@@ -1,3 +1,3 @@
 SELECT ROUND(CAST(SUM(`Sales`.`salesamount`) AS NUMERIC), 2) AS `Total Sales`
-FROM ``.`orionbelt_1`.`sales` AS `Sales`
+FROM `orionbelt_1`.`sales` AS `Sales`
 WHERE `Sales`.`salesdate` = '2025-01-01'

--- a/tests/integration/drift/compile_only/bigquery/15_total_account_balance.sql
+++ b/tests/integration/drift/compile_only/bigquery/15_total_account_balance.sql
@@ -1,2 +1,2 @@
 SELECT ROUND(CAST(SUM(`Account Balances`.`balanceamt`) AS NUMERIC), 2) AS `Total Account Balance`
-FROM ``.`orionbelt_1`.`acctbal` AS `Account Balances`
+FROM `orionbelt_1`.`acctbal` AS `Account Balances`

--- a/tests/integration/drift/compile_only/databricks/01_total_sales.sql
+++ b/tests/integration/drift/compile_only/databricks/01_total_sales.sql
@@ -1,2 +1,2 @@
 SELECT CAST(SUM(`Sales`.`salesamount`) AS DECIMAL(18, 2)) AS `Total Sales`
-FROM ``.`orionbelt_1`.`sales` AS `Sales`
+FROM `orionbelt_1`.`sales` AS `Sales`

--- a/tests/integration/drift/compile_only/databricks/02_total_sales_by_country.sql
+++ b/tests/integration/drift/compile_only/databricks/02_total_sales_by_country.sql
@@ -1,5 +1,5 @@
 SELECT `Countries`.`countryname` AS `Sales Country Name`, CAST(SUM(`Sales`.`salesamount`) AS DECIMAL(18, 2)) AS `Total Sales`
-FROM ``.`orionbelt_1`.`sales` AS `Sales`
-LEFT JOIN ``.`orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`
-LEFT JOIN ``.`orionbelt_1`.`countries` AS `Countries` ON `Clients`.`clientcountryid` = `Countries`.`countryid`
+FROM `orionbelt_1`.`sales` AS `Sales`
+LEFT JOIN `orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`
+LEFT JOIN `orionbelt_1`.`countries` AS `Countries` ON `Clients`.`clientcountryid` = `Countries`.`countryid`
 GROUP BY ALL

--- a/tests/integration/drift/compile_only/databricks/03_total_sales_by_year_month.sql
+++ b/tests/integration/drift/compile_only/databricks/03_total_sales_by_year_month.sql
@@ -1,3 +1,3 @@
 SELECT date_trunc('year', `Sales`.`salesdate`) AS `Sales Year`, date_trunc('month', `Sales`.`salesdate`) AS `Sales Month`, CAST(SUM(`Sales`.`salesamount`) AS DECIMAL(18, 2)) AS `Total Sales`
-FROM ``.`orionbelt_1`.`sales` AS `Sales`
+FROM `orionbelt_1`.`sales` AS `Sales`
 GROUP BY ALL

--- a/tests/integration/drift/compile_only/databricks/04_sales_returns_cfl_by_country.sql
+++ b/tests/integration/drift/compile_only/databricks/04_sales_returns_cfl_by_country.sql
@@ -1,14 +1,14 @@
 WITH `composite_01` AS (
 SELECT `Countries`.`countryname` AS `Sales Country Name`, CAST(`Sales`.`salesamount` AS DECIMAL(18, 2)) AS `Total Sales`, CAST(NULL AS DECIMAL(18, 2)) AS `Total Returns`
-FROM ``.`orionbelt_1`.`sales` AS `Sales`
-LEFT JOIN ``.`orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`
-LEFT JOIN ``.`orionbelt_1`.`countries` AS `Countries` ON `Clients`.`clientcountryid` = `Countries`.`countryid`
+FROM `orionbelt_1`.`sales` AS `Sales`
+LEFT JOIN `orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`
+LEFT JOIN `orionbelt_1`.`countries` AS `Countries` ON `Clients`.`clientcountryid` = `Countries`.`countryid`
 UNION ALL
 SELECT `Countries`.`countryname` AS `Sales Country Name`, CAST(NULL AS DECIMAL(18, 2)) AS `Total Sales`, CAST(`Returns`.`returnamount` AS DECIMAL(18, 2)) AS `Total Returns`
-FROM ``.`orionbelt_1`.`returns` AS `Returns`
-LEFT JOIN ``.`orionbelt_1`.`sales` AS `Sales` ON `Returns`.`returnsalesid` = `Sales`.`salesid`
-LEFT JOIN ``.`orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`
-LEFT JOIN ``.`orionbelt_1`.`countries` AS `Countries` ON `Clients`.`clientcountryid` = `Countries`.`countryid`
+FROM `orionbelt_1`.`returns` AS `Returns`
+LEFT JOIN `orionbelt_1`.`sales` AS `Sales` ON `Returns`.`returnsalesid` = `Sales`.`salesid`
+LEFT JOIN `orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`
+LEFT JOIN `orionbelt_1`.`countries` AS `Countries` ON `Clients`.`clientcountryid` = `Countries`.`countryid`
 )
 SELECT `Sales Country Name` AS `Sales Country Name`, CAST(SUM(`composite_01`.`Total Sales`) AS DECIMAL(18, 2)) AS `Total Sales`, CAST(SUM(`composite_01`.`Total Returns`) AS DECIMAL(18, 2)) AS `Total Returns`
 FROM `composite_01` AS `composite_01`

--- a/tests/integration/drift/compile_only/databricks/05_sales_purchases_cfl_ungrouped.sql
+++ b/tests/integration/drift/compile_only/databricks/05_sales_purchases_cfl_ungrouped.sql
@@ -1,9 +1,9 @@
 WITH `composite_01` AS (
 SELECT CAST(`Sales`.`salesamount` AS DECIMAL(18, 2)) AS `Total Sales`, CAST(NULL AS DECIMAL(18, 2)) AS `Total Purchases`
-FROM ``.`orionbelt_1`.`sales` AS `Sales`
+FROM `orionbelt_1`.`sales` AS `Sales`
 UNION ALL
 SELECT CAST(NULL AS DECIMAL(18, 2)) AS `Total Sales`, CAST(`Purchases`.`purchaseamount` AS DECIMAL(18, 2)) AS `Total Purchases`
-FROM ``.`orionbelt_1`.`purchases` AS `Purchases`
+FROM `orionbelt_1`.`purchases` AS `Purchases`
 )
 SELECT CAST(SUM(`composite_01`.`Total Sales`) AS DECIMAL(18, 2)) AS `Total Sales`, CAST(SUM(`composite_01`.`Total Purchases`) AS DECIMAL(18, 2)) AS `Total Purchases`
 FROM `composite_01` AS `composite_01`

--- a/tests/integration/drift/compile_only/databricks/06_total_sales_by_sales_client.sql
+++ b/tests/integration/drift/compile_only/databricks/06_total_sales_by_sales_client.sql
@@ -1,4 +1,4 @@
 SELECT `Clients`.`clientname` AS `Sales Client Name`, CAST(SUM(`Sales`.`salesamount`) AS DECIMAL(18, 2)) AS `Total Sales`
-FROM ``.`orionbelt_1`.`sales` AS `Sales`
-LEFT JOIN ``.`orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`
+FROM `orionbelt_1`.`sales` AS `Sales`
+LEFT JOIN `orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`
 GROUP BY ALL

--- a/tests/integration/drift/compile_only/databricks/07_total_sales_by_client_with_complaints.sql
+++ b/tests/integration/drift/compile_only/databricks/07_total_sales_by_client_with_complaints.sql
@@ -1,11 +1,11 @@
 WITH `composite_01` AS (
 SELECT `Clients`.`clientname` AS `Sales Client Name`, CAST(NULL AS STRING) AS `Complaint Client Name`, CAST(`Sales`.`salesamount` AS DECIMAL(18, 2)) AS `Total Sales`, CAST(NULL AS INT) AS `Client Complaints Count`
-FROM ``.`orionbelt_1`.`sales` AS `Sales`
-LEFT JOIN ``.`orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`
+FROM `orionbelt_1`.`sales` AS `Sales`
+LEFT JOIN `orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`
 UNION ALL
 SELECT CAST(NULL AS STRING) AS `Sales Client Name`, `Clients`.`clientname` AS `Complaint Client Name`, CAST(NULL AS DECIMAL(18, 2)) AS `Total Sales`, CAST(1 AS INT) AS `Client Complaints Count`
-FROM ``.`orionbelt_1`.`clientcomplaints` AS `Client Complaints`
-LEFT JOIN ``.`orionbelt_1`.`clients` AS `Clients` ON `Client Complaints`.`complclientid` = `Clients`.`clientid`
+FROM `orionbelt_1`.`clientcomplaints` AS `Client Complaints`
+LEFT JOIN `orionbelt_1`.`clients` AS `Clients` ON `Client Complaints`.`complclientid` = `Clients`.`clientid`
 )
 SELECT COALESCE(`Sales Client Name`, `Complaint Client Name`) AS `Client`, CAST(SUM(`composite_01`.`Total Sales`) AS DECIMAL(18, 2)) AS `Total Sales`, CAST(COUNT(`composite_01`.`Client Complaints Count`) AS INT) AS `Client Complaints Count`
 FROM `composite_01` AS `composite_01`

--- a/tests/integration/drift/compile_only/databricks/08_average_sale.sql
+++ b/tests/integration/drift/compile_only/databricks/08_average_sale.sql
@@ -1,2 +1,2 @@
 SELECT CAST(SUM(`Sales`.`salesamount`) / NULLIF(COUNT(1), 0) AS DECIMAL(18, 2)) AS `Average Sale`
-FROM ``.`orionbelt_1`.`sales` AS `Sales`
+FROM `orionbelt_1`.`sales` AS `Sales`

--- a/tests/integration/drift/compile_only/databricks/09_return_rate.sql
+++ b/tests/integration/drift/compile_only/databricks/09_return_rate.sql
@@ -1,9 +1,9 @@
 WITH `composite_01` AS (
 SELECT CAST(`Returns`.`returnamount` AS DECIMAL(18, 2)) AS `Total Returns`, CAST(NULL AS DECIMAL(18, 2)) AS `Total Sales`
-FROM ``.`orionbelt_1`.`returns` AS `Returns`
+FROM `orionbelt_1`.`returns` AS `Returns`
 UNION ALL
 SELECT CAST(NULL AS DECIMAL(18, 2)) AS `Total Returns`, CAST(`Sales`.`salesamount` AS DECIMAL(18, 2)) AS `Total Sales`
-FROM ``.`orionbelt_1`.`sales` AS `Sales`
+FROM `orionbelt_1`.`sales` AS `Sales`
 )
 SELECT CAST(SUM(`composite_01`.`Total Returns`) / NULLIF(SUM(`composite_01`.`Total Sales`), 0) AS DECIMAL(18, 4)) AS `Return Rate`
 FROM `composite_01` AS `composite_01`

--- a/tests/integration/drift/compile_only/databricks/10_cumulative_sales_by_month.sql
+++ b/tests/integration/drift/compile_only/databricks/10_cumulative_sales_by_month.sql
@@ -1,6 +1,6 @@
 WITH `cumulative_base` AS (
 SELECT date_trunc('month', `Sales`.`salesdate`) AS `Sales Month`, CAST(SUM(`Sales`.`salesamount`) AS DECIMAL(18, 2)) AS `Total Sales`
-FROM ``.`orionbelt_1`.`sales` AS `Sales`
+FROM `orionbelt_1`.`sales` AS `Sales`
 GROUP BY ALL
 )
 SELECT `Sales Month` AS `Sales Month`, CAST(SUM(`Total Sales`) OVER (ORDER BY `Sales Month` ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS DECIMAL(18, 2)) AS `Cumulative Sales`

--- a/tests/integration/drift/compile_only/databricks/11_rolling_30_day_sales.sql
+++ b/tests/integration/drift/compile_only/databricks/11_rolling_30_day_sales.sql
@@ -1,6 +1,6 @@
 WITH `cumulative_base` AS (
 SELECT date_trunc('day', `Sales`.`salesdate`) AS `Sales Date`, CAST(SUM(`Sales`.`salesamount`) AS DECIMAL(18, 2)) AS `Total Sales`
-FROM ``.`orionbelt_1`.`sales` AS `Sales`
+FROM `orionbelt_1`.`sales` AS `Sales`
 GROUP BY ALL
 )
 SELECT `Sales Date` AS `Sales Date`, CAST(AVG(`Total Sales`) OVER (ORDER BY `Sales Date` ASC ROWS BETWEEN 29 PRECEDING AND CURRENT ROW) AS DECIMAL(18, 0)) AS `Rolling 30 Day Sales`

--- a/tests/integration/drift/compile_only/databricks/12_total_sales_country_in_filter.sql
+++ b/tests/integration/drift/compile_only/databricks/12_total_sales_country_in_filter.sql
@@ -1,5 +1,5 @@
 SELECT CAST(SUM(`Sales`.`salesamount`) AS DECIMAL(18, 2)) AS `Total Sales`
-FROM ``.`orionbelt_1`.`sales` AS `Sales`
-LEFT JOIN ``.`orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`
-LEFT JOIN ``.`orionbelt_1`.`countries` AS `Countries` ON `Clients`.`clientcountryid` = `Countries`.`countryid`
+FROM `orionbelt_1`.`sales` AS `Sales`
+LEFT JOIN `orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`
+LEFT JOIN `orionbelt_1`.`countries` AS `Countries` ON `Clients`.`clientcountryid` = `Countries`.`countryid`
 WHERE `Countries`.`countryname` IN ('Croatia', 'Austria')

--- a/tests/integration/drift/compile_only/databricks/13_sales_yoy_growth.sql
+++ b/tests/integration/drift/compile_only/databricks/13_sales_yoy_growth.sql
@@ -1,7 +1,7 @@
 WITH `date_range` AS (
 SELECT date_trunc('month', MIN(`Sales`.`salesdate`)) AS min_date,
        date_trunc('month', MAX(`Sales`.`salesdate`)) AS max_date
-  FROM ``.`orionbelt_1`.`sales` AS `Sales`
+  FROM `orionbelt_1`.`sales` AS `Sales`
 ),
 `date_spine` AS (
 SELECT d AS spine_date,
@@ -13,7 +13,7 @@ FROM (SELECT EXPLODE(SEQUENCE((SELECT min_date FROM `date_range`), (SELECT max_d
 SELECT `date_spine`.spine_date AS `Sales Month`,
        SUM(`Sales`.`salesamount`) AS `Total Sales`
   FROM `date_spine`
-  LEFT JOIN ``.`orionbelt_1`.`sales` AS `Sales`
+  LEFT JOIN `orionbelt_1`.`sales` AS `Sales`
     ON date_trunc('month', `Sales`.`salesdate`) = `date_spine`.spine_date
   GROUP BY 1
 ),

--- a/tests/integration/drift/compile_only/databricks/14_total_sales_year_filter.sql
+++ b/tests/integration/drift/compile_only/databricks/14_total_sales_year_filter.sql
@@ -1,3 +1,3 @@
 SELECT CAST(SUM(`Sales`.`salesamount`) AS DECIMAL(18, 2)) AS `Total Sales`
-FROM ``.`orionbelt_1`.`sales` AS `Sales`
+FROM `orionbelt_1`.`sales` AS `Sales`
 WHERE `Sales`.`salesdate` = '2025-01-01'

--- a/tests/integration/drift/compile_only/databricks/15_total_account_balance.sql
+++ b/tests/integration/drift/compile_only/databricks/15_total_account_balance.sql
@@ -1,2 +1,2 @@
 SELECT CAST(SUM(`Account Balances`.`balanceamt`) AS DECIMAL(18, 2)) AS `Total Account Balance`
-FROM ``.`orionbelt_1`.`acctbal` AS `Account Balances`
+FROM `orionbelt_1`.`acctbal` AS `Account Balances`

--- a/tests/integration/drift/compile_only/snowflake/01_total_sales.sql
+++ b/tests/integration/drift/compile_only/snowflake/01_total_sales.sql
@@ -1,2 +1,2 @@
 SELECT CAST(SUM("Sales"."salesamount") AS NUMBER(18, 2)) AS "Total Sales"
-FROM ""."orionbelt_1"."sales" AS "Sales"
+FROM "orionbelt_1"."sales" AS "Sales"

--- a/tests/integration/drift/compile_only/snowflake/02_total_sales_by_country.sql
+++ b/tests/integration/drift/compile_only/snowflake/02_total_sales_by_country.sql
@@ -1,5 +1,5 @@
 SELECT "Countries"."countryname" AS "Sales Country Name", CAST(SUM("Sales"."salesamount") AS NUMBER(18, 2)) AS "Total Sales"
-FROM ""."orionbelt_1"."sales" AS "Sales"
-LEFT JOIN ""."orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"
-LEFT JOIN ""."orionbelt_1"."countries" AS "Countries" ON "Clients"."clientcountryid" = "Countries"."countryid"
+FROM "orionbelt_1"."sales" AS "Sales"
+LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"
+LEFT JOIN "orionbelt_1"."countries" AS "Countries" ON "Clients"."clientcountryid" = "Countries"."countryid"
 GROUP BY ALL

--- a/tests/integration/drift/compile_only/snowflake/03_total_sales_by_year_month.sql
+++ b/tests/integration/drift/compile_only/snowflake/03_total_sales_by_year_month.sql
@@ -1,3 +1,3 @@
 SELECT DATE_TRUNC('year', "Sales"."salesdate") AS "Sales Year", DATE_TRUNC('month', "Sales"."salesdate") AS "Sales Month", CAST(SUM("Sales"."salesamount") AS NUMBER(18, 2)) AS "Total Sales"
-FROM ""."orionbelt_1"."sales" AS "Sales"
+FROM "orionbelt_1"."sales" AS "Sales"
 GROUP BY ALL

--- a/tests/integration/drift/compile_only/snowflake/04_sales_returns_cfl_by_country.sql
+++ b/tests/integration/drift/compile_only/snowflake/04_sales_returns_cfl_by_country.sql
@@ -1,14 +1,14 @@
 WITH "composite_01" AS (
 SELECT "Countries"."countryname" AS "Sales Country Name", CAST("Sales"."salesamount" AS NUMBER(18, 2)) AS "Total Sales"
-FROM ""."orionbelt_1"."sales" AS "Sales"
-LEFT JOIN ""."orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"
-LEFT JOIN ""."orionbelt_1"."countries" AS "Countries" ON "Clients"."clientcountryid" = "Countries"."countryid"
+FROM "orionbelt_1"."sales" AS "Sales"
+LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"
+LEFT JOIN "orionbelt_1"."countries" AS "Countries" ON "Clients"."clientcountryid" = "Countries"."countryid"
 UNION ALL BY NAME
 SELECT "Countries"."countryname" AS "Sales Country Name", CAST("Returns"."returnamount" AS NUMBER(18, 2)) AS "Total Returns"
-FROM ""."orionbelt_1"."returns" AS "Returns"
-LEFT JOIN ""."orionbelt_1"."sales" AS "Sales" ON "Returns"."returnsalesid" = "Sales"."salesid"
-LEFT JOIN ""."orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"
-LEFT JOIN ""."orionbelt_1"."countries" AS "Countries" ON "Clients"."clientcountryid" = "Countries"."countryid"
+FROM "orionbelt_1"."returns" AS "Returns"
+LEFT JOIN "orionbelt_1"."sales" AS "Sales" ON "Returns"."returnsalesid" = "Sales"."salesid"
+LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"
+LEFT JOIN "orionbelt_1"."countries" AS "Countries" ON "Clients"."clientcountryid" = "Countries"."countryid"
 )
 SELECT "Sales Country Name" AS "Sales Country Name", CAST(SUM("composite_01"."Total Sales") AS NUMBER(18, 2)) AS "Total Sales", CAST(SUM("composite_01"."Total Returns") AS NUMBER(18, 2)) AS "Total Returns"
 FROM "composite_01" AS "composite_01"

--- a/tests/integration/drift/compile_only/snowflake/05_sales_purchases_cfl_ungrouped.sql
+++ b/tests/integration/drift/compile_only/snowflake/05_sales_purchases_cfl_ungrouped.sql
@@ -1,9 +1,9 @@
 WITH "composite_01" AS (
 SELECT CAST("Sales"."salesamount" AS NUMBER(18, 2)) AS "Total Sales"
-FROM ""."orionbelt_1"."sales" AS "Sales"
+FROM "orionbelt_1"."sales" AS "Sales"
 UNION ALL BY NAME
 SELECT CAST("Purchases"."purchaseamount" AS NUMBER(18, 2)) AS "Total Purchases"
-FROM ""."orionbelt_1"."purchases" AS "Purchases"
+FROM "orionbelt_1"."purchases" AS "Purchases"
 )
 SELECT CAST(SUM("composite_01"."Total Sales") AS NUMBER(18, 2)) AS "Total Sales", CAST(SUM("composite_01"."Total Purchases") AS NUMBER(18, 2)) AS "Total Purchases"
 FROM "composite_01" AS "composite_01"

--- a/tests/integration/drift/compile_only/snowflake/06_total_sales_by_sales_client.sql
+++ b/tests/integration/drift/compile_only/snowflake/06_total_sales_by_sales_client.sql
@@ -1,4 +1,4 @@
 SELECT "Clients"."clientname" AS "Sales Client Name", CAST(SUM("Sales"."salesamount") AS NUMBER(18, 2)) AS "Total Sales"
-FROM ""."orionbelt_1"."sales" AS "Sales"
-LEFT JOIN ""."orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"
+FROM "orionbelt_1"."sales" AS "Sales"
+LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"
 GROUP BY ALL

--- a/tests/integration/drift/compile_only/snowflake/07_total_sales_by_client_with_complaints.sql
+++ b/tests/integration/drift/compile_only/snowflake/07_total_sales_by_client_with_complaints.sql
@@ -1,11 +1,11 @@
 WITH "composite_01" AS (
 SELECT "Clients"."clientname" AS "Sales Client Name", CAST("Sales"."salesamount" AS NUMBER(18, 2)) AS "Total Sales"
-FROM ""."orionbelt_1"."sales" AS "Sales"
-LEFT JOIN ""."orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"
+FROM "orionbelt_1"."sales" AS "Sales"
+LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"
 UNION ALL BY NAME
 SELECT "Clients"."clientname" AS "Complaint Client Name", CAST(1 AS NUMBER(38, 0)) AS "Client Complaints Count"
-FROM ""."orionbelt_1"."clientcomplaints" AS "Client Complaints"
-LEFT JOIN ""."orionbelt_1"."clients" AS "Clients" ON "Client Complaints"."complclientid" = "Clients"."clientid"
+FROM "orionbelt_1"."clientcomplaints" AS "Client Complaints"
+LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Client Complaints"."complclientid" = "Clients"."clientid"
 )
 SELECT COALESCE("Sales Client Name", "Complaint Client Name") AS "Client", CAST(SUM("composite_01"."Total Sales") AS NUMBER(18, 2)) AS "Total Sales", CAST(COUNT("composite_01"."Client Complaints Count") AS NUMBER(38, 0)) AS "Client Complaints Count"
 FROM "composite_01" AS "composite_01"

--- a/tests/integration/drift/compile_only/snowflake/08_average_sale.sql
+++ b/tests/integration/drift/compile_only/snowflake/08_average_sale.sql
@@ -1,2 +1,2 @@
 SELECT CAST(SUM("Sales"."salesamount") / NULLIF(COUNT(1), 0) AS NUMBER(18, 2)) AS "Average Sale"
-FROM ""."orionbelt_1"."sales" AS "Sales"
+FROM "orionbelt_1"."sales" AS "Sales"

--- a/tests/integration/drift/compile_only/snowflake/09_return_rate.sql
+++ b/tests/integration/drift/compile_only/snowflake/09_return_rate.sql
@@ -1,9 +1,9 @@
 WITH "composite_01" AS (
 SELECT CAST("Returns"."returnamount" AS NUMBER(18, 2)) AS "Total Returns"
-FROM ""."orionbelt_1"."returns" AS "Returns"
+FROM "orionbelt_1"."returns" AS "Returns"
 UNION ALL BY NAME
 SELECT CAST("Sales"."salesamount" AS NUMBER(18, 2)) AS "Total Sales"
-FROM ""."orionbelt_1"."sales" AS "Sales"
+FROM "orionbelt_1"."sales" AS "Sales"
 )
 SELECT CAST(SUM("composite_01"."Total Returns") / NULLIF(SUM("composite_01"."Total Sales"), 0) AS NUMBER(18, 4)) AS "Return Rate"
 FROM "composite_01" AS "composite_01"

--- a/tests/integration/drift/compile_only/snowflake/10_cumulative_sales_by_month.sql
+++ b/tests/integration/drift/compile_only/snowflake/10_cumulative_sales_by_month.sql
@@ -1,6 +1,6 @@
 WITH "cumulative_base" AS (
 SELECT DATE_TRUNC('month', "Sales"."salesdate") AS "Sales Month", CAST(SUM("Sales"."salesamount") AS NUMBER(18, 2)) AS "Total Sales"
-FROM ""."orionbelt_1"."sales" AS "Sales"
+FROM "orionbelt_1"."sales" AS "Sales"
 GROUP BY ALL
 )
 SELECT "Sales Month" AS "Sales Month", CAST(SUM("Total Sales") OVER (ORDER BY "Sales Month" ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS NUMBER(18, 2)) AS "Cumulative Sales"

--- a/tests/integration/drift/compile_only/snowflake/11_rolling_30_day_sales.sql
+++ b/tests/integration/drift/compile_only/snowflake/11_rolling_30_day_sales.sql
@@ -1,6 +1,6 @@
 WITH "cumulative_base" AS (
 SELECT DATE_TRUNC('day', "Sales"."salesdate") AS "Sales Date", CAST(SUM("Sales"."salesamount") AS NUMBER(18, 2)) AS "Total Sales"
-FROM ""."orionbelt_1"."sales" AS "Sales"
+FROM "orionbelt_1"."sales" AS "Sales"
 GROUP BY ALL
 )
 SELECT "Sales Date" AS "Sales Date", CAST(AVG("Total Sales") OVER (ORDER BY "Sales Date" ASC ROWS BETWEEN 29 PRECEDING AND CURRENT ROW) AS NUMBER(18, 0)) AS "Rolling 30 Day Sales"

--- a/tests/integration/drift/compile_only/snowflake/12_total_sales_country_in_filter.sql
+++ b/tests/integration/drift/compile_only/snowflake/12_total_sales_country_in_filter.sql
@@ -1,5 +1,5 @@
 SELECT CAST(SUM("Sales"."salesamount") AS NUMBER(18, 2)) AS "Total Sales"
-FROM ""."orionbelt_1"."sales" AS "Sales"
-LEFT JOIN ""."orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"
-LEFT JOIN ""."orionbelt_1"."countries" AS "Countries" ON "Clients"."clientcountryid" = "Countries"."countryid"
+FROM "orionbelt_1"."sales" AS "Sales"
+LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"
+LEFT JOIN "orionbelt_1"."countries" AS "Countries" ON "Clients"."clientcountryid" = "Countries"."countryid"
 WHERE "Countries"."countryname" IN ('Croatia', 'Austria')

--- a/tests/integration/drift/compile_only/snowflake/13_sales_yoy_growth.sql
+++ b/tests/integration/drift/compile_only/snowflake/13_sales_yoy_growth.sql
@@ -1,7 +1,7 @@
 WITH "date_range" AS (
 SELECT DATE_TRUNC('month', MIN("Sales"."salesdate")) AS min_date,
        DATE_TRUNC('month', MAX("Sales"."salesdate")) AS max_date
-  FROM ""."orionbelt_1"."sales" AS "Sales"
+  FROM "orionbelt_1"."sales" AS "Sales"
 ),
 "date_spine" AS (
 SELECT DATEADD('month', rn - 1, (SELECT min_date FROM "date_range"))::date AS spine_date,
@@ -17,7 +17,7 @@ WHERE DATEADD('month', rn - 1, (SELECT min_date FROM "date_range"))::date <= (SE
 SELECT "date_spine".spine_date AS "Sales Month",
        SUM("Sales"."salesamount") AS "Total Sales"
   FROM "date_spine"
-  LEFT JOIN ""."orionbelt_1"."sales" AS "Sales"
+  LEFT JOIN "orionbelt_1"."sales" AS "Sales"
     ON DATE_TRUNC('month', "Sales"."salesdate") = "date_spine".spine_date
   GROUP BY 1
 ),

--- a/tests/integration/drift/compile_only/snowflake/14_total_sales_year_filter.sql
+++ b/tests/integration/drift/compile_only/snowflake/14_total_sales_year_filter.sql
@@ -1,3 +1,3 @@
 SELECT CAST(SUM("Sales"."salesamount") AS NUMBER(18, 2)) AS "Total Sales"
-FROM ""."orionbelt_1"."sales" AS "Sales"
+FROM "orionbelt_1"."sales" AS "Sales"
 WHERE "Sales"."salesdate" = '2025-01-01'

--- a/tests/integration/drift/compile_only/snowflake/15_total_account_balance.sql
+++ b/tests/integration/drift/compile_only/snowflake/15_total_account_balance.sql
@@ -1,2 +1,2 @@
 SELECT CAST(SUM("Account Balances"."balanceamt") AS NUMBER(18, 2)) AS "Total Account Balance"
-FROM ""."orionbelt_1"."acctbal" AS "Account Balances"
+FROM "orionbelt_1"."acctbal" AS "Account Balances"

--- a/tests/integration/drift/vendor_exec/conftest.py
+++ b/tests/integration/drift/vendor_exec/conftest.py
@@ -14,6 +14,7 @@ the full vendor-exec sweep with::
 
 from __future__ import annotations
 
+import os
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
@@ -37,11 +38,19 @@ from testcontainers.mysql import MySqlContainer  # noqa: E402
 from testcontainers.postgres import PostgresContainer  # noqa: E402
 
 from ._seed import (  # noqa: E402
+    SCHEMA as SEED_SCHEMA,
+)
+from ._seed import (  # noqa: E402
     seed_clickhouse,
     seed_duckdb,
     seed_mysql,
     seed_postgres,
 )
+
+# Row count of the bundled commerce ``sales`` table. A cloud vendor whose
+# seed does not match this is stale, and every comparison against the DuckDB
+# golden would fail for that reason rather than a real dialect difference.
+EXPECTED_SALES_ROWS = 10000
 
 
 @dataclass
@@ -192,3 +201,70 @@ def vendor_clickhouse() -> VendorTarget:
             yield VendorTarget(name="clickhouse", dialect="clickhouse", execute=_execute)
         finally:
             client.close()
+
+
+# ---------------------------------------------------------------------------
+# Snowflake (live account — no container exists for it)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def vendor_snowflake() -> VendorTarget:
+    """Live Snowflake, seeded out of band from ``seed_sql/snowflake/``.
+
+    The cloud vendors have no testcontainer, so the seed is applied once by
+    ``scripts/seed_cloud_vendor.py`` rather than per session: re-loading 26k
+    rows over the network on every run would dominate the suite, and the data
+    is static. The fixture asserts the schema is present and current rather
+    than creating it, so a stale or missing seed fails loudly here instead of
+    surfacing as a row-count mismatch in every test.
+
+    Skipped unless ``SNOWFLAKE_ACCOUNT`` and friends are set.
+    """
+    connector = pytest.importorskip(
+        "snowflake.connector",
+        reason="snowflake-connector-python required for snowflake vendor exec",
+    )
+    missing = [
+        name
+        for name in (
+            "SNOWFLAKE_ACCOUNT",
+            "SNOWFLAKE_USER",
+            "SNOWFLAKE_PASSWORD",
+            "SNOWFLAKE_DATABASE",
+        )
+        if not os.environ.get(name)
+    ]
+    if missing:
+        pytest.skip(f"Snowflake credentials not configured: {', '.join(missing)}")
+
+    conn = connector.connect(
+        account=os.environ["SNOWFLAKE_ACCOUNT"],
+        user=os.environ["SNOWFLAKE_USER"],
+        password=os.environ["SNOWFLAKE_PASSWORD"],
+        warehouse=os.environ.get("SNOWFLAKE_WAREHOUSE"),
+        database=os.environ["SNOWFLAKE_DATABASE"],
+    )
+
+    def _execute(sql: str) -> list[dict[str, Any]]:
+        with conn.cursor() as cur:
+            cur.execute(sql)
+            cols = [d[0] for d in cur.description]
+            return [dict(zip(cols, row, strict=True)) for row in cur.fetchall()]
+
+    try:
+        try:
+            seeded = _execute(f'SELECT COUNT(*) AS n FROM "{SEED_SCHEMA}"."sales"')[0]["N"]
+        except Exception as exc:  # noqa: BLE001 — any failure here means "not seeded"
+            pytest.skip(
+                f"Snowflake schema '{SEED_SCHEMA}' is not loaded ({exc}). Seed it with:\n"
+                f"  uv run python scripts/seed_cloud_vendor.py snowflake"
+            )
+        assert seeded == EXPECTED_SALES_ROWS, (
+            f"Snowflake '{SEED_SCHEMA}'.sales has {seeded} rows, expected "
+            f"{EXPECTED_SALES_ROWS}. Re-seed with: "
+            f"uv run python scripts/seed_cloud_vendor.py snowflake"
+        )
+        yield VendorTarget(name="snowflake", dialect="snowflake", execute=_execute)
+    finally:
+        conn.close()

--- a/tests/integration/drift/vendor_exec/conftest.py
+++ b/tests/integration/drift/vendor_exec/conftest.py
@@ -53,6 +53,33 @@ from ._seed import (  # noqa: E402
 EXPECTED_SALES_ROWS = 10000
 
 
+def _require_seed(
+    vendor: str,
+    execute: Callable[[str], list[dict[str, Any]]],
+    sales_ref: str,
+) -> None:
+    """Skip unless *vendor* carries a current commerce seed.
+
+    Cloud vendors are seeded once, out of band, so a missing or stale schema
+    is reported here with the command that fixes it rather than surfacing as a
+    row mismatch in every test.
+    """
+    try:
+        row = execute(f"SELECT COUNT(*) AS n FROM {sales_ref}")[0]
+    except Exception as exc:  # noqa: BLE001 — any failure here means "not seeded"
+        pytest.skip(
+            f"{vendor} schema '{SEED_SCHEMA}' is not loaded ({exc}). Seed it with:\n"
+            f"  uv run python scripts/seed_cloud_vendor.py {vendor}"
+        )
+    count = next(iter(row.values()))
+    if count != EXPECTED_SALES_ROWS:
+        raise AssertionError(
+            f"{vendor} '{SEED_SCHEMA}'.sales has {count} rows, expected "
+            f"{EXPECTED_SALES_ROWS}. Re-seed with: "
+            f"uv run python scripts/seed_cloud_vendor.py {vendor}"
+        )
+
+
 @dataclass
 class VendorTarget:
     """Single contract every vendor fixture must satisfy.
@@ -253,18 +280,86 @@ def vendor_snowflake() -> VendorTarget:
             return [dict(zip(cols, row, strict=True)) for row in cur.fetchall()]
 
     try:
-        try:
-            seeded = _execute(f'SELECT COUNT(*) AS n FROM "{SEED_SCHEMA}"."sales"')[0]["N"]
-        except Exception as exc:  # noqa: BLE001 — any failure here means "not seeded"
-            pytest.skip(
-                f"Snowflake schema '{SEED_SCHEMA}' is not loaded ({exc}). Seed it with:\n"
-                f"  uv run python scripts/seed_cloud_vendor.py snowflake"
-            )
-        assert seeded == EXPECTED_SALES_ROWS, (
-            f"Snowflake '{SEED_SCHEMA}'.sales has {seeded} rows, expected "
-            f"{EXPECTED_SALES_ROWS}. Re-seed with: "
-            f"uv run python scripts/seed_cloud_vendor.py snowflake"
-        )
+        _require_seed("snowflake", _execute, f'"{SEED_SCHEMA}"."sales"')
         yield VendorTarget(name="snowflake", dialect="snowflake", execute=_execute)
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# BigQuery (live project — no container exists for it)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def vendor_bigquery() -> VendorTarget:
+    """Live BigQuery, seeded out of band from ``seed_sql/bigquery/``.
+
+    ``orionbelt_1`` is the dataset; the project comes from the client, so the
+    model's two-part ``dataset.table`` reference resolves without a
+    ``database:`` field. Skipped unless ``BIGQUERY_PROJECT`` is set.
+    """
+    bigquery = pytest.importorskip(
+        "google.cloud.bigquery", reason="google-cloud-bigquery required for bigquery vendor exec"
+    )
+    project = os.environ.get("BIGQUERY_PROJECT")
+    if not project:
+        pytest.skip("BIGQUERY_PROJECT not set")
+
+    client = bigquery.Client(project=project, location=os.environ.get("BIGQUERY_LOCATION"))
+
+    def _execute(sql: str) -> list[dict[str, Any]]:
+        return [dict(row) for row in client.query(sql).result()]
+
+    try:
+        _require_seed("bigquery", _execute, f"`{SEED_SCHEMA}`.`sales`")
+        yield VendorTarget(name="bigquery", dialect="bigquery", execute=_execute)
+    finally:
+        client.close()
+
+
+# ---------------------------------------------------------------------------
+# Databricks (live workspace — no container exists for it)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def vendor_databricks() -> VendorTarget:
+    """Live Databricks SQL warehouse, seeded out of band from ``seed_sql/databricks/``.
+
+    ``orionbelt_1`` is the schema and the catalog comes from the connection,
+    so the model's two-part reference resolves as-is. Skipped unless the
+    workspace variables are set, and again if the warehouse cannot be reached
+    — a stopped warehouse answers ``BAD_REQUEST: Cannot create the resource``
+    rather than a connection error, so that is treated as unavailable too.
+    """
+    dbsql = pytest.importorskip(
+        "databricks.sql", reason="databricks-sql-connector required for databricks vendor exec"
+    )
+    host = os.environ.get("DATABRICKS_SERVER_HOSTNAME")
+    http_path = os.environ.get("DATABRICKS_HTTP_PATH")
+    token = os.environ.get("DATABRICKS_TOKEN") or os.environ.get("DATABRICKS_ACCESS_TOKEN")
+    if not (host and http_path and token):
+        pytest.skip("Databricks workspace variables not configured")
+
+    try:
+        conn = dbsql.connect(
+            server_hostname=host,
+            http_path=http_path,
+            access_token=token,
+            catalog=os.environ.get("DATABRICKS_CATALOG", "main"),
+        )
+    except Exception as exc:  # noqa: BLE001 — an unreachable warehouse is a skip, not a failure
+        pytest.skip(f"Could not connect to Databricks: {exc}")
+
+    def _execute(sql: str) -> list[dict[str, Any]]:
+        with conn.cursor() as cur:
+            cur.execute(sql)
+            cols = [d[0] for d in cur.description]
+            return [dict(zip(cols, row, strict=True)) for row in cur.fetchall()]
+
+    try:
+        _require_seed("databricks", _execute, f"`{SEED_SCHEMA}`.`sales`")
+        yield VendorTarget(name="databricks", dialect="databricks", execute=_execute)
     finally:
         conn.close()

--- a/tests/integration/drift/vendor_exec/test_vendor_exec.py
+++ b/tests/integration/drift/vendor_exec/test_vendor_exec.py
@@ -124,6 +124,9 @@ def _normalize_value(v: Any) -> Any:
     # ``"00123"`` and exponent-form strings like ``"1e3"`` as distinct
     # string values — coercing them would silently collapse different
     # IDs into equal cells and mask cross-vendor key-handling bugs.
+    # ``bool`` is an ``int`` subclass and must not be coerced to "1"/"0".
+    if isinstance(v, int) and not isinstance(v, bool):
+        return f"{float(v):.11g}"
     if isinstance(v, (Decimal, float)):
         return f"{float(v):.11g}"
     if isinstance(v, str) and _CANONICAL_DECIMAL_RE.match(v):
@@ -172,7 +175,17 @@ def _load_golden(query_id: str) -> list[list[Any]]:
 # test is tracked but doesn't break CI.
 # ---------------------------------------------------------------------------
 
-_KNOWN_ISSUES: dict[tuple[str, str], str] = {}
+_KNOWN_ISSUES: dict[tuple[str, str], str] = {
+    ("snowflake", "13_sales_yoy_growth"): (
+        "Period-over-period metrics ignore their declared dataType: pop_wrap is "
+        "the only wrapper that never calls _apply_metric_cast, so the ratio is "
+        "emitted uncast and each engine falls back to its own decimal-division "
+        "scale. DuckDB gives 0.9931620307032472, Snowflake NUMBER scale 8 "
+        "(0.99316203); the model declares decimal(18, 4), which would give "
+        "0.9932 on both. The golden is DuckDB-derived, so it encodes one "
+        "engine's default rather than the declared type."
+    ),
+}
 
 
 def _assert_matches_golden(
@@ -252,3 +265,14 @@ def test_clickhouse_vendor_exec(
 ) -> None:
     """ClickHouse latest testcontainer."""
     _assert_matches_golden(entry, vendor_clickhouse, commerce_model, pipeline)
+
+
+@pytest.mark.parametrize("entry", CORPUS, ids=lambda e: e.id)
+def test_snowflake_vendor_exec(
+    entry: CorpusEntry,
+    vendor_snowflake: VendorTarget,
+    commerce_model: SemanticModel,
+    pipeline: CompilationPipeline,
+) -> None:
+    """Live Snowflake account, seeded by scripts/seed_cloud_vendor.py."""
+    _assert_matches_golden(entry, vendor_snowflake, commerce_model, pipeline)

--- a/tests/integration/drift/vendor_exec/test_vendor_exec.py
+++ b/tests/integration/drift/vendor_exec/test_vendor_exec.py
@@ -175,16 +175,30 @@ def _load_golden(query_id: str) -> list[list[Any]]:
 # test is tracked but doesn't break CI.
 # ---------------------------------------------------------------------------
 
+# A period-over-period metric's declared ``dataType`` is never applied:
+# ``pop_wrap`` is the only wrapper that does not call ``_apply_metric_cast``,
+# so the ratio is emitted uncast and every engine falls back to its own
+# decimal-division scale. The model declares ``decimal(18, 4)`` (0.9932);
+# no engine produces that:
+#
+#     DuckDB     0.9931620307032472   (float division)
+#     BigQuery   0.993162031          (NUMERIC, scale 9)
+#     Snowflake  0.99316203           (NUMBER, scale 8)
+#
+# The golden is DuckDB-derived, so it encodes one engine's default rather than
+# the declared type. Fixing this changes DuckDB output too, so it needs its own
+# change; until then every three-part cloud vendor diverges here.
+_POP_DATATYPE_REASON = (
+    "Period-over-period metrics ignore their declared dataType (pop_wrap never "
+    "calls _apply_metric_cast), so the ratio's scale is whatever the engine's "
+    "decimal division produces. DuckDB 0.9931620307032472, BigQuery 0.993162031, "
+    "Snowflake 0.99316203; the model declares decimal(18, 4) -> 0.9932."
+)
+
 _KNOWN_ISSUES: dict[tuple[str, str], str] = {
-    ("snowflake", "13_sales_yoy_growth"): (
-        "Period-over-period metrics ignore their declared dataType: pop_wrap is "
-        "the only wrapper that never calls _apply_metric_cast, so the ratio is "
-        "emitted uncast and each engine falls back to its own decimal-division "
-        "scale. DuckDB gives 0.9931620307032472, Snowflake NUMBER scale 8 "
-        "(0.99316203); the model declares decimal(18, 4), which would give "
-        "0.9932 on both. The golden is DuckDB-derived, so it encodes one "
-        "engine's default rather than the declared type."
-    ),
+    ("snowflake", "13_sales_yoy_growth"): _POP_DATATYPE_REASON,
+    ("bigquery", "13_sales_yoy_growth"): _POP_DATATYPE_REASON,
+    ("databricks", "13_sales_yoy_growth"): _POP_DATATYPE_REASON,
 }
 
 
@@ -276,3 +290,25 @@ def test_snowflake_vendor_exec(
 ) -> None:
     """Live Snowflake account, seeded by scripts/seed_cloud_vendor.py."""
     _assert_matches_golden(entry, vendor_snowflake, commerce_model, pipeline)
+
+
+@pytest.mark.parametrize("entry", CORPUS, ids=lambda e: e.id)
+def test_bigquery_vendor_exec(
+    entry: CorpusEntry,
+    vendor_bigquery: VendorTarget,
+    commerce_model: SemanticModel,
+    pipeline: CompilationPipeline,
+) -> None:
+    """Live BigQuery project, seeded by scripts/seed_cloud_vendor.py."""
+    _assert_matches_golden(entry, vendor_bigquery, commerce_model, pipeline)
+
+
+@pytest.mark.parametrize("entry", CORPUS, ids=lambda e: e.id)
+def test_databricks_vendor_exec(
+    entry: CorpusEntry,
+    vendor_databricks: VendorTarget,
+    commerce_model: SemanticModel,
+    pipeline: CompilationPipeline,
+) -> None:
+    """Live Databricks SQL warehouse, seeded by scripts/seed_cloud_vendor.py."""
+    _assert_matches_golden(entry, vendor_databricks, commerce_model, pipeline)

--- a/tests/unit/test_dialects.py
+++ b/tests/unit/test_dialects.py
@@ -996,3 +996,42 @@ class TestMedianRendering:
         expr = FunctionCall(name="MEDIAN", args=[ColumnRef(name="price")])
         with pytest.raises(UnsupportedAggregationError, match="mysql.*MEDIAN"):
             dialect.compile_expr(expr)
+
+
+class TestTableRefWithoutDatabase:
+    """``database`` is optional in OBML, and an omitted one must be dropped.
+
+    Quoting it anyway produced ``""."schema"."table"``, which Snowflake
+    rejects with ``Database '""' does not exist`` and BigQuery/Databricks
+    with the backquoted equivalent. Dropping it lets the reference resolve
+    against the connection's current database, which is what lets one model
+    serve several deployments of the same schema.
+    """
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "bigquery",
+            "clickhouse",
+            "databricks",
+            "dremio",
+            "duckdb",
+            "mysql",
+            "postgres",
+            "snowflake",
+        ],
+    )
+    def test_empty_database_is_omitted(self, name: str) -> None:
+        ref = DialectRegistry.get(name).format_table_ref("", "orionbelt_1", "sales")
+        assert "orionbelt_1" in ref and "sales" in ref
+        # No empty quoted component of any quoting style.
+        for empty in ('""', "``", "[]"):
+            assert empty not in ref, f"{name}: {ref}"
+
+    @pytest.mark.parametrize("name", ["bigquery", "databricks", "snowflake"])
+    def test_three_part_ref_is_unchanged_when_database_is_set(self, name: str) -> None:
+        dialect = DialectRegistry.get(name)
+        ref = dialect.format_table_ref("proj", "ds", "tbl")
+        assert ref.count(".") == 2
+        for part in ("proj", "ds", "tbl"):
+            assert part in ref

--- a/tests/unit/test_dialects.py
+++ b/tests/unit/test_dialects.py
@@ -22,6 +22,7 @@ from orionbelt.ast.nodes import (
     WindowFunction,
 )
 from orionbelt.dialect import DialectRegistry
+from orionbelt.dialect.base import AmbiguousTableReferenceError
 from orionbelt.dialect.bigquery import BigQueryDialect
 from orionbelt.dialect.clickhouse import ClickHouseDialect
 from orionbelt.dialect.databricks import DatabricksDialect
@@ -1035,3 +1036,32 @@ class TestTableRefWithoutDatabase:
         assert ref.count(".") == 2
         for part in ("proj", "ds", "tbl"):
             assert part in ref
+
+    @pytest.mark.parametrize("name", ["bigquery", "databricks", "snowflake"])
+    def test_database_without_schema_is_refused(self, name: str) -> None:
+        """``proj.tbl`` would be read as ``schema.table``, not ``database.table``.
+
+        The resolver defaults both fields to ``""``, so a model declaring
+        ``database: PROD`` and no ``schema`` is legal OBML. Dropping the empty
+        middle would silently point the query at a different namespace, and
+        there is no portable three-part form with an empty middle, so this is
+        refused rather than guessed.
+        """
+        with pytest.raises(AmbiguousTableReferenceError) as excinfo:
+            DialectRegistry.get(name).format_table_ref("proj", "", "tbl")
+        assert "proj" in str(excinfo.value)
+        assert "schema" in str(excinfo.value)
+
+    @pytest.mark.parametrize("name", ["clickhouse", "duckdb", "mysql", "postgres"])
+    def test_two_part_dialects_collapse_an_empty_schema(self, name: str) -> None:
+        """``database`` is not part of the name here, so this is not ambiguous."""
+        ref = DialectRegistry.get(name).format_table_ref("proj", "", "tbl")
+        assert "tbl" in ref
+        assert "proj" not in ref
+        for empty in ('""', "``"):
+            assert empty not in ref
+
+    def test_dremio_treats_it_as_a_two_level_path(self) -> None:
+        """Dremio paths have no fixed arity, so the pair names what it says."""
+        ref = DialectRegistry.get("dremio").format_table_ref("space", "", "tbl")
+        assert ref == '"space"."tbl"'


### PR DESCRIPTION
Extends the vendor-execution suite (corpus queries compared against the DuckDB golden) to the three cloud warehouses, and fixes two things that blocked them.

```
pytest -m docker -k "snowflake or bigquery or databricks"
  ->  28 passed, 2 xfailed, 15 skipped
```

| Vendor | Result |
|---|---|
| snowflake | 14 passed, 1 xfailed |
| bigquery | 14 passed, 1 xfailed |
| databricks | 15 skipped - SQL warehouse cannot be provisioned on this account |

**Correction to this PR's original description.** It claimed the cloud dialects had "compile-only snapshots and nothing else". That was wrong: `tests/integration/test_{snowflake,bigquery,databricks}_execution.py` already run the 59-case commerce battery live, and Snowflake and BigQuery both pass today. What this PR adds is the *corpus* set under the vendor-exec harness, which compares against the DuckDB golden rather than against DuckDB computed inline. The gap was narrower than stated.

## Two fixes were needed

**1. A model without `database:` could not resolve on any three-part dialect.**

`format_table_ref` always emitted three components, so an omitted database became an empty quoted identifier:

| Dialect | Before | After |
|---|---|---|
| snowflake | `""."orionbelt_1"."sales"` | `"orionbelt_1"."sales"` |
| databricks | `` ``.`orionbelt_1`.`sales` `` | `` `orionbelt_1`.`sales` `` |
| bigquery | `` ``.`orionbelt_1`.`sales` `` | `` `orionbelt_1`.`sales` `` |
| dremio | `"orionbelt_1"."sales"` | unchanged, already correct |
| postgres / mysql / clickhouse / duckdb | two-part | unchanged |

Snowflake rejects the old form with `Database '""' does not exist`. Dremio already dropped empty parts, so this brings the three-part dialects in line with it, and lets BigQuery take the project from the client and Databricks the catalog from the connection.

The existing execution suites sidestep this by rewriting `database` on every data object (`_commerce.load_commerce_model(database=...)`), which is why they pass without it. Dropping the component means the shipped model works unmodified.

45 compile-only snapshots had recorded the empty component and are regenerated. The diff is confined to `FROM`/`JOIN` lines in the `bigquery`, `databricks` and `snowflake` directories.

**2. The row normaliser did not coerce `int`.** Snowflake returns `int` where other drivers return `Decimal`, so equal values compared unequal (`4324` vs `"4324"`). `bool` is excluded, being an `int` subclass.

## Seeding

Out of band, via the new `scripts/seed_cloud_vendor.py`, which replays the generated dump under `seed_sql/<vendor>/` for all three vendors:

```
uv run python scripts/seed_cloud_vendor.py bigquery
uv run python scripts/seed_cloud_vendor.py --check snowflake
```

Re-loading 26k rows per session would dominate the suite and the data is static, so `_require_seed` asserts the schema is present at the expected row count and skips with the seed command when it is not - one actionable failure instead of 15 row mismatches.

Those dumps are gitignored build artifacts. A stale local BigQuery dump escaped quotes as `''` instead of `\'`, so BigQuery parsed `'Sage O''Brien'` as two concatenated literals; regenerating with `_seed.py` fixed it. The generator was already correct, so nothing changed there - but it is worth knowing the dumps can drift.

## One real gap found, recorded not hidden

**A period-over-period metric's declared `dataType` is never applied.** `pop_wrap` is the only wrapper that does not call `_apply_metric_cast`, so the ratio is emitted uncast and each engine falls back to its own decimal-division scale.

| Engine | `13_sales_yoy_growth` |
|---|---|
| Model declares `decimal(18, 4)` | `0.9932` |
| DuckDB | `0.9931620307032472` |
| BigQuery | `0.993162031` (NUMERIC, scale 9) |
| Snowflake | `0.99316203` (NUMBER, scale 8) |

Three engines, three scales, none of them the declared type. That corroboration is the value here: with only DuckDB in the loop the uncast ratio looked right, because the golden *was* DuckDB's own default. Entered once in `_KNOWN_ISSUES` and shared across the three vendors. Fixing it changes DuckDB output too, so it wants its own PR.

## Not covered

- Databricks is wired but unverifiable here: its SQL warehouse answers `BAD_REQUEST: Cannot create the resource`. The pre-existing `test_databricks_execution.py` skips for the same reason on this account, so the fixture is written to skip rather than fail, and will run once a warehouse is available.
- `measure:Sales by Country` fails in the DuckDB measure sweep with a `ResolutionError`. Pre-existing, reproduces on `main` with this branch stashed, untouched here.