### PR TITLE
fix(compiler): rebuild a measure's aggregate from what the plan projects

### DIFF
--- a/src/orionbelt/compiler/cfl.py
+++ b/src/orionbelt/compiler/cfl.py
@@ -722,6 +722,14 @@ class CFLPlanner:
                 outer_builder.select(AliasedExpr(expr=metric_expr, alias=m.name))
                 outer_measure_exprs[m.name] = metric_expr
 
+        # Recorded for the wrappers that run after planning. Each of them
+        # re-projects some measure's aggregate into a CTE of its own, and every
+        # such CTE selects from the composite below - where the fact tables the
+        # resolved expressions name are not in scope, so rebuilding from those
+        # produces SQL that does not bind.
+        resolved.projected_expressions = dict(outer_measure_exprs)
+        resolved.composite_cte = cte_name
+
         outer_builder.from_(cte_name, alias=cte_name)
 
         # GROUP BY dimensions.  Coalesce groups group by the COALESCE expression

--- a/src/orionbelt/compiler/cumulative_wrap.py
+++ b/src/orionbelt/compiler/cumulative_wrap.py
@@ -159,7 +159,7 @@ def _component_base_column(
     # An anchored measure's aggregate reads conformed subquery columns, not the
     # foreign fact's own, so re-deriving it here would name a table this CTE
     # joins a GROUP BY subquery in place of.
-    rebuilt = resolved.conformed_expressions.get(comp.name, comp.expression)
+    rebuilt = resolved.projected_expressions.get(comp.name, comp.expression)
     # Taking the column by alias is required whenever the input is already a
     # CTE, not only after grain dedup: a CFL composite holds the aggregate too,
     # and neither the fact tables nor an anchored measure's conformed

--- a/src/orionbelt/compiler/passes.py
+++ b/src/orionbelt/compiler/passes.py
@@ -419,6 +419,43 @@ def evaluate_compatibility(
                 ]
             )
 
+    # Rule 2c (raising): a filterContext measure is computed in a CTE of its
+    # own, whose WHERE is the query's with some filters dropped or added. Under
+    # a multi-fact plan there is nothing to compute it from: the union legs
+    # applied the query's filters before the composite CTE existed, so a context
+    # that drops one cannot un-apply it, and the fact columns a context of its
+    # own would filter on are not among the composite's columns either. The
+    # projection came out reading tables the CTE does not select from, which no
+    # engine binds — refuse instead, since suppressing the pass would answer the
+    # unfiltered number under the filtered measure's name.
+    if resolved.composite_cte is not None:
+        fc_measures = sorted(m.name for m in resolved.measures if m.filter_context is not None)
+        if fc_measures:
+            listed = ", ".join(f"'{m}'" for m in fc_measures)
+            raise ResolutionError(
+                [
+                    SemanticError(
+                        code="INCOMPATIBLE_COMBINATION",
+                        message=(
+                            f"Measure(s) {listed} declare a filterContext, which needs its "
+                            f"own filtered scan of the fact. This query spans facts that "
+                            f"cannot be joined, so it is planned as a UNION ALL whose legs "
+                            f"are already filtered and whose columns are the projected "
+                            f"measures, leaving nothing for that scan to read."
+                        ),
+                        path="select.measures",
+                        hint=(
+                            "Query the filterContext measure without the measures from the "
+                            "other fact, or drop the filterContext."
+                        ),
+                        context={
+                            "measures": fc_measures,
+                            "conflictsWith": ["a multi-fact (CFL) plan"],
+                        },
+                    )
+                ]
+            )
+
     # Rule 3 (raising): grain dedup splits the projection across CTEs keyed on
     # the query grain. Every wrapper in ``incompatible_with`` restructures that
     # same projection, and ROLLUP/CUBE changes the grain itself, so the join

--- a/src/orionbelt/compiler/passes.py
+++ b/src/orionbelt/compiler/passes.py
@@ -419,14 +419,53 @@ def evaluate_compatibility(
                 ]
             )
 
-    # Rule 2c (raising): a filterContext measure is computed in a CTE of its
+    # Rule 2c (raising): ``filter_wrap`` isolates the measures the query
+    # *selects*, so a filterContext declared on a metric's component never gets
+    # a CTE of its own. The planner inlines that component's aggregate into the
+    # metric column instead, where the query's WHERE applies to it like any
+    # other - the metric then answers a number that looks right and is not the
+    # one the context asked for. Refuse until the component can be split out
+    # the way ``grain_dedup`` splits a deduplicated one.
+    fc_components = sorted(
+        {
+            f"{m.name}.{comp.name}"
+            for m in resolved.measures
+            if m.component_measures
+            for comp in metric_leaf_components(m, resolved.metric_components)
+            if comp.filter_context is not None
+        }
+    )
+    if fc_components:
+        listed = ", ".join(f"'{c}'" for c in fc_components)
+        raise ResolutionError(
+            [
+                SemanticError(
+                    code="INCOMPATIBLE_COMBINATION",
+                    message=(
+                        f"Measure(s) {listed} declare a filterContext and are read through "
+                        f"a metric. A filterContext needs the measure computed in its own "
+                        f"filtered scan, which only a directly selected measure gets - "
+                        f"through a metric the aggregate is inlined into the metric's "
+                        f"column and the query's filters apply to it."
+                    ),
+                    path="select.measures",
+                    hint=(
+                        "Select the filterContext measure directly, or drop the "
+                        "filterContext from the measure the metric reads."
+                    ),
+                    context={"components": fc_components},
+                )
+            ]
+        )
+
+    # Rule 2d (raising): a filterContext measure is computed in a CTE of its
     # own, whose WHERE is the query's with some filters dropped or added. Under
     # a multi-fact plan there is nothing to compute it from: the union legs
     # applied the query's filters before the composite CTE existed, so a context
     # that drops one cannot un-apply it, and the fact columns a context of its
     # own would filter on are not among the composite's columns either. The
     # projection came out reading tables the CTE does not select from, which no
-    # engine binds — refuse instead, since suppressing the pass would answer the
+    # engine binds - refuse instead, since suppressing the pass would answer the
     # unfiltered number under the filtered measure's name.
     if resolved.composite_cte is not None:
         fc_measures = sorted(m.name for m in resolved.measures if m.filter_context is not None)

--- a/src/orionbelt/compiler/resolution.py
+++ b/src/orionbelt/compiler/resolution.py
@@ -424,14 +424,29 @@ class ResolvedQuery:
     out so the deduplicated ones can be computed in their own CTE and the metric
     recomputed from the results."""
 
-    conformed_expressions: dict[str, Expr] = field(default_factory=dict)
-    """Anchored measures, mapped to the expression that reads their conformed columns.
+    composite_cte: str | None = None
+    """Name of the UNION ALL composite CTE, when the plan actually built one.
 
-    Set by the star planner once it has built the conformed subqueries. Any pass
-    that re-projects a measure's aggregate must read it from here: the resolved
-    expression still names the foreign fact's own table, which the conformed
-    plan joins a ``GROUP BY`` subquery in place of. Empty for every query with
-    no anchored measure."""
+    ``requires_cfl`` says a multi-fact plan was *asked for*; this says one was
+    *produced* - the CFL planner delegates back to the star planner whenever the
+    measures turn out to reach a single leg. A pass that has to reason about
+    what its own CTE can select from wants this one."""
+
+    projected_expressions: dict[str, Expr] = field(default_factory=dict)
+    """Measures and metric components, mapped to the expression the plan
+    projects them as.
+
+    Set by whichever planner ran, and read by every pass that *re-projects* a
+    measure's aggregate into a CTE of its own rather than passing its column
+    through. Those passes cannot use the resolved expression: it names the fact
+    table the measure was resolved against, and the plan may not select from it.
+
+    The star planner records the anchored measures, whose aggregate reads a
+    conformed ``GROUP BY`` subquery in place of the foreign fact; it leaves the
+    rest out, since a plain star's CTE reuses the planner's own FROM and joins
+    and the resolved expression is exactly right there. The CFL planner records
+    *every* measure, because its outer query reads the composite CTE the union
+    legs feed and none of the fact tables are in scope at all."""
 
     anchored_measures: dict[str, str] = field(default_factory=dict)
     """Measures whose expression is evaluated at a declared object's grain,

--- a/src/orionbelt/compiler/resolution.py
+++ b/src/orionbelt/compiler/resolution.py
@@ -523,8 +523,23 @@ class ResolvedQuery:
 
     @property
     def has_filter_context(self) -> bool:
-        """Check if any measure has a filter context override."""
-        return any(m.filter_context is not None for m in self.measures)
+        """Check if any measure (direct or metric component) has a filter context.
+
+        Components count for the same reason they do in :attr:`has_totals`: a
+        metric inlines their aggregates, so a context declared on one is a
+        context this query has to honour. ``filter_wrap`` isolates only the
+        directly selected ones, which is why a metric over such a component is
+        refused in ``compiler.passes`` rather than compiled - reporting False
+        here instead would skip the pass and answer the query-filtered number
+        under the unfiltered measure's name.
+        """
+        for m in self.measures:
+            if m.filter_context is not None:
+                return True
+            for comp in self._components_of(m):
+                if comp.filter_context is not None:
+                    return True
+        return False
 
     @property
     def has_cumulative(self) -> bool:

--- a/src/orionbelt/compiler/star.py
+++ b/src/orionbelt/compiler/star.py
@@ -142,7 +142,7 @@ class StarSchemaPlanner:
         # Recorded for the wrappers that run after planning: each re-projects a
         # measure's aggregate into its own CTE, and the resolved expression they
         # would otherwise use still names the foreign fact's table.
-        resolved.conformed_expressions = conformed_exprs
+        resolved.projected_expressions = conformed_exprs
 
         # SELECT: dimensions (apply time grain truncation if specified)
         grouping_dim_aliases: list[str] = []

--- a/src/orionbelt/compiler/total_wrap.py
+++ b/src/orionbelt/compiler/total_wrap.py
@@ -243,7 +243,7 @@ def wrap_with_totals(ast: Select, resolved: ResolvedQuery) -> Select:
                     continue  # Already present as a direct measure
                 if _is_avg_total(comp, resolved.dedup_measures):
                     # AVG total needs sum + count helper columns
-                    comp_expr = resolved.conformed_expressions.get(comp.name, comp.expression)
+                    comp_expr = resolved.projected_expressions.get(comp.name, comp.expression)
                     base_columns.append(_build_avg_helpers_base_col(comp, "sum", comp_expr))
                     base_columns.append(_build_avg_helpers_base_col(comp, "count", comp_expr))
                 else:
@@ -253,7 +253,7 @@ def wrap_with_totals(ast: Select, resolved: ResolvedQuery) -> Select:
                     base_columns.append(
                         _peel_default(
                             AliasedExpr(
-                                expr=resolved.conformed_expressions.get(comp.name, comp.expression),
+                                expr=resolved.projected_expressions.get(comp.name, comp.expression),
                                 alias=comp.name,
                             ),
                             comp,

--- a/src/orionbelt/compiler/window_wrap.py
+++ b/src/orionbelt/compiler/window_wrap.py
@@ -352,7 +352,7 @@ def wrap_with_window(
                                 over_cte,
                                 model,
                                 dialect,
-                                resolved.conformed_expressions,
+                                resolved.projected_expressions,
                             )
                         )
         elif alias and alias in ddm_names:
@@ -370,7 +370,7 @@ def wrap_with_window(
                 if already_in_base:
                     continue
                 comp_expr = _apply_measure_cast(
-                    resolved.conformed_expressions.get(base_comp.name, base_comp.expression),
+                    resolved.projected_expressions.get(base_comp.name, base_comp.expression),
                     base_comp.name,
                     model,
                     dialect,

--- a/tests/unit/test_anchored_measures.py
+++ b/tests/unit/test_anchored_measures.py
@@ -507,7 +507,7 @@ def test_a_wrapper_reprojecting_an_anchored_measure_reads_the_conformed_columns(
     column, so both projected the raw ``SUM("Sales"."qty" * "Returns"."qty")``
     into a CTE whose FROM joins conformed subqueries in place of those tables.
     The expression they re-project now comes from
-    ``ResolvedQuery.conformed_expressions``.
+    ``ResolvedQuery.projected_expressions``.
     """
     sql = _sql(WRAPPED_YAML, [metric])
     assert '"Sales"."qty" * "Returns"."qty"' not in sql

--- a/tests/unit/test_cfl_rebuilt_aggregates.py
+++ b/tests/unit/test_cfl_rebuilt_aggregates.py
@@ -1,0 +1,232 @@
+"""What a post-planning pass may rebuild a measure's aggregate from.
+
+Most wrappers pass a measure's column through by name, but several re-project
+its *aggregate* into a CTE of their own: ``total_wrap`` decomposes a metric's
+components, ``window_wrap`` and ``cumulative_wrap`` rebuild a base measure. Each
+used the measure's resolved expression for that, which names the fact table the
+measure was resolved against - true under a star plan, whose CTE reuses the
+planner's own FROM, and false under a multi-fact one, whose CTE selects from the
+UNION ALL composite and has no fact table in scope at all.
+
+The plan now records what it projects each measure as
+(``ResolvedQuery.projected_expressions``), so a pass rebuilds from that rather
+than from the resolved expression. The one thing that cannot be rebuilt is a
+``filterContext``, and that is refused rather than mis-compiled.
+"""
+
+from __future__ import annotations
+
+import duckdb
+import pytest
+
+from orionbelt.compiler.pipeline import CompilationPipeline
+from orionbelt.compiler.resolution import QueryResolver, ResolutionError
+from orionbelt.models.query import QueryObject, QuerySelect
+from orionbelt.models.semantic import SemanticModel
+from orionbelt.parser.loader import TrackedLoader
+from orionbelt.parser.resolver import ReferenceResolver
+
+PIPELINE = CompilationPipeline()
+
+MODEL_YAML = """\
+version: 1.0
+
+dataObjects:
+  Dates:
+    code: DATES
+    database: WH
+    schema: PUBLIC
+    columns:
+      Date Key: {code: DATE_KEY, abstractType: int, primaryKey: true}
+      Month: {code: MONTH, abstractType: int}
+
+  Sales:
+    code: SALES
+    database: WH
+    schema: PUBLIC
+    columns:
+      Date Key: {code: DATE_KEY, abstractType: int}
+      Amount: {code: AMOUNT, abstractType: float}
+    joins:
+      - joinType: many-to-one
+        joinTo: Dates
+        columnsFrom: [Date Key]
+        columnsTo: [Date Key]
+
+  Refunds:
+    code: REFUNDS
+    database: WH
+    schema: PUBLIC
+    columns:
+      Date Key: {code: DATE_KEY, abstractType: int}
+      Refund: {code: REFUND, abstractType: float}
+    joins:
+      - joinType: many-to-one
+        joinTo: Dates
+        columnsFrom: [Date Key]
+        columnsTo: [Date Key]
+
+dimensions:
+  Month: {dataObject: Dates, column: Month, resultType: int}
+
+measures:
+  Sales Amount:
+    columns: [{dataObject: Sales, column: Amount}]
+    resultType: float
+    aggregation: sum
+  Total Sales:
+    columns: [{dataObject: Sales, column: Amount}]
+    resultType: float
+    aggregation: sum
+    total: true
+  Avg Sales:
+    columns: [{dataObject: Sales, column: Amount}]
+    resultType: float
+    aggregation: avg
+    total: true
+  Refund Amount:
+    columns: [{dataObject: Refunds, column: Refund}]
+    resultType: float
+    aggregation: sum
+  Unfiltered Sales:
+    columns: [{dataObject: Sales, column: Amount}]
+    resultType: float
+    aggregation: sum
+    filterContext:
+      mode: FIXED
+
+metrics:
+  Sales Share:
+    expression: "{[Sales Amount]} / {[Total Sales]}"
+  Sales vs Average:
+    expression: "{[Sales Amount]} / {[Avg Sales]}"
+"""
+
+
+def _model() -> SemanticModel:
+    raw, source_map = TrackedLoader().load_string(MODEL_YAML)
+    model, result = ReferenceResolver().resolve(raw, source_map)
+    assert result.valid, result.errors
+    return model
+
+
+def _sql(measures: list[str], dialect: str = "duckdb") -> str:
+    return PIPELINE.compile(
+        QueryObject(select=QuerySelect(dimensions=["Month"], measures=measures)),
+        _model(),
+        dialect,
+    ).sql
+
+
+def _run(sql: str) -> list[tuple]:
+    con = duckdb.connect(":memory:")
+    con.execute('CREATE SCHEMA "PUBLIC"')
+    con.execute('CREATE TABLE "PUBLIC"."DATES" (DATE_KEY INT, MONTH INT)')
+    con.execute('CREATE TABLE "PUBLIC"."SALES" (DATE_KEY INT, AMOUNT DOUBLE)')
+    con.execute('CREATE TABLE "PUBLIC"."REFUNDS" (DATE_KEY INT, REFUND DOUBLE)')
+    con.execute('INSERT INTO "PUBLIC"."DATES" VALUES (1, 1), (2, 2)')
+    # 30 across two months, so a share of the grand total is a round number.
+    con.execute('INSERT INTO "PUBLIC"."SALES" VALUES (1, 10.0), (2, 15.0), (2, 5.0)')
+    con.execute('INSERT INTO "PUBLIC"."REFUNDS" VALUES (1, 1.0)')
+    return con.execute(sql).fetchall()
+
+
+class TestAMetricOverATotalComponent:
+    """``total_wrap`` splits a metric into its components so it can put a window
+    over the ones carrying ``total``. Under CFL those components have to be
+    re-aggregated from the composite CTE, not from the fact the resolved
+    expression names."""
+
+    def test_the_plan_is_multi_fact(self) -> None:
+        assert "UNION ALL" in _sql(["Sales Share", "Refund Amount"])
+
+    def test_components_read_the_composite(self) -> None:
+        sql = _sql(["Sales Share", "Refund Amount"])
+        assert 'SUM("composite_01"."Sales Amount")' in sql
+        assert '"Sales"."AMOUNT"' not in sql.split("UNION ALL")[-1]
+
+    def test_it_binds_and_answers(self) -> None:
+        rows = sorted(_run(_sql(["Sales Share", "Refund Amount"])))
+        # Month 1 is 10 of 30, month 2 is 20 of 30.
+        assert [(r[0], round(r[1], 4)) for r in rows] == [(1, 0.3333), (2, 0.6667)]
+
+    def test_an_avg_component_decomposes_over_the_composite(self) -> None:
+        """A total AVG becomes SUM and COUNT helpers, whose argument is the
+        column the plan projects — the composite's, not the fact's."""
+        sql = _sql(["Sales vs Average", "Refund Amount"])
+        assert 'SUM("composite_01"."Avg Sales")' in sql
+        assert 'COUNT("composite_01"."Avg Sales")' in sql
+
+    def test_the_avg_metric_binds_and_answers(self) -> None:
+        rows = sorted(_run(_sql(["Sales vs Average", "Refund Amount"])))
+        # The average is over rows (30/3 = 10), not over months.
+        assert [(r[0], round(r[1], 4)) for r in rows] == [(1, 1.0), (2, 2.0)]
+
+    def test_a_direct_total_avg_too(self) -> None:
+        """Not only through a metric: a total AVG selected directly was
+        decomposing the same way."""
+        sql = _sql(["Avg Sales", "Refund Amount"])
+        assert 'SUM("composite_01"."Avg Sales")' in sql
+        assert {round(r[1], 4) for r in _run(sql)} == {10.0}
+
+    def test_a_single_fact_plan_is_unchanged(self) -> None:
+        """The star plan's CTE reuses the planner's FROM, so there the resolved
+        expression is exactly right and still what gets projected."""
+        sql = _sql(["Sales Share"])
+        assert "UNION ALL" not in sql
+        assert 'SUM("Sales"."AMOUNT")' in sql
+
+
+class TestFilterContextInAMultiFactPlan:
+    """A ``filterContext`` needs its own filtered scan of the fact. The
+    composite offers neither: its legs applied the query's filters before it
+    existed, and its columns are the projected measures rather than the fact's.
+    """
+
+    def test_it_is_refused(self) -> None:
+        with pytest.raises(ResolutionError) as exc:
+            _sql(["Unfiltered Sales", "Refund Amount"])
+        message = str(exc.value)
+        assert "Unfiltered Sales" in message
+        assert "filterContext" in message
+
+    def test_the_refusal_names_the_plan_as_the_reason(self) -> None:
+        with pytest.raises(ResolutionError) as exc:
+            _sql(["Unfiltered Sales", "Refund Amount"])
+        assert "UNION ALL" in str(exc.value)
+
+    @pytest.mark.parametrize("dialect", ["bigquery", "clickhouse", "postgres", "snowflake"])
+    def test_refused_on_every_dialect(self, dialect: str) -> None:
+        """The plan is the reason, not the engine — so no dialect quietly
+        compiles it."""
+        with pytest.raises(ResolutionError):
+            _sql(["Unfiltered Sales", "Refund Amount"], dialect)
+
+    def test_still_allowed_on_a_single_fact(self) -> None:
+        sql = _sql(["Unfiltered Sales", "Sales Amount"])
+        assert "UNION ALL" not in sql
+        assert "fc_0" in sql
+        assert _run(sql)
+
+
+class TestTheCompositeFlag:
+    """``composite_cte`` says a union was *built*, where ``requires_cfl`` only
+    says one was asked for — the CFL planner delegates back to the star planner
+    whenever the measures turn out to reach a single leg."""
+
+    def test_set_when_the_plan_unions(self) -> None:
+        model = _model()
+        query = QueryObject(
+            select=QuerySelect(dimensions=["Month"], measures=["Sales Amount", "Refund Amount"])
+        )
+        resolved = QueryResolver().resolve(query, model)
+        assert resolved.requires_cfl
+        PIPELINE._cfl_planner.plan(resolved, model, union_by_name=True)
+        assert resolved.composite_cte == "composite_01"
+
+    def test_unset_on_a_star_plan(self) -> None:
+        model = _model()
+        query = QueryObject(select=QuerySelect(dimensions=["Month"], measures=["Sales Amount"]))
+        resolved = QueryResolver().resolve(query, model)
+        PIPELINE._star_planner.plan(resolved, model)
+        assert resolved.composite_cte is None

--- a/tests/unit/test_cfl_rebuilt_aggregates.py
+++ b/tests/unit/test_cfl_rebuilt_aggregates.py
@@ -21,7 +21,7 @@ import pytest
 
 from orionbelt.compiler.pipeline import CompilationPipeline
 from orionbelt.compiler.resolution import QueryResolver, ResolutionError
-from orionbelt.models.query import QueryObject, QuerySelect
+from orionbelt.models.query import FilterOperator, QueryFilter, QueryObject, QuerySelect
 from orionbelt.models.semantic import SemanticModel
 from orionbelt.parser.loader import TrackedLoader
 from orionbelt.parser.resolver import ReferenceResolver
@@ -94,12 +94,22 @@ measures:
     aggregation: sum
     filterContext:
       mode: FIXED
+  Grand Unfiltered Sales:
+    columns: [{dataObject: Sales, column: Amount}]
+    resultType: float
+    aggregation: sum
+    grain:
+      mode: FIXED
+    filterContext:
+      mode: FIXED
 
 metrics:
   Sales Share:
     expression: "{[Sales Amount]} / {[Total Sales]}"
   Sales vs Average:
     expression: "{[Sales Amount]} / {[Avg Sales]}"
+  Filtered Share:
+    expression: "{[Sales Amount]} / {[Unfiltered Sales]}"
 """
 
 
@@ -230,3 +240,79 @@ class TestTheCompositeFlag:
         resolved = QueryResolver().resolve(query, model)
         PIPELINE._star_planner.plan(resolved, model)
         assert resolved.composite_cte is None
+
+
+class TestFilterContextReadThroughAMetric:
+    """``filter_wrap`` isolates the measures the query *selects*. A metric
+    inlines its components' aggregates into one column instead, so a context
+    declared on a component never gets the filtered scan it asks for and the
+    query's WHERE applies to it like any other aggregate. The metric then
+    answers a number that looks right and is not the one that was asked for,
+    which is why it is refused on every plan rather than only under CFL.
+    """
+
+    @staticmethod
+    def _sql_filtered(measures: list[str]) -> str:
+        return PIPELINE.compile(
+            QueryObject(
+                select=QuerySelect(dimensions=["Month"], measures=measures),
+                where=[QueryFilter(field="Month", op=FilterOperator.EQUALS, value=1)],
+            ),
+            _model(),
+            "duckdb",
+        ).sql
+
+    def test_refused_on_a_single_fact_plan(self) -> None:
+        with pytest.raises(ResolutionError) as exc:
+            self._sql_filtered(["Filtered Share"])
+        assert "Filtered Share.Unfiltered Sales" in str(exc.value)
+
+    def test_refused_alongside_another_fact(self) -> None:
+        with pytest.raises(ResolutionError) as exc:
+            self._sql_filtered(["Filtered Share", "Refund Amount"])
+        assert "Filtered Share.Unfiltered Sales" in str(exc.value)
+
+    def test_the_refusal_says_what_a_metric_does_to_it(self) -> None:
+        with pytest.raises(ResolutionError) as exc:
+            self._sql_filtered(["Filtered Share"])
+        message = str(exc.value)
+        assert "filterContext" in message
+        assert "metric" in message
+
+    def test_the_component_still_works_when_selected_directly(self) -> None:
+        """The refusal is about how the metric reads it, not about the
+        measure — selecting it by name still gets its own filtered scan, with
+        the query's WHERE left out of it."""
+        sql = self._sql_filtered(["Grand Unfiltered Sales", "Sales Amount"])
+        assert "fc_0" in sql
+        # The wrapper projects the inline measure first, then the isolated one.
+        rows = [(float(r[1]), float(r[2])) for r in _run(sql)]
+        # Month 1 holds 10 of the 30, and the unfiltered measure reports all 30
+        # even though the query asked only for month 1.
+        assert rows == [(10.0, 30.0)]
+
+    def test_a_metric_over_plain_components_is_untouched(self) -> None:
+        assert "Sales Share" in self._sql_filtered(["Sales Share"])
+
+
+class TestTheFilterContextFlagCoversComponents:
+    """``has_filter_context`` decides whether the pass runs at all, and it read
+    only the directly selected measures while its siblings (``has_totals``,
+    ``has_grain_overrides``) walk metric components. That gap is what let the
+    metric case through silently."""
+
+    @staticmethod
+    def _resolved(measures: list[str]):
+        return QueryResolver().resolve(
+            QueryObject(select=QuerySelect(dimensions=["Month"], measures=measures)),
+            _model(),
+        )
+
+    def test_true_for_a_directly_selected_measure(self) -> None:
+        assert self._resolved(["Unfiltered Sales"]).has_filter_context
+
+    def test_true_for_a_component_read_through_a_metric(self) -> None:
+        assert self._resolved(["Filtered Share"]).has_filter_context
+
+    def test_false_without_one(self) -> None:
+        assert not self._resolved(["Sales Amount"]).has_filter_context

--- a/tests/unit/test_compiler_passes.py
+++ b/tests/unit/test_compiler_passes.py
@@ -66,6 +66,7 @@ def _resolved(**attrs: object) -> ResolvedQuery:
         having_filters=attrs.get("having_filters") or [],
         measures=measures,
         metric_components={},
+        composite_cte=attrs.get("composite_cte"),
     )
     return cast(ResolvedQuery, ns)
 

--- a/tests/unit/test_default_value_and_required_joins.py
+++ b/tests/unit/test_default_value_and_required_joins.py
@@ -480,14 +480,10 @@ SHAPES_DEFAULTED = SHAPES.replace(
 
 _DEFAULT_LITERALS = {"0", "'none'"}
 
-# Two measures produce SQL that does not bind when a second fact puts the query
-# on the CFL path — on this branch and on ``main`` alike, with and without a
-# declared default. ``filter_wrap`` and the metric branch of ``total_wrap`` both
-# rebuild the aggregate from the measure's resolved expression, which names a
-# fact table the CFL plan replaced with the composite CTE. That is the same
-# mistake this file is about, in a place the default has nothing to do with, so
-# it is recorded here rather than fixed in a change about ``defaultValue``.
-UNBOUND_IN_CFL = {"Early Amount", "Amount Share"}
+# ``Early Amount`` declares a filterContext, which a multi-fact plan refuses —
+# see ``test_cfl_rebuilt_aggregates``. The refusal is compared like any other in
+# the equivalence tests; it just has no SQL to execute.
+REFUSED_IN_CFL = {"Early Amount"}
 
 
 def _without_defaults(sql: str) -> str:
@@ -605,7 +601,7 @@ class TestTheDefaultOnlyEverAddsACoalesce:
         con.execute('INSERT INTO "PUBLIC"."REFUNDS" VALUES (1, 1.0)')
         for measure in (*_SHAPE_MEASURES, "Net Amount", "Amount Share", "Running Amount"):
             for measures in ([measure], [measure, "Refund Amount"]):
-                if len(measures) > 1 and measure in UNBOUND_IN_CFL:
+                if len(measures) > 1 and measure in REFUSED_IN_CFL:
                     continue
                 sql = _compiled(SHAPES_DEFAULTED, measures, ["Month"])
                 if not sql.lstrip().upper().startswith(("WITH", "SELECT")):


### PR DESCRIPTION
Fixes the two cases the `defaultValue` PR recorded as `UNBOUND_IN_CFL`. Both produced SQL that no engine binds, on `main` and with no `defaultValue` anywhere.

## The bug

Most wrapper passes carry a measure's column through by name, but several re-project its *aggregate* into a CTE of their own:

- `total_wrap` decomposes a metric's components, and a total AVG into SUM/COUNT helpers
- `window_wrap` and `cumulative_wrap` rebuild a base measure

Each took the measure's **resolved expression** for that, which names the fact table the measure was resolved against. Under a star plan that is right: the CTE reuses the planner's own FROM. Under a multi-fact plan it is not: the CTE selects from the UNION ALL composite and no fact table is in scope.

```sql
-- before: a metric over a total component, in a two-fact query
"base" AS (
SELECT "Month", ..., SUM("Sales"."AMOUNT") AS "Sales Amount", ...
FROM "composite_01" AS "composite_01"   -- "Sales" is not here
)
```

## The fix

The star planner already recorded a map for exactly this reason (anchored measures, whose aggregate reads a conformed subquery rather than the foreign fact). That map is the general answer:

- renamed `conformed_expressions` -> `projected_expressions`, documented as what the plan projects each measure as
- the CFL planner fills it too, from the `outer_measure_exprs` it already built for HAVING expansion

Every rebuild site was already reading that map with the resolved expression as a fallback, so filling it is the whole fix. Across ten measure shapes in a multi-fact query, exactly one line of generated SQL changes: the one that did not bind.

## The part that cannot be fixed, and is now refused

A `filterContext` measure needs its own filtered scan of the fact. The composite offers neither half: its legs applied the query's filters before the union existed, so a context that *drops* one cannot un-apply it, and the fact columns a context of its own would filter on are not among the composite's columns.

Suppressing the pass would answer the unfiltered number under the filtered measure's name, so `evaluate_compatibility` raises instead, alongside the other cross-feature rules:

> Measure(s) 'Unfiltered Sales' declare a filterContext, which needs its own filtered scan of the fact. This query spans facts that cannot be joined, so it is planned as a UNION ALL whose legs are already filtered and whose columns are the projected measures, leaving nothing for that scan to read.

The refusal keys on a new `composite_cte`, set by the CFL planner when it actually builds a union: `requires_cfl` only says one was asked for, and the planner delegates back to star whenever the measures reach a single leg. A `filterContext` on a single-fact plan is unaffected.

## Verification

- `tests/unit/test_cfl_rebuilt_aggregates.py`: 13 tests, the metric cases executed on DuckDB against real rows rather than only string-matched
- full suite 3317 passed, 584 skipped; ruff + mypy clean
- TPC-DS sweep unchanged: 39 exact on DuckDB sf=1 plus the known Q99 reference variant