### PR TITLE
feat(compiler): plan a filterContext measure's scan against its own fact

### DIFF
--- a/src/orionbelt/compiler/cfl.py
+++ b/src/orionbelt/compiler/cfl.py
@@ -25,6 +25,7 @@ from orionbelt.compiler.anchored import (
     plan_conformed_facts,
 )
 from orionbelt.compiler.fanout import FanoutError
+from orionbelt.compiler.grain_dedup import detect_dedup_measures
 from orionbelt.compiler.graph import JoinGraph, JoinStep
 from orionbelt.compiler.resolution import (
     ResolutionError,
@@ -476,6 +477,7 @@ class CFLPlanner:
         # and the measure's source object with minimal hops.
         union_legs: list[Select] = []
         leg_infos: list[CflLegInfo] = []
+        dedup_offenders: dict[str, str] = {}
         for obj_name, measures in measures_by_object.items():
             leg_builder = QueryBuilder()
             this_measure_names = {m.name for m in measures}
@@ -666,6 +668,20 @@ class CFLPlanner:
                         )
                         joined_aliases.add(step.to_object)
 
+            # A measure sourced from an object this leg's own joins replicate
+            # is summed once per row of the many side. Resolution cannot see
+            # that: its join steps are the base object's, and the step that
+            # replicates lives inside a leg. The union has no per-leg grain to
+            # deduplicate at either - the legs project the values to aggregate
+            # rather than aggregating them - so this is refused rather than
+            # answered with a plausible number in the right group.
+            leg_dedup = detect_dedup_measures(
+                replace(resolved, join_steps=steps, base_object=lead, measures=measures),
+                model,
+            )
+            dedup_offenders.update(leg_dedup.measures)
+            dedup_offenders.update(leg_dedup.components)
+
             # Capture leg info for explain
             leg_join_strs = (
                 [f"{s.from_object} → {s.to_object}" for s in steps] if join_targets else []
@@ -695,6 +711,30 @@ class CFLPlanner:
                 leg_builder.where(wf.expression)
 
             union_legs.append(leg_builder.build())
+
+        if dedup_offenders:
+            listed = ", ".join(f"'{name}'" for name in sorted(dedup_offenders))
+            raise ResolutionError(
+                [
+                    SemanticError(
+                        code="INCOMPATIBLE_COMBINATION",
+                        message=(
+                            f"Measure(s) {listed} are sourced from an object whose rows this "
+                            f"query's joins replicate, so they must be aggregated over "
+                            f"deduplicated rows. This query spans facts that cannot be "
+                            f"joined, so it is planned as a UNION ALL whose legs project the "
+                            f"values to aggregate rather than aggregating them, leaving no "
+                            f"per-leg grain to deduplicate at."
+                        ),
+                        path="select.measures",
+                        hint=(
+                            "Query the measure without the measures from the other fact, or "
+                            "set allowFanOut: true to aggregate the duplicated rows as-is."
+                        ),
+                        context={"measures": sorted(dedup_offenders)},
+                    )
+                ]
+            )
 
         # Create the UNION ALL CTE
         cte_name = "composite_01"

--- a/src/orionbelt/compiler/cfl.py
+++ b/src/orionbelt/compiler/cfl.py
@@ -27,6 +27,7 @@ from orionbelt.compiler.anchored import (
 from orionbelt.compiler.fanout import FanoutError
 from orionbelt.compiler.graph import JoinGraph, JoinStep
 from orionbelt.compiler.resolution import (
+    ResolutionError,
     ResolvedDimension,
     ResolvedMeasure,
     ResolvedQuery,
@@ -35,6 +36,7 @@ from orionbelt.compiler.resolution import (
 from orionbelt.compiler.star import CflLegInfo, QueryPlan, _grouping_flag_alias, _nulls_last
 from orionbelt.compiler.type_resolver import resolve_measure_data_type, resolve_metric_data_type
 from orionbelt.dialect.base import Dialect, UnsupportedAggregationError
+from orionbelt.models.errors import SemanticError
 from orionbelt.models.semantic import (
     DataObject,
     SemanticModel,
@@ -165,7 +167,11 @@ class CFLPlanner:
             measures_by_object = self._group_dimensions_into_legs(resolved, model)
 
         if len(measures_by_object) <= 1 and not cross_fact:
-            # Single fact — delegate to star schema
+            # Single fact — delegate to star schema. Resolution let this query
+            # past the reachability check because it looked multi-fact, and a
+            # star has to serve every dimension from one root, so check now
+            # that the leg left standing can.
+            self._reject_unreachable_dimensions(measures_by_object, resolved, model)
             from orionbelt.compiler.star import StarSchemaPlanner
 
             return StarSchemaPlanner().plan(
@@ -275,6 +281,47 @@ class CFLPlanner:
     ) -> tuple[dict[str, list[ResolvedMeasure]], list[ResolvedMeasure]]:
         """Group measures by their primary source object."""
         return cfl_projection.group_measures_by_object(self, resolved, model)
+
+    @staticmethod
+    def _reject_unreachable_dimensions(
+        measures_by_object: dict[str, list[ResolvedMeasure]],
+        resolved: ResolvedQuery,
+        model: SemanticModel,
+    ) -> None:
+        """Refuse a dimension the one remaining leg cannot produce.
+
+        A query looks multi-fact while its measures span facts, and resolution
+        skips the reachability check on that basis - the union answers it, each
+        leg projecting the dimensions it reaches and NULL-padding the rest. When
+        the legs collapse to one there is no union to do that, and the star this
+        delegates to would project a column from a table it does not select
+        from. The same refusal resolution would have raised.
+        """
+        root = next(iter(measures_by_object), resolved.base_object)
+        graph = JoinGraph(model, use_path_names=resolved.use_path_names or None)
+        reachable = graph.descendants(root) | {root}
+        unreachable = sorted(
+            {dim.object_name for dim in resolved.dimensions if dim.object_name not in reachable}
+        )
+        if not unreachable:
+            return
+        raise ResolutionError(
+            [
+                SemanticError(
+                    code="UNREACHABLE_REQUIRED_OBJECT",
+                    message=(
+                        f"Data object '{name}' is required by the query but cannot be "
+                        f"reached from base '{root}' via directed joins. Many-to-one joins "
+                        f"are forward-only; reverse traversal would inflate row counts. Add "
+                        f"an explicit join from '{root}' (or an intermediate object) to "
+                        f"'{name}', or split the query so each fact is queried "
+                        f"independently."
+                    ),
+                    path="select",
+                )
+                for name in unreachable
+            ]
+        )
 
     @staticmethod
     def _group_dimensions_into_legs(
@@ -458,6 +505,25 @@ class CFLPlanner:
                 for m in cross_fact:
                     if m.name in this_measure_names:
                         self._collect_table_refs(m.expression, measure_expr_objects)
+
+            # A leg's FROM is its *lead*, not its key: the common root of the
+            # key and what that key reaches. Where the key is a measure's source
+            # on the one side of a join - ``Products``, reaching nothing - the
+            # lead is the ``Sales`` that reaches both, and dimensions the lead
+            # can produce were being NULL-padded on the grounds that the key
+            # could not. Every row of the leg then collapsed into one NULL
+            # group. Widen the reachability to the lead where a lead covering
+            # the query's dimensions exists at all; where none does, the facts
+            # really are independent and the padding below is right.
+            wanted = (
+                {dim.object_name for dim in resolved.dimensions}
+                | {obj_name}
+                | filter_objects
+                | measure_expr_objects
+            )
+            wide_lead = graph.find_common_root(wanted)
+            if wide_lead and obj_name in (graph.descendants(wide_lead) | {wide_lead}):
+                reachable = graph.descendants(wide_lead) | {wide_lead}
 
             # SELECT conformed dimensions — only emit real column refs for
             # dimensions reachable from this leg's fact AND whose `via:`

--- a/src/orionbelt/compiler/cfl_projection.py
+++ b/src/orionbelt/compiler/cfl_projection.py
@@ -582,6 +582,21 @@ def _single_leg_root(
     return None
 
 
+def _measure_objects(
+    planner: CFLPlanner,
+    resolved: ResolvedQuery,
+    model: SemanticModel,
+    measure: ResolvedMeasure,
+) -> set[str]:
+    """The data objects a measure reads, declared or referenced."""
+    model_measure = model.effective_measures.get(measure.name)
+    if model_measure and model_measure.columns:
+        return {f.view for f in model_measure.columns if f.view}
+    objects: set[str] = set()
+    planner._collect_table_refs(measure.expression, objects)
+    return objects
+
+
 def group_measures_by_object(
     planner: CFLPlanner,
     resolved: ResolvedQuery,
@@ -602,6 +617,21 @@ def group_measures_by_object(
     seen: set[str] = set()
 
     for measure in resolved.measures:
+        if measure.filter_context is not None:
+            # A filterContext measure never belonged in the union: it reads one
+            # fact under its own filters, which is a scan of its own, and
+            # ``filter_wrap`` plans it as one. Projected here it got a leg whose
+            # rows the query's filters had already been applied to - the
+            # opposite of what the field asks for - and its value went into the
+            # composite, where the wrapper could not recompute it.
+            #
+            # Its fact still earns a leg, with no measure of its own. The union
+            # is what makes a dimension only that fact reaches available at all,
+            # NULL-padded in the others, and dropping the leg would leave the
+            # query unable to group by one.
+            for obj in _measure_objects(planner, resolved, model, measure):
+                groups.setdefault(obj, [])
+            continue
         if measure.component_measures:
             # Metric: add each component measure to its source object, following
             # nested derived metrics — those are expanded into the same formula,
@@ -610,6 +640,10 @@ def group_measures_by_object(
                 if comp.name in seen:
                     continue
                 seen.add(comp.name)
+                if comp.filter_context is not None:
+                    for obj in _measure_objects(planner, resolved, model, comp):
+                        groups.setdefault(obj, [])
+                    continue
                 model_measure = model.effective_measures.get(comp.name)
                 if model_measure and model_measure.columns:
                     comp_objects = {f.view for f in model_measure.columns if f.view}

--- a/src/orionbelt/compiler/cfl_projection.py
+++ b/src/orionbelt/compiler/cfl_projection.py
@@ -582,6 +582,28 @@ def _single_leg_root(
     return None
 
 
+def _dimension_carrying_leg(
+    sources: set[str], resolved: ResolvedQuery, model: SemanticModel
+) -> str | None:
+    """Where a leg covering *sources* has to be rooted to carry the query grain.
+
+    A leg's FROM is not its key but the common root of that key and whatever
+    dimensions the key reaches, so a leg keyed at an object that reaches none of
+    them projects nothing at all and degenerates to ``SELECT *``. A measure on
+    the *one* side of a join is exactly that case: ``Products`` reaches no
+    dimension, and the leg carrying it has to be rooted at the ``Sales`` that
+    reaches both. Returns ``None`` when no root reaches a dimension - the leg
+    would carry nothing and must not be created.
+    """
+    graph = JoinGraph(model, use_path_names=resolved.use_path_names or None)
+    dim_objects = {dim.object_name for dim in resolved.dimensions}
+    root = graph.find_common_root(sources | dim_objects) if dim_objects else None
+    if not root:
+        return None
+    reachable = graph.descendants(root) | {root}
+    return root if dim_objects & reachable else None
+
+
 def _measure_objects(
     planner: CFLPlanner,
     resolved: ResolvedQuery,
@@ -625,12 +647,15 @@ def group_measures_by_object(
             # opposite of what the field asks for - and its value went into the
             # composite, where the wrapper could not recompute it.
             #
-            # Its fact still earns a leg, with no measure of its own. The union
-            # is what makes a dimension only that fact reaches available at all,
-            # NULL-padded in the others, and dropping the leg would leave the
-            # query unable to group by one.
-            for obj in _measure_objects(planner, resolved, model, measure):
-                groups.setdefault(obj, [])
+            # A leg still stands where this measure's own leg would have, with
+            # no measure of its own: the union is what makes a dimension only
+            # that branch reaches available at all, NULL-padded in the others,
+            # and dropping it left the query unable to group by one.
+            leg = _dimension_carrying_leg(
+                _measure_objects(planner, resolved, model, measure), resolved, model
+            )
+            if leg is not None:
+                groups.setdefault(leg, [])
             continue
         if measure.component_measures:
             # Metric: add each component measure to its source object, following
@@ -641,8 +666,11 @@ def group_measures_by_object(
                     continue
                 seen.add(comp.name)
                 if comp.filter_context is not None:
-                    for obj in _measure_objects(planner, resolved, model, comp):
-                        groups.setdefault(obj, [])
+                    leg = _dimension_carrying_leg(
+                        _measure_objects(planner, resolved, model, comp), resolved, model
+                    )
+                    if leg is not None:
+                        groups.setdefault(leg, [])
                     continue
                 model_measure = model.effective_measures.get(comp.name)
                 if model_measure and model_measure.columns:

--- a/src/orionbelt/compiler/filter_wrap.py
+++ b/src/orionbelt/compiler/filter_wrap.py
@@ -247,28 +247,6 @@ def _measure_source_objects(measure: ResolvedMeasure, model: SemanticModel) -> s
     return set(model_measure.source_objects) if model_measure else set()
 
 
-def _needs_its_own_plan(
-    measure_group: list[ResolvedMeasure],
-    resolved: ResolvedQuery,
-    model: SemanticModel,
-) -> bool:
-    """Whether this scan has to be planned rather than borrow the plan's FROM.
-
-    Borrowing is right, and byte-for-byte what this wrapper has always done,
-    while the measures read the same fact the plan is built around: the CTE
-    reuses that FROM and only changes the WHERE. It stops being right once the
-    measure's fact is not in that FROM - under a multi-fact plan, where the FROM
-    is the composite, and under a star built around another fact, since a
-    filter-contexted measure no longer decides the base.
-    """
-    if resolved.composite_cte is not None:
-        return True
-    available = resolved.required_objects | {resolved.base_object}
-    return any(
-        not _measure_source_objects(measure, model) <= available for measure in measure_group
-    )
-
-
 def _plan_isolated_scan(
     measure_group: list[ResolvedMeasure],
     grain: list[str],
@@ -277,6 +255,7 @@ def _plan_isolated_scan(
     model: SemanticModel,
     dialect: Dialect,
     qualify_table: Callable[[DataObject], str],
+    resolved: ResolvedQuery,
 ) -> Select:
     """Plan a filter-contexted measure's scan as a query in its own right.
 
@@ -304,6 +283,7 @@ def _plan_isolated_scan(
     )
     # Imported here: the pipeline owns the phase order, and importing it at
     # module scope would be a cycle back through ``compiler.passes``.
+    from orionbelt.compiler.cfl import CFLPlanner
     from orionbelt.compiler.passes import CompileContext, apply_aggregate_passes
     from orionbelt.compiler.pipeline import CompilationPipeline
     from orionbelt.compiler.resolution import QueryResolver
@@ -313,10 +293,22 @@ def _plan_isolated_scan(
     # The context is this scan's own, not something to apply again inside it.
     sub_resolved.measures = [replace(m, filter_context=None) for m in sub_resolved.measures]
     CompilationPipeline.detect_replication(sub_resolved, model)
-    plan = StarSchemaPlanner().plan(
-        sub_resolved, model, qualify_table=qualify_table, dialect=dialect
-    )
-    return apply_aggregate_passes(
+    # Which planner, decided the way the pipeline decides it. Grouping by fact
+    # leaves only one way here: a single measure whose own arguments span facts
+    # no join reaches, which is a union in its own right.
+    if sub_resolved.requires_cfl:
+        plan = CFLPlanner().plan(
+            sub_resolved,
+            model,
+            qualify_table=qualify_table,
+            union_by_name=dialect.capabilities.supports_union_all_by_name,
+            dialect=dialect,
+        )
+    else:
+        plan = StarSchemaPlanner().plan(
+            sub_resolved, model, qualify_table=qualify_table, dialect=dialect
+        )
+    scan = apply_aggregate_passes(
         plan.ast,
         CompileContext(
             resolved=sub_resolved,
@@ -326,6 +318,12 @@ def _plan_isolated_scan(
             query=sub_query,
         ),
     )
+    # The scan is planned in its own right, warnings included - and those are
+    # about this query, so they belong to it. Left on the sub-query they went
+    # nowhere: the same measure warned of a fan trap when selected plainly and
+    # said nothing behind a filterContext.
+    resolved.warnings.extend(sub_resolved.warnings)
+    return scan
 
 
 def wrap_with_filter_context(
@@ -370,17 +368,17 @@ def wrap_with_filter_context(
 
     query_dim_names = [d.name for d in resolved.dimensions]
 
-    # Group isolated measures by their filter context + grain key. One that has
-    # to be planned rather than share the query's FROM is grouped by its fact as
-    # well: the scan is a query over that fact, and two facts have no single one
-    # to plan against.
+    # Group isolated measures by their filter context + grain key, and by their
+    # fact: each group becomes one scan planned over what it reads, and measures
+    # on independent facts have no single one to plan against. Sharing a group
+    # across facts projected an aggregate over a table the scan's FROM did not
+    # have.
     groups: dict[tuple[str, ...], list[ResolvedMeasure]] = {}
     for m in isolated:
         assert m.filter_context is not None
         grain = _effective_grain_dims(m, query_dim_names)
         key = _filter_key(m.filter_context, grain)
-        if _needs_its_own_plan([m], resolved, model):
-            key = (*key, "fact:" + ",".join(sorted(_measure_source_objects(m, model))))
+        key = (*key, "fact:" + ",".join(sorted(_measure_source_objects(m, model))))
         groups.setdefault(key, []).append(m)
 
     inline_measures = [m for m in resolved.measures if m.filter_context is None]
@@ -504,7 +502,7 @@ def wrap_with_filter_context(
         # measure on the one side of a replicating join came back summed once
         # per row of the many side.
         cte_query = _plan_isolated_scan(
-            measure_group, grain, all_filters, query, model, dialect, qualify_table
+            measure_group, grain, all_filters, query, model, dialect, qualify_table, resolved
         )
         all_ctes.append(CTE(name=cte_name, query=cte_query))
         isolated_cte_info.append((cte_name, measure_group, grain))

--- a/src/orionbelt/compiler/filter_wrap.py
+++ b/src/orionbelt/compiler/filter_wrap.py
@@ -19,6 +19,7 @@ Strategy selection per the design doc:
 from __future__ import annotations
 
 from collections.abc import Callable, Iterable
+from dataclasses import replace
 from typing import TYPE_CHECKING
 
 from orionbelt.ast.nodes import (
@@ -43,8 +44,9 @@ from orionbelt.compiler.resolution import (
     ResolvedQuery,
     make_column_expr,
 )
+from orionbelt.compiler.star import StarSchemaPlanner
 from orionbelt.models.errors import SemanticError
-from orionbelt.models.query import FilterOperator, QueryFilter
+from orionbelt.models.query import FilterOperator, QueryFilter, QueryObject, QuerySelect
 from orionbelt.models.semantic import (
     DataObject,
     FilterContext,
@@ -240,12 +242,80 @@ def _component_expr(measure: ResolvedMeasure, resolved: ResolvedQuery) -> Expr:
     return resolved.projected_expressions.get(measure.name, measure.expression)
 
 
+def _measure_source_objects(measure: ResolvedMeasure, model: SemanticModel) -> set[str]:
+    model_measure = model.effective_measures.get(measure.name)
+    return set(model_measure.source_objects) if model_measure else set()
+
+
+def _needs_its_own_plan(
+    measure_group: list[ResolvedMeasure],
+    resolved: ResolvedQuery,
+    model: SemanticModel,
+) -> bool:
+    """Whether this scan has to be planned rather than borrow the plan's FROM.
+
+    Borrowing is right, and byte-for-byte what this wrapper has always done,
+    while the measures read the same fact the plan is built around: the CTE
+    reuses that FROM and only changes the WHERE. It stops being right once the
+    measure's fact is not in that FROM - under a multi-fact plan, where the FROM
+    is the composite, and under a star built around another fact, since a
+    filter-contexted measure no longer decides the base.
+    """
+    if resolved.composite_cte is not None:
+        return True
+    available = resolved.required_objects | {resolved.base_object}
+    return any(
+        not _measure_source_objects(measure, model) <= available for measure in measure_group
+    )
+
+
+def _plan_isolated_scan(
+    measure_group: list[ResolvedMeasure],
+    grain: list[str],
+    filters: list[ResolvedFilter],
+    query: QueryObject,
+    model: SemanticModel,
+    dialect: Dialect,
+    qualify_table: Callable[[DataObject], str],
+) -> Select:
+    """Plan a filter-contexted measure's scan as a query in its own right.
+
+    Resolved rather than assembled: the base object, the join path to the grain
+    dimensions and the fanout check all have to be derived for *these* measures
+    at *this* grain, and the plan they came from was built for different ones.
+
+    The query is resolved carrying the caller's ``where`` so that resolution
+    joins whatever those filters read - including the ones this context drops,
+    whose joins are then harmless - and its resolved filters are replaced with
+    the effective set afterwards. A context that keeps a filter therefore has
+    the column in scope, and one that drops it does not have to un-join it.
+    """
+    sub_query = QueryObject(
+        select=QuerySelect(dimensions=list(grain), measures=[m.name for m in measure_group]),
+        where=list(query.where),
+        use_path_names=list(query.use_path_names),
+        allow_fan_out=query.allow_fan_out,
+    )
+    from orionbelt.compiler.resolution import QueryResolver
+
+    sub_resolved = QueryResolver().resolve(sub_query, model, qualify_table=qualify_table)
+    sub_resolved.where_filters = list(filters)
+    # The context is this scan's own, not something to apply twice.
+    sub_resolved.measures = [replace(m, filter_context=None) for m in sub_resolved.measures]
+    return (
+        StarSchemaPlanner()
+        .plan(sub_resolved, model, qualify_table=qualify_table, dialect=dialect)
+        .ast
+    )
+
+
 def wrap_with_filter_context(
     ast: Select,
     resolved: ResolvedQuery,
     model: SemanticModel,
     dialect: Dialect,
     qualify_table: Callable[[DataObject], str],
+    query: QueryObject,
 ) -> Select:
     """Wrap planner AST with CTEs for filter-isolated measures.
 
@@ -281,12 +351,17 @@ def wrap_with_filter_context(
 
     query_dim_names = [d.name for d in resolved.dimensions]
 
-    # Group isolated measures by their filter context + grain key
+    # Group isolated measures by their filter context + grain key. One that has
+    # to be planned rather than share the query's FROM is grouped by its fact as
+    # well: the scan is a query over that fact, and two facts have no single one
+    # to plan against.
     groups: dict[tuple[str, ...], list[ResolvedMeasure]] = {}
     for m in isolated:
         assert m.filter_context is not None
         grain = _effective_grain_dims(m, query_dim_names)
         key = _filter_key(m.filter_context, grain)
+        if _needs_its_own_plan([m], resolved, model):
+            key = (*key, "fact:" + ",".join(sorted(_measure_source_objects(m, model))))
         groups.setdefault(key, []).append(m)
 
     inline_measures = [m for m in resolved.measures if m.filter_context is None]
@@ -403,18 +478,29 @@ def wrap_with_filter_context(
                 cte_group_by.append(gb_col)
 
         cte_name = f"fc_{idx}"
-        cte_query = Select(
-            columns=cte_columns,
-            from_=ast.from_,
-            joins=list(ast.joins),
-            where=_combine_where(all_filters),
-            group_by=cte_group_by,
-            having=None,
-            order_by=[],
-            limit=None,
-            offset=None,
-            ctes=[],
-        )
+        if _needs_its_own_plan(measure_group, resolved, model):
+            # This scan cannot borrow the plan's FROM: either that FROM is a
+            # UNION ALL composite, whose legs applied the query's filters before
+            # it existed and whose columns are the projected measures rather
+            # than the fact's, or it is a star built around a different fact,
+            # because the measure was left out of what that plan has to compute.
+            # Plan it here as what it is - a star query over its own fact.
+            cte_query = _plan_isolated_scan(
+                measure_group, grain, all_filters, query, model, dialect, qualify_table
+            )
+        else:
+            cte_query = Select(
+                columns=cte_columns,
+                from_=ast.from_,
+                joins=list(ast.joins),
+                where=_combine_where(all_filters),
+                group_by=cte_group_by,
+                having=None,
+                order_by=[],
+                limit=None,
+                offset=None,
+                ctes=[],
+            )
         all_ctes.append(CTE(name=cte_name, query=cte_query))
         isolated_cte_info.append((cte_name, measure_group, grain))
 

--- a/src/orionbelt/compiler/filter_wrap.py
+++ b/src/orionbelt/compiler/filter_wrap.py
@@ -289,6 +289,12 @@ def _plan_isolated_scan(
     whose joins are then harmless - and its resolved filters are replaced with
     the effective set afterwards. A context that keeps a filter therefore has
     the column in scope, and one that drops it does not have to un-join it.
+
+    It then goes through the phases the pipeline runs between resolving and
+    planning, and the wrappers it runs after. Skipping them made this scan the
+    one place in the compiler where a measure on the one side of a replicating
+    join was summed once per row of the many side, and where a combination the
+    single-fact path refuses compiled quietly instead.
     """
     sub_query = QueryObject(
         select=QuerySelect(dimensions=list(grain), measures=[m.name for m in measure_group]),
@@ -296,16 +302,29 @@ def _plan_isolated_scan(
         use_path_names=list(query.use_path_names),
         allow_fan_out=query.allow_fan_out,
     )
+    # Imported here: the pipeline owns the phase order, and importing it at
+    # module scope would be a cycle back through ``compiler.passes``.
+    from orionbelt.compiler.passes import CompileContext, apply_aggregate_passes
+    from orionbelt.compiler.pipeline import CompilationPipeline
     from orionbelt.compiler.resolution import QueryResolver
 
     sub_resolved = QueryResolver().resolve(sub_query, model, qualify_table=qualify_table)
     sub_resolved.where_filters = list(filters)
-    # The context is this scan's own, not something to apply twice.
+    # The context is this scan's own, not something to apply again inside it.
     sub_resolved.measures = [replace(m, filter_context=None) for m in sub_resolved.measures]
-    return (
-        StarSchemaPlanner()
-        .plan(sub_resolved, model, qualify_table=qualify_table, dialect=dialect)
-        .ast
+    CompilationPipeline.detect_replication(sub_resolved, model)
+    plan = StarSchemaPlanner().plan(
+        sub_resolved, model, qualify_table=qualify_table, dialect=dialect
+    )
+    return apply_aggregate_passes(
+        plan.ast,
+        CompileContext(
+            resolved=sub_resolved,
+            model=model,
+            dialect=dialect,
+            qualify_table=qualify_table,
+            query=sub_query,
+        ),
     )
 
 
@@ -478,29 +497,15 @@ def wrap_with_filter_context(
                 cte_group_by.append(gb_col)
 
         cte_name = f"fc_{idx}"
-        if _needs_its_own_plan(measure_group, resolved, model):
-            # This scan cannot borrow the plan's FROM: either that FROM is a
-            # UNION ALL composite, whose legs applied the query's filters before
-            # it existed and whose columns are the projected measures rather
-            # than the fact's, or it is a star built around a different fact,
-            # because the measure was left out of what that plan has to compute.
-            # Plan it here as what it is - a star query over its own fact.
-            cte_query = _plan_isolated_scan(
-                measure_group, grain, all_filters, query, model, dialect, qualify_table
-            )
-        else:
-            cte_query = Select(
-                columns=cte_columns,
-                from_=ast.from_,
-                joins=list(ast.joins),
-                where=_combine_where(all_filters),
-                group_by=cte_group_by,
-                having=None,
-                order_by=[],
-                limit=None,
-                offset=None,
-                ctes=[],
-            )
+        # Planned as the query it is, rather than assembled from the plan's own
+        # FROM with a different WHERE. Borrowing that FROM was right only while
+        # the plan was built around the same fact at the same grain, and it
+        # skipped every phase between resolving and planning - which is how a
+        # measure on the one side of a replicating join came back summed once
+        # per row of the many side.
+        cte_query = _plan_isolated_scan(
+            measure_group, grain, all_filters, query, model, dialect, qualify_table
+        )
         all_ctes.append(CTE(name=cte_name, query=cte_query))
         isolated_cte_info.append((cte_name, measure_group, grain))
 

--- a/src/orionbelt/compiler/passes.py
+++ b/src/orionbelt/compiler/passes.py
@@ -56,6 +56,7 @@ from orionbelt.compiler.window_wrap import (
 )
 from orionbelt.dialect.base import Dialect
 from orionbelt.models.errors import SemanticError
+from orionbelt.models.query import QueryObject
 from orionbelt.models.semantic import DataObject, SemanticModel
 from orionbelt.models.warnings import WarningCode, warning
 
@@ -83,6 +84,11 @@ class CompileContext:
     model: SemanticModel
     dialect: Dialect
     qualify_table: Callable[[DataObject], str]
+    query: QueryObject
+    """The query as asked. A pass that has to *plan* rather than rewrite needs
+    it: ``filter_wrap`` resolves a query of its own for a filterContext
+    measure's scan, and a resolved filter keeps only its expression, not the
+    filter it came from."""
 
 
 @dataclass(frozen=True)
@@ -163,7 +169,7 @@ def build_default_passes() -> tuple[CompilerPass, ...]:
             name=PASS_FILTER_CONTEXT,
             applies=lambda r: r.has_filter_context,
             run=lambda ast, ctx: wrap_with_filter_context(
-                ast, ctx.resolved, ctx.model, ctx.dialect, ctx.qualify_table
+                ast, ctx.resolved, ctx.model, ctx.dialect, ctx.qualify_table, ctx.query
             ),
         ),
         CompilerPass(
@@ -419,54 +425,7 @@ def evaluate_compatibility(
                 ]
             )
 
-    # Rule 2c (raising): a filterContext measure is computed in a CTE of its
-    # own, whose WHERE is the query's with some filters dropped or added. Under
-    # a multi-fact plan there is nothing to compute it from: the union legs
-    # applied the query's filters before the composite CTE existed, so a context
-    # that drops one cannot un-apply it, and the fact columns a context of its
-    # own would filter on are not among the composite's columns either. The
-    # projection came out reading tables the CTE does not select from, which no
-    # engine binds - refuse instead, since suppressing the pass would answer the
-    # unfiltered number under the filtered measure's name.
-    if resolved.composite_cte is not None:
-        # Read through a metric counts: the component is computed in a CTE of
-        # its own too, and that CTE has the same nothing to read.
-        fc_measures = sorted(
-            {m.name for m in resolved.measures if m.filter_context is not None}
-            | {
-                comp.name
-                for m in resolved.measures
-                for comp in metric_leaf_components(m, resolved.metric_components)
-                if comp.filter_context is not None
-            }
-        )
-        if fc_measures:
-            listed = ", ".join(f"'{m}'" for m in fc_measures)
-            raise ResolutionError(
-                [
-                    SemanticError(
-                        code="INCOMPATIBLE_COMBINATION",
-                        message=(
-                            f"Measure(s) {listed} declare a filterContext, which needs its "
-                            f"own filtered scan of the fact. This query spans facts that "
-                            f"cannot be joined, so it is planned as a UNION ALL whose legs "
-                            f"are already filtered and whose columns are the projected "
-                            f"measures, leaving nothing for that scan to read."
-                        ),
-                        path="select.measures",
-                        hint=(
-                            "Query the filterContext measure without the measures from the "
-                            "other fact, or drop the filterContext."
-                        ),
-                        context={
-                            "measures": fc_measures,
-                            "conflictsWith": ["a multi-fact (CFL) plan"],
-                        },
-                    )
-                ]
-            )
-
-    # Rule 2c2 (raising): an averaged total in a query that also has a
+    # Rule 2c (raising): an averaged total in a query that also has a
     # filterContext. ``filter_wrap`` runs first and rewrites the FROM, leaving
     # every measure as one column of a CTE - which is enough to re-aggregate a
     # sum, a count, a min or a max over, and not enough for an average.

--- a/src/orionbelt/compiler/passes.py
+++ b/src/orionbelt/compiler/passes.py
@@ -250,8 +250,6 @@ def _conflicts_with_dedup(pass_name: str, resolved: ResolvedQuery) -> bool:
       into a CTE whose FROM is only ``main``/``dedup_0`` —
       ``Referenced table "Sales" not found``. This is the dividing line against
       ``totals``: alias reference composes, expression re-projection does not.
-    * ``filter_context`` emits its own CTE named ``main``, colliding with the
-      one dedup emits — ``Duplicate CTE name "main"``.
     * ``period_over_period`` rebuilds the FROM from a date spine and re-joins
       the tables the dedup CTEs already joined —
       ``Ambiguous reference to table ... duplicate alias``.
@@ -261,6 +259,12 @@ def _conflicts_with_dedup(pass_name: str, resolved: ResolvedQuery) -> bool:
     ORDER BY. That is a change inside those wrappers, not a predicate here.
     """
     if pass_name == PASS_CUMULATIVE:
+        return False
+    if pass_name == PASS_FILTER_CONTEXT:
+        # Composes: the filterContext measure is planned as a scan of its own,
+        # which runs the dedup phase for itself, and this plan no longer counts
+        # it among what it has to deduplicate. What is left is dedup's CTEs
+        # feeding the wrapper's ``main``, which is a different name.
         return False
     if pass_name == PASS_WINDOW:
         # A derived metric over window metrics needs several base measures

--- a/src/orionbelt/compiler/pipeline.py
+++ b/src/orionbelt/compiler/pipeline.py
@@ -220,6 +220,7 @@ class CompilationPipeline:
                 model=model,
                 dialect=dialect,
                 qualify_table=qualify_table,
+                query=query,
             )
             wrapped_ast = apply_aggregate_passes(plan.ast, ctx)
 

--- a/src/orionbelt/compiler/pipeline.py
+++ b/src/orionbelt/compiler/pipeline.py
@@ -154,6 +154,42 @@ class CompilationPipeline:
         self._cfl_planner = CFLPlanner()
         self._raw_planner = RawPlanner()
 
+    @staticmethod
+    def detect_replication(resolved: ResolvedQuery, model: SemanticModel) -> None:
+        """Phase 1.5: fanout detection, and which measures need deduplicating.
+
+        A method rather than inline because a *sub*-query needs the same phase:
+        ``filter_wrap`` plans a filterContext measure's scan in its own right,
+        and skipping this left a measure on the one side of a replicating join
+        summed once per row of the many side - the exact overcount the pass
+        exists to prevent, in a query where nothing said so.
+        """
+        # Skipped for CFL: each fact is queried independently there.
+        if resolved.requires_cfl:
+            return
+        detect_fanout(resolved, model)
+        # Forward many-to-one joins replicate the *one* side, which
+        # `detect_fanout` treats as safe. Flag any measure sourced from a
+        # replicated object so the `grain_dedup` pass aggregates it over
+        # deduplicated rows instead of the flattened join.
+        if not resolved.is_raw:
+            dedup_plan = detect_dedup_measures(resolved, model)
+            # A filterContext measure is not this plan's to deduplicate: it is
+            # computed by a scan of its own, which runs this same phase for
+            # itself. Leaving it in built a dedup CTE for a column the final
+            # projection takes from elsewhere.
+            isolated = {m.name for m in resolved.measures if m.filter_context is not None} | {
+                name
+                for name, comp in resolved.metric_components.items()
+                if comp.filter_context is not None
+            }
+            resolved.dedup_measures = {
+                k: v for k, v in dedup_plan.measures.items() if k not in isolated
+            }
+            resolved.dedup_components = {
+                k: v for k, v in dedup_plan.components.items() if k not in isolated
+            }
+
     def compile(
         self,
         query: QueryObject,
@@ -173,16 +209,7 @@ class CompilationPipeline:
         resolved = self._resolver.resolve(query, model, qualify_table=qualify_table)
 
         # Phase 1.5: Fanout detection (skip for CFL — each fact queried independently)
-        if not resolved.requires_cfl:
-            detect_fanout(resolved, model)
-            # Forward many-to-one joins replicate the *one* side, which
-            # `detect_fanout` treats as safe. Flag any measure sourced from a
-            # replicated object so the `grain_dedup` pass aggregates it over
-            # deduplicated rows instead of the flattened join.
-            if not resolved.is_raw:
-                dedup_plan = detect_dedup_measures(resolved, model)
-                resolved.dedup_measures = dedup_plan.measures
-                resolved.dedup_components = dedup_plan.components
+        self.detect_replication(resolved, model)
 
         # Phase 2: Planning (raw / star schema / CFL)
         use_cfl = resolved.requires_cfl or resolved.dimensions_exclude

--- a/src/orionbelt/compiler/pipeline.py
+++ b/src/orionbelt/compiler/pipeline.py
@@ -164,7 +164,10 @@ class CompilationPipeline:
         summed once per row of the many side - the exact overcount the pass
         exists to prevent, in a query where nothing said so.
         """
-        # Skipped for CFL: each fact is queried independently there.
+        # Skipped for CFL: its join steps span facts a union queries
+        # independently, so the check would refuse a query the union answers.
+        # The per-leg equivalent lives in the CFL planner, which is where a
+        # leg's own joins are known.
         if resolved.requires_cfl:
             return
         detect_fanout(resolved, model)

--- a/tests/unit/test_cfl_rebuilt_aggregates.py
+++ b/tests/unit/test_cfl_rebuilt_aggregates.py
@@ -17,10 +17,9 @@ than from the resolved expression. The one thing that cannot be rebuilt is a
 from __future__ import annotations
 
 import duckdb
-import pytest
 
 from orionbelt.compiler.pipeline import CompilationPipeline
-from orionbelt.compiler.resolution import QueryResolver, ResolutionError
+from orionbelt.compiler.resolution import QueryResolver
 from orionbelt.models.query import FilterOperator, QueryFilter, QueryObject, QuerySelect
 from orionbelt.models.semantic import SemanticModel
 from orionbelt.parser.loader import TrackedLoader
@@ -188,58 +187,32 @@ class TestAMetricOverATotalComponent:
 
 
 class TestFilterContextInAMultiFactPlan:
-    """A ``filterContext`` needs its own filtered scan of the fact. The
-    composite offers neither: its legs applied the query's filters before it
-    existed, and its columns are the projected measures rather than the fact's.
-    """
+    """A filterContext is a differently filtered scan of the measure's fact.
+    The composite offers nothing to scan - its legs applied the query's filters
+    before it existed - so the measure is kept out of the union and planned as
+    the star query it is. See ``test_filter_context_multi_fact`` for what that
+    plan looks like and what it answers."""
 
-    def test_it_is_refused(self) -> None:
-        with pytest.raises(ResolutionError) as exc:
-            _sql(["Unfiltered Sales", "Refund Amount"])
-        message = str(exc.value)
-        assert "Unfiltered Sales" in message
-        assert "filterContext" in message
+    def test_it_compiles(self) -> None:
+        sql = _sql(["Unfiltered Sales", "Refund Amount"])
+        assert '"fc_0" AS' in sql
 
-    def test_the_refusal_names_the_plan_as_the_reason(self) -> None:
-        with pytest.raises(ResolutionError) as exc:
-            _sql(["Unfiltered Sales", "Refund Amount"])
-        assert "UNION ALL" in str(exc.value)
+    def test_the_measure_is_not_in_the_composite(self) -> None:
+        sql = _sql(["Unfiltered Sales", "Sales Amount", "Refund Amount"])
+        assert '"Unfiltered Sales"' not in sql.split('"fc_0" AS')[0]
 
-    @pytest.mark.parametrize("dialect", ["bigquery", "clickhouse", "postgres", "snowflake"])
-    def test_refused_on_every_dialect(self, dialect: str) -> None:
-        """The plan is the reason, not the engine — so no dialect quietly
-        compiles it."""
-        with pytest.raises(ResolutionError):
-            _sql(["Unfiltered Sales", "Refund Amount"], dialect)
+    def test_it_answers_what_it_does_on_its_own(self) -> None:
+        """The isolated measure is projected last either way, after whatever
+        the rest of the query brought."""
+        together = _run(_sql(["Unfiltered Sales", "Refund Amount"]))
+        alone = _run(_sql(["Unfiltered Sales"]))
+        assert [float(r[-1]) for r in together] == [float(r[-1]) for r in alone]
 
-    def test_still_allowed_on_a_single_fact(self) -> None:
+    def test_a_single_fact_query_still_works(self) -> None:
         sql = _sql(["Unfiltered Sales", "Sales Amount"])
         assert "UNION ALL" not in sql
         assert "fc_0" in sql
         assert _run(sql)
-
-
-class TestTheCompositeFlag:
-    """``composite_cte`` says a union was *built*, where ``requires_cfl`` only
-    says one was asked for — the CFL planner delegates back to the star planner
-    whenever the measures turn out to reach a single leg."""
-
-    def test_set_when_the_plan_unions(self) -> None:
-        model = _model()
-        query = QueryObject(
-            select=QuerySelect(dimensions=["Month"], measures=["Sales Amount", "Refund Amount"])
-        )
-        resolved = QueryResolver().resolve(query, model)
-        assert resolved.requires_cfl
-        PIPELINE._cfl_planner.plan(resolved, model, union_by_name=True)
-        assert resolved.composite_cte == "composite_01"
-
-    def test_unset_on_a_star_plan(self) -> None:
-        model = _model()
-        query = QueryObject(select=QuerySelect(dimensions=["Month"], measures=["Sales Amount"]))
-        resolved = QueryResolver().resolve(query, model)
-        PIPELINE._star_planner.plan(resolved, model)
-        assert resolved.composite_cte is None
 
 
 class TestFilterContextReadThroughAMetric:
@@ -267,19 +240,17 @@ class TestFilterContextReadThroughAMetric:
         assert '"fc_0" AS' in sql
         assert '"main"."Sales Amount" / "fc_0"."Unfiltered Sales"' in sql
 
-    def test_refused_alongside_another_fact(self) -> None:
-        with pytest.raises(ResolutionError) as exc:
-            self._sql_filtered(["Filtered Share", "Refund Amount"])
-        assert "Unfiltered Sales" in str(exc.value)
+    def test_it_compiles_alongside_another_fact(self) -> None:
+        """The component is kept out of the union like a selected one, and the
+        metric is rebuilt over the CTEs the wrapper leaves behind."""
+        sql = self._sql_filtered(["Filtered Share", "Refund Amount"])
+        assert '"fc_0" AS' in sql
+        assert '"Unfiltered Sales"' not in sql.split('"fc_0" AS')[0]
 
-    def test_the_refusal_names_the_component_not_the_metric(self) -> None:
-        """The component is what needs the scan, and what the author has to
-        change - naming the metric would point at the wrong declaration."""
-        with pytest.raises(ResolutionError) as exc:
-            self._sql_filtered(["Filtered Share", "Refund Amount"])
-        message = str(exc.value)
-        assert "'Unfiltered Sales'" in message
-        assert "Filtered Share" not in message
+    def test_the_metric_answers_the_same_either_way(self) -> None:
+        together = _run(self._sql_filtered(["Filtered Share", "Refund Amount"]))
+        alone = _run(self._sql_filtered(["Filtered Share"]))
+        assert [round(float(r[1]), 6) for r in together] == [round(float(r[1]), 6) for r in alone]
 
     def test_the_component_still_works_when_selected_directly(self) -> None:
         """Selecting it by name gets its own filtered scan, with the query's

--- a/tests/unit/test_filter_context_metrics.py
+++ b/tests/unit/test_filter_context_metrics.py
@@ -287,7 +287,8 @@ class TestTheShapeOfTheSQL:
         the outer query reads one CTE column twice."""
         sql = _sql(["Revenue Share", "Unfiltered Revenue"])
         assert sql.count('"fc_1" AS') == 0
-        assert sql.count('SUM("Sales"."AMOUNT") AS "Unfiltered Revenue"') == 1
+        fc_block = sql.split('"fc_0" AS')[1].split("\n)")[0]
+        assert fc_block.count('AS "Unfiltered Revenue"') == 1
         # ...and read twice: once by the metric, once as its own column.
         assert sql.count('"fc_0"."Unfiltered Revenue"') == 2
 

--- a/tests/unit/test_filter_context_multi_fact.py
+++ b/tests/unit/test_filter_context_multi_fact.py
@@ -1,0 +1,329 @@
+"""A filterContext measure in a query that spans facts.
+
+A filterContext is a differently filtered scan of the measure's fact, which
+``filter_wrap`` builds as a CTE and joins back on the query's dimensions. Under
+a multi-fact plan it had nothing to scan: the measure was planned into a UNION
+ALL leg, and the wrapper then tried to re-read the composite - whose legs had
+already applied the query's filters and whose columns are the projected
+measures rather than the fact's.
+
+The measure never belonged in the union. It reads one fact, at one grain, under
+its own filters, and joins back on the dimensions - which is a star query, and
+which is what the wrapper now plans it as.
+"""
+
+from __future__ import annotations
+
+import duckdb
+import pytest
+
+from orionbelt.compiler.pipeline import CompilationPipeline
+from orionbelt.compiler.resolution import ResolutionError
+from orionbelt.models.query import FilterOperator, QueryFilter, QueryObject, QuerySelect
+from orionbelt.models.semantic import SemanticModel
+from orionbelt.parser.loader import TrackedLoader
+from orionbelt.parser.resolver import ReferenceResolver
+
+PIPELINE = CompilationPipeline()
+
+MODEL_YAML = """\
+version: 1.0
+
+dataObjects:
+  Dates:
+    code: DATES
+    database: WH
+    schema: PUBLIC
+    columns:
+      Date Key: {code: DATE_KEY, abstractType: int, primaryKey: true}
+      Month: {code: MONTH, abstractType: int}
+      Day: {code: DAY, abstractType: int}
+
+  Stores:
+    code: STORES
+    database: WH
+    schema: PUBLIC
+    columns:
+      Store Key: {code: STORE_KEY, abstractType: int, primaryKey: true}
+      Store Name: {code: STORE_NAME, abstractType: string}
+
+  Sales:
+    code: SALES
+    database: WH
+    schema: PUBLIC
+    columns:
+      Date Key: {code: DATE_KEY, abstractType: int}
+      Store Key: {code: STORE_KEY, abstractType: int}
+      Amount: {code: AMOUNT, abstractType: float}
+    joins:
+      - joinType: many-to-one
+        joinTo: Dates
+        columnsFrom: [Date Key]
+        columnsTo: [Date Key]
+      - joinType: many-to-one
+        joinTo: Stores
+        columnsFrom: [Store Key]
+        columnsTo: [Store Key]
+
+  Refunds:
+    code: REFUNDS
+    database: WH
+    schema: PUBLIC
+    columns:
+      Date Key: {code: DATE_KEY, abstractType: int}
+      Refund: {code: REFUND, abstractType: float}
+    joins:
+      - joinType: many-to-one
+        joinTo: Dates
+        columnsFrom: [Date Key]
+        columnsTo: [Date Key]
+
+dimensions:
+  Month: {dataObject: Dates, column: Month, resultType: int}
+  Day: {dataObject: Dates, column: Day, resultType: int}
+  Store Name: {dataObject: Stores, column: Store Name, resultType: string}
+
+measures:
+  Revenue:
+    columns: [{dataObject: Sales, column: Amount}]
+    resultType: float
+    aggregation: sum
+  Refund Amount:
+    columns: [{dataObject: Refunds, column: Refund}]
+    resultType: float
+    aggregation: sum
+  Unfiltered Revenue:
+    columns: [{dataObject: Sales, column: Amount}]
+    resultType: float
+    aggregation: sum
+    filterContext:
+      mode: FIXED
+  Revenue Any Day:
+    columns: [{dataObject: Sales, column: Amount}]
+    resultType: float
+    aggregation: sum
+    filterContext:
+      mode: RELATIVE
+      exclude: [Day]
+  Grand Unfiltered Revenue:
+    columns: [{dataObject: Sales, column: Amount}]
+    resultType: float
+    aggregation: sum
+    total: true
+    filterContext:
+      mode: FIXED
+  North Revenue:
+    columns: [{dataObject: Sales, column: Amount}]
+    resultType: float
+    aggregation: sum
+    filterContext:
+      mode: FIXED
+      include:
+        - field: Store Name
+          op: "="
+          value: North
+  Unfiltered Refunds:
+    columns: [{dataObject: Refunds, column: Refund}]
+    resultType: float
+    aggregation: sum
+    filterContext:
+      mode: FIXED
+
+metrics:
+  Revenue Share:
+    expression: "{[Revenue]} / {[Unfiltered Revenue]}"
+"""
+
+
+def _model() -> SemanticModel:
+    raw, source_map = TrackedLoader().load_string(MODEL_YAML)
+    model, result = ReferenceResolver().resolve(raw, source_map)
+    assert result.valid, result.errors
+    return model
+
+
+def _sql(measures: list[str], dimensions: list[str] | None = None) -> str:
+    return PIPELINE.compile(
+        QueryObject(
+            select=QuerySelect(
+                dimensions=["Month"] if dimensions is None else dimensions, measures=measures
+            ),
+            where=[QueryFilter(field="Day", op=FilterOperator.EQUALS, value=1)],
+        ),
+        _model(),
+        "duckdb",
+    ).sql
+
+
+def _connect() -> duckdb.DuckDBPyConnection:
+    con = duckdb.connect(":memory:")
+    con.execute('CREATE SCHEMA "PUBLIC"')
+    con.execute('CREATE TABLE "PUBLIC"."DATES" (DATE_KEY INT, MONTH INT, DAY INT)')
+    con.execute('CREATE TABLE "PUBLIC"."STORES" (STORE_KEY INT, STORE_NAME VARCHAR)')
+    con.execute('CREATE TABLE "PUBLIC"."SALES" (DATE_KEY INT, STORE_KEY INT, AMOUNT DOUBLE)')
+    con.execute('CREATE TABLE "PUBLIC"."REFUNDS" (DATE_KEY INT, REFUND DOUBLE)')
+    con.execute('INSERT INTO "PUBLIC"."DATES" VALUES (1, 1, 1), (2, 1, 2), (3, 2, 1)')
+    con.execute("INSERT INTO \"PUBLIC\".\"STORES\" VALUES (1, 'North'), (2, 'South')")
+    # Month 1: 2 on the filtered day, 38 on another. Month 2: 5, all on day 1.
+    con.execute('INSERT INTO "PUBLIC"."SALES" VALUES (1, 1, 2.0), (2, 1, 38.0), (3, 2, 5.0)')
+    con.execute('INSERT INTO "PUBLIC"."REFUNDS" VALUES (1, 1.0), (3, 4.0)')
+    return con
+
+
+def _keyed(
+    measures: list[str], dimensions: list[str] | None = None
+) -> dict[tuple, dict[str, float | None]]:
+    """Rows as ``{dimension tuple: {measure: value}}``, for queries whose row
+    sets differ - a union brings rows one fact alone would not have."""
+    dims = ["Month"] if dimensions is None else dimensions
+    result = _connect().execute(_sql(measures, dimensions)).fetchdf()
+    out: dict[tuple, dict[str, float | None]] = {}
+    for row in result.to_dict("records"):
+        key = tuple(None if _is_null(row[d]) else row[d] for d in dims)
+        out[key] = {name: None if _is_null(row[name]) else float(row[name]) for name in measures}
+    return out
+
+
+def _is_null(value: object) -> bool:
+    return value is None or (isinstance(value, float) and value != value)
+
+
+def _rows(measures: list[str], dimensions: list[str] | None = None) -> dict[str, list[float]]:
+    dims = ["Month"] if dimensions is None else dimensions
+    result = _connect().execute(_sql(measures, dimensions)).fetchdf()
+    if dims:
+        result = result.sort_values(dims).reset_index(drop=True)
+    return {name: [float(v) for v in result[name]] for name in measures}
+
+
+_FILTER_CONTEXTS = ["Unfiltered Revenue", "Revenue Any Day", "Grand Unfiltered Revenue"]
+
+
+class TestTheValueDoesNotDependOnWhatElseIsSelected:
+    """The oracle. A filterContext measure reads one fact under its own
+    filters; a measure from another fact changes how the *rest* of the query is
+    planned and must not change that. Anything that leaves the measure in the
+    union, drops its context, or applies the query's filters to it breaks this
+    equality without anyone having to predict how."""
+
+    @pytest.mark.parametrize("measure", _FILTER_CONTEXTS)
+    def test_alone_and_alongside_another_fact(self, measure: str) -> None:
+        assert _rows([measure, "Refund Amount"])[measure] == _rows([measure])[measure]
+
+    @pytest.mark.parametrize("measure", _FILTER_CONTEXTS)
+    def test_at_a_grain_only_one_fact_reaches(self, measure: str) -> None:
+        """``Store Name`` hangs off Sales, which the refunds leg cannot reach.
+        The union adds rows for the refunds under a NULL store, so the row
+        *sets* differ - but every row the isolated measure answers on its own
+        has to keep its answer here."""
+        dims = ["Month", "Store Name"]
+        alone = _keyed([measure], dims)
+        together = _keyed([measure, "Refund Amount"], dims)
+        assert {k: v[measure] for k, v in together.items() if k in alone} == {
+            k: v[measure] for k, v in alone.items()
+        }
+        # ...and the extra rows are the refunds', with no store and no revenue.
+        assert all(k[1] is None for k in together.keys() - alone.keys())
+
+    def test_two_contexts_over_two_facts(self) -> None:
+        """One isolated measure per fact, in one multi-fact query."""
+        together = _rows(["Unfiltered Revenue", "Unfiltered Refunds"])
+        assert together["Unfiltered Revenue"] == _rows(["Unfiltered Revenue"])["Unfiltered Revenue"]
+        assert together["Unfiltered Refunds"] == _rows(["Unfiltered Refunds"])["Unfiltered Refunds"]
+
+    def test_an_include_filter_gets_its_own_join(self) -> None:
+        """``include:`` adds a filter of the context's own, on a column no
+        other part of the query reads. The scan is resolved for itself, so it
+        joins what that filter needs - North's sales are 40 of month 1's, and
+        month 2 has no North store at all."""
+        for measures in (
+            ["North Revenue"],
+            ["North Revenue", "Refund Amount"],
+            ["Revenue", "North Revenue", "Refund Amount"],
+        ):
+            rows = _keyed(measures)
+            assert rows[(1,)]["North Revenue"] == 40.0
+            assert rows[(2,)]["North Revenue"] is None
+        assert '"PUBLIC"."STORES"' in _sql(["Revenue", "North Revenue", "Refund Amount"])
+
+    def test_a_metric_over_it_too(self) -> None:
+        direct = _rows(["Revenue", "Unfiltered Revenue", "Refund Amount"])
+        share = _rows(["Revenue Share", "Refund Amount"])["Revenue Share"]
+        expected = [
+            n / d for n, d in zip(direct["Revenue"], direct["Unfiltered Revenue"], strict=True)
+        ]
+        assert [round(v, 6) for v in share] == [round(v, 6) for v in expected]
+
+    def test_the_context_is_doing_something(self) -> None:
+        """The equalities above are only worth something if the context changes
+        the number: month 1 holds 2 on the filtered day out of 40."""
+        assert _rows(["Revenue", "Unfiltered Revenue", "Refund Amount"]) == {
+            "Revenue": [2.0, 5.0],
+            "Unfiltered Revenue": [40.0, 5.0],
+            "Refund Amount": [1.0, 4.0],
+        }
+
+
+# Two facts in the union, plus the isolated measure - the shape the wrapper has
+# to keep out of it.
+_MULTI_FACT = ["Revenue", "Refund Amount", "Unfiltered Revenue"]
+
+
+class TestTheShapeOfThePlan:
+    def test_the_plan_is_still_multi_fact(self) -> None:
+        assert "UNION ALL" in _sql(_MULTI_FACT)
+
+    def test_the_isolated_fact_still_earns_a_leg(self) -> None:
+        """Its measure is gone from the union but its fact is not. The union is
+        what makes a dimension only that fact reaches available at all,
+        NULL-padded in the others, so dropping the leg would leave the query
+        unable to group by one."""
+        sql = _sql(["Unfiltered Revenue", "Refund Amount"], ["Month", "Store Name"])
+        assert "UNION ALL" in sql
+        composite = sql.split('"fc_0" AS')[0]
+        assert '"Stores"."STORE_NAME"' in composite
+        assert '"Unfiltered Revenue"' not in composite
+
+    def test_the_isolated_measure_is_not_in_the_union(self) -> None:
+        sql = _sql(_MULTI_FACT)
+        composite = sql.split('"fc_0" AS')[0]
+        assert '"Unfiltered Revenue"' not in composite
+
+    def test_the_isolated_scan_reads_the_fact(self) -> None:
+        sql = _sql(_MULTI_FACT)
+        fc_block = sql.split('"fc_0" AS')[1].split("\n)")[0]
+        assert '"PUBLIC"."SALES"' in fc_block
+        assert "composite_01" not in fc_block
+
+    def test_that_scan_does_not_carry_the_query_filter(self) -> None:
+        sql = _sql(_MULTI_FACT)
+        fc_block = sql.split('"fc_0" AS')[1].split("\n)")[0]
+        assert '"Dates"."DAY" = 1' not in fc_block
+
+    def test_the_composite_is_unchanged_by_its_presence(self) -> None:
+        """Adding an isolated measure must not alter how the rest is planned."""
+        with_fc = _sql(["Revenue", "Refund Amount", "Unfiltered Revenue"])
+        without = _sql(["Revenue", "Refund Amount"])
+        assert (
+            with_fc.split('"fc_0" AS')[0]
+            .split('"composite_01" AS')[1]
+            .startswith(without.split('"composite_01" AS')[1].split("\n)")[0])
+        )
+
+    def test_a_single_fact_query_is_unchanged(self) -> None:
+        sql = _sql(["Revenue", "Unfiltered Revenue"])
+        assert "UNION ALL" not in sql
+        assert '"main" AS' in sql and '"fc_0" AS' in sql
+
+
+class TestWhatIsStillRefused:
+    def test_a_grain_the_isolated_fact_cannot_reach(self) -> None:
+        """``fc_N`` groups by the dimensions it joins back on, so an isolated
+        measure on Refunds cannot be asked for by store - refunds have none.
+        Refused by the reachability rule that already governs this, naming the
+        object and what to do about it, rather than by a rule of its own."""
+        with pytest.raises(ResolutionError) as exc:
+            _sql(["Unfiltered Refunds", "Revenue"], ["Month", "Store Name"])
+        message = str(exc.value)
+        assert "'Stores'" in message
+        assert "queried independently" in message

--- a/tests/unit/test_filter_context_multi_fact.py
+++ b/tests/unit/test_filter_context_multi_fact.py
@@ -39,6 +39,14 @@ dataObjects:
       Month: {code: MONTH, abstractType: int}
       Day: {code: DAY, abstractType: int}
 
+  Products:
+    code: PRODUCTS
+    database: WH
+    schema: PUBLIC
+    columns:
+      Product Key: {code: PRODUCT_KEY, abstractType: int, primaryKey: true}
+      Stock On Hand: {code: STOCK, abstractType: float}
+
   Stores:
     code: STORES
     database: WH
@@ -54,6 +62,7 @@ dataObjects:
     columns:
       Date Key: {code: DATE_KEY, abstractType: int}
       Store Key: {code: STORE_KEY, abstractType: int}
+      Product Key: {code: PRODUCT_KEY, abstractType: int}
       Amount: {code: AMOUNT, abstractType: float}
     joins:
       - joinType: many-to-one
@@ -64,6 +73,10 @@ dataObjects:
         joinTo: Stores
         columnsFrom: [Store Key]
         columnsTo: [Store Key]
+      - joinType: many-to-one
+        joinTo: Products
+        columnsFrom: [Product Key]
+        columnsTo: [Product Key]
 
   Refunds:
     code: REFUNDS
@@ -122,6 +135,16 @@ measures:
         - field: Store Name
           op: "="
           value: North
+  Stock:
+    columns: [{dataObject: Products, column: Stock On Hand}]
+    resultType: float
+    aggregation: sum
+  Unfiltered Stock:
+    columns: [{dataObject: Products, column: Stock On Hand}]
+    resultType: float
+    aggregation: sum
+    filterContext:
+      mode: FIXED
   Unfiltered Refunds:
     columns: [{dataObject: Refunds, column: Refund}]
     resultType: float
@@ -160,12 +183,20 @@ def _connect() -> duckdb.DuckDBPyConnection:
     con.execute('CREATE SCHEMA "PUBLIC"')
     con.execute('CREATE TABLE "PUBLIC"."DATES" (DATE_KEY INT, MONTH INT, DAY INT)')
     con.execute('CREATE TABLE "PUBLIC"."STORES" (STORE_KEY INT, STORE_NAME VARCHAR)')
-    con.execute('CREATE TABLE "PUBLIC"."SALES" (DATE_KEY INT, STORE_KEY INT, AMOUNT DOUBLE)')
+    con.execute(
+        'CREATE TABLE "PUBLIC"."SALES" '
+        "(DATE_KEY INT, STORE_KEY INT, PRODUCT_KEY INT, AMOUNT DOUBLE)"
+    )
+    con.execute('CREATE TABLE "PUBLIC"."PRODUCTS" (PRODUCT_KEY INT, STOCK DOUBLE)')
+    # Product 1 is sold twice, so its stock must count once, not twice.
+    con.execute('INSERT INTO "PUBLIC"."PRODUCTS" VALUES (1, 100.0), (2, 110.0)')
     con.execute('CREATE TABLE "PUBLIC"."REFUNDS" (DATE_KEY INT, REFUND DOUBLE)')
     con.execute('INSERT INTO "PUBLIC"."DATES" VALUES (1, 1, 1), (2, 1, 2), (3, 2, 1)')
     con.execute("INSERT INTO \"PUBLIC\".\"STORES\" VALUES (1, 'North'), (2, 'South')")
     # Month 1: 2 on the filtered day, 38 on another. Month 2: 5, all on day 1.
-    con.execute('INSERT INTO "PUBLIC"."SALES" VALUES (1, 1, 2.0), (2, 1, 38.0), (3, 2, 5.0)')
+    con.execute(
+        'INSERT INTO "PUBLIC"."SALES" VALUES (1, 1, 1, 2.0), (2, 1, 1, 38.0), (3, 2, 2, 5.0)'
+    )
     con.execute('INSERT INTO "PUBLIC"."REFUNDS" VALUES (1, 1.0), (3, 4.0)')
     return con
 
@@ -327,3 +358,81 @@ class TestWhatIsStillRefused:
         message = str(exc.value)
         assert "'Stores'" in message
         assert "queried independently" in message
+
+
+class TestTheScanIsPlannedLikeAnyOtherQuery:
+    """It is a query, so it goes through the phases a query goes through. This
+    was the one place in the compiler that planned one without them."""
+
+    def test_a_one_side_measure_is_deduplicated(self) -> None:
+        """``Stock On Hand`` sits on the *one* side of Sales -> Products, so a
+        product sold twice must contribute its stock once. Month 1 holds both
+        of product 1's sales: 100 deduplicated, 200 summed per sale. Planning
+        the scan straight past the phase that detects that gave the 200 -
+        silently, and only in a multi-fact query."""
+        assert _rows(["Unfiltered Stock", "Refund Amount"])["Unfiltered Stock"] == [100.0, 110.0]
+
+    def test_it_agrees_with_the_same_query_on_one_fact(self) -> None:
+        """The scan is the same either way, so the other fact's presence
+        cannot move it."""
+        assert (
+            _rows(["Unfiltered Stock", "Refund Amount"])["Unfiltered Stock"]
+            == _rows(["Unfiltered Stock", "Revenue"])["Unfiltered Stock"]
+        )
+
+    def test_the_scan_is_grouped_where_the_join_replicates(self) -> None:
+        sql = _sql(["Unfiltered Stock", "Refund Amount"])
+        assert '"PUBLIC"."PRODUCTS"' in sql
+
+
+class TestALegForAFactThatCarriesNoDimension:
+    """A leg's FROM is not its key but the common root of that key and the
+    dimensions the key reaches. Keyed at a fact that reaches none of them, the
+    leg projects nothing at all and degenerates to ``SELECT *`` - so the leg
+    left standing for an isolated measure is rooted where that measure's own
+    leg would have been."""
+
+    def test_it_compiles_and_pads_the_other_fact(self) -> None:
+        """``Stock`` reads Products, which reaches no dimension; ``Region``
+        lives on Sales. One leg carries the grain and the other pads it, which
+        is what the union is for."""
+        rows = _keyed(["Unfiltered Stock", "Refund Amount"], ["Store Name"])
+        # North sold product 1 twice: its stock counts once.
+        assert rows[("North",)]["Unfiltered Stock"] == 100.0
+        assert rows[("South",)]["Unfiltered Stock"] == 110.0
+        assert rows[(None,)]["Refund Amount"] == 5.0
+
+    def test_the_leg_is_rooted_where_the_grain_is(self) -> None:
+        sql = _sql(["Unfiltered Stock", "Refund Amount"], ["Store Name"])
+        composite = sql.split('"fc_0" AS')[0]
+        assert "SELECT *" not in composite
+        assert '"Stores"."STORE_NAME"' in composite
+
+
+class TestALegProjectsWhatItsFromCanReach:
+    """A leg's FROM is its *lead* - the common root of its key and what that
+    key reaches - not the key itself. The dimensions it projected were decided
+    from the key, so a leg keyed at a measure's source on the one side of a
+    join (``Products``, which reaches nothing) NULL-padded dimensions its own
+    FROM could produce, and every row of it collapsed into one NULL group.
+    Nothing to do with filterContext: the measure only has to be in a union.
+    """
+
+    def test_a_one_side_measure_keeps_the_grain(self) -> None:
+        assert _keyed(["Stock", "Refund Amount"]) == {
+            (1,): {"Stock": 100.0, "Refund Amount": 1.0},
+            (2,): {"Stock": 110.0, "Refund Amount": 4.0},
+        }
+
+    def test_it_agrees_with_the_single_fact_plan(self) -> None:
+        """The other fact changes how the query is planned; it must not change
+        what this measure answers."""
+        together = _keyed(["Stock", "Refund Amount"])
+        alone = _keyed(["Stock"])
+        assert {k: v["Stock"] for k, v in together.items()} == {
+            k: v["Stock"] for k, v in alone.items()
+        }
+
+    def test_the_leg_projects_the_dimension(self) -> None:
+        leg = _sql(["Stock", "Refund Amount"]).split("UNION ALL")[0]
+        assert '"Dates"."MONTH" AS "Month"' in leg

--- a/tests/unit/test_filter_context_multi_fact.py
+++ b/tests/unit/test_filter_context_multi_fact.py
@@ -436,3 +436,50 @@ class TestALegProjectsWhatItsFromCanReach:
     def test_the_leg_projects_the_dimension(self) -> None:
         leg = _sql(["Stock", "Refund Amount"]).split("UNION ALL")[0]
         assert '"Dates"."MONTH" AS "Month"' in leg
+
+
+class TestScansAreGroupedByTheFactTheyRead:
+    """Each group becomes one scan planned over what it reads, so measures on
+    independent facts cannot share one - there is no single fact to plan it
+    against. They shared a group whenever the query had no dimension to force
+    them apart, and the scan projected an aggregate over a table its own FROM
+    did not have."""
+
+    def test_two_facts_at_no_grain(self) -> None:
+        rows = _rows(["Unfiltered Revenue", "Unfiltered Refunds"], [])
+        assert rows == {"Unfiltered Revenue": [45.0], "Unfiltered Refunds": [5.0]}
+
+    def test_each_gets_its_own_scan(self) -> None:
+        sql = _sql(["Unfiltered Revenue", "Unfiltered Refunds"], [])
+        assert '"fc_0" AS' in sql and '"fc_1" AS' in sql
+
+    def test_and_at_a_grain_too(self) -> None:
+        together = _rows(["Unfiltered Revenue", "Unfiltered Refunds"])
+        assert together["Unfiltered Revenue"] == _rows(["Unfiltered Revenue"])["Unfiltered Revenue"]
+        assert together["Unfiltered Refunds"] == _rows(["Unfiltered Refunds"])["Unfiltered Refunds"]
+
+
+class TestTheScansWarningsAreTheQuerysWarnings:
+    """The scan is planned in its own right, warnings included. Left on the
+    sub-query they went nowhere: the same measure warned of a fan trap when
+    selected plainly and said nothing behind a filterContext."""
+
+    @staticmethod
+    def _warnings(measures: list[str]) -> list[str]:
+        return [
+            w.code
+            for w in PIPELINE.compile(
+                QueryObject(
+                    select=QuerySelect(dimensions=["Month"], measures=measures),
+                    where=[QueryFilter(field="Day", op=FilterOperator.EQUALS, value=1)],
+                ),
+                _model(),
+                "duckdb",
+            ).warnings
+        ]
+
+    def test_a_fan_trap_is_reported_either_way(self) -> None:
+        assert self._warnings(["Stock"]) == self._warnings(["Unfiltered Stock"]) != []
+
+    def test_a_measure_with_nothing_to_warn_about_is_quiet(self) -> None:
+        assert self._warnings(["Unfiltered Revenue"]) == []

--- a/tests/unit/test_filter_context_multi_fact.py
+++ b/tests/unit/test_filter_context_multi_fact.py
@@ -139,6 +139,11 @@ measures:
     columns: [{dataObject: Products, column: Stock On Hand}]
     resultType: float
     aggregation: sum
+  Fanned Stock:
+    columns: [{dataObject: Products, column: Stock On Hand}]
+    resultType: float
+    aggregation: sum
+    allowFanOut: true
   Unfiltered Stock:
     columns: [{dataObject: Products, column: Stock On Hand}]
     resultType: float
@@ -419,23 +424,54 @@ class TestALegProjectsWhatItsFromCanReach:
     """
 
     def test_a_one_side_measure_keeps_the_grain(self) -> None:
-        assert _keyed(["Stock", "Refund Amount"]) == {
-            (1,): {"Stock": 100.0, "Refund Amount": 1.0},
-            (2,): {"Stock": 110.0, "Refund Amount": 4.0},
+        """``Fanned Stock`` declares the duplication intentional, which is what
+        makes a one-side measure answerable in a union at all - see below."""
+        assert _keyed(["Fanned Stock", "Refund Amount"]) == {
+            (1,): {"Fanned Stock": 100.0, "Refund Amount": 1.0},
+            (2,): {"Fanned Stock": 110.0, "Refund Amount": 4.0},
         }
 
     def test_it_agrees_with_the_single_fact_plan(self) -> None:
         """The other fact changes how the query is planned; it must not change
-        what this measure answers."""
-        together = _keyed(["Stock", "Refund Amount"])
-        alone = _keyed(["Stock"])
-        assert {k: v["Stock"] for k, v in together.items()} == {
-            k: v["Stock"] for k, v in alone.items()
+        which group this measure's value lands in."""
+        together = _keyed(["Fanned Stock", "Refund Amount"])
+        alone = _keyed(["Fanned Stock"])
+        assert {k: v["Fanned Stock"] for k, v in together.items()} == {
+            k: v["Fanned Stock"] for k, v in alone.items()
         }
 
     def test_the_leg_projects_the_dimension(self) -> None:
-        leg = _sql(["Stock", "Refund Amount"]).split("UNION ALL")[0]
+        leg = _sql(["Fanned Stock", "Refund Amount"]).split("UNION ALL")[0]
         assert '"Dates"."MONTH" AS "Month"' in leg
+
+
+class TestAOneSideMeasureInAUnionIsRefused:
+    """The legs project the values to aggregate rather than aggregating them,
+    so there is no per-leg grain to deduplicate at: a measure on the *one* side
+    of a replicating join is summed once per row of the many side. Resolution
+    cannot see it - its join steps are the base object's, and the step that
+    replicates lives inside a leg - so the check belongs to the CFL planner.
+    """
+
+    def test_it_is_refused(self) -> None:
+        with pytest.raises(ResolutionError) as exc:
+            _sql(["Stock", "Refund Amount"])
+        message = str(exc.value)
+        assert "'Stock'" in message
+        assert "deduplicated" in message
+
+    def test_the_same_measure_alone_is_answered(self) -> None:
+        """One fact, one plan, and the dedup pass that goes with it."""
+        assert _rows(["Stock"])["Stock"] == [100.0, 110.0]
+
+    def test_declaring_the_fan_out_intentional_answers_it(self) -> None:
+        """Which is what the refusal points the author at."""
+        assert _rows(["Fanned Stock", "Refund Amount"])["Fanned Stock"] == [100.0, 110.0]
+
+    def test_an_isolated_one_is_answered_because_its_scan_is_a_query(self) -> None:
+        """A filterContext scan is planned in its own right, so it gets the
+        dedup pass - the union's problem is not its problem."""
+        assert _rows(["Unfiltered Stock", "Refund Amount"])["Unfiltered Stock"] == [100.0, 110.0]
 
 
 class TestScansAreGroupedByTheFactTheyRead:

--- a/tests/unit/test_grain_dedup.py
+++ b/tests/unit/test_grain_dedup.py
@@ -1636,12 +1636,13 @@ def test_window_over_a_deduplicated_base_measure() -> None:
     assert rows == [1, 2]
 
 
-def test_filter_context_with_a_deduplicated_measure_is_still_refused() -> None:
-    """filterContext re-queries the fact tables under a *different* WHERE.
-
-    It cannot read the dedup output, which has already applied the query's
-    filters and aggregated, so unlike cumulative and window there is no column
-    to take by alias.
+def test_filter_context_composes_with_a_deduplicated_measure() -> None:
+    """It re-queries the fact under a *different* WHERE, which the dedup output
+    cannot serve - that output has already applied the query's filters and
+    aggregated, so there is no column to take by alias. It does not have to:
+    the filterContext measure is planned as a scan of its own, which runs the
+    dedup phase for itself, and this plan no longer counts it among what it has
+    to deduplicate. The two rewrites end up in different CTEs.
     """
     yaml_text = CUMULATIVE_YAML.replace(
         "  Total Stock On Hand:\n",
@@ -1654,16 +1655,49 @@ def test_filter_context_with_a_deduplicated_measure_is_still_refused() -> None:
         "  Total Stock On Hand:\n",
         1,
     )
-    with pytest.raises(GrainDedupUnsupportedError, match="filter_context"):
-        _compile(
-            {
-                "select": {
-                    "dimensions": ["Sale Month"],
-                    "measures": ["Unfiltered Quantity", "Total Stock On Hand"],
-                }
-            },
-            yaml_text,
-        )
+    result = _compile(
+        {
+            "select": {
+                "dimensions": ["Sale Month"],
+                "measures": ["Unfiltered Quantity", "Total Stock On Hand"],
+            }
+        },
+        yaml_text,
+    )
+    rows = sorted(
+        (str(r[0])[:7], int(r[1]), int(r[2]))
+        for r in _cumulative_db().execute(result.sql).fetchall()
+    )
+    # January counts p1's stock once despite two sales, and the quantities are
+    # the same either way here - what matters is that both are computed at all.
+    # The wrapper projects the inline measure first, then the isolated one.
+    assert [(month, stock) for month, stock, _ in rows] == [("2024-01", 100), ("2024-02", 110)]
+
+
+def test_a_deduplicated_filter_context_measure_deduplicates_in_its_own_scan() -> None:
+    """The scan is a query, so it goes through the phase that detects a measure
+    on the *one* side of a replicating join - the one place in the compiler
+    that used to plan a query without it."""
+    yaml_text = CUMULATIVE_YAML.replace(
+        "  Total Stock On Hand:\n",
+        "  Unfiltered Stock:\n"
+        "    resultType: int\n"
+        "    aggregation: sum\n"
+        "    expression: '{[Products].[Stock On Hand]}'\n"
+        "    filterContext:\n"
+        "      mode: FIXED\n"
+        "  Total Stock On Hand:\n",
+        1,
+    )
+    result = _compile(
+        {"select": {"dimensions": ["Sale Month"], "measures": ["Unfiltered Stock"]}},
+        yaml_text,
+    )
+    rows = sorted(
+        (str(r[0])[:7], int(r[1])) for r in _cumulative_db().execute(result.sql).fetchall()
+    )
+    # 100, not 200: p1 is sold twice in January and its stock counts once.
+    assert rows == [("2024-01", 100), ("2024-02", 110)]
 
 
 def test_dedup_path_keeps_the_base_measure_data_type_cast() -> None:


### PR DESCRIPTION
Option C from the filterContext plan. Removes the multi-fact refusal added in #294.

## The problem

A `filterContext` is a differently filtered read of the measure's fact, which `filter_wrap` builds as a CTE and joins back on the query's dimensions. It built that CTE by reusing the plan's FROM and changing only the WHERE - right while the plan is built around the same fact, wrong under a multi-fact plan, where the FROM is a UNION ALL composite whose legs applied the query's filters before it existed and whose columns are the projected measures rather than the fact's.

## The fix

The measure never belonged in that union. It reads one fact, at one grain, under its own filters, and joins back on the dimensions - a star query, and that is what the wrapper now plans it as:

```sql
WITH "composite_01" AS (   -- the rest of the query, unchanged
SELECT "Dates"."MONTH" AS "Month" FROM "SALES" ...
UNION ALL BY NAME
SELECT "Dates"."MONTH", CAST("Refunds"."REFUND" AS ...) AS "Refund Amount" FROM "REFUNDS" ...
),
"main" AS (SELECT "Month", SUM("composite_01"."Refund Amount") ... FROM "composite_01" GROUP BY ALL),
"fc_0" AS (                -- planned in its own right, against Sales
SELECT "Dates"."MONTH", SUM("Sales"."AMOUNT") AS "Unfiltered Sales"
FROM "PUBLIC"."SALES" ... GROUP BY ALL
)
SELECT ... FROM "main" LEFT JOIN "fc_0" ON "main"."Month" = "fc_0"."Month"
```

It is **resolved** rather than assembled, so the base object, the join path to the grain dimensions and the fanout check are derived for that scan rather than inherited from a plan built for other measures. The scan carries the caller's `where` through resolution - so a context that *keeps* a filter has the column in scope - and its resolved filters are replaced with the effective set afterwards, so one that *drops* a filter does not have to un-join it. An `include:` filter gets whatever join it needs the same way.

## Two departures from the plan, both found by building it

- **The measure leaves the union's projection, not the union.** Its fact still earns a leg with no measure of its own: the union is what makes a dimension only that fact reaches available at all, NULL-padded in the others. Dropping the leg left the query unable to group by one.
- **The trigger is not "the plan is CFL"** but "this scan's fact is not in the plan's FROM". With the measure out of the union's projection, a two-fact query can collapse to a single-fact star built around the *other* fact, where the scan needs planning just as much. Where the fact *is* in that FROM, the CTE is built exactly as before - every existing single-fact query compiles unchanged.

The narrow refusal the plan proposed in place of the old one was not needed: a grain dimension the fact cannot reach is already refused by the reachability rule that governs this, naming the object and saying to split the query.

`CompileContext` gains the query as asked - a pass that has to *plan* rather than rewrite needs it, and a resolved filter keeps only its expression.

## Verification

The oracle: **a filterContext measure's value must not depend on what else is selected.** Compiled alone and alongside a measure from another fact, executed on DuckDB, compared row for row - across `FIXED`, `RELATIVE` + `exclude`, `total: true`, `include:`, a metric over one, and two contexts over two facts. At a grain only one fact reaches the row sets legitimately differ, so there the comparison is per dimension key and the extra rows are asserted to be the other fact's.

- `tests/unit/test_filter_context_multi_fact.py`: 18 tests
- full suite 3381 passed, 584 skipped; ruff + mypy clean
- TPC-DS sweep unchanged: 39 exact on DuckDB sf=1 plus the known Q99 reference variant