### PR TITLE
feat(compiler): exists subquery filters traverse the target's joins

### DIFF
--- a/docs/guide/query-language.md
+++ b/docs/guide/query-language.md
@@ -664,10 +664,42 @@ where:
 
 **Subquery filter rules**
 
-`subquery.filter` accepts the same operator vocabulary as the outer filter, with two exceptions:
+`subquery.filter` accepts the same operator vocabulary as the outer filter, with one exception: nested `exists` / `nonexists` are rejected (`NESTED_SUBQUERY_NOT_SUPPORTED`) — that keeps the planner simple.
 
-* Nested `exists` / `nonexists` are rejected (`NESTED_SUBQUERY_NOT_SUPPORTED`) — keeps the planner simple.
-* `field` is interpreted as a column **on the target data object** (e.g. `Is Returned` lives on `OrderItems`), not a dimension on the model.
+Its `field` resolves like an outer `where` field, minus measure names — a correlated subquery filters rows, not aggregates:
+
+1. a column on the target data object (e.g. `Is Returned` on `OrderItems`),
+2. a dimension name,
+3. a qualified `DataObject.Column`.
+
+A field on a *different* data object is joined in **inside** the subquery, so a semi-join can be windowed by something one or more joins past the target:
+
+```yaml
+where:
+  - field: Customer Country            # subject: Customers
+    op: exists
+    subquery:
+      dataObject: Orders               # target
+      filter:
+        - field: Order Year            # dimension on Dates, one join past Orders
+          op: equals
+          value: 2024
+```
+
+```sql
+EXISTS (
+  SELECT 1 FROM ORDERS "Orders"
+  INNER JOIN DATES "Dates" ON "Orders"."DATE_KEY" = "Dates"."DATE_KEY"
+  WHERE "Customers"."CUSTOMER_ID" = "Orders"."CUSTOMER_ID" AND "Dates"."YEAR" = 2024
+)
+```
+
+Two rules bound the traversal:
+
+* The object must be reachable from the target by the same forward-only join walk the outer query uses, or the filter is rejected (`UNREACHABLE_SUBQUERY_FILTER_OBJECT`) rather than silently dropped.
+* It must not be, or be reached through, the **subject** of the correlation (`SUBQUERY_FILTER_OBJECT_NOT_JOINABLE`): joining the subject inside the body would shadow its outer alias and rebind the correlation predicate to the subquery's own rows. Filter the subject in the outer `where` instead.
+
+A column of the target wins over a same-named dimension, so adding a dimension to a model never changes what an existing subquery filter compiles to.
 
 **`exists` / `nonexists` are WHERE-only.** Both operators are rejected in `having:` with `INVALID_FILTER_OPERATOR` because the correlation predicate references the subject's row-level column, which is out of scope after `GROUP BY`. Measure-level EXISTS — "groups where some matching child row exists" — is a deferred follow-up (`MeasureFilter.subquery`).
 
@@ -717,7 +749,9 @@ Invalid queries return error responses:
 | `INVALID_RELATIVE_FILTER` | 400 | Malformed relative time filter |
 | `UNKNOWN_SUBQUERY_DATA_OBJECT` | 400 | `exists` / `nonexists` references an unknown target data object |
 | `NO_JOIN_PATH_TO_SUBQUERY` | 400 | No join path exists from the filter subject to the subquery target |
-| `UNKNOWN_SUBQUERY_FILTER_COLUMN` | 400 | `subquery.filter` references a column not on the target |
+| `UNKNOWN_SUBQUERY_FILTER_COLUMN` | 400 | `subquery.filter` field is neither a column of the target, a dimension, nor a valid `DataObject.Column` |
+| `UNREACHABLE_SUBQUERY_FILTER_OBJECT` | 400 | `subquery.filter` names a data object not reachable from the target |
+| `SUBQUERY_FILTER_OBJECT_NOT_JOINABLE` | 400 | `subquery.filter` resolves to (or only through) the correlation subject |
 | `NESTED_SUBQUERY_NOT_SUPPORTED` | 400 | `subquery.filter` cannot contain another `exists` / `nonexists` |
 | `UNKNOWN_PATH_NAME` | 400 | `subquery.pathName` does not match any declared secondary join |
 | `AMBIGUOUS_JOIN` | 422 | Multiple join paths possible |

--- a/examples/tpcds.obml.yml
+++ b/examples/tpcds.obml.yml
@@ -168,6 +168,18 @@ dataObjects:
       Credit Rating:
         code: cd_credit_rating
         abstractType: string
+      Dependent Count:
+        code: cd_dep_count
+        abstractType: int
+        numClass: non-additive
+      Employed Dependent Count:
+        code: cd_dep_employed_count
+        abstractType: int
+        numClass: non-additive
+      College Dependent Count:
+        code: cd_dep_college_count
+        abstractType: int
+        numClass: non-additive
 
   Item:
     code: item
@@ -719,6 +731,9 @@ dataObjects:
       Bill Customer Key:
         code: cs_bill_customer_sk
         abstractType: int
+      Ship Customer Key:
+        code: cs_ship_customer_sk
+        abstractType: int
       Bill CDemo Key:
         code: cs_bill_cdemo_sk
         abstractType: int
@@ -810,6 +825,12 @@ dataObjects:
         columnsTo: [Date Key]
         secondary: true
         pathName: ship_date
+      - joinType: many-to-one
+        joinTo: Customer
+        columnsFrom: [Ship Customer Key]
+        columnsTo: [Customer Key]
+        secondary: true
+        pathName: ship_customer
 
   Catalog Returns:
     code: catalog_returns
@@ -1240,6 +1261,21 @@ dimensions:
     dataObject: Customer Demographics
     column: Credit Rating
     resultType: string
+
+  Customer Dependent Count:
+    dataObject: Customer Demographics
+    column: Dependent Count
+    resultType: int
+
+  Customer Employed Dependent Count:
+    dataObject: Customer Demographics
+    column: Employed Dependent Count
+    resultType: int
+
+  Customer College Dependent Count:
+    dataObject: Customer Demographics
+    column: College Dependent Count
+    resultType: int
 
   Reason Description:
     dataObject: Reason

--- a/schema/query-schema.json
+++ b/schema/query-schema.json
@@ -61,7 +61,7 @@
         },
         "filter": {
           "type": "array",
-          "description": "Optional predicates restricting which target rows count. Same operator vocabulary as the outer filter; nested 'exists' / 'nonexists' are rejected.",
+          "description": "Optional predicates restricting which target rows count. Same operator vocabulary as the outer filter; nested 'exists' / 'nonexists' are rejected. Each field names a column of the target data object, a dimension, or a qualified 'DataObject.Column'; an object other than the target is joined in inside the subquery when it is reachable from the target and is not the correlation subject.",
           "items": {
             "$ref": "#/definitions/queryFilter"
           }

--- a/src/orionbelt/compiler/filter_resolution.py
+++ b/src/orionbelt/compiler/filter_resolution.py
@@ -270,7 +270,14 @@ def resolve_filter(
             )
             return None
         qt = ctx.qualify_table or (lambda obj: obj.qualified_code)
-        filter_expr = build_exists_filter_expr(qf, ctx.model, subject_object, qt, ctx.errors)
+        filter_expr = build_exists_filter_expr(
+            qf,
+            ctx.model,
+            subject_object,
+            qt,
+            ctx.errors,
+            touched_objects=ctx.result.subquery_objects,
+        )
     else:
         filter_expr = build_filter_expr(col_expr, qf, ctx.errors)
 

--- a/src/orionbelt/compiler/filters.py
+++ b/src/orionbelt/compiler/filters.py
@@ -574,9 +574,10 @@ def _join_filter_object_into_subquery(
     """Make *ref_object* addressable inside the ``EXISTS`` body.
 
     Objects already in *scope* — the subquery's own target and the hops the
-    correlation path walked through — need nothing. Anything else is joined in
-    with the same forward-only reachability rule the outer query uses, and the
-    resulting INNER JOINs are appended to *joins* (and *scope*) in place.
+    correlation path walked through — need nothing. Anything else is reached
+    with the same walker the outer query uses (forward along many-to-one,
+    either way along the row-preserving cardinalities), and the resulting
+    INNER JOINs are appended to *joins* (and *scope*) in place.
 
     Returns ``False`` (with a :class:`SemanticError` appended) when the object
     cannot be reached, or when reaching it would re-enter the correlation
@@ -600,7 +601,10 @@ def _join_filter_object_into_subquery(
         )
         return False
 
-    if not any(ref_object in graph.descendants(obj) for obj in sorted(scope)):
+    # Ask the walker itself rather than a separate reachability test: it is
+    # what decides which hops are legal, so a second rule would only diverge.
+    steps = graph.find_join_path(set(scope), {ref_object})
+    if not steps:
         errors.append(
             SemanticError(
                 code="UNREACHABLE_SUBQUERY_FILTER_OBJECT",
@@ -614,8 +618,11 @@ def _join_filter_object_into_subquery(
         )
         return False
 
-    steps = graph.find_join_path(set(scope), {ref_object})
-    if any(step.to_object == subject_object for step in steps):
+    # ``JoinStep`` keeps from/to in the declared join direction, so the object
+    # a step actually brings into the body is the far end of its *traversal*.
+    joined_objects = [step.from_object if step.reversed else step.to_object for step in steps]
+
+    if subject_object in joined_objects:
         errors.append(
             SemanticError(
                 code="SUBQUERY_FILTER_OBJECT_NOT_JOINABLE",
@@ -629,21 +636,21 @@ def _join_filter_object_into_subquery(
         )
         return False
 
-    for step in steps:
-        if step.to_object in scope:
+    for step, joined_object in zip(steps, joined_objects, strict=True):
+        if joined_object in scope:
             continue
-        step_obj = model.data_objects.get(step.to_object)
+        step_obj = model.data_objects.get(joined_object)
         if step_obj is None:
             continue
         joins.append(
             Join(
                 join_type=JoinType.INNER,
                 source=qualify_table(step_obj),
-                alias=step.to_object,
+                alias=joined_object,
                 on=graph.build_join_condition(step),
             )
         )
-        scope.add(step.to_object)
+        scope.add(joined_object)
     return True
 
 

--- a/src/orionbelt/compiler/filters.py
+++ b/src/orionbelt/compiler/filters.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import TypedDict
+from typing import TYPE_CHECKING, TypedDict
 
 from orionbelt.ast.nodes import (
     Between,
@@ -34,6 +34,9 @@ from orionbelt.models.semantic import (
     MeasureFilterItem,
     SemanticModel,
 )
+
+if TYPE_CHECKING:
+    from orionbelt.compiler.graph import JoinGraph
 
 
 def _escape_like(val: str) -> str:
@@ -508,12 +511,149 @@ def collect_measure_filter_objects(item: MeasureFilterItem, objects: set[str]) -
 # ---------------------------------------------------------------------------
 
 
+def _resolve_subquery_filter_field(
+    field: str,
+    model: SemanticModel,
+    target_object: str,
+    errors: list[SemanticError],
+) -> tuple[str, str] | None:
+    """Resolve a subquery filter's ``field`` to a ``(data object, column)`` pair.
+
+    Accepts, in precedence order, a column of the subquery's own data object,
+    a dimension name, or a qualified ``DataObject.Column`` — the same
+    vocabulary the outer ``where`` understands, minus measure names: a
+    correlated subquery filters rows, not aggregates.
+
+    Column-of-the-target wins over a same-named dimension so a model that
+    grew a dimension shadowing a column keeps compiling to the same SQL.
+    """
+    target_obj = model.data_objects.get(target_object)
+    if target_obj is not None and field in target_obj.columns:
+        return target_object, field
+
+    dim = model.dimensions.get(field)
+    if dim is not None and dim.view:
+        dim_obj = model.data_objects.get(dim.view)
+        if dim_obj is not None and dim.column in dim_obj.columns:
+            return dim.view, dim.column
+
+    if "." in field:
+        obj_name, _, col_name = field.partition(".")
+        obj_name, col_name = obj_name.strip(), col_name.strip()
+        obj = model.data_objects.get(obj_name)
+        if obj is not None and col_name in obj.columns:
+            return obj_name, col_name
+
+    errors.append(
+        SemanticError(
+            code="UNKNOWN_SUBQUERY_FILTER_COLUMN",
+            message=(
+                f"Subquery filter references unknown column '{field}' on "
+                f"'{target_object}' — use a column of that data object, a "
+                f"dimension name, or a qualified 'DataObject.Column'"
+            ),
+            path="filters",
+        )
+    )
+    return None
+
+
+def _join_filter_object_into_subquery(
+    ref_object: str,
+    field: str,
+    *,
+    graph: JoinGraph,
+    model: SemanticModel,
+    subject_object: str,
+    target_object: str,
+    scope: set[str],
+    joins: list[Join],
+    qualify_table: Callable[[DataObject], str],
+    errors: list[SemanticError],
+) -> bool:
+    """Make *ref_object* addressable inside the ``EXISTS`` body.
+
+    Objects already in *scope* — the subquery's own target and the hops the
+    correlation path walked through — need nothing. Anything else is joined in
+    with the same forward-only reachability rule the outer query uses, and the
+    resulting INNER JOINs are appended to *joins* (and *scope*) in place.
+
+    Returns ``False`` (with a :class:`SemanticError` appended) when the object
+    cannot be reached, or when reaching it would re-enter the correlation
+    subject: an inner ``FROM``/``JOIN`` alias shadows the outer one, which
+    would silently rebind the correlation predicate to the subquery's own rows.
+    """
+    if ref_object in scope:
+        return True
+
+    if ref_object == subject_object:
+        errors.append(
+            SemanticError(
+                code="SUBQUERY_FILTER_OBJECT_NOT_JOINABLE",
+                message=(
+                    f"Subquery filter field '{field}' resolves to "
+                    f"'{ref_object}', the subject of the correlation — filter "
+                    f"it in the outer 'where' instead"
+                ),
+                path="filters",
+            )
+        )
+        return False
+
+    if not any(ref_object in graph.descendants(obj) for obj in sorted(scope)):
+        errors.append(
+            SemanticError(
+                code="UNREACHABLE_SUBQUERY_FILTER_OBJECT",
+                message=(
+                    f"Subquery filter field '{field}' is on '{ref_object}', "
+                    f"which is not reachable from '{target_object}' — declare "
+                    f"a 'joins:' block"
+                ),
+                path="filters",
+            )
+        )
+        return False
+
+    steps = graph.find_join_path(set(scope), {ref_object})
+    if any(step.to_object == subject_object for step in steps):
+        errors.append(
+            SemanticError(
+                code="SUBQUERY_FILTER_OBJECT_NOT_JOINABLE",
+                message=(
+                    f"Subquery filter field '{field}' is on '{ref_object}', "
+                    f"reachable only through '{subject_object}' — the subject "
+                    f"of the correlation cannot be joined inside the subquery"
+                ),
+                path="filters",
+            )
+        )
+        return False
+
+    for step in steps:
+        if step.to_object in scope:
+            continue
+        step_obj = model.data_objects.get(step.to_object)
+        if step_obj is None:
+            continue
+        joins.append(
+            Join(
+                join_type=JoinType.INNER,
+                source=qualify_table(step_obj),
+                alias=step.to_object,
+                on=graph.build_join_condition(step),
+            )
+        )
+        scope.add(step.to_object)
+    return True
+
+
 def build_exists_filter_expr(
     qf: QueryFilter,
     model: SemanticModel,
     subject_object: str,
     qualify_table: Callable[[DataObject], str],
     errors: list[SemanticError],
+    touched_objects: set[str] | None = None,
 ) -> Expr | None:
     """Compile an ``exists`` / ``nonexists`` filter into an ``Exists`` AST node.
 
@@ -521,6 +661,15 @@ def build_exists_filter_expr(
     resolved by walking the model's existing ``joins:`` — the same machinery
     the query planner uses.  Single-hop is the common case; multi-hop paths
     are supported and emit INNER JOINs inside the subquery.
+
+    Subquery filters resolve against the target's join graph, not only its own
+    columns, so a semi-join can be windowed by a dimension one or more hops
+    away; the joins that makes necessary are emitted inside the ``EXISTS``
+    body.
+
+    Every data object the body reads is added to *touched_objects* when given,
+    so the caller can key the freshness cache on tables that never appear in
+    the outer FROM/JOIN chain.
 
     Returns ``None`` and appends ``SemanticError``s on validation failure.
     """
@@ -645,6 +794,11 @@ def build_exists_filter_expr(
 
     where_parts: list[Expr] = [graph.build_join_condition(first_step)]
 
+    # Aliases the subquery body owns: its target plus every hop the
+    # correlation path walked through. The subject stays outside — it is
+    # referenced by the correlation predicate, not joined.
+    scope = {step.to_object for step in path}
+
     nested_seen = False
     for sub_qf in sub.filter:
         if sub_qf.op in (FilterOperator.EXISTS, FilterOperator.NONEXISTS):
@@ -661,22 +815,30 @@ def build_exists_filter_expr(
                 )
                 nested_seen = True
             continue
-        if sub_qf.field not in target_obj.columns:
-            errors.append(
-                SemanticError(
-                    code="UNKNOWN_SUBQUERY_FILTER_COLUMN",
-                    message=(
-                        f"Subquery filter references unknown column "
-                        f"'{sub_qf.field}' on '{sub.data_object}'"
-                    ),
-                    path="filters",
-                )
-            )
+        ref = _resolve_subquery_filter_field(sub_qf.field, model, sub.data_object, errors)
+        if ref is None:
             continue
-        col_expr = make_column_expr(model, sub.data_object, sub_qf.field)
+        ref_object, ref_column = ref
+        if not _join_filter_object_into_subquery(
+            ref_object,
+            sub_qf.field,
+            graph=graph,
+            model=model,
+            subject_object=subject_object,
+            target_object=sub.data_object,
+            scope=scope,
+            joins=joins,
+            qualify_table=qualify_table,
+            errors=errors,
+        ):
+            continue
+        col_expr = make_column_expr(model, ref_object, ref_column)
         sub_expr = build_filter_expr(col_expr, sub_qf, errors)
         if sub_expr is not None:
             where_parts.append(sub_expr)
+
+    if touched_objects is not None:
+        touched_objects.update(scope)
 
     where_expr: Expr = where_parts[0]
     for part in where_parts[1:]:

--- a/src/orionbelt/compiler/graph.py
+++ b/src/orionbelt/compiler/graph.py
@@ -261,14 +261,16 @@ class JoinGraph:
                         cardinality=edge_data["cardinality"],
                     )
                 else:
-                    # Path traverses edge in reverse direction.
-                    # from_object/to_object are swapped, so columns must be
-                    # swapped too to keep the ON clause correctly oriented.
+                    # Path traverses the edge against its declared direction.
+                    # ``JoinStep`` keeps from/to in *declared* order — ``edge[1]``
+                    # is the object that declares the join, so it keeps
+                    # ``columns_from`` — and records the real traversal
+                    # direction in ``reversed``.
                     step = JoinStep(
                         from_object=edge[1],
                         to_object=edge[0],
-                        from_columns=edge_data["columns_to"],
-                        to_columns=edge_data["columns_from"],
+                        from_columns=edge_data["columns_from"],
+                        to_columns=edge_data["columns_to"],
                         join_type=ASTJoinType.LEFT,
                         cardinality=edge_data["cardinality"],
                         reversed=True,

--- a/src/orionbelt/compiler/pipeline.py
+++ b/src/orionbelt/compiler/pipeline.py
@@ -120,8 +120,12 @@ def _compute_physical_tables(
     ``resolved.required_objects`` (they live behind a correlated subquery,
     not in the FROM/JOIN chain), so the original query is walked too —
     otherwise child-table edits would not invalidate cached results.
+    ``resolved.subquery_objects`` adds the tables only the compiler knows
+    about: the hops a correlation path walked and the objects a subquery
+    filter joined in.
     """
     object_names: set[str] = set(resolved.required_objects)
+    object_names.update(resolved.subquery_objects)
     object_names.update(_collect_subquery_objects(list(query.where)))
     object_names.update(_collect_subquery_objects(list(query.having)))
 

--- a/src/orionbelt/compiler/resolution.py
+++ b/src/orionbelt/compiler/resolution.py
@@ -414,6 +414,15 @@ class ResolvedQuery:
     flip the query into a CFL plan whose ``UNION ALL`` is exactly what the
     anchor exists to avoid."""
 
+    subquery_objects: set[str] = field(default_factory=set)
+    """Data objects read inside a correlated ``EXISTS`` body.
+
+    The subquery's own target, the hops its correlation path walked through,
+    and anything a subquery filter reached through the join graph. Deliberately
+    absent from :attr:`required_objects` — none of them is in the outer
+    FROM/JOIN chain — but the compiled SQL does read them, so the freshness
+    cache has to key on them all the same."""
+
     having_only_measures: set[str] = field(default_factory=set)
     """Measures auto-included by HAVING (not in ``select.measures``).
 

--- a/src/orionbelt/compiler/sql_translator.py
+++ b/src/orionbelt/compiler/sql_translator.py
@@ -1257,8 +1257,9 @@ def _atom_to_query_filter(
     # The outer-row subject column is derived from the SELECT's first
     # dim / measure (``exists_subject``) — the planner uses it only to
     # locate the outer data object for join resolution. Inner WHERE
-    # predicates become ``Subquery.filter`` items where ``field`` is a
-    # bare column name on the target data object.
+    # predicates become ``Subquery.filter`` items whose ``field`` is a bare
+    # name — a column of the target, or a dimension the planner resolves
+    # against the target's joins.
     if isinstance(atom, exp.Exists) or (
         isinstance(atom, exp.Not) and isinstance(atom.this, exp.Exists)
     ):
@@ -1435,8 +1436,10 @@ def _translate_exists(
     Inner ``SELECT`` is consumed for two things only:
 
     * ``FROM <target>`` — names the target data object (single source).
-    * ``WHERE <preds>`` — optional predicates on the *target's* columns;
-      become ``Subquery.filter`` items.
+    * ``WHERE <preds>`` — optional predicates; become ``Subquery.filter``
+      items. Each names the target's own column or a dimension, which the
+      planner resolves against the target's joins and joins into the
+      ``EXISTS`` body when it lives one or more hops away.
 
     ``SELECT`` list, ``GROUP BY``, ``ORDER BY``, ``LIMIT``, and joins on
     the inner query are rejected — the planner derives the correlation

--- a/src/orionbelt/models/query.py
+++ b/src/orionbelt/models/query.py
@@ -117,6 +117,11 @@ class Subquery(BaseModel):
     resolved by walking the model's existing ``joins:`` from the subject's
     data object to ``dataObject`` (same path-resolution machinery the
     query planner uses).
+
+    Each entry in ``filter`` names a column of ``dataObject``, a dimension,
+    or a qualified ``DataObject.Column``. A field on another data object is
+    joined in inside the subquery when it is reachable from ``dataObject``,
+    which is what lets a semi-join be windowed by, say, a date dimension.
     """
 
     data_object: str = Field(alias="dataObject")

--- a/tests/unit/test_exists_filter.py
+++ b/tests/unit/test_exists_filter.py
@@ -293,6 +293,87 @@ measures:
 """
 
 
+# Like TRAVERSAL_MODEL, but the objects hanging off OrderItems declare their
+# joins the other way round: ItemDetails → OrderItems one-to-one and ItemTags
+# → OrderItems many-to-many. Neither is a *directed* descendant of OrderItems,
+# yet both are row-preserving and therefore legal traversals.
+REVERSE_MODEL = """\
+version: 1.0
+
+dataObjects:
+  Customers:
+    code: CUSTOMERS
+    database: WAREHOUSE
+    schema: PUBLIC
+    columns:
+      Customer ID: {code: CUSTOMER_ID, abstractType: string}
+      Country: {code: COUNTRY, abstractType: string}
+
+  Orders:
+    code: ORDERS
+    database: WAREHOUSE
+    schema: PUBLIC
+    columns:
+      Order ID: {code: ORDER_ID, abstractType: string}
+      Order Customer ID: {code: CUSTOMER_ID, abstractType: string}
+    joins:
+      - joinType: many-to-one
+        joinTo: Customers
+        columnsFrom: [Order Customer ID]
+        columnsTo: [Customer ID]
+
+  OrderItems:
+    code: ORDER_ITEMS
+    database: WAREHOUSE
+    schema: PUBLIC
+    columns:
+      Item ID: {code: ITEM_ID, abstractType: string}
+      Item Order ID: {code: ORDER_ID, abstractType: string}
+    joins:
+      - joinType: many-to-one
+        joinTo: Orders
+        columnsFrom: [Item Order ID]
+        columnsTo: [Order ID]
+
+  ItemDetails:
+    code: ITEM_DETAILS
+    database: WAREHOUSE
+    schema: PUBLIC
+    columns:
+      Detail Item ID: {code: DETAIL_ITEM_ID, abstractType: string}
+      Gift Wrapped: {code: GIFT_WRAPPED, abstractType: boolean}
+    joins:
+      - joinType: one-to-one
+        joinTo: OrderItems
+        columnsFrom: [Detail Item ID]
+        columnsTo: [Item ID]
+
+  ItemTags:
+    code: ITEM_TAGS
+    database: WAREHOUSE
+    schema: PUBLIC
+    columns:
+      Tag Item ID: {code: TAG_ITEM_ID, abstractType: string}
+      Tag Name: {code: TAG_NAME, abstractType: string}
+    joins:
+      - joinType: many-to-many
+        joinTo: OrderItems
+        columnsFrom: [Tag Item ID]
+        columnsTo: [Item ID]
+
+dimensions:
+  Customer Country: {dataObject: Customers, column: Country, resultType: string}
+  Order ID: {dataObject: Orders, column: Order ID, resultType: string}
+  Gift Wrapped: {dataObject: ItemDetails, column: Gift Wrapped, resultType: boolean}
+
+measures:
+  Order Count:
+    columns: [{dataObject: Orders, column: Order ID}]
+    resultType: int
+    aggregation: count
+"""
+
+
 def _exists_on_items(sub_filters: list[QueryFilter]) -> QueryObject:
     """Orders-by-country query semi-joined to OrderItems with *sub_filters*."""
     return QueryObject(
@@ -589,6 +670,59 @@ class TestSubqueryFilterTraversal:
         refs = PIPELINE.compile(query, model, "postgres").physical_tables
         assert any(r.endswith(".PRODUCTS") for r in refs), refs
         assert any(r.endswith(".ORDER_ITEMS") for r in refs), refs
+
+
+class TestSubqueryFilterReverseTraversal:
+    """Row-preserving joins declared *towards* the subquery's target.
+
+    ``EXISTS`` bodies reach filter objects with the same walker the outer
+    query uses, and that walker treats one-to-one and many-to-many joins as
+    bidirectional. A reachability rule that only followed declared direction
+    would refuse these paths even though the walker would happily emit them.
+    """
+
+    def test_reverse_one_to_one_dimension(self) -> None:
+        model = _load_model(REVERSE_MODEL)
+        query = _exists_on_items(
+            [QueryFilter(field="Gift Wrapped", op=FilterOperator.EQUALS, value=True)]
+        )
+        sql = PIPELINE.compile(query, model, "postgres").sql
+        assert 'INNER JOIN "PUBLIC"."ITEM_DETAILS" AS "ItemDetails"' in sql
+        assert '"ItemDetails"."DETAIL_ITEM_ID" = "OrderItems"."ITEM_ID"' in sql
+        assert '"ItemDetails"."GIFT_WRAPPED" = TRUE' in sql
+        assert sql.index("EXISTS (") < sql.index("INNER JOIN")
+
+    def test_reverse_many_to_many_qualified_column(self) -> None:
+        model = _load_model(REVERSE_MODEL)
+        query = _exists_on_items(
+            [QueryFilter(field="ItemTags.Tag Name", op=FilterOperator.EQUALS, value="gift")]
+        )
+        sql = PIPELINE.compile(query, model, "postgres").sql
+        assert 'INNER JOIN "PUBLIC"."ITEM_TAGS" AS "ItemTags"' in sql
+        assert '"ItemTags"."TAG_ITEM_ID" = "OrderItems"."ITEM_ID"' in sql
+        assert '"ItemTags"."TAG_NAME" = \'gift\'' in sql
+
+    def test_reverse_join_tracked_in_physical_tables(self) -> None:
+        model = _load_model(REVERSE_MODEL)
+        query = _exists_on_items(
+            [QueryFilter(field="Gift Wrapped", op=FilterOperator.EQUALS, value=True)]
+        )
+        refs = PIPELINE.compile(query, model, "postgres").physical_tables
+        assert any(r.endswith(".ITEM_DETAILS") for r in refs), refs
+
+    def test_reverse_many_to_one_still_refused(self) -> None:
+        """Only row-preserving joins are bidirectional: Orders stays the
+        subject, so nothing changes for the many-to-one direction."""
+        model = _load_model(REVERSE_MODEL)
+        with pytest.raises(ResolutionError) as excinfo:
+            PIPELINE.compile(
+                _exists_on_items(
+                    [QueryFilter(field="Customers.Country", op=FilterOperator.EQUALS, value="DE")]
+                ),
+                model,
+                "postgres",
+            )
+        assert "SUBQUERY_FILTER_OBJECT_NOT_JOINABLE" in {e.code for e in excinfo.value.errors}
 
 
 class TestSubqueryFilterTraversalValidation:

--- a/tests/unit/test_exists_filter.py
+++ b/tests/unit/test_exists_filter.py
@@ -194,6 +194,119 @@ measures:
 """
 
 
+# A model whose subquery targets join onward, so a subquery filter has
+# somewhere to traverse to: OrderItems → Products, Orders → Dates. Payments
+# hangs off Orders on a many-to-one, which makes it unreachable *from*
+# OrderItems — the negative case.
+TRAVERSAL_MODEL = """\
+version: 1.0
+
+dataObjects:
+  Customers:
+    code: CUSTOMERS
+    database: WAREHOUSE
+    schema: PUBLIC
+    columns:
+      Customer ID: {code: CUSTOMER_ID, abstractType: string}
+      Country: {code: COUNTRY, abstractType: string}
+
+  Dates:
+    code: DATES
+    database: WAREHOUSE
+    schema: PUBLIC
+    columns:
+      Date Key: {code: DATE_KEY, abstractType: string}
+      Year: {code: YEAR, abstractType: int}
+
+  Orders:
+    code: ORDERS
+    database: WAREHOUSE
+    schema: PUBLIC
+    columns:
+      Order ID: {code: ORDER_ID, abstractType: string}
+      Order Customer ID: {code: CUSTOMER_ID, abstractType: string}
+      Order Date Key: {code: DATE_KEY, abstractType: string}
+      Amount: {code: AMOUNT, abstractType: float}
+    joins:
+      - joinType: many-to-one
+        joinTo: Customers
+        columnsFrom: [Order Customer ID]
+        columnsTo: [Customer ID]
+      - joinType: many-to-one
+        joinTo: Dates
+        columnsFrom: [Order Date Key]
+        columnsTo: [Date Key]
+
+  OrderItems:
+    code: ORDER_ITEMS
+    database: WAREHOUSE
+    schema: PUBLIC
+    columns:
+      Item ID: {code: ITEM_ID, abstractType: string}
+      Item Order ID: {code: ORDER_ID, abstractType: string}
+      Item Product ID: {code: PRODUCT_ID, abstractType: string}
+      SKU: {code: SKU, abstractType: string}
+    joins:
+      - joinType: many-to-one
+        joinTo: Orders
+        columnsFrom: [Item Order ID]
+        columnsTo: [Order ID]
+      - joinType: many-to-one
+        joinTo: Products
+        columnsFrom: [Item Product ID]
+        columnsTo: [Product ID]
+
+  Products:
+    code: PRODUCTS
+    database: WAREHOUSE
+    schema: PUBLIC
+    columns:
+      Product ID: {code: PRODUCT_ID, abstractType: string}
+      Category: {code: CATEGORY, abstractType: string}
+      Product SKU: {code: PRODUCT_SKU, abstractType: string}
+
+  Payments:
+    code: PAYMENTS
+    database: WAREHOUSE
+    schema: PUBLIC
+    columns:
+      Payment ID: {code: PAYMENT_ID, abstractType: string}
+      Payment Order ID: {code: ORDER_ID, abstractType: string}
+    joins:
+      - joinType: many-to-one
+        joinTo: Orders
+        columnsFrom: [Payment Order ID]
+        columnsTo: [Order ID]
+
+dimensions:
+  Customer Country: {dataObject: Customers, column: Country, resultType: string}
+  Order ID: {dataObject: Orders, column: Order ID, resultType: string}
+  Product Category: {dataObject: Products, column: Category, resultType: string}
+  Order Year: {dataObject: Dates, column: Year, resultType: int}
+  SKU: {dataObject: Products, column: Product SKU, resultType: string}
+
+measures:
+  Order Count:
+    columns: [{dataObject: Orders, column: Order ID}]
+    resultType: int
+    aggregation: count
+"""
+
+
+def _exists_on_items(sub_filters: list[QueryFilter]) -> QueryObject:
+    """Orders-by-country query semi-joined to OrderItems with *sub_filters*."""
+    return QueryObject(
+        select=QuerySelect(dimensions=["Customer Country"], measures=["Order Count"]),
+        where=[
+            QueryFilter(
+                field="Order ID",
+                op=FilterOperator.EXISTS,
+                subquery=Subquery(data_object="OrderItems", filter=sub_filters),
+            )
+        ],
+    )
+
+
 # ---------------------------------------------------------------------------
 # Pydantic-level model validation
 # ---------------------------------------------------------------------------
@@ -372,6 +485,173 @@ class TestExistsCompilation:
         result = PIPELINE.compile(query, model, "postgres")
         assert '"Returns"."ORDER_ID"' in result.sql
         assert '"Returns"."WAREHOUSE_ID"' not in result.sql
+
+
+# ---------------------------------------------------------------------------
+# Subquery filters that traverse the target's joins
+# ---------------------------------------------------------------------------
+
+
+class TestSubqueryFilterTraversal:
+    """A ``Subquery.filter`` may name a dimension or a qualified column on any
+    data object reachable from the subquery's target; the join it needs is
+    emitted inside the ``EXISTS`` body."""
+
+    def test_dimension_one_hop_joins_inside_exists(self) -> None:
+        model = _load_model(TRAVERSAL_MODEL)
+        query = _exists_on_items(
+            [QueryFilter(field="Product Category", op=FilterOperator.EQUALS, value="Toys")]
+        )
+        sql = PIPELINE.compile(query, model, "postgres").sql
+        assert '"Products"."CATEGORY" = \'Toys\'' in sql
+        # The join lands inside the subquery, as an INNER JOIN, and the outer
+        # query is left untouched: Products appears exactly once.
+        assert sql.count("PRODUCTS") == 1
+        assert 'INNER JOIN "PUBLIC"."PRODUCTS" AS "Products"' in sql
+        assert sql.index("EXISTS (") < sql.index("INNER JOIN")
+
+    def test_qualified_column_one_hop(self) -> None:
+        model = _load_model(TRAVERSAL_MODEL)
+        query = _exists_on_items(
+            [QueryFilter(field="Products.Category", op=FilterOperator.EQUALS, value="Toys")]
+        )
+        sql = PIPELINE.compile(query, model, "postgres").sql
+        assert '"Products"."CATEGORY" = \'Toys\'' in sql
+        assert sql.count("PRODUCTS") == 1
+
+    def test_target_column_wins_over_same_named_dimension(self) -> None:
+        """``SKU`` is both a column of OrderItems and a dimension on Products.
+        The target's own column takes precedence, so no join is added."""
+        model = _load_model(TRAVERSAL_MODEL)
+        query = _exists_on_items(
+            [QueryFilter(field="SKU", op=FilterOperator.EQUALS, value="sku-a")]
+        )
+        sql = PIPELINE.compile(query, model, "postgres").sql
+        assert '"OrderItems"."SKU" = \'sku-a\'' in sql
+        assert "PRODUCTS" not in sql
+
+    def test_same_object_joined_once_for_two_filters(self) -> None:
+        model = _load_model(TRAVERSAL_MODEL)
+        query = _exists_on_items(
+            [
+                QueryFilter(field="Product Category", op=FilterOperator.EQUALS, value="Toys"),
+                QueryFilter(field="Products.Product SKU", op=FilterOperator.EQUALS, value="p-1"),
+            ]
+        )
+        sql = PIPELINE.compile(query, model, "postgres").sql
+        assert sql.count('INNER JOIN "PUBLIC"."PRODUCTS"') == 1
+        assert '"Products"."CATEGORY"' in sql
+        assert '"Products"."PRODUCT_SKU"' in sql
+
+    def test_semi_join_windowed_by_a_date_dimension(self) -> None:
+        """The shape this unlocks: "customers who ordered in 2024", where the
+        window lives on a Date object one join past the subquery's target."""
+        model = _load_model(TRAVERSAL_MODEL)
+        query = QueryObject(
+            select=QuerySelect(dimensions=["Customer Country"], measures=["Order Count"]),
+            where=[
+                QueryFilter(
+                    field="Customer Country",
+                    op=FilterOperator.EXISTS,
+                    subquery=Subquery(
+                        data_object="Orders",
+                        filter=[
+                            QueryFilter(field="Order Year", op=FilterOperator.EQUALS, value=2024)
+                        ],
+                    ),
+                )
+            ],
+        )
+        sql = PIPELINE.compile(query, model, "postgres").sql
+        assert 'INNER JOIN "PUBLIC"."DATES" AS "Dates"' in sql
+        assert '"Dates"."YEAR" = 2024' in sql
+        assert sql.index("EXISTS (") < sql.index("INNER JOIN")
+
+    @pytest.mark.parametrize("dialect_name", ALL_DIALECTS)
+    def test_traversing_filter_compiles_per_dialect(self, dialect_name: str) -> None:
+        model = _load_model(TRAVERSAL_MODEL)
+        query = _exists_on_items(
+            [QueryFilter(field="Product Category", op=FilterOperator.EQUALS, value="Toys")]
+        )
+        sql = PIPELINE.compile(query, model, dialect_name).sql
+        assert "EXISTS (" in sql, f"{dialect_name}: missing EXISTS"
+        assert "INNER JOIN" in sql, f"{dialect_name}: subquery join not emitted"
+        assert sql.index("EXISTS (") < sql.index("INNER JOIN"), (
+            f"{dialect_name}: join landed outside the subquery"
+        )
+
+    def test_joined_object_tracked_in_physical_tables(self) -> None:
+        """The cache key must cover tables only the EXISTS body reads."""
+        model = _load_model(TRAVERSAL_MODEL)
+        query = _exists_on_items(
+            [QueryFilter(field="Product Category", op=FilterOperator.EQUALS, value="Toys")]
+        )
+        refs = PIPELINE.compile(query, model, "postgres").physical_tables
+        assert any(r.endswith(".PRODUCTS") for r in refs), refs
+        assert any(r.endswith(".ORDER_ITEMS") for r in refs), refs
+
+
+class TestSubqueryFilterTraversalValidation:
+    def _expect(self, query: QueryObject, model, code: str) -> None:
+        with pytest.raises(ResolutionError) as excinfo:
+            PIPELINE.compile(query, model, "postgres")
+        codes = {e.code for e in excinfo.value.errors}
+        assert code in codes, f"expected {code} in {codes}"
+
+    def test_unreachable_object_rejected(self) -> None:
+        """Payments joins *to* Orders many-to-one, so it is not reachable from
+        OrderItems — filtering on it inside the subquery must not silently
+        widen the semi-join."""
+        model = _load_model(TRAVERSAL_MODEL)
+        self._expect(
+            _exists_on_items(
+                [QueryFilter(field="Payments.Payment ID", op=FilterOperator.EQUALS, value="p1")]
+            ),
+            model,
+            "UNREACHABLE_SUBQUERY_FILTER_OBJECT",
+        )
+
+    def test_subject_object_rejected(self) -> None:
+        """Joining the correlation subject inside the body would shadow its
+        outer alias and rebind the correlation predicate."""
+        model = _load_model(TRAVERSAL_MODEL)
+        self._expect(
+            _exists_on_items([QueryFilter(field="Orders.Amount", op=FilterOperator.GT, value=10)]),
+            model,
+            "SUBQUERY_FILTER_OBJECT_NOT_JOINABLE",
+        )
+
+    def test_path_through_the_subject_rejected(self) -> None:
+        """Customers is reachable from OrderItems only via Orders, the
+        subject — same shadowing hazard, one hop further out."""
+        model = _load_model(TRAVERSAL_MODEL)
+        self._expect(
+            _exists_on_items(
+                [QueryFilter(field="Customers.Country", op=FilterOperator.EQUALS, value="DE")]
+            ),
+            model,
+            "SUBQUERY_FILTER_OBJECT_NOT_JOINABLE",
+        )
+
+    def test_unknown_qualified_column_rejected(self) -> None:
+        model = _load_model(TRAVERSAL_MODEL)
+        self._expect(
+            _exists_on_items(
+                [QueryFilter(field="Products.No Such", op=FilterOperator.EQUALS, value="x")]
+            ),
+            model,
+            "UNKNOWN_SUBQUERY_FILTER_COLUMN",
+        )
+
+    def test_unknown_data_object_in_qualified_field_rejected(self) -> None:
+        model = _load_model(TRAVERSAL_MODEL)
+        self._expect(
+            _exists_on_items(
+                [QueryFilter(field="Nope.Category", op=FilterOperator.EQUALS, value="x")]
+            ),
+            model,
+            "UNKNOWN_SUBQUERY_FILTER_COLUMN",
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -754,3 +1034,109 @@ class TestExistsExecution:
         by_country = {country: count for country, count in rows}
         # Only o3 (France) has a returned item.
         assert by_country == {"France": 1}
+
+
+class TestTraversingSubqueryFilterExecution:
+    """The joined-in filter must restrict the semi-join, not the outer rows."""
+
+    def _setup_duckdb(self):
+        import duckdb
+
+        conn = duckdb.connect(":memory:")
+        conn.execute("CREATE SCHEMA PUBLIC")
+        conn.execute("CREATE TABLE PUBLIC.CUSTOMERS (CUSTOMER_ID TEXT, COUNTRY TEXT)")
+        conn.execute("CREATE TABLE PUBLIC.DATES (DATE_KEY TEXT, YEAR INTEGER)")
+        conn.execute(
+            "CREATE TABLE PUBLIC.ORDERS "
+            "(ORDER_ID TEXT, CUSTOMER_ID TEXT, DATE_KEY TEXT, AMOUNT DOUBLE)"
+        )
+        conn.execute(
+            "CREATE TABLE PUBLIC.ORDER_ITEMS "
+            "(ITEM_ID TEXT, ORDER_ID TEXT, PRODUCT_ID TEXT, SKU TEXT)"
+        )
+        conn.execute(
+            "CREATE TABLE PUBLIC.PRODUCTS (PRODUCT_ID TEXT, CATEGORY TEXT, PRODUCT_SKU TEXT)"
+        )
+        conn.execute("CREATE TABLE PUBLIC.PAYMENTS (PAYMENT_ID TEXT, ORDER_ID TEXT)")
+        conn.execute("INSERT INTO PUBLIC.CUSTOMERS VALUES ('c1', 'Germany'), ('c2', 'France')")
+        conn.execute("INSERT INTO PUBLIC.DATES VALUES ('d2023', 2023), ('d2024', 2024)")
+        # o1 (Germany, 2024) has a Toys item; o2 (Germany, 2023) has a Books
+        # item; o3 (France, 2024) has a Books item.
+        conn.execute(
+            "INSERT INTO PUBLIC.ORDERS VALUES "
+            "('o1', 'c1', 'd2024', 100), ('o2', 'c1', 'd2023', 50), ('o3', 'c2', 'd2024', 200)"
+        )
+        conn.execute(
+            "INSERT INTO PUBLIC.PRODUCTS VALUES "
+            "('p1', 'Toys', 'sku-toy'), ('p2', 'Books', 'sku-book')"
+        )
+        conn.execute(
+            "INSERT INTO PUBLIC.ORDER_ITEMS VALUES "
+            "('i1', 'o1', 'p1', 'sku-a'), ('i2', 'o2', 'p2', 'sku-b'), "
+            "('i3', 'o3', 'p2', 'sku-c')"
+        )
+        return conn
+
+    def test_filter_on_joined_object_restricts_the_semi_join(self) -> None:
+        conn = self._setup_duckdb()
+        model = _load_model(TRAVERSAL_MODEL)
+        query = _exists_on_items(
+            [QueryFilter(field="Product Category", op=FilterOperator.EQUALS, value="Toys")]
+        )
+        result = PIPELINE.compile(query, model, "duckdb")
+        rows = conn.execute(result.sql).fetchall()
+        # Only o1 has a Toys item, and it belongs to Germany.
+        assert {country: count for country, count in rows} == {"Germany": 1}
+
+    def test_semi_join_windowed_by_a_date_dimension(self) -> None:
+        conn = self._setup_duckdb()
+        model = _load_model(TRAVERSAL_MODEL)
+        query = QueryObject(
+            select=QuerySelect(dimensions=["Customer Country"], measures=["Order Count"]),
+            where=[
+                QueryFilter(
+                    field="Customer Country",
+                    op=FilterOperator.EXISTS,
+                    subquery=Subquery(
+                        data_object="Orders",
+                        filter=[
+                            QueryFilter(field="Order Year", op=FilterOperator.EQUALS, value=2024)
+                        ],
+                    ),
+                )
+            ],
+        )
+        result = PIPELINE.compile(query, model, "duckdb")
+        rows = conn.execute(result.sql).fetchall()
+        # Both customers ordered in 2024, so both are kept — and every one of
+        # their orders is counted, 2023 included. That is the semi-join's
+        # meaning: the window restricts *which customers qualify*, not which
+        # of the outer rows survive.
+        assert {country: count for country, count in rows} == {"Germany": 2, "France": 1}
+
+    def test_nonexists_with_a_traversing_filter(self) -> None:
+        conn = self._setup_duckdb()
+        model = _load_model(TRAVERSAL_MODEL)
+        query = QueryObject(
+            select=QuerySelect(dimensions=["Customer Country"], measures=["Order Count"]),
+            where=[
+                QueryFilter(
+                    field="Order ID",
+                    op=FilterOperator.NONEXISTS,
+                    subquery=Subquery(
+                        data_object="OrderItems",
+                        filter=[
+                            QueryFilter(
+                                field="Product Category",
+                                op=FilterOperator.EQUALS,
+                                value="Toys",
+                            )
+                        ],
+                    ),
+                )
+            ],
+        )
+        result = PIPELINE.compile(query, model, "duckdb")
+        rows = conn.execute(result.sql).fetchall()
+        # o2 and o3 carry no Toys item.
+        assert {country: count for country, count in rows} == {"Germany": 1, "France": 1}

--- a/tests/unit/test_graph.py
+++ b/tests/unit/test_graph.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from orionbelt.ast.nodes import BinaryOp, ColumnRef
 from orionbelt.compiler.graph import JoinGraph
 from orionbelt.models.semantic import SemanticModel
 from orionbelt.parser.loader import TrackedLoader
@@ -178,3 +179,84 @@ class TestCommonRootDisconnected:
     def test_connected_objects_still_resolve_to_the_real_root(self) -> None:
         """The fallback must not disturb the ordinary directed-ancestor answer."""
         assert self._graph().find_common_root({"Products", "Sales"}) == "Sales"
+
+
+_ROW_PRESERVING_MODEL_YAML = """\
+version: 1.0
+
+dataObjects:
+  Orders:
+    code: ORDERS
+    database: WH
+    schema: PUBLIC
+    columns:
+      Order ID:
+        code: ORDER_ID
+        abstractType: string
+      Amount:
+        code: AMOUNT
+        abstractType: float
+
+  OrderExtras:
+    code: ORDER_EXTRAS
+    database: WH
+    schema: PUBLIC
+    columns:
+      Extra Order ID:
+        code: EXT_ORDER_ID
+        abstractType: string
+      Gift Wrapped:
+        code: GIFT_WRAPPED
+        abstractType: boolean
+    joins:
+      - joinType: one-to-one
+        joinTo: Orders
+        columnsFrom: [Extra Order ID]
+        columnsTo: [Order ID]
+
+dimensions:
+  Gift Wrapped:
+    dataObject: OrderExtras
+    column: Gift Wrapped
+    resultType: boolean
+"""
+
+
+class TestReverseTraversal:
+    """Walking a row-preserving join against its declared direction.
+
+    One-to-one and many-to-many joins are bidirectional in the traversal
+    graph, so ``find_join_path`` can reach ``OrderExtras`` from ``Orders``
+    even though the join is declared the other way round.
+    """
+
+    @staticmethod
+    def _graph() -> JoinGraph:
+        loader = TrackedLoader()
+        raw, source_map = loader.load_string(_ROW_PRESERVING_MODEL_YAML)
+        model, result = ReferenceResolver().resolve(raw, source_map)
+        assert result.valid, result.errors
+        return JoinGraph(model)
+
+    def test_one_to_one_is_reachable_backwards(self) -> None:
+        steps = self._graph().find_join_path({"Orders"}, {"OrderExtras"})
+        assert len(steps) == 1
+        assert steps[0].reversed is True
+
+    def test_reversed_step_keeps_columns_with_their_object(self) -> None:
+        """from/to stay in *declared* order, so the columns must not be swapped.
+
+        Swapping them pairs ``OrderExtras`` with the ``Orders`` column, and
+        ``build_join_condition`` then renders an unresolvable identifier.
+        """
+        steps = self._graph().find_join_path({"Orders"}, {"OrderExtras"})
+        step = steps[0]
+        assert (step.from_object, step.from_columns) == ("OrderExtras", ["Extra Order ID"])
+        assert (step.to_object, step.to_columns) == ("Orders", ["Order ID"])
+
+    def test_reversed_step_builds_a_resolvable_on_clause(self) -> None:
+        graph = self._graph()
+        condition = graph.build_join_condition(graph.find_join_path({"Orders"}, {"OrderExtras"})[0])
+        assert isinstance(condition, BinaryOp)
+        assert condition.left == ColumnRef(name="EXT_ORDER_ID", table="OrderExtras")
+        assert condition.right == ColumnRef(name="ORDER_ID", table="Orders")


### PR DESCRIPTION
## What

`exists` / `nonexists` subquery filters can now resolve against the target's join graph instead of only the target's own columns, and the joins that needs are emitted inside the `EXISTS` body.

Before, `Subquery.filter` accepted a raw column of `subquery.dataObject` and nothing else, so a semi-join could not be windowed by a dimension one join away:

```
Subquery filter references unknown column 'Year' on 'Store Sales'
```

Now a subquery filter field resolves like an outer `where` field, minus measure names (a correlated subquery filters rows, not aggregates):

1. a column of the target data object,
2. a dimension name,
3. a qualified `DataObject.Column`.

```yaml
where:
  - field: Customer.Customer Key
    op: exists
    subquery:
      dataObject: Store Sales
      filter:
        - {field: Year, op: "=", value: 2001}          # on Date, one join past Store Sales
        - {field: Month of Year, op: between, value: [4, 6]}
```

```sql
EXISTS (
  SELECT 1
  FROM "tpcds"."store_sales" AS "Store Sales"
  INNER JOIN "tpcds"."date_dim" AS "Date" ON "Store Sales"."ss_sold_date_sk" = "Date"."d_date_sk"
  WHERE "Customer"."c_customer_sk" = "Store Sales"."ss_customer_sk"
    AND "Date"."d_year" = 2001 AND "Date"."d_moy" BETWEEN 4 AND 6
)
```

## Refusals, not silent wrongness

- `UNREACHABLE_SUBQUERY_FILTER_OBJECT`: the object is not reachable from the target by the same forward-only walk the outer query uses. Silently dropping it would answer a different question.
- `SUBQUERY_FILTER_OBJECT_NOT_JOINABLE`: the object is, or is only reachable through, the correlation subject. An inner `FROM`/`JOIN` alias shadows the outer one, so joining the subject inside the body would rebind the correlation predicate to the subquery's own rows. The message points at the outer `where` instead.

A column of the target still wins over a same-named dimension, so adding a dimension to a model never changes what an existing subquery filter compiles to.

## Cache correctness

`ResolvedQuery.subquery_objects` records every data object the `EXISTS` body reads, and `physical_tables` unions it. This also closes a pre-existing gap: a multi-hop correlation path already emitted INNER JOINs for its intermediate objects, and none of them reached the freshness cache key.

## Verification

30-query TPC-DS sweep, unchanged on both engines: DuckDB 29/30, ClickHouse 27/30 (the non-matches are the documented reference-variant artifacts, not defects).

Two queries the phase unlocks, both exact against their engine's own reference:

| Query | DuckDB | ClickHouse |
|---|---|---|
| Q69 (store purchases, no web or catalog, same window) | exact | exact |
| Q10 (store purchases and web or catalog, OR-ed semi-joins) | exact | exact |

Q16 and Q94 were listed under the same finding, but each also needs a self-join on a column-to-column inequality (`cs_warehouse_sk <> cs2.cs_warehouse_sk`), which is the separate cross-object-predicate gap. They stay blocked.

22 new unit tests in `tests/unit/test_exists_filter.py`: traversal by dimension and by qualified column, the join landing inside the body on all 8 dialects, one join for two filters on the same object, precedence over a same-named dimension, both refusals, `physical_tables` coverage, and DuckDB execution round-trips for `exists`, `nonexists` and a date-windowed semi-join.

`uv run pytest` 3159 passed, `ruff check`, `ruff format --check`, `mypy src/` all clean.

## Model additions (examples)

`examples/tpcds.obml.yml` gains `catalog_sales.cs_ship_customer_sk` with a `ship_customer` secondary path to Customer, and the three dependent-count columns of `customer_demographics` plus dimensions for them. Q69 correlates on the first, Q10 groups on the second.
