### PR TITLE
docs: what the filterContext work changed, and what a union still refuses

### DIFF
--- a/docs/guide/compilation.md
+++ b/docs/guide/compilation.md
@@ -299,6 +299,18 @@ below) and the query plans as an ordinary star.
     total. Queries that trigger this rewrite carry a `FAN_TRAP_RISK` warning
     saying so. Query the measure at its own grain for a total that adds up.
 
+!!! note "Not available in a multi-fact plan"
+    This rewrite needs a grain to deduplicate at. A multi-fact query is a
+    `UNION ALL` whose legs *project* the values to aggregate rather than
+    aggregating them, so there is none, and a one-side measure would be summed
+    once per row of the many side inside its leg. Asking for one alongside a
+    measure from a fact it cannot be joined to is refused rather than answered.
+
+    Three ways forward, in the order worth trying: query the measure without
+    the other fact; give it a `filterContext`, whose scan is planned as a query
+    in its own right and so deduplicates normally; or declare
+    `allowFanOut: true` on the measure if the duplication is what you want.
+
 A `total: true` measure is deduplicated at **no** grain: one row per source
 object row across the whole query, in its own `dedup_total_N` CTE that is
 `CROSS JOIN`ed in. It cannot be a window over this pass's output, because those

--- a/docs/guide/dialects.md
+++ b/docs/guide/dialects.md
@@ -196,6 +196,25 @@ OrionBelt automatically wraps aggregate expressions with `CAST` based on resolve
 | Snowflake, DuckDB, Databricks, Dremio | 38 |
 | BigQuery | 38 |
 
