### PR TITLE
feat(compiler): compute a filterContext measure read through a metric

### DIFF
--- a/src/orionbelt/compiler/filter_wrap.py
+++ b/src/orionbelt/compiler/filter_wrap.py
@@ -130,7 +130,16 @@ def _resolve_include_filters(
 
 
 def _effective_grain_dims(measure: ResolvedMeasure, query_dims: list[str]) -> list[str]:
-    """Get the effective grain dimensions for a filter-isolated measure."""
+    """The dimensions a filter-isolated measure's own CTE groups by.
+
+    ``total: true`` is the same claim as ``grain: {mode: FIXED}`` with nothing
+    kept - a grand total - but only the grain override reaches
+    ``effective_grain``. Read from the query grain instead, the measure came
+    back per group, and ``total_wrap`` was never going to correct it: it skips
+    filter-contexted measures on the grounds that this wrapper owns them.
+    """
+    if measure.total:
+        return []
     if measure.effective_grain is not None:
         return measure.effective_grain
     return query_dims

--- a/src/orionbelt/compiler/filter_wrap.py
+++ b/src/orionbelt/compiler/filter_wrap.py
@@ -404,6 +404,21 @@ def wrap_with_filter_context(
                 )
             )
 
+    # Recorded for the wrappers that run after this one. Each of them
+    # re-projects some measure's aggregate into a CTE of its own, and their CTE
+    # selects from what this wrapper built - where the fact tables the resolved
+    # expressions name are gone, and every component is one column of ``main``
+    # or of an isolated CTE. Without this, a metric mixing a filterContext
+    # component with a ``total`` one had the second rebuilt as
+    # ``SUM("Sales"."AMOUNT")`` against a FROM that no longer has ``Sales``.
+    for cte_name, measure_group, _ in isolated_cte_info:
+        for m in measure_group:
+            resolved.projected_expressions[m.name] = ColumnRef(name=m.name, table=cte_name)
+    for metric in split_metrics.values():
+        for comp in leaf_components[metric.name]:
+            if comp.filter_context is None:
+                resolved.projected_expressions[comp.name] = ColumnRef(name=comp.name, table=anchor)
+
     # --- ORDER BY remapping: resolve to CTE aliases ---
     dim_map: dict[tuple[str, str | None], str] = {
         (d.source_column, d.object_name): d.name for d in resolved.dimensions

--- a/src/orionbelt/compiler/filter_wrap.py
+++ b/src/orionbelt/compiler/filter_wrap.py
@@ -34,6 +34,7 @@ from orionbelt.ast.nodes import (
     Select,
 )
 from orionbelt.compiler.filters import build_filter_expr
+from orionbelt.compiler.metric_expansion import metric_leaf_components, metric_over_components
 from orionbelt.compiler.resolution import (
     ResolvedFilter,
     ResolvedMeasure,
@@ -164,6 +165,17 @@ def _combine_where(filters: list[ResolvedFilter]) -> Expr | None:
     return combined
 
 
+def _component_expr(measure: ResolvedMeasure, resolved: ResolvedQuery) -> Expr:
+    """The aggregate to project for *measure*, in a CTE of this wrapper's own.
+
+    ``projected_expressions`` when the plan rewrote it - an anchored measure
+    reads a conformed subquery rather than its own fact - and the resolved
+    expression otherwise. Same rule every pass that re-projects an aggregate
+    follows; see ``ResolvedQuery.projected_expressions``.
+    """
+    return resolved.projected_expressions.get(measure.name, measure.expression)
+
+
 def wrap_with_filter_context(
     ast: Select,
     resolved: ResolvedQuery,
@@ -175,7 +187,31 @@ def wrap_with_filter_context(
 
     Returns ``ast`` unchanged if no measures have filter context.
     """
-    isolated = [m for m in resolved.measures if m.filter_context is not None]
+    leaf_components = {
+        m.name: metric_leaf_components(m, resolved.metric_components) for m in resolved.measures
+    }
+    # A metric whose formula reads a filter-contexted measure. The planner
+    # inlined that component's aggregate into the metric's one column, where the
+    # query's WHERE applies to it like any other - so the column is dropped and
+    # the formula rebuilt in the outer query over the components' own columns,
+    # each read from whichever CTE computed it.
+    split_metrics = {
+        m.name: m
+        for m in resolved.measures
+        if m.component_measures
+        and any(c.filter_context is not None for c in leaf_components[m.name])
+    }
+
+    # Isolated: the filter-contexted measures the query selects, plus the ones
+    # it only reads through a metric. Deduplicated by name, since selecting a
+    # measure *and* a metric over it must still compute it once.
+    isolated: list[ResolvedMeasure] = [m for m in resolved.measures if m.filter_context is not None]
+    seen_isolated = {m.name for m in isolated}
+    for metric in split_metrics.values():
+        for comp in leaf_components[metric.name]:
+            if comp.filter_context is not None and comp.name not in seen_isolated:
+                seen_isolated.add(comp.name)
+                isolated.append(comp)
     if not isolated:
         return ast
 
@@ -190,7 +226,7 @@ def wrap_with_filter_context(
         groups.setdefault(key, []).append(m)
 
     inline_measures = [m for m in resolved.measures if m.filter_context is None]
-    inline_names = {m.name for m in inline_measures}
+    inline_names = {m.name for m in inline_measures if m.name not in split_metrics}
 
     # --- Build main CTE from planner AST ---
     main_columns: list[Expr] = []
@@ -200,6 +236,16 @@ def wrap_with_filter_context(
         if alias and alias not in inline_names and alias not in dim_names:
             continue
         main_columns.append(col_node)
+
+    # A split metric's column is gone, so the components it carried that stay
+    # in ``main`` have to be projected in their own right.
+    main_aliases = {a for c in main_columns if (a := _get_alias(c)) is not None}
+    for metric in split_metrics.values():
+        for comp in leaf_components[metric.name]:
+            if comp.filter_context is not None or comp.name in main_aliases:
+                continue
+            main_columns.append(AliasedExpr(expr=_component_expr(comp, resolved), alias=comp.name))
+            main_aliases.add(comp.name)
 
     main_cte_query = Select(
         columns=main_columns,
@@ -214,10 +260,16 @@ def wrap_with_filter_context(
         ctes=[],
         grouping=ast.grouping,
     )
+    # With no dimensions and every measure isolated, ``main`` projects nothing
+    # and degenerates to ``SELECT *`` - one row per fact row, which the CROSS
+    # JOIN below then multiplies the scalar result by. The isolated CTEs are
+    # each one row at this grain and stand on their own, so drop it.
+    keep_main = bool(main_columns)
+
     main_cte = CTE(name="main", query=main_cte_query)
 
     # --- Build isolated CTEs ---
-    all_ctes = list(ast.ctes) + [main_cte]
+    all_ctes = list(ast.ctes) + ([main_cte] if keep_main else [])
     isolated_cte_info: list[tuple[str, list[ResolvedMeasure], list[str]]] = []
 
     for idx, (_key, measure_group) in enumerate(groups.items()):
@@ -240,7 +292,7 @@ def wrap_with_filter_context(
                 cte_columns.append(AliasedExpr(expr=col, alias=dim.name))
 
         for m in measure_group:
-            cte_columns.append(AliasedExpr(expr=m.expression, alias=m.name))
+            cte_columns.append(AliasedExpr(expr=_component_expr(m, resolved), alias=m.name))
 
         # GROUP BY
         cte_group_by: list[Expr] = []
@@ -273,17 +325,45 @@ def wrap_with_filter_context(
         outer_columns.append(
             AliasedExpr(expr=ColumnRef(name=dim.name, table="main"), alias=dim.name)
         )
+    cte_of: dict[str, str] = {
+        m.name: cte_name for cte_name, measure_group, _ in isolated_cte_info for m in measure_group
+    }
     for m in inline_measures:
+        if m.name in split_metrics:
+            outer_columns.append(
+                AliasedExpr(
+                    expr=metric_over_components(
+                        m,
+                        resolved.metric_components,
+                        lambda name: ColumnRef(name=name, table=cte_of.get(name, "main")),
+                        model,
+                        dialect,
+                    ),
+                    alias=m.name,
+                )
+            )
+            continue
         outer_columns.append(AliasedExpr(expr=ColumnRef(name=m.name, table="main"), alias=m.name))
+    selected_names = {m.name for m in resolved.measures}
     for cte_name, measure_group, _ in isolated_cte_info:
         for m in measure_group:
+            # A component the query reads only through a metric is computed in
+            # this CTE but is not one of the query's columns - the metric that
+            # reads it is.
+            if m.name not in selected_names:
+                continue
             outer_columns.append(
                 AliasedExpr(expr=ColumnRef(name=m.name, table=cte_name), alias=m.name)
             )
 
     # --- JOINs from main to isolated CTEs ---
+    # Without ``main`` the first isolated CTE anchors the FROM and the rest
+    # cross-join onto it, which is what they would have done anyway.
+    anchor = "main" if keep_main else isolated_cte_info[0][0]
     outer_joins: list[Join] = []
     for cte_name, _, grain in isolated_cte_info:
+        if cte_name == anchor:
+            continue
         if not grain:
             outer_joins.append(
                 Join(
@@ -298,7 +378,7 @@ def wrap_with_filter_context(
             for dim_name in grain:
                 on_parts.append(
                     BinaryOp(
-                        left=ColumnRef(name=dim_name, table="main"),
+                        left=ColumnRef(name=dim_name, table=anchor),
                         op="=",
                         right=ColumnRef(name=dim_name, table=cte_name),
                     )
@@ -323,14 +403,32 @@ def wrap_with_filter_context(
         (make_column_expr(model, d.object_name, d.column_name), d.name) for d in resolved.dimensions
     ]
     measure_exprs: list[tuple[Expr, str]] = [(m.expression, m.name) for m in resolved.measures]
+
+    def order_ref(name: str) -> Expr:
+        """Where to read *name* from in the outer query.
+
+        A rebuilt metric has no CTE column at all - it is assembled in this
+        query's own projection - so it orders by its select alias.
+        """
+        if name in split_metrics:
+            return ColumnRef(name=name)
+        return ColumnRef(name=name, table=cte_of.get(name, anchor))
+
     outer_order_by: list[OrderByItem] = []
     for ob in ast.order_by:
-        remapped = _remap_fc_order_expr(ob.expr, dim_map, dim_exprs, measure_exprs)
+        remapped = _remap_fc_order_expr(
+            ob.expr,
+            dim_map,
+            dim_exprs,
+            measure_exprs,
+            order_ref,
+            lambda name: ColumnRef(name=name, table=anchor),
+        )
         outer_order_by.append(OrderByItem(expr=remapped, desc=ob.desc, nulls_last=ob.nulls_last))
 
     return Select(
         columns=outer_columns,
-        from_=From(source="main", alias="main"),
+        from_=From(source=anchor, alias=anchor),
         joins=outer_joins,
         where=None,
         group_by=[],
@@ -347,20 +445,28 @@ def _remap_fc_order_expr(
     dim_map: dict[tuple[str, str | None], str],
     dim_exprs: list[tuple[Expr, str]],
     measure_exprs: list[tuple[Expr, str]],
+    order_ref: Callable[[str], Expr],
+    dim_ref: Callable[[str], Expr],
 ) -> Expr:
-    """Remap one ORDER BY expression for the filter-context outer query."""
+    """Remap one ORDER BY expression for the filter-context outer query.
+
+    The planner ordered by the raw expression; here every value is a column of
+    one of the CTEs, and *which* CTE depends on the value - a dimension is in
+    the anchor, a measure is in whichever CTE computed it. Ordering by the
+    measure's aggregate as written would read the wrong scan.
+    """
     if isinstance(expr, ColumnRef) and expr.table is not None:
         key = (expr.name, expr.table)
         if key in dim_map:
-            return ColumnRef(name=dim_map[key], table="main")
-        return ColumnRef(name=expr.name, table="main")
+            return dim_ref(dim_map[key])
+        return dim_ref(expr.name)
     # A computed dimension orders by its inlined expression, not by a column
     # reference, so it is matched structurally against the same expression the
     # CTE projected under its alias.
     for dim_expr, name in dim_exprs:
         if expr == dim_expr:
-            return ColumnRef(name=name, table="main")
+            return dim_ref(name)
     for meas_expr, name in measure_exprs:
         if expr is meas_expr or expr == meas_expr:
-            return ColumnRef(name=name, table="main")
+            return order_ref(name)
     return expr

--- a/src/orionbelt/compiler/grain_dedup.py
+++ b/src/orionbelt/compiler/grain_dedup.py
@@ -80,8 +80,8 @@ from orionbelt.compiler.fanout import FanoutError
 from orionbelt.compiler.filters import collect_measure_filter_objects
 from orionbelt.compiler.having_hoist import windowed_aliases
 from orionbelt.compiler.metric_expansion import (
-    expand_metric_expression,
     metric_leaf_components,
+    metric_over_components,
 )
 from orionbelt.compiler.resolution import (
     ResolvedFilter,
@@ -89,7 +89,6 @@ from orionbelt.compiler.resolution import (
     ResolvedQuery,
     make_column_expr,
 )
-from orionbelt.compiler.type_resolver import resolve_metric_data_type
 from orionbelt.models.errors import SemanticError
 from orionbelt.models.semantic import Cardinality, Measure, SemanticModel
 from orionbelt.models.warnings import WarningCode, warning
@@ -396,33 +395,6 @@ def _combine(exprs: Iterable[Expr]) -> Expr | None:
     return combined
 
 
-def _metric_over_components(
-    metric: ResolvedMeasure,
-    components: dict[str, ResolvedMeasure],
-    measure_ref: Callable[[str], Expr],
-    model: SemanticModel,
-    dialect: Dialect,
-) -> Expr:
-    """Rebuild a metric's expression from its components' finished values.
-
-    The planner inlines each component's aggregate into the metric's column,
-    which over a replicating join reads the inflated value. Here the formula is
-    re-expanded against *measure_ref* instead, so every component is read from
-    whichever CTE computed it — deduplicated or not — with nested derived
-    metrics expanded on the way, exactly as the planner expands them. The
-    declared ``dataType`` cast is reapplied as ``star.py`` applies it, since the
-    column it wrapped no longer exists.
-    """
-    expr = expand_metric_expression(
-        metric.expression, components, lambda comp: measure_ref(comp.name)
-    )
-    metric_def = model.metrics.get(metric.name)
-    if metric_def is None:
-        return expr
-    result_type = resolve_metric_data_type(metric_def, model.settings)
-    return dialect.cast_to_obml_type(expr, result_type) if result_type else expr
-
-
 def _reject_unmovable_having(
     outer_having: list[ResolvedFilter],
     available: dict[str, Expr],
@@ -703,7 +675,7 @@ def wrap_with_grain_dedup(
         if alias in split_metrics:
             outer_columns.append(
                 AliasedExpr(
-                    expr=_metric_over_components(
+                    expr=metric_over_components(
                         split_metrics[alias],
                         resolved.metric_components,
                         measure_ref,

--- a/src/orionbelt/compiler/metric_expansion.py
+++ b/src/orionbelt/compiler/metric_expansion.py
@@ -24,9 +24,12 @@ from typing import TYPE_CHECKING
 
 from orionbelt.ast.nodes import ColumnRef, Expr
 from orionbelt.compiler.expr_rewrite import map_column_refs
+from orionbelt.compiler.type_resolver import resolve_metric_data_type
+from orionbelt.models.semantic import SemanticModel
 
 if TYPE_CHECKING:
     from orionbelt.compiler.resolution import ResolvedMeasure
+    from orionbelt.dialect.base import Dialect
 
 
 def expand_metric_expression(
@@ -129,3 +132,31 @@ def metric_leaf_components(
 
     walk(measure)
     return out
+
+
+def metric_over_components(
+    metric: ResolvedMeasure,
+    components: dict[str, ResolvedMeasure],
+    measure_ref: Callable[[str], Expr],
+    model: SemanticModel,
+    dialect: Dialect,
+) -> Expr:
+    """Rebuild a metric's expression from its components' finished values.
+
+    The planner inlines each component's aggregate into the metric's column,
+    which is right only while every component belongs in that column. A pass
+    that computes one somewhere else - ``grain_dedup`` in a deduplicated CTE,
+    ``filter_wrap`` in a differently filtered one - has to re-expand the formula
+    instead, reading each component from whichever CTE holds it via
+    *measure_ref*. Nested derived metrics are expanded on the way, exactly as
+    the planner expands them, and the declared ``dataType`` cast is reapplied as
+    ``star.py`` applies it, since the column it wrapped no longer exists.
+    """
+    expr = expand_metric_expression(
+        metric.expression, components, lambda comp: measure_ref(comp.name)
+    )
+    metric_def = model.metrics.get(metric.name)
+    if metric_def is None:
+        return expr
+    result_type = resolve_metric_data_type(metric_def, model.settings)
+    return dialect.cast_to_obml_type(expr, result_type) if result_type else expr

--- a/src/orionbelt/compiler/passes.py
+++ b/src/orionbelt/compiler/passes.py
@@ -604,6 +604,46 @@ def apply_aggregate_passes(ast: Select, ctx: CompileContext) -> Select:
     # there names a table out of scope. Refused rather than emitted, the same
     # treatment grain dedup already gives period-over-period for the same
     # reason: the wrapper rebuilds a FROM the rewrite's output cannot serve.
+    # The same rebuilt FROM cannot carry a filterContext's CTE either. That
+    # scan is the whole of what the field means - a differently filtered read of
+    # the fact - and period-over-period reassembles the query around a date
+    # spine, projecting each measure's aggregate afresh. The CTE was built and
+    # then ignored, so the metric compared the query-filtered value under the
+    # filter-contexted measure's name. Refused for both, since the pass regroups
+    # the whole query to its own grain: an unrelated filterContext measure in
+    # the same query comes back at that grain rather than the query's.
+    if ctx.resolved.has_pop and ctx.resolved.has_filter_context:
+        contexts = sorted(
+            {m.name for m in ctx.resolved.measures if m.filter_context is not None}
+            | {
+                comp.name
+                for comp in ctx.resolved.metric_components.values()
+                if comp.filter_context is not None
+            }
+        )
+        listed = ", ".join(f"'{name}'" for name in contexts)
+        raise ResolutionError(
+            [
+                SemanticError(
+                    code="INCOMPATIBLE_COMBINATION",
+                    message=(
+                        f"Measure(s) {listed} declare a filterContext, which is computed as "
+                        f"a differently filtered scan of the fact in a CTE of its own. A "
+                        f"period-over-period metric rebuilds the query's FROM from a date "
+                        f"spine, which cannot read that CTE and regroups the query to its "
+                        f"own grain."
+                    ),
+                    path="select.measures",
+                    hint=(
+                        "Query the period-over-period metric without the filterContext "
+                        "measure, or compare periods on a measure that takes the query's "
+                        "filters."
+                    ),
+                    context={"measures": contexts},
+                )
+            ]
+        )
+
     if ctx.resolved.has_pop and ctx.resolved.anchored_measures:
         anchored = sorted(ctx.resolved.anchored_measures)
         listed = ", ".join(f"'{name}'" for name in anchored)

--- a/src/orionbelt/compiler/passes.py
+++ b/src/orionbelt/compiler/passes.py
@@ -419,46 +419,7 @@ def evaluate_compatibility(
                 ]
             )
 
-    # Rule 2c (raising): ``filter_wrap`` isolates the measures the query
-    # *selects*, so a filterContext declared on a metric's component never gets
-    # a CTE of its own. The planner inlines that component's aggregate into the
-    # metric column instead, where the query's WHERE applies to it like any
-    # other - the metric then answers a number that looks right and is not the
-    # one the context asked for. Refuse until the component can be split out
-    # the way ``grain_dedup`` splits a deduplicated one.
-    fc_components = sorted(
-        {
-            f"{m.name}.{comp.name}"
-            for m in resolved.measures
-            if m.component_measures
-            for comp in metric_leaf_components(m, resolved.metric_components)
-            if comp.filter_context is not None
-        }
-    )
-    if fc_components:
-        listed = ", ".join(f"'{c}'" for c in fc_components)
-        raise ResolutionError(
-            [
-                SemanticError(
-                    code="INCOMPATIBLE_COMBINATION",
-                    message=(
-                        f"Measure(s) {listed} declare a filterContext and are read through "
-                        f"a metric. A filterContext needs the measure computed in its own "
-                        f"filtered scan, which only a directly selected measure gets - "
-                        f"through a metric the aggregate is inlined into the metric's "
-                        f"column and the query's filters apply to it."
-                    ),
-                    path="select.measures",
-                    hint=(
-                        "Select the filterContext measure directly, or drop the "
-                        "filterContext from the measure the metric reads."
-                    ),
-                    context={"components": fc_components},
-                )
-            ]
-        )
-
-    # Rule 2d (raising): a filterContext measure is computed in a CTE of its
+    # Rule 2c (raising): a filterContext measure is computed in a CTE of its
     # own, whose WHERE is the query's with some filters dropped or added. Under
     # a multi-fact plan there is nothing to compute it from: the union legs
     # applied the query's filters before the composite CTE existed, so a context
@@ -468,7 +429,17 @@ def evaluate_compatibility(
     # engine binds - refuse instead, since suppressing the pass would answer the
     # unfiltered number under the filtered measure's name.
     if resolved.composite_cte is not None:
-        fc_measures = sorted(m.name for m in resolved.measures if m.filter_context is not None)
+        # Read through a metric counts: the component is computed in a CTE of
+        # its own too, and that CTE has the same nothing to read.
+        fc_measures = sorted(
+            {m.name for m in resolved.measures if m.filter_context is not None}
+            | {
+                comp.name
+                for m in resolved.measures
+                for comp in metric_leaf_components(m, resolved.metric_components)
+                if comp.filter_context is not None
+            }
+        )
         if fc_measures:
             listed = ", ".join(f"'{m}'" for m in fc_measures)
             raise ResolutionError(
@@ -494,6 +465,46 @@ def evaluate_compatibility(
                     )
                 ]
             )
+
+    # Rule 2d (raising): a HAVING predicate is evaluated inside the CTE the
+    # planner built, which for a filterContext measure is the *main* one - under
+    # the query's filters, on an aggregate that is not the measure's. The
+    # predicate then reads the filtered value and silently keeps the wrong
+    # groups. Moving it to the outer query is the fix (``grain_dedup`` does that
+    # for a deduplicated measure); until then, refuse.
+    fc_names = {m.name for m in resolved.measures if m.filter_context is not None} | {
+        m.name
+        for m in resolved.measures
+        if m.component_measures
+        and any(
+            comp.filter_context is not None
+            for comp in metric_leaf_components(m, resolved.metric_components)
+        )
+    }
+    fc_having = sorted(
+        {name for hf in resolved.having_filters for name in hf.referenced_fields & fc_names}
+    )
+    if fc_having:
+        listed = ", ".join(f"'{name}'" for name in fc_having)
+        raise ResolutionError(
+            [
+                SemanticError(
+                    code="INCOMPATIBLE_COMBINATION",
+                    message=(
+                        f"HAVING references {listed}, which a filterContext computes in a "
+                        f"CTE of its own. The predicate is evaluated in the query's own "
+                        f"scan instead, where that value does not exist and the "
+                        f"query-filtered aggregate stands in for it."
+                    ),
+                    path="having",
+                    hint=(
+                        "Filter on a measure without a filterContext, or apply the "
+                        "threshold in the caller."
+                    ),
+                    context={"measures": fc_having},
+                )
+            ]
+        )
 
     # Rule 3 (raising): grain dedup splits the projection across CTEs keyed on
     # the query grain. Every wrapper in ``incompatible_with`` restructures that

--- a/src/orionbelt/compiler/passes.py
+++ b/src/orionbelt/compiler/passes.py
@@ -48,7 +48,7 @@ from orionbelt.compiler.having_hoist import (
 from orionbelt.compiler.metric_expansion import metric_leaf_components
 from orionbelt.compiler.pop_wrap import wrap_with_pop
 from orionbelt.compiler.resolution import ResolutionError, ResolvedQuery
-from orionbelt.compiler.total_wrap import wrap_with_totals
+from orionbelt.compiler.total_wrap import is_avg_total, wrap_with_totals
 from orionbelt.compiler.window_wrap import (
     _ddm_window_components,
     window_pass_applies,
@@ -462,6 +462,47 @@ def evaluate_compatibility(
                             "measures": fc_measures,
                             "conflictsWith": ["a multi-fact (CFL) plan"],
                         },
+                    )
+                ]
+            )
+
+    # Rule 2c2 (raising): an averaged total in a query that also has a
+    # filterContext. ``filter_wrap`` runs first and rewrites the FROM, leaving
+    # every measure as one column of a CTE - which is enough to re-aggregate a
+    # sum, a count, a min or a max over, and not enough for an average.
+    # ``total_wrap`` builds an AVG's grand total from SUM and COUNT of the
+    # aggregate's *argument*, and by then the argument is a value that has
+    # already been averaged; it was emitting ``SUM(1)`` and ``COUNT(1)``,
+    # neither the right number nor valid SQL.
+    if resolved.has_filter_context:
+        candidates = list(resolved.measures) + [
+            comp
+            for m in resolved.measures
+            for comp in metric_leaf_components(m, resolved.metric_components)
+        ]
+        avg_totals = sorted(
+            {c.name for c in candidates if is_avg_total(c, resolved.dedup_measures)}
+        )
+        if avg_totals:
+            listed = ", ".join(f"'{name}'" for name in avg_totals)
+            raise ResolutionError(
+                [
+                    SemanticError(
+                        code="INCOMPATIBLE_COMBINATION",
+                        message=(
+                            f"Measure(s) {listed} average over a total or grain override, in "
+                            f"a query that also has a filterContext. The filterContext is "
+                            f"computed first, in a CTE of its own, and leaves every measure "
+                            f"as one column - enough to re-aggregate a sum or a count over, "
+                            f"and not enough for an average, whose total is built from the "
+                            f"rows it averaged."
+                        ),
+                        path="select.measures",
+                        hint=(
+                            "Total a sum rather than an average, or query the averaged "
+                            "total without the filterContext measure."
+                        ),
+                        context={"measures": avg_totals},
                     )
                 ]
             )

--- a/src/orionbelt/compiler/resolution.py
+++ b/src/orionbelt/compiler/resolution.py
@@ -533,13 +533,17 @@ class ResolvedQuery:
         here instead would skip the pass and answer the query-filtered number
         under the unfiltered measure's name.
         """
-        for m in self.measures:
-            if m.filter_context is not None:
-                return True
-            for comp in self._components_of(m):
-                if comp.filter_context is not None:
-                    return True
-        return False
+        if any(m.filter_context is not None for m in self.measures):
+            return True
+        # Every component, not only the leaves a metric inlines:
+        # ``metric_leaf_components`` stops at a cumulative / window /
+        # period-over-period metric, because that one is computed by its own
+        # wrapper rather than substituted into the formula. Its *base measure*
+        # is still a measure this query has to compute, and a context declared
+        # on it is still one to honour - a derived metric over a window metric
+        # over a filter-contexted measure hid one exactly there, and the
+        # window's CTE was built under the query's WHERE.
+        return any(c.filter_context is not None for c in self.metric_components.values())
 
     @property
     def has_cumulative(self) -> bool:

--- a/src/orionbelt/compiler/total_wrap.py
+++ b/src/orionbelt/compiler/total_wrap.py
@@ -84,8 +84,13 @@ def _needs_window_wrap(measure: ResolvedMeasure, dedup_measures: Container[str])
     return measure.total or measure.grain_override is not None
 
 
-def _is_avg_total(measure: ResolvedMeasure, dedup_measures: Container[str]) -> bool:
-    """Check if a measure is an AVG total/grain-override (needs sum+count helpers)."""
+def is_avg_total(measure: ResolvedMeasure, dedup_measures: Container[str]) -> bool:
+    """Whether a measure is an AVG total/grain-override, needing sum+count helpers.
+
+    Public because it is also a *precondition*: the helpers decompose the
+    aggregate's argument, so this measure cannot be window-wrapped over a value
+    some earlier pass already averaged. ``compiler.passes`` refuses that.
+    """
     return _needs_window_wrap(measure, dedup_measures) and measure.aggregation.upper() == "AVG"
 
 
@@ -138,7 +143,7 @@ def _build_total_window(measure: ResolvedMeasure, dedup_measures: Container[str]
 
 def _build_total_window_expr(measure: ResolvedMeasure, dedup_measures: Container[str]) -> Expr:
     partition_by = _partition_by_exprs(measure)
-    if _is_avg_total(measure, dedup_measures):
+    if is_avg_total(measure, dedup_measures):
         return BinaryOp(
             left=WindowFunction(
                 func_name="SUM",
@@ -241,7 +246,7 @@ def wrap_with_totals(ast: Select, resolved: ResolvedQuery) -> Select:
             for comp in metric_leaf_components(metric, resolved.metric_components):
                 if comp.name in direct_measure_names:
                     continue  # Already present as a direct measure
-                if _is_avg_total(comp, resolved.dedup_measures):
+                if is_avg_total(comp, resolved.dedup_measures):
                     # AVG total needs sum + count helper columns
                     comp_expr = resolved.projected_expressions.get(comp.name, comp.expression)
                     base_columns.append(_build_avg_helpers_base_col(comp, "sum", comp_expr))
@@ -393,7 +398,7 @@ def _is_avg_window_wrap_by_name(name: str, resolved: ResolvedQuery) -> bool:
     """Check if a direct measure with given name is an AVG total/grain-override."""
     for m in resolved.measures:
         if m.name == name and not m.component_measures:
-            return _is_avg_total(m, resolved.dedup_measures)
+            return is_avg_total(m, resolved.dedup_measures)
     return False
 
 

--- a/tests/unit/test_cfl_rebuilt_aggregates.py
+++ b/tests/unit/test_cfl_rebuilt_aggregates.py
@@ -243,12 +243,12 @@ class TestTheCompositeFlag:
 
 
 class TestFilterContextReadThroughAMetric:
-    """``filter_wrap`` isolates the measures the query *selects*. A metric
-    inlines its components' aggregates into one column instead, so a context
-    declared on a component never gets the filtered scan it asks for and the
-    query's WHERE applies to it like any other aggregate. The metric then
-    answers a number that looks right and is not the one that was asked for,
-    which is why it is refused on every plan rather than only under CFL.
+    """A metric inlines its components' aggregates into one column, so a
+    context declared on a component used to be dropped silently. The component
+    now gets the same CTE a selected measure gets, and the formula is rebuilt
+    over the CTEs' columns - see ``test_filter_context_metrics``. Under a
+    multi-fact plan that CTE has the same nothing to read as a selected one, so
+    the refusal covers components too.
     """
 
     @staticmethod
@@ -262,27 +262,28 @@ class TestFilterContextReadThroughAMetric:
             "duckdb",
         ).sql
 
-    def test_refused_on_a_single_fact_plan(self) -> None:
-        with pytest.raises(ResolutionError) as exc:
-            self._sql_filtered(["Filtered Share"])
-        assert "Filtered Share.Unfiltered Sales" in str(exc.value)
+    def test_it_compiles_on_a_single_fact_plan(self) -> None:
+        sql = self._sql_filtered(["Filtered Share"])
+        assert '"fc_0" AS' in sql
+        assert '"main"."Sales Amount" / "fc_0"."Unfiltered Sales"' in sql
 
     def test_refused_alongside_another_fact(self) -> None:
         with pytest.raises(ResolutionError) as exc:
             self._sql_filtered(["Filtered Share", "Refund Amount"])
-        assert "Filtered Share.Unfiltered Sales" in str(exc.value)
+        assert "Unfiltered Sales" in str(exc.value)
 
-    def test_the_refusal_says_what_a_metric_does_to_it(self) -> None:
+    def test_the_refusal_names_the_component_not_the_metric(self) -> None:
+        """The component is what needs the scan, and what the author has to
+        change - naming the metric would point at the wrong declaration."""
         with pytest.raises(ResolutionError) as exc:
-            self._sql_filtered(["Filtered Share"])
+            self._sql_filtered(["Filtered Share", "Refund Amount"])
         message = str(exc.value)
-        assert "filterContext" in message
-        assert "metric" in message
+        assert "'Unfiltered Sales'" in message
+        assert "Filtered Share" not in message
 
     def test_the_component_still_works_when_selected_directly(self) -> None:
-        """The refusal is about how the metric reads it, not about the
-        measure — selecting it by name still gets its own filtered scan, with
-        the query's WHERE left out of it."""
+        """Selecting it by name gets its own filtered scan, with the query's
+        WHERE left out of it."""
         sql = self._sql_filtered(["Grand Unfiltered Sales", "Sales Amount"])
         assert "fc_0" in sql
         # The wrapper projects the inline measure first, then the isolated one.

--- a/tests/unit/test_compiler_passes.py
+++ b/tests/unit/test_compiler_passes.py
@@ -48,7 +48,11 @@ def _resolved(**attrs: object) -> ResolvedQuery:
     """
     grouping = attrs.get("grouping")
     has_window = bool(attrs.get("has_window", False))
-    measures = [SimpleNamespace(is_window=True, component_measures=[])] if has_window else []
+    measures = (
+        [SimpleNamespace(is_window=True, component_measures=[], filter_context=None)]
+        if has_window
+        else []
+    )
     ns = SimpleNamespace(
         grouping=SimpleNamespace(value=grouping) if grouping is not None else None,
         has_totals=attrs.get("has_totals", False),

--- a/tests/unit/test_filter_context_metrics.py
+++ b/tests/unit/test_filter_context_metrics.py
@@ -87,6 +87,21 @@ measures:
     columns: [{dataObject: Sales, column: Amount}]
     resultType: int
     aggregation: count
+  Grand Revenue:
+    columns: [{dataObject: Sales, column: Amount}]
+    resultType: float
+    aggregation: sum
+    total: true
+  Month Revenue:
+    columns: [{dataObject: Sales, column: Amount}]
+    resultType: float
+    aggregation: sum
+    grain: {mode: FIXED, keepOnly: [Month]}
+  Grand Avg:
+    columns: [{dataObject: Sales, column: Amount}]
+    resultType: float
+    aggregation: avg
+    total: true
   Unfiltered Total Revenue:
     columns: [{dataObject: Sales, column: Amount}]
     resultType: float
@@ -112,6 +127,12 @@ metrics:
     measure: Unfiltered Revenue
   Doubled Rank:
     expression: "{[Rank Unfiltered]} * 2"
+  Share Of Grand:
+    expression: "{[Unfiltered Revenue]} / {[Grand Revenue]}"
+  Share Of Month:
+    expression: "{[Unfiltered Revenue]} / {[Month Revenue]}"
+  Share Of Grand Avg:
+    expression: "{[Unfiltered Revenue]} / {[Grand Avg]}"
 """
 
 
@@ -349,3 +370,61 @@ class TestAContextBehindAWindowMetric:
 
         resolved = QueryResolver().resolve(_query(["Rank Unfiltered"]), _model())
         assert resolved.has_filter_context
+
+
+class TestAMetricMixingAContextWithATotal:
+    """This wrapper runs before ``total_wrap`` and rewrites the FROM, so the
+    components it leaves behind are columns of ``main`` and of the isolated
+    CTEs. ``total_wrap`` decomposes the same metric next and was rebuilding
+    those components from their resolved expressions - naming a fact table its
+    own CTE no longer selects from. It reads what this wrapper projected
+    instead, recorded in ``projected_expressions`` the way the planners record
+    theirs."""
+
+    def test_a_total_component_composes(self) -> None:
+        sql = _sql(["Share Of Grand"])
+        assert '"Sales"."AMOUNT"' not in sql.split('"base" AS')[-1]
+        assert 'SUM("Grand Revenue") OVER ()' in sql
+
+    def test_it_answers_what_the_two_measures_do(self) -> None:
+        direct = _rows(["Unfiltered Revenue", "Grand Revenue"])
+        share = _rows(["Share Of Grand"])["Share Of Grand"]
+        expected = [
+            n / d
+            for n, d in zip(direct["Unfiltered Revenue"], direct["Grand Revenue"], strict=True)
+        ]
+        assert [round(v, 6) for v in share] == [round(v, 6) for v in expected]
+
+    def test_a_grain_override_component_composes(self) -> None:
+        direct = _rows(["Unfiltered Revenue", "Month Revenue"])
+        share = _rows(["Share Of Month"])["Share Of Month"]
+        expected = [
+            n / d
+            for n, d in zip(direct["Unfiltered Revenue"], direct["Month Revenue"], strict=True)
+        ]
+        assert [round(v, 6) for v in share] == [round(v, 6) for v in expected]
+
+    @pytest.mark.parametrize(
+        "measures",
+        [
+            ["Share Of Grand Avg"],
+            ["Unfiltered Revenue", "Grand Avg"],
+        ],
+        ids=["through a metric", "side by side"],
+    )
+    def test_an_averaged_total_is_refused(self, measures: list[str]) -> None:
+        """An AVG total decomposes into SUM and COUNT of the aggregate's
+        *argument*, and by the time this wrapper has run the argument is a
+        value that has already been averaged. It was emitting ``SUM(1)`` and
+        ``COUNT(1)`` - neither the right number nor valid SQL - and it did so
+        whether the two met inside a metric or merely in the same query."""
+        with pytest.raises(ResolutionError) as exc:
+            _sql(measures)
+        message = str(exc.value)
+        assert "Grand Avg" in message
+        assert "average" in message
+
+    def test_an_averaged_total_without_a_context_is_untouched(self) -> None:
+        """The refusal is about what filterContext does to the plan, so a query
+        without one still gets its averaged total."""
+        assert _rows(["Grand Avg"])["Grand Avg"] == [3.5, 3.5]

--- a/tests/unit/test_filter_context_metrics.py
+++ b/tests/unit/test_filter_context_metrics.py
@@ -1,0 +1,276 @@
+"""A metric reading a measure that declares a ``filterContext``.
+
+``filterContext`` says which of the query's WHERE filters apply to a measure,
+and a different WHERE needs a scan of its own - ``filter_wrap`` gives a
+*selected* measure exactly that, in a CTE joined back on the query dimensions.
+
+A metric is one column, though, and the planner builds it by substituting each
+component's aggregate into the formula. Both halves of ``{[Revenue]} /
+{[Unfiltered Revenue]}`` therefore landed in the same SELECT under the same
+WHERE, the context was dropped, and the ratio came back 1. The component is now
+computed in the same CTE a selected measure would get, and the formula is
+rebuilt in the outer query out of CTE columns - the move ``grain_dedup`` makes
+for a deduplicated component and ``total_wrap`` for a windowed one.
+"""
+
+from __future__ import annotations
+
+import duckdb
+import pytest
+
+from orionbelt.compiler.pipeline import CompilationPipeline
+from orionbelt.compiler.resolution import ResolutionError
+from orionbelt.models.query import (
+    FilterOperator,
+    QueryFilter,
+    QueryObject,
+    QueryOrderBy,
+    QuerySelect,
+)
+from orionbelt.models.semantic import SemanticModel
+from orionbelt.parser.loader import TrackedLoader
+from orionbelt.parser.resolver import ReferenceResolver
+
+PIPELINE = CompilationPipeline()
+
+MODEL_YAML = """\
+version: 1.0
+
+dataObjects:
+  Dates:
+    code: DATES
+    database: WH
+    schema: PUBLIC
+    columns:
+      Date Key: {code: DATE_KEY, abstractType: int, primaryKey: true}
+      Month: {code: MONTH, abstractType: int}
+      Day: {code: DAY, abstractType: int}
+
+  Sales:
+    code: SALES
+    database: WH
+    schema: PUBLIC
+    columns:
+      Date Key: {code: DATE_KEY, abstractType: int}
+      Region: {code: REGION, abstractType: string}
+      Amount: {code: AMOUNT, abstractType: float}
+    joins:
+      - joinType: many-to-one
+        joinTo: Dates
+        columnsFrom: [Date Key]
+        columnsTo: [Date Key]
+
+dimensions:
+  Month: {dataObject: Dates, column: Month, resultType: int}
+  Day: {dataObject: Dates, column: Day, resultType: int}
+  Region: {dataObject: Sales, column: Region, resultType: string}
+
+measures:
+  Revenue:
+    columns: [{dataObject: Sales, column: Amount}]
+    resultType: float
+    aggregation: sum
+  Unfiltered Revenue:
+    columns: [{dataObject: Sales, column: Amount}]
+    resultType: float
+    aggregation: sum
+    filterContext:
+      mode: FIXED
+  Revenue Any Day:
+    columns: [{dataObject: Sales, column: Amount}]
+    resultType: float
+    aggregation: sum
+    filterContext:
+      mode: RELATIVE
+      exclude: [Day]
+  Sale Count:
+    columns: [{dataObject: Sales, column: Amount}]
+    resultType: int
+    aggregation: count
+
+metrics:
+  Revenue Share:
+    expression: "{[Revenue]} / {[Unfiltered Revenue]}"
+  Day Share:
+    expression: "{[Revenue]} / {[Revenue Any Day]}"
+  Two Contexts:
+    expression: "{[Unfiltered Revenue]} / {[Revenue Any Day]}"
+  Plain Ratio:
+    expression: "{[Revenue]} / {[Sale Count]}"
+"""
+
+
+def _model() -> SemanticModel:
+    raw, source_map = TrackedLoader().load_string(MODEL_YAML)
+    model, result = ReferenceResolver().resolve(raw, source_map)
+    assert result.valid, result.errors
+    return model
+
+
+def _dims(dimensions: list[str] | None) -> list[str]:
+    """``None`` means the default grain; ``[]`` means no dimensions at all."""
+    return ["Month"] if dimensions is None else dimensions
+
+
+def _query(measures: list[str], dimensions: list[str] | None = None) -> QueryObject:
+    """Every query filters on Day, which is the filter the contexts act on."""
+    return QueryObject(
+        select=QuerySelect(dimensions=_dims(dimensions), measures=measures),
+        where=[QueryFilter(field="Day", op=FilterOperator.EQUALS, value=1)],
+    )
+
+
+def _sql(measures: list[str], dimensions: list[str] | None = None) -> str:
+    return PIPELINE.compile(_query(measures, dimensions), _model(), "duckdb").sql
+
+
+def _rows(measures: list[str], dimensions: list[str] | None = None) -> dict[str, list]:
+    """Execute, returning one list of values per selected measure."""
+    con = duckdb.connect(":memory:")
+    con.execute('CREATE SCHEMA "PUBLIC"')
+    con.execute('CREATE TABLE "PUBLIC"."DATES" (DATE_KEY INT, MONTH INT, DAY INT)')
+    con.execute('CREATE TABLE "PUBLIC"."SALES" (DATE_KEY INT, REGION VARCHAR, AMOUNT DOUBLE)')
+    # Month 1 has 10 on day 1 and 30 on day 2; month 2 has 5 on day 1.
+    con.execute('INSERT INTO "PUBLIC"."DATES" VALUES (1, 1, 1), (2, 1, 2), (3, 2, 1)')
+    con.execute(
+        "INSERT INTO \"PUBLIC\".\"SALES\" VALUES (1, 'EU', 10.0), (2, 'EU', 30.0), (3, 'US', 5.0)"
+    )
+    result = con.execute(_sql(measures, dimensions)).fetchdf()
+    # Sorted on the dimensions: nothing orders the rows, and two queries have to
+    # be comparable row for row.
+    if _dims(dimensions):
+        result = result.sort_values(_dims(dimensions)).reset_index(drop=True)
+    return {name: [float(v) for v in result[name]] for name in measures}
+
+
+class TestTheContextSurvivesTheMetric:
+    """The oracle: a component's value inside a metric has to be the value the
+    same measure reports when selected on its own. Anything that drops the
+    context, or applies it twice, breaks that equality without anyone having to
+    predict which."""
+
+    @pytest.mark.parametrize(
+        ("metric", "numerator", "denominator"),
+        [
+            ("Revenue Share", "Revenue", "Unfiltered Revenue"),
+            ("Day Share", "Revenue", "Revenue Any Day"),
+            ("Two Contexts", "Unfiltered Revenue", "Revenue Any Day"),
+            ("Plain Ratio", "Revenue", "Sale Count"),
+        ],
+    )
+    def test_the_metric_equals_its_components(
+        self, metric: str, numerator: str, denominator: str
+    ) -> None:
+        direct = _rows([numerator, denominator])
+        computed = _rows([metric])[metric]
+        expected = [n / d for n, d in zip(direct[numerator], direct[denominator], strict=True)]
+        assert [round(v, 6) for v in computed] == [round(v, 6) for v in expected]
+
+    def test_the_context_actually_changes_the_number(self) -> None:
+        """The equality above is only worth something if the two sides differ.
+        Month 1 holds 10 on the filtered day out of 40 altogether; month 2's
+        one row is on that day, so there the context changes nothing."""
+        assert _rows(["Revenue", "Unfiltered Revenue"], ["Month"]) == {
+            "Revenue": [10.0, 5.0],
+            "Unfiltered Revenue": [40.0, 5.0],
+        }
+
+    def test_it_holds_at_a_second_grain(self) -> None:
+        direct = _rows(["Revenue", "Unfiltered Revenue"], ["Month", "Region"])
+        share = _rows(["Revenue Share"], ["Month", "Region"])["Revenue Share"]
+        expected = [
+            n / d for n, d in zip(direct["Revenue"], direct["Unfiltered Revenue"], strict=True)
+        ]
+        assert [round(v, 6) for v in share] == [round(v, 6) for v in expected]
+
+
+class TestTheShapeOfTheSQL:
+    def test_the_component_gets_its_own_cte(self) -> None:
+        sql = _sql(["Revenue Share"])
+        assert '"fc_0" AS' in sql
+
+    def test_that_cte_does_not_carry_the_query_filter(self) -> None:
+        sql = _sql(["Revenue Share"])
+        fc_block = sql.split('"fc_0" AS')[1]
+        assert '"Dates"."DAY" = 1' not in fc_block
+
+    def test_the_formula_reads_columns_not_aggregates(self) -> None:
+        """Rebuilt in the outer query out of the two CTEs' columns, rather than
+        inlined as two aggregates over one filtered scan."""
+        sql = _sql(["Revenue Share"])
+        outer = sql.rsplit("\nSELECT ", 1)[1]
+        assert '"main"."Revenue" / "fc_0"."Unfiltered Revenue"' in outer
+        assert "SUM(" not in outer
+
+    def test_two_contexts_get_two_ctes(self) -> None:
+        sql = _sql(["Two Contexts"])
+        assert '"fc_0" AS' in sql and '"fc_1" AS' in sql
+
+    def test_a_metric_over_plain_components_is_untouched(self) -> None:
+        """No filterContext anywhere in it, so no CTE and no rebuild."""
+        sql = _sql(["Plain Ratio"])
+        assert "fc_0" not in sql
+        assert "SUM(" in sql
+
+    def test_the_component_is_projected_once_when_also_selected(self) -> None:
+        """Selecting the measure *and* a metric over it aggregates it once —
+        the outer query reads one CTE column twice."""
+        sql = _sql(["Revenue Share", "Unfiltered Revenue"])
+        assert sql.count('"fc_1" AS') == 0
+        assert sql.count('SUM("Sales"."AMOUNT") AS "Unfiltered Revenue"') == 1
+        # ...and read twice: once by the metric, once as its own column.
+        assert sql.count('"fc_0"."Unfiltered Revenue"') == 2
+
+    def test_both_read_the_same_column(self) -> None:
+        rows = _rows(["Revenue Share", "Unfiltered Revenue"])
+        assert rows["Unfiltered Revenue"] == [40.0, 5.0]
+        assert [round(v, 6) for v in rows["Revenue Share"]] == [0.25, 1.0]
+
+
+class TestTheEdgesTheRebuildReaches:
+    """Three things the wrapper got wrong, two of them reachable only once a
+    metric could put a filterContext measure in play."""
+
+    def test_a_scalar_metric_returns_one_row(self) -> None:
+        """No dimensions and every component isolated leaves the ``main`` CTE
+        with nothing to project — it degenerated to ``SELECT *``, one row per
+        fact row, and the CROSS JOIN multiplied the scalar result by all of
+        them. It is dropped instead, and an isolated CTE anchors the query."""
+        sql = _sql(["Two Contexts"], [])
+        assert '"main" AS' not in sql
+        assert _rows(["Two Contexts"], [])["Two Contexts"] == [1.0]
+
+    def test_ordering_by_a_rebuilt_metric(self) -> None:
+        """The metric is assembled in the outer projection and has no CTE
+        column, so it orders by its own select alias."""
+        query = _query(["Revenue Share"])
+        query.order_by = [QueryOrderBy(field="Revenue Share", direction="desc")]
+        sql = PIPELINE.compile(query, _model(), "duckdb").sql
+        assert 'ORDER BY "Revenue Share" DESC' in sql
+
+    def test_ordering_by_an_isolated_measure(self) -> None:
+        """It orders by the CTE that computed it. Ordering by ``main`` — which
+        is where every measure used to be looked up — named a column that CTE
+        does not have, and the engine rejected the query outright."""
+        query = _query(["Unfiltered Revenue"])
+        query.order_by = [QueryOrderBy(field="Unfiltered Revenue", direction="desc")]
+        sql = PIPELINE.compile(query, _model(), "duckdb").sql
+        assert '"fc_0"."Unfiltered Revenue" DESC' in sql
+        assert '"main"."Unfiltered Revenue"' not in sql
+
+    @pytest.mark.parametrize("measure", ["Unfiltered Revenue", "Revenue Share"])
+    def test_having_on_a_filter_contexted_value_is_refused(self, measure: str) -> None:
+        """HAVING is evaluated inside the CTE the planner built, where the
+        measure's own value does not exist — the query-filtered aggregate stood
+        in for it and the wrong groups survived, without any sign of it."""
+        query = _query([measure])
+        query.having = [QueryFilter(field=measure, op=FilterOperator.GREATER, value=10)]
+        with pytest.raises(ResolutionError) as exc:
+            PIPELINE.compile(query, _model(), "duckdb")
+        assert measure in str(exc.value)
+
+    def test_having_on_a_plain_measure_still_works(self) -> None:
+        query = _query(["Revenue", "Unfiltered Revenue"])
+        query.having = [QueryFilter(field="Revenue", op=FilterOperator.GREATER, value=6)]
+        sql = PIPELINE.compile(query, _model(), "duckdb").sql
+        assert "HAVING" in sql

--- a/tests/unit/test_filter_context_metrics.py
+++ b/tests/unit/test_filter_context_metrics.py
@@ -87,6 +87,13 @@ measures:
     columns: [{dataObject: Sales, column: Amount}]
     resultType: int
     aggregation: count
+  Unfiltered Total Revenue:
+    columns: [{dataObject: Sales, column: Amount}]
+    resultType: float
+    aggregation: sum
+    total: true
+    filterContext:
+      mode: FIXED
 
 metrics:
   Revenue Share:
@@ -97,6 +104,14 @@ metrics:
     expression: "{[Unfiltered Revenue]} / {[Revenue Any Day]}"
   Plain Ratio:
     expression: "{[Revenue]} / {[Sale Count]}"
+  Total Share:
+    expression: "{[Revenue]} / {[Unfiltered Total Revenue]}"
+  Rank Unfiltered:
+    type: window
+    windowFunction: rank
+    measure: Unfiltered Revenue
+  Doubled Rank:
+    expression: "{[Rank Unfiltered]} * 2"
 """
 
 
@@ -130,10 +145,12 @@ def _rows(measures: list[str], dimensions: list[str] | None = None) -> dict[str,
     con.execute('CREATE SCHEMA "PUBLIC"')
     con.execute('CREATE TABLE "PUBLIC"."DATES" (DATE_KEY INT, MONTH INT, DAY INT)')
     con.execute('CREATE TABLE "PUBLIC"."SALES" (DATE_KEY INT, REGION VARCHAR, AMOUNT DOUBLE)')
-    # Month 1 has 10 on day 1 and 30 on day 2; month 2 has 5 on day 1.
+    # Month 1 has 2 on day 1 and 38 on day 2; month 2 has 5 on day 1. So month 1
+    # is the larger month overall and the smaller one on the filtered day —
+    # which is what lets a rank tell a dropped context from an honoured one.
     con.execute('INSERT INTO "PUBLIC"."DATES" VALUES (1, 1, 1), (2, 1, 2), (3, 2, 1)')
     con.execute(
-        "INSERT INTO \"PUBLIC\".\"SALES\" VALUES (1, 'EU', 10.0), (2, 'EU', 30.0), (3, 'US', 5.0)"
+        "INSERT INTO \"PUBLIC\".\"SALES\" VALUES (1, 'EU', 2.0), (2, 'EU', 38.0), (3, 'US', 5.0)"
     )
     result = con.execute(_sql(measures, dimensions)).fetchdf()
     # Sorted on the dimensions: nothing orders the rows, and two queries have to
@@ -156,6 +173,7 @@ class TestTheContextSurvivesTheMetric:
             ("Day Share", "Revenue", "Revenue Any Day"),
             ("Two Contexts", "Unfiltered Revenue", "Revenue Any Day"),
             ("Plain Ratio", "Revenue", "Sale Count"),
+            ("Total Share", "Revenue", "Unfiltered Total Revenue"),
         ],
     )
     def test_the_metric_equals_its_components(
@@ -168,10 +186,10 @@ class TestTheContextSurvivesTheMetric:
 
     def test_the_context_actually_changes_the_number(self) -> None:
         """The equality above is only worth something if the two sides differ.
-        Month 1 holds 10 on the filtered day out of 40 altogether; month 2's
-        one row is on that day, so there the context changes nothing."""
+        Month 1 holds 2 on the filtered day out of 40 altogether; month 2's one
+        row is on that day, so there the context changes nothing."""
         assert _rows(["Revenue", "Unfiltered Revenue"], ["Month"]) == {
-            "Revenue": [10.0, 5.0],
+            "Revenue": [2.0, 5.0],
             "Unfiltered Revenue": [40.0, 5.0],
         }
 
@@ -224,7 +242,7 @@ class TestTheShapeOfTheSQL:
     def test_both_read_the_same_column(self) -> None:
         rows = _rows(["Revenue Share", "Unfiltered Revenue"])
         assert rows["Unfiltered Revenue"] == [40.0, 5.0]
-        assert [round(v, 6) for v in rows["Revenue Share"]] == [0.25, 1.0]
+        assert [round(v, 6) for v in rows["Revenue Share"]] == [0.05, 1.0]
 
 
 class TestTheEdgesTheRebuildReaches:
@@ -274,3 +292,60 @@ class TestTheEdgesTheRebuildReaches:
         query.having = [QueryFilter(field="Revenue", op=FilterOperator.GREATER, value=6)]
         sql = PIPELINE.compile(query, _model(), "duckdb").sql
         assert "HAVING" in sql
+
+
+class TestAContextOnATotalMeasure:
+    """``total: true`` and ``grain: {mode: FIXED}`` make the same claim - a
+    grand total - but only the grain override reaches ``effective_grain``. The
+    isolated CTE read the query grain instead and came back per group, and
+    ``total_wrap`` was never going to correct it: it skips filter-contexted
+    measures on the grounds that this wrapper owns them."""
+
+    def test_the_isolated_cte_has_no_grain(self) -> None:
+        sql = _sql(["Unfiltered Total Revenue"])
+        assert "CROSS JOIN" in sql
+        fc_block = sql.split('"fc_0" AS')[1].split("\n)")[0]
+        assert '"Month"' not in fc_block
+
+    def test_it_is_the_same_value_on_every_row(self) -> None:
+        """Sales total 45 across both months and both days; the query asks for
+        one day of one month, and this measure reports all of it regardless."""
+        assert _rows(["Unfiltered Total Revenue"])["Unfiltered Total Revenue"] == [45.0, 45.0]
+
+    def test_the_total_is_what_distinguishes_it(self) -> None:
+        """Without ``total`` the same context reports per month, so the two
+        measures must not agree — otherwise the assertion above proves
+        nothing."""
+        assert _rows(["Unfiltered Revenue"])["Unfiltered Revenue"] == [40.0, 5.0]
+
+
+class TestAContextBehindAWindowMetric:
+    """``metric_leaf_components`` stops at a cumulative / window /
+    period-over-period metric, because that one is computed by its own wrapper
+    rather than substituted into the formula. Its *base measure* is still a
+    measure the query computes, and a context declared on it is still one to
+    honour - a derived metric over a window metric over a filter-contexted
+    measure hid one exactly there."""
+
+    def test_a_window_metric_over_it_honours_the_context(self) -> None:
+        sql = _sql(["Rank Unfiltered"])
+        assert '"fc_0" AS' in sql
+        # Unfiltered: month 1 has 110, month 2 has 50. Filtered it is the other
+        # way round, so a dropped context would swap the ranks.
+        assert _rows(["Rank Unfiltered"])["Rank Unfiltered"] == [1.0, 2.0]
+
+    def test_a_derived_metric_over_that_window_is_refused(self) -> None:
+        """The derived expression is a placeholder until the window pass
+        resolves it, and this wrapper's CTE would materialize it first. The
+        rule that says so could not see the context to fire on."""
+        with pytest.raises(ResolutionError) as exc:
+            _sql(["Doubled Rank"])
+        message = str(exc.value)
+        assert "Doubled Rank" in message
+        assert "window metric" in message
+
+    def test_the_flag_sees_it(self) -> None:
+        from orionbelt.compiler.resolution import QueryResolver
+
+        resolved = QueryResolver().resolve(_query(["Rank Unfiltered"]), _model())
+        assert resolved.has_filter_context

--- a/tests/unit/test_filter_context_metrics.py
+++ b/tests/unit/test_filter_context_metrics.py
@@ -45,6 +45,7 @@ dataObjects:
       Date Key: {code: DATE_KEY, abstractType: int, primaryKey: true}
       Month: {code: MONTH, abstractType: int}
       Day: {code: DAY, abstractType: int}
+      Order Date: {code: ODATE, abstractType: date}
 
   Sales:
     code: SALES
@@ -64,6 +65,7 @@ dimensions:
   Month: {dataObject: Dates, column: Month, resultType: int}
   Day: {dataObject: Dates, column: Day, resultType: int}
   Region: {dataObject: Sales, column: Region, resultType: string}
+  Order Date: {dataObject: Dates, column: Order Date, resultType: date}
 
 measures:
   Revenue:
@@ -133,6 +135,24 @@ metrics:
     expression: "{[Unfiltered Revenue]} / {[Month Revenue]}"
   Share Of Grand Avg:
     expression: "{[Unfiltered Revenue]} / {[Grand Avg]}"
+  Unfiltered YoY:
+    type: period_over_period
+    expression: "{[Unfiltered Revenue]}"
+    periodOverPeriod:
+      timeDimension: Order Date
+      grain: year
+      offset: -1
+      offsetGrain: year
+      comparison: previousValue
+  Revenue YoY:
+    type: period_over_period
+    expression: "{[Revenue]}"
+    periodOverPeriod:
+      timeDimension: Order Date
+      grain: year
+      offset: -1
+      offsetGrain: year
+      comparison: previousValue
 """
 
 
@@ -164,12 +184,15 @@ def _rows(measures: list[str], dimensions: list[str] | None = None) -> dict[str,
     """Execute, returning one list of values per selected measure."""
     con = duckdb.connect(":memory:")
     con.execute('CREATE SCHEMA "PUBLIC"')
-    con.execute('CREATE TABLE "PUBLIC"."DATES" (DATE_KEY INT, MONTH INT, DAY INT)')
+    con.execute('CREATE TABLE "PUBLIC"."DATES" (DATE_KEY INT, MONTH INT, DAY INT, ODATE DATE)')
     con.execute('CREATE TABLE "PUBLIC"."SALES" (DATE_KEY INT, REGION VARCHAR, AMOUNT DOUBLE)')
     # Month 1 has 2 on day 1 and 38 on day 2; month 2 has 5 on day 1. So month 1
     # is the larger month overall and the smaller one on the filtered day —
     # which is what lets a rank tell a dropped context from an honoured one.
-    con.execute('INSERT INTO "PUBLIC"."DATES" VALUES (1, 1, 1), (2, 1, 2), (3, 2, 1)')
+    con.execute(
+        'INSERT INTO "PUBLIC"."DATES" VALUES '
+        "(1, 1, 1, DATE '2024-01-01'), (2, 1, 2, DATE '2024-01-02'), (3, 2, 1, DATE '2024-02-01')"
+    )
     con.execute(
         "INSERT INTO \"PUBLIC\".\"SALES\" VALUES (1, 'EU', 2.0), (2, 'EU', 38.0), (3, 'US', 5.0)"
     )
@@ -428,3 +451,30 @@ class TestAMetricMixingAContextWithATotal:
         """The refusal is about what filterContext does to the plan, so a query
         without one still gets its averaged total."""
         assert _rows(["Grand Avg"])["Grand Avg"] == [3.5, 3.5]
+
+
+class TestAContextUnderAPeriodOverPeriodMetric:
+    """A filterContext *is* a differently filtered scan of the fact, held in a
+    CTE of its own. Period-over-period rebuilds the query's FROM from a date
+    spine, which cannot read that CTE - it was being built and then ignored, so
+    the comparison ran on the query-filtered value under the filter-contexted
+    measure's name. Refused, the same treatment an anchored measure already
+    gets for the same reason."""
+
+    def test_a_pop_metric_over_such_a_measure_is_refused(self) -> None:
+        with pytest.raises(ResolutionError) as exc:
+            _sql(["Unfiltered YoY"], ["Order Date"])
+        message = str(exc.value)
+        assert "Unfiltered Revenue" in message
+        assert "date spine" in message
+
+    def test_an_unrelated_one_in_the_same_query_is_refused_too(self) -> None:
+        """The pass regroups the whole query to its own grain, so a
+        filterContext measure that the metric does not read comes back at that
+        grain rather than the query's."""
+        with pytest.raises(ResolutionError) as exc:
+            _sql(["Revenue YoY", "Unfiltered Revenue"], ["Order Date"])
+        assert "Unfiltered Revenue" in str(exc.value)
+
+    def test_a_pop_metric_without_one_still_compiles(self) -> None:
+        assert "Revenue YoY" in _sql(["Revenue YoY"], ["Order Date"])


### PR DESCRIPTION
Phase 2 of the filterContext plan. Turns the refusal added in #294 into a computed answer, for single-fact plans.

## The problem

`filterContext` says which of the query's WHERE filters apply to a measure, and a different WHERE needs a scan of its own. `filter_wrap` gives a *selected* measure exactly that. But a metric is one column, and the planner builds it by substituting each component's aggregate into the formula, so both halves ended up under the same WHERE:

```sql
-- {[Revenue]} / {[Unfiltered Revenue]}, with a Day = 1 filter
SELECT SUM("Sales"."AMOUNT") / SUM("Sales"."AMOUNT") AS "Revenue Share"
FROM "SALES" ... WHERE "Dates"."DAY" = 1
```

The context was dropped and the ratio came back 1. #294 refused it; this computes it.

## The fix

The component gets the same CTE a selected measure gets, and the formula is rebuilt in the outer query over the CTEs' columns:

```sql
WITH "main" AS (... WHERE "Dates"."DAY" = 1 ...),
     "fc_0" AS (...        no WHERE        )
SELECT "main"."Revenue" / "fc_0"."Unfiltered Revenue" AS "Revenue Share"
FROM "main" LEFT JOIN "fc_0" ON "main"."Month" = "fc_0"."Month"
```

That is the move `grain_dedup` already makes for a deduplicated component and `total_wrap` for a windowed one, so `_metric_over_components` moves out of `grain_dedup` into `metric_expansion` (where `expand_metric_expression` lives) and the third caller shares it. Selecting the measure *and* a metric over it computes it once and reads the column twice.

## The test is a property, not a shape

> A component's value inside a metric must equal the value that measure reports when selected on its own.

Executed on DuckDB across the filterContext modes (`FIXED`, `RELATIVE` + `exclude`, two different contexts in one metric, and a metric with no context at all as the control). Anything that drops the context or applies it twice breaks that equality without anyone having to predict how.

## Three defects found on the way

Two were reachable only once a metric could put a filterContext measure in play:

| | |
|---|---|
| **Scalar metric multiplied its own result** | A metric of nothing but fc components left `main` with no columns, so it degenerated to `SELECT *` (one row per fact row) and the CROSS JOIN multiplied the scalar by all of them. `main` is dropped when empty; an isolated CTE anchors the query. |
| **ORDER BY named a column that does not exist** | Every measure was looked up in `main`. It now reads whichever CTE computed the value, and a rebuilt metric orders by its select alias. Pre-existing: ordering by a *selected* filterContext measure was a hard engine error on `main`. |
| **HAVING silently kept the wrong groups** | Refused, not fixed. The predicate is evaluated inside `main`, under the query's filters, against an aggregate that is not the measure's. Also pre-existing for a plain selected measure. Hoisting it to the outer query is the same move `grain_dedup` makes; recorded as phase 2b. |

Under a multi-fact plan this stays refused, and the refusal now covers components: the composite has nothing for that CTE to read either way.

## Verification

- `tests/unit/test_filter_context_metrics.py`: 19 tests, the equivalence oracle executed on DuckDB
- full suite 3344 passed, 584 skipped; ruff + mypy clean
- TPC-DS sweep unchanged: 39 exact on DuckDB sf=1 plus the known Q99 reference variant