### PR TITLE
feat(compiler): evaluate HAVING on a filterContext measure where its value is

### DIFF
--- a/src/orionbelt/compiler/filter_wrap.py
+++ b/src/orionbelt/compiler/filter_wrap.py
@@ -33,7 +33,7 @@ from orionbelt.ast.nodes import (
     OrderByItem,
     Select,
 )
-from orionbelt.compiler.expr_rewrite import map_column_refs
+from orionbelt.compiler.expr_rewrite import map_column_refs, map_nodes
 from orionbelt.compiler.filters import build_filter_expr
 from orionbelt.compiler.having_hoist import windowed_aliases
 from orionbelt.compiler.metric_expansion import metric_leaf_components, metric_over_components
@@ -188,6 +188,39 @@ def _substitute_aliases(expr: Expr, by_alias: dict[str, Expr]) -> Expr:
     )
 
 
+def _outer_predicate(
+    expr: Expr,
+    by_alias: dict[str, Expr],
+    dim_map: dict[tuple[str, str | None], str],
+    dim_exprs: list[tuple[Expr, str]],
+    dim_ref: Callable[[str], Expr],
+) -> Expr:
+    """A HAVING predicate rewritten for the outer query's scope.
+
+    Measures arrive as bare ``ColumnRef`` placeholders and become whatever the
+    projection holds. A *dimension* does not: a predicate grouping one with a
+    measure (``Unfiltered Revenue > 10 OR Month = 2``) carries the physical
+    column the planner referenced, and out here the table it names is no longer
+    in the FROM. It reads by the alias the CTEs projected it under instead -
+    matched on that physical reference, or structurally for a computed
+    dimension, whose source is an inlined expression rather than a column.
+    """
+
+    def rewrite(node: Expr) -> Expr | None:
+        for dim_expr, name in dim_exprs:
+            if node == dim_expr:
+                return dim_ref(name)
+        if isinstance(node, ColumnRef):
+            if node.table is None:
+                return by_alias.get(node.name)
+            mapped = dim_map.get((node.name, node.table))
+            if mapped is not None:
+                return dim_ref(mapped)
+        return None
+
+    return map_nodes(expr, rewrite)
+
+
 def _combine_exprs(exprs: Iterable[Expr]) -> Expr | None:
     """AND a run of predicates together, or ``None`` if there are none."""
     combined: Expr | None = None