+!!! warning "ClickHouse: decimal division keeps the operand's scale"
+
+    Dividing two decimals on ClickHouse produces a result at the *operands'*
+    scale rather than widening it, so a ratio built from `decimal(18, 2)`
+    columns is truncated to two places:
+
+    ```sql
+    SELECT toDecimal64(4254, 2) / toDecimal64(10000, 2)   -- 0.42
+    SELECT toDecimal64(4254, 4) / toDecimal64(10000, 4)   -- 0.4254
+    ```
+
+    Every other supported dialect widens the scale for you. If a metric divides
+    decimal measures and you need the precision, declare the metric's
+    `dataType` with the scale you want, or give the measures a `float`
+    `resultType` so the division happens in floating point. This is a
+    ClickHouse arithmetic rule, not something OrionBelt applies -- it is
+    documented here because a ratio that reads `0.42` on one engine and
+    `0.4254` on another looks like a compiler bug and is not.
+
 === "BigQuery / Databricks / Dremio / DuckDB / MySQL / Postgres / Snowflake"
 
     ```sql

--- a/docs/guide/grain-filter-context.md
+++ b/docs/guide/grain-filter-context.md
@@ -305,11 +305,52 @@ The compilation pipeline handles grain and filter context in two phases:
 
 ### CTE Structure for Filter Context
 
-Measures with `filterContext` are grouped by their effective filter+grain combination. Each group gets its own CTE:
+Measures with `filterContext` are grouped by their effective filter + grain
+combination, and by the fact they read. Each group gets its own CTE:
 
 - **`main`** CTE: the original query with inline measures (no filter context)
-- **`fc_0`, `fc_1`, ...** CTEs: isolated queries with modified WHERE clauses
+- **`fc_0`, `fc_1`, ...** CTEs: the isolated scans
 - **Outer SELECT**: joins all CTEs together (LEFT JOIN on shared dimensions, CROSS JOIN for scalar)
+
+An isolated scan is **planned as a query in its own right**, not assembled from
+the main query's `FROM` with a different `WHERE`. It resolves its own base
+object, its own join path to the grain dimensions, and runs the same
+fanout and deduplication phases any query runs. That is what lets it read a
+fact the rest of the query does not, and what makes a measure on the *one* side
+of a join count once rather than once per row of the many side.
+
+Two consequences worth knowing:
+
+- The scan joins whatever its own filters need. An `include:` filter on a
+  column nothing else in the query reads still gets its join.
+- A filterContext measure does not decide the main query's base object, since
+  it is not planned there. Removing it from that decision can leave the rest of
+  the query single-fact where it used to be multi-fact -- the same answer,
+  planned more directly.
+
+## What Composes
+
+| Combination | Result |
+|---|---|
+| Read through a metric (`{[Revenue]} / {[Unfiltered Revenue]}`) | Works. The component is computed in the same CTE a selected measure gets, and the formula is rebuilt in the outer query over the CTEs' columns. |
+| `total: true` or a `grain` override on the same measure | Works. `total: true` is read as the empty grain it is, so the scan groups by nothing and reports a grand total. |
+| A query spanning facts that cannot be joined | Works. The measure is kept out of the UNION ALL and its scan reads its own fact. |
+| `HAVING` on the measure, or on a metric reading it | Works. The predicate moves to the outer query, where the value is a column. |
+| `ORDER BY` on the measure | Works. It reads whichever CTE computed the value. |
+| Several contexts, over one fact or several | Works. One scan per (context, grain, fact). |
+| A **cumulative** metric over the measure | Works. The running total accumulates the context's values, not the query-filtered ones. |
+
+## What Is Refused
+
+Each of these is refused, with a message naming what is wrong and what to
+change, rather than compiled into a number that looks right:
+
+| Combination | Why |
+|---|---|
+| An **averaged** `total: true` measure in the same query | A total average is rebuilt from the `SUM` and `COUNT` of the aggregate's argument. Once the filter context has been computed, that argument is a value already averaged. Total a sum instead. |
+| A **period-over-period** metric in the same query | PoP rebuilds the query's `FROM` from a date spine, which cannot read the isolated scan and regroups the query to its own grain. |
+| A measure whose own arguments span facts no join reaches | There is no single fact to plan the scan against. |
+| A grain dimension the measure's fact cannot reach | The scan has to group by the dimensions it joins back on. Reported as an unreachable object, by the same rule that governs any query asking for one. |
 
 ## Constraints
 
@@ -317,7 +358,7 @@ Measures with `filterContext` are grouped by their effective filter+grain combin
     - The effective grain must be a subset of the query dimensions (superset/disjoint grains are rejected to prevent fanout).
     - `total: true` and `grain` are mutually exclusive on the same measure.
     - `mode: FIXED` cannot be combined with `exclude` on either `grain` or `filterContext`.
-    - Grain and filter context overrides are not combined with period-over-period or cumulative metrics in the same query. A warning is emitted if attempted.
+    - Grain overrides are not combined with period-over-period or cumulative metrics in the same query. A warning is emitted if attempted.
 
 ## Dialect Support
 


### PR DESCRIPTION
Phase 7, the last item on the TPC-DS plan. Two of its three deliverables turned out to be elsewhere already, so this is what was actually missing.

## The guide described a feature that had since changed shape

`grain-filter-context.md` documented `filterContext` as of before #294-#298 and said nothing about a metric reading one, `total:` on one, a multi-fact query, HAVING, or ORDER BY. It gains two sections:

**What Composes** - a metric reading the measure, `total: true`, a query spanning facts, HAVING, ORDER BY, several contexts, and a cumulative metric over it.

**What Is Refused** - an averaged total, a period-over-period metric, a cross-fact measure, an unreachable grain dimension - each with the reason rather than the error code.

Every row was executed before it was written. The cumulative row is in because it turned out to compose (running total 40 then 45, accumulating the context's values), not because it was assumed to; and one refusal's description was corrected after checking what the message actually names.

## Two notes that stop a correct answer looking like a bug

`compilation.md` now says grain deduplication is unavailable in a multi-fact plan, and gives the three ways forward. A query that answers on its own refuses once a measure from an unjoinable fact is added, and the reason is not guessable.

`dialects.md` gains the ClickHouse decimal-division note the plan carried as an aside. Verified against the server rather than quoted:

```sql
SELECT toDecimal64(4254, 2) / toDecimal64(10000, 2)   -- 0.42
SELECT toDecimal64(4254, 4) / toDecimal64(10000, 4)   -- 0.4254
```

Every other supported dialect widens the scale. A ratio that reads `0.42` on one engine and `0.4254` on another looks like a compiler bug and is not.

## Deliberately not built

The validator warning the finding floated - a bare `/` whose divisor is a column reference - would fire on every safe ratio between two non-nullable columns. The guidance it would carry is already in the guide, where phase 4 put it.

## Elsewhere

The refusal catalogue and the plan's status live in the gitignored `design/` notes, updated in the same pass: inventory re-taken from the raise sites, the `filterContext` case struck out as fixed, four new cases added, and Q25/Q29/Q17 recorded as deliberate three-fact fan-out refusals rather than misses.

## Verification

- `mkdocs build` clean, page renders
- docs-only: no source or test changes