@@ -285,7 +318,17 @@ def wrap_with_filter_context(
     # outer query instead, where every measure is one column of a CTE. The rest
     # stay where the planner put them, expression for expression.
     hoisted = {m.name for m in isolated} | set(split_metrics)
-    outer_having = [hf for hf in resolved.having_filters if hf.referenced_fields & hoisted]
+    windowed = windowed_aliases(resolved)
+    # A predicate that also names a value a later wrapper windows belongs to
+    # neither scope: its window does not exist yet here, and hoisting it would
+    # apply it to the pre-window value *and* leave ``PASS_HAVING_WINDOW`` to
+    # apply it again over the windowed rows. That pass sees both values, so it
+    # is the one place the predicate holds together.
+    outer_having = [
+        hf
+        for hf in resolved.having_filters
+        if hf.referenced_fields & hoisted and not hf.referenced_fields & windowed
+    ]
     main_having = ast.having
     if outer_having:
         planner_exprs = {
@@ -296,7 +339,7 @@ def wrap_with_filter_context(
         # A predicate on a measure a *later* wrapper windows stays withheld:
         # the planner left it out deliberately and ``PASS_HAVING_WINDOW``
         # applies it once over the windowed rows.
-        deferred = hoisted | windowed_aliases(resolved)
+        deferred = hoisted | windowed
         main_having = _combine_exprs(
             _substitute_aliases(hf.expression, planner_exprs)
             for hf in resolved.having_filters
@@ -451,6 +494,17 @@ def wrap_with_filter_context(
                 )
             )
 
+    # How a dimension reads in the outer query, needed by both the hoisted
+    # predicates and the ORDER BY: by the alias the CTEs projected it under,
+    # matched either on the physical column the planner referenced or - for a
+    # computed dimension, whose source is an inlined expression - structurally.
+    dim_map: dict[tuple[str, str | None], str] = {
+        (d.source_column, d.object_name): d.name for d in resolved.dimensions
+    }
+    dim_exprs: list[tuple[Expr, str]] = [
+        (make_column_expr(model, d.object_name, d.column_name), d.name) for d in resolved.dimensions
+    ]
+
     # The hoisted predicates, rebuilt over the outer projection. One row per
     # query grain here, so filtering it is exactly what HAVING would have done
     # had the value been available where the planner put the predicate.
@@ -460,7 +514,14 @@ def wrap_with_filter_context(
         if isinstance(col, AliasedExpr) and (alias := _get_alias(col)) is not None
     }
     outer_where = _combine_exprs(
-        _substitute_aliases(hf.expression, outer_exprs) for hf in outer_having
+        _outer_predicate(
+            hf.expression,
+            outer_exprs,
+            dim_map,
+            dim_exprs,
+            lambda name: ColumnRef(name=name, table=anchor),
+        )
+        for hf in outer_having
     )
 
     # Recorded for the wrappers that run after this one. Each of them
@@ -479,12 +540,6 @@ def wrap_with_filter_context(
                 resolved.projected_expressions[comp.name] = ColumnRef(name=comp.name, table=anchor)
 
     # --- ORDER BY remapping: resolve to CTE aliases ---
-    dim_map: dict[tuple[str, str | None], str] = {
-        (d.source_column, d.object_name): d.name for d in resolved.dimensions
-    }
-    dim_exprs: list[tuple[Expr, str]] = [
-        (make_column_expr(model, d.object_name, d.column_name), d.name) for d in resolved.dimensions
-    ]
     measure_exprs: list[tuple[Expr, str]] = [(m.expression, m.name) for m in resolved.measures]
 
     def order_ref(name: str) -> Expr:

--- a/src/orionbelt/compiler/filter_wrap.py
+++ b/src/orionbelt/compiler/filter_wrap.py
@@ -18,7 +18,7 @@ Strategy selection per the design doc:
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING
 
 from orionbelt.ast.nodes import (
@@ -33,7 +33,9 @@ from orionbelt.ast.nodes import (
     OrderByItem,
     Select,
 )
+from orionbelt.compiler.expr_rewrite import map_column_refs
 from orionbelt.compiler.filters import build_filter_expr
+from orionbelt.compiler.having_hoist import windowed_aliases
 from orionbelt.compiler.metric_expansion import metric_leaf_components, metric_over_components
 from orionbelt.compiler.resolution import (
     ResolvedFilter,
@@ -174,6 +176,26 @@ def _combine_where(filters: list[ResolvedFilter]) -> Expr | None:
     return combined
 
 
+def _substitute_aliases(expr: Expr, by_alias: dict[str, Expr]) -> Expr:
+    """Replace every bare (unqualified) ``ColumnRef`` that names a mapped alias.
+
+    A HAVING predicate references a measure as a table-less ``ColumnRef``
+    carrying its name, so this turns one into whichever expression the target
+    scope projects under that name.
+    """
+    return map_column_refs(
+        expr, lambda ref: by_alias.get(ref.name, ref) if ref.table is None else ref
+    )
+
+
+def _combine_exprs(exprs: Iterable[Expr]) -> Expr | None:
+    """AND a run of predicates together, or ``None`` if there are none."""
+    combined: Expr | None = None
+    for expr in exprs:
+        combined = expr if combined is None else BinaryOp(left=combined, op="AND", right=expr)
+    return combined
+
+
 def _component_expr(measure: ResolvedMeasure, resolved: ResolvedQuery) -> Expr:
     """The aggregate to project for *measure*, in a CTE of this wrapper's own.
 
@@ -256,13 +278,38 @@ def wrap_with_filter_context(
             main_columns.append(AliasedExpr(expr=_component_expr(comp, resolved), alias=comp.name))
             main_aliases.add(comp.name)
 
+    # A HAVING predicate is evaluated inside the CTE the planner built. For an
+    # isolated measure that CTE is ``main``, under the query's filters and over
+    # an aggregate that is not the measure's - the predicate read the wrong
+    # value and silently kept the wrong groups. Those predicates move to the
+    # outer query instead, where every measure is one column of a CTE. The rest
+    # stay where the planner put them, expression for expression.
+    hoisted = {m.name for m in isolated} | set(split_metrics)
+    outer_having = [hf for hf in resolved.having_filters if hf.referenced_fields & hoisted]
+    main_having = ast.having
+    if outer_having:
+        planner_exprs = {
+            alias: col.expr
+            for col in ast.columns
+            if isinstance(col, AliasedExpr) and (alias := _get_alias(col)) is not None
+        }
+        # A predicate on a measure a *later* wrapper windows stays withheld:
+        # the planner left it out deliberately and ``PASS_HAVING_WINDOW``
+        # applies it once over the windowed rows.
+        deferred = hoisted | windowed_aliases(resolved)
+        main_having = _combine_exprs(
+            _substitute_aliases(hf.expression, planner_exprs)
+            for hf in resolved.having_filters
+            if not hf.referenced_fields & deferred
+        )
+
     main_cte_query = Select(
         columns=main_columns,
         from_=ast.from_,
         joins=ast.joins,
         where=ast.where,
         group_by=ast.group_by,
-        having=ast.having,
+        having=main_having,
         order_by=[],
         limit=None,
         offset=None,
@@ -404,6 +451,18 @@ def wrap_with_filter_context(
                 )
             )
 
+    # The hoisted predicates, rebuilt over the outer projection. One row per
+    # query grain here, so filtering it is exactly what HAVING would have done
+    # had the value been available where the planner put the predicate.
+    outer_exprs = {
+        alias: col.expr
+        for col in outer_columns
+        if isinstance(col, AliasedExpr) and (alias := _get_alias(col)) is not None
+    }
+    outer_where = _combine_exprs(
+        _substitute_aliases(hf.expression, outer_exprs) for hf in outer_having
+    )
+
     # Recorded for the wrappers that run after this one. Each of them
     # re-projects some measure's aggregate into a CTE of its own, and their CTE
     # selects from what this wrapper built - where the fact tables the resolved
@@ -454,7 +513,7 @@ def wrap_with_filter_context(
         columns=outer_columns,
         from_=From(source=anchor, alias=anchor),
         joins=outer_joins,
-        where=None,
+        where=outer_where,
         group_by=[],
         having=None,
         order_by=outer_order_by,

--- a/src/orionbelt/compiler/passes.py
+++ b/src/orionbelt/compiler/passes.py
@@ -507,46 +507,6 @@ def evaluate_compatibility(
                 ]
             )
 
-    # Rule 2d (raising): a HAVING predicate is evaluated inside the CTE the
-    # planner built, which for a filterContext measure is the *main* one - under
-    # the query's filters, on an aggregate that is not the measure's. The
-    # predicate then reads the filtered value and silently keeps the wrong
-    # groups. Moving it to the outer query is the fix (``grain_dedup`` does that
-    # for a deduplicated measure); until then, refuse.
-    fc_names = {m.name for m in resolved.measures if m.filter_context is not None} | {
-        m.name
-        for m in resolved.measures
-        if m.component_measures
-        and any(
-            comp.filter_context is not None
-            for comp in metric_leaf_components(m, resolved.metric_components)
-        )
-    }
-    fc_having = sorted(
-        {name for hf in resolved.having_filters for name in hf.referenced_fields & fc_names}
-    )
-    if fc_having:
-        listed = ", ".join(f"'{name}'" for name in fc_having)
-        raise ResolutionError(
-            [
-                SemanticError(
-                    code="INCOMPATIBLE_COMBINATION",
-                    message=(
-                        f"HAVING references {listed}, which a filterContext computes in a "
-                        f"CTE of its own. The predicate is evaluated in the query's own "
-                        f"scan instead, where that value does not exist and the "
-                        f"query-filtered aggregate stands in for it."
-                    ),
-                    path="having",
-                    hint=(
-                        "Filter on a measure without a filterContext, or apply the "
-                        "threshold in the caller."
-                    ),
-                    context={"measures": fc_having},
-                )
-            ]
-        )
-
     # Rule 3 (raising): grain dedup splits the projection across CTEs keyed on
     # the query grain. Every wrapper in ``incompatible_with`` restructures that
     # same projection, and ROLLUP/CUBE changes the grain itself, so the join

--- a/tests/unit/test_filter_context_metrics.py
+++ b/tests/unit/test_filter_context_metrics.py
@@ -15,6 +15,8 @@ for a deduplicated component and ``total_wrap`` for a windowed one.
 
 from __future__ import annotations
 
+from decimal import Decimal
+
 import duckdb
 import pytest
 
@@ -23,6 +25,7 @@ from orionbelt.compiler.resolution import ResolutionError
 from orionbelt.models.query import (
     FilterOperator,
     QueryFilter,
+    QueryFilterGroup,
     QueryObject,
     QueryOrderBy,
     QuerySelect,
@@ -511,3 +514,80 @@ class TestAContextUnderAPeriodOverPeriodMetric:
 
     def test_a_pop_metric_without_one_still_compiles(self) -> None:
         assert "Revenue YoY" in _sql(["Revenue YoY"], ["Order Date"])
+
+
+class TestAHoistedPredicateThatIsNotAloneInItsGroup:
+    """Hoisting reads a predicate's *referenced fields*, and a grouped one can
+    name more than a filter-contexted measure."""
+
+    @staticmethod
+    def _or(*filters: QueryFilter) -> list[QueryFilterGroup]:
+        return [QueryFilterGroup(logic="or", filters=list(filters))]
+
+    @staticmethod
+    def _run_having(measures: list[str], having: list[QueryFilterGroup]) -> list[tuple]:
+        query = _query(measures)
+        query.having = having
+        sql = PIPELINE.compile(query, _model(), "duckdb").sql
+        return [
+            tuple(float(v) if isinstance(v, (int, float, Decimal)) else v for v in row)
+            for row in _connect().execute(sql).fetchall()
+        ]
+
+    @pytest.mark.parametrize(
+        ("unfiltered_over", "grand_over", "expected"),
+        [
+            # Unfiltered revenue is 40 and 5; the grand total is 7 on every row.
+            (10, 6, [(1.0, 40.0, 7.0), (2.0, 5.0, 7.0)]),
+            (1000, 6, [(1.0, 40.0, 7.0), (2.0, 5.0, 7.0)]),
+            (10, 100, [(1.0, 40.0, 7.0)]),
+            (1000, 100, []),
+        ],
+    )
+    def test_grouped_with_a_windowed_value(
+        self, unfiltered_over: int, grand_over: int, expected: list[tuple]
+    ) -> None:
+        """A predicate naming both belongs to neither scope: the window does
+        not exist yet in this wrapper, so hoisting it would test the pre-window
+        value here and leave ``PASS_HAVING_WINDOW`` to test it again over the
+        windowed rows. It stays whole, for the pass that sees both values - it
+        was reading a per-group 2 where the total is 7."""
+        assert (
+            self._run_having(
+                ["Unfiltered Revenue", "Grand Revenue"],
+                self._or(
+                    QueryFilter(
+                        field="Unfiltered Revenue",
+                        op=FilterOperator.GREATER,
+                        value=unfiltered_over,
+                    ),
+                    QueryFilter(field="Grand Revenue", op=FilterOperator.GREATER, value=grand_over),
+                ),
+            )
+            == expected
+        )
+
+    @pytest.mark.parametrize(
+        ("unfiltered_over", "expected"),
+        [(10, [(1.0, 40.0), (2.0, 5.0)]), (1000, [(2.0, 5.0)])],
+    )
+    def test_grouped_with_a_dimension(self, unfiltered_over: int, expected: list[tuple]) -> None:
+        """The measure arrives as a bare placeholder, but the dimension carries
+        the physical column the planner referenced - and out here that table is
+        no longer in the FROM. It reads by the alias the CTEs projected it
+        under instead; it was emitting `"Dates"."MONTH"` against a query that
+        selects from ``main``, which no engine binds."""
+        assert (
+            self._run_having(
+                ["Unfiltered Revenue"],
+                self._or(
+                    QueryFilter(
+                        field="Unfiltered Revenue",
+                        op=FilterOperator.GREATER,
+                        value=unfiltered_over,
+                    ),
+                    QueryFilter(field="Month", op=FilterOperator.EQUALS, value=2),
+                ),
+            )
+            == expected
+        )

--- a/tests/unit/test_filter_context_metrics.py
+++ b/tests/unit/test_filter_context_metrics.py
@@ -180,8 +180,8 @@ def _sql(measures: list[str], dimensions: list[str] | None = None) -> str:
     return PIPELINE.compile(_query(measures, dimensions), _model(), "duckdb").sql
 
 
-def _rows(measures: list[str], dimensions: list[str] | None = None) -> dict[str, list]:
-    """Execute, returning one list of values per selected measure."""
+def _connect() -> duckdb.DuckDBPyConnection:
+    """A DuckDB with the fixture rows loaded."""
     con = duckdb.connect(":memory:")
     con.execute('CREATE SCHEMA "PUBLIC"')
     con.execute('CREATE TABLE "PUBLIC"."DATES" (DATE_KEY INT, MONTH INT, DAY INT, ODATE DATE)')
@@ -196,7 +196,12 @@ def _rows(measures: list[str], dimensions: list[str] | None = None) -> dict[str,
     con.execute(
         "INSERT INTO \"PUBLIC\".\"SALES\" VALUES (1, 'EU', 2.0), (2, 'EU', 38.0), (3, 'US', 5.0)"
     )
-    result = con.execute(_sql(measures, dimensions)).fetchdf()
+    return con
+
+
+def _rows(measures: list[str], dimensions: list[str] | None = None) -> dict[str, list]:
+    """Execute, returning one list of values per selected measure."""
+    result = _connect().execute(_sql(measures, dimensions)).fetchdf()
     # Sorted on the dimensions: nothing orders the rows, and two queries have to
     # be comparable row for row.
     if _dims(dimensions):
@@ -321,21 +326,49 @@ class TestTheEdgesTheRebuildReaches:
         assert '"main"."Unfiltered Revenue"' not in sql
 
     @pytest.mark.parametrize("measure", ["Unfiltered Revenue", "Revenue Share"])
-    def test_having_on_a_filter_contexted_value_is_refused(self, measure: str) -> None:
-        """HAVING is evaluated inside the CTE the planner built, where the
-        measure's own value does not exist — the query-filtered aggregate stood
-        in for it and the wrong groups survived, without any sign of it."""
-        query = _query([measure])
+    def test_having_on_a_filter_contexted_value_reads_that_value(self, measure: str) -> None:
+        """HAVING is evaluated inside the CTE the planner built, which for an
+        isolated measure is ``main`` - under the query's filters and over an
+        aggregate that is not the measure's. The predicate read the wrong value
+        and silently kept the wrong groups; it moves to the outer query, where
+        every measure is one column of a CTE."""
+        query = _query([measure, "Revenue"])
         query.having = [QueryFilter(field=measure, op=FilterOperator.GREATER, value=10)]
-        with pytest.raises(ResolutionError) as exc:
-            PIPELINE.compile(query, _model(), "duckdb")
-        assert measure in str(exc.value)
+        sql = PIPELINE.compile(query, _model(), "duckdb").sql
+        assert "HAVING" not in sql
+        assert sql.rstrip().splitlines()[-1].startswith("WHERE ")
 
-    def test_having_on_a_plain_measure_still_works(self) -> None:
+    def test_the_threshold_keeps_the_right_groups(self) -> None:
+        """Unfiltered revenue is 40 for month 1 and 5 for month 2, so a
+        threshold of 10 keeps month 1. Read from ``main`` it would have been
+        the filtered 2 and 5, and kept neither."""
+        query = _query(["Unfiltered Revenue"])
+        query.having = [
+            QueryFilter(field="Unfiltered Revenue", op=FilterOperator.GREATER, value=10)
+        ]
+        sql = PIPELINE.compile(query, _model(), "duckdb").sql
+        assert [(r[0], float(r[1])) for r in _connect().execute(sql).fetchall()] == [(1, 40.0)]
+
+    def test_having_on_a_plain_measure_stays_where_the_planner_put_it(self) -> None:
         query = _query(["Revenue", "Unfiltered Revenue"])
-        query.having = [QueryFilter(field="Revenue", op=FilterOperator.GREATER, value=6)]
+        query.having = [QueryFilter(field="Revenue", op=FilterOperator.GREATER, value=3)]
         sql = PIPELINE.compile(query, _model(), "duckdb").sql
         assert "HAVING" in sql
+        assert sql.rstrip().splitlines()[-1].startswith("LEFT JOIN ")
+        assert [(r[0], float(r[1])) for r in _connect().execute(sql).fetchall()] == [(2, 5.0)]
+
+    def test_a_query_can_have_one_of_each(self) -> None:
+        """One predicate stays in ``main``'s HAVING and the other moves out;
+        both have to hold."""
+        query = _query(["Revenue", "Unfiltered Revenue"])
+        query.having = [
+            QueryFilter(field="Revenue", op=FilterOperator.GREATER, value=1),
+            QueryFilter(field="Unfiltered Revenue", op=FilterOperator.GREATER, value=10),
+        ]
+        sql = PIPELINE.compile(query, _model(), "duckdb").sql
+        assert "HAVING" in sql and "\nWHERE " in sql
+        rows = [(r[0], float(r[1]), float(r[2])) for r in _connect().execute(sql).fetchall()]
+        assert rows == [(1, 2.0, 40.0)]
 
 
 class TestAContextOnATotalMeasure:


### PR DESCRIPTION
Phase 2b. Turns the refusal from #295 into an answer.

## The problem

A HAVING predicate is evaluated inside the CTE the planner built. For a `filterContext` measure that CTE is `main` - under the query's filters, over an aggregate that is not the measure's:

```sql
-- HAVING "Unfiltered Revenue" > 10
"main" AS (
SELECT "Dates"."MONTH", ...
WHERE "Dates"."DAY" = 1
GROUP BY ALL
HAVING CAST(SUM("Sales"."AMOUNT") AS DECIMAL(18, 2)) > 10   -- the *filtered* sum
)
```

The predicate read a value that was not the one it named, and kept the wrong groups with nothing to show for it. #295 refused it; this answers it.

## The fix

Predicates naming a filter-contexted measure, or a metric reading one, move to the outer query - where every value is one column of a CTE and the query is already one row per grain:

```sql
SELECT "main"."Month", "main"."Revenue", "fc_0"."Unfiltered Revenue"
FROM "main" LEFT JOIN "fc_0" ON "main"."Month" = "fc_0"."Month"
WHERE "fc_0"."Unfiltered Revenue" > 10
```

That is the same hoist `grain_dedup` performs for a deduplicated measure, including its care not to rebuild a predicate a later wrapper windows: the planner withheld that one deliberately and `PASS_HAVING_WINDOW` applies it once over the windowed rows.

Two properties worth noting:

- **The rest stay put.** `main`'s HAVING is only rebuilt when something actually moves out, so a query with no filterContext predicate compiles byte-identically.
- **No restriction on mixed predicates.** Unlike the dedup hoist, an OR spanning a filter-contexted measure and a plain one holds together here, because the outer query has both as columns.

## Verification

- `tests/unit/test_filter_context_metrics.py`: the threshold keeps the right groups (unfiltered 40 for month 1, 5 for month 2; a threshold of 10 keeps month 1, where reading `main` would have seen 2 and 5 and kept neither), a plain predicate stays in HAVING, and a query with one of each satisfies both
- full suite 3362 passed, 584 skipped; ruff + mypy clean
- TPC-DS sweep unchanged: 39 exact on DuckDB sf=1 plus the known Q99 reference variant