### PR TITLE
fix(tests): sweep a grain-fixed measure at its own grain

### DIFF
--- a/tests/integration/_measure_dimensions.py
+++ b/tests/integration/_measure_dimensions.py
@@ -1,0 +1,28 @@
+"""Which dimensions a measure cannot be queried without.
+
+Both measure sweeps ask every measure of the commerce model to execute, one
+against the local vendor containers and one against live Dremio through pgwire,
+and both hit the same wall: a measure whose grain is fixed to a dimension list
+cannot answer a grand total. Resolution refuses it, because aggregating at a
+grain the query does not group by is what multiplies rows.
+
+That is a bad question rather than a vendor bug, so the sweeps ask the right one
+instead of skipping the measure - the grain path is exactly the kind of SQL they
+exist to execute against a real engine. The rule lives here so the two cannot
+drift, which they already did once: the fix landed in one sweep while the other
+went on failing.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from orionbelt.models.semantic import GrainMode
+
+
+def required_dimensions(measure: Any) -> list[str]:
+    """The dimensions a query must group by for *measure* to be answerable."""
+    grain = getattr(measure, "grain", None)
+    if grain is None or grain.mode != GrainMode.FIXED:
+        return []
+    return [*grain.include, *grain.keep_only]

--- a/tests/integration/dremio/test_dremio_measure_sweep.py
+++ b/tests/integration/dremio/test_dremio_measure_sweep.py
@@ -32,6 +32,7 @@ import yaml
 
 from orionbelt.parser.loader import TrackedLoader
 from orionbelt.parser.resolver import ReferenceResolver
+from tests.integration._measure_dimensions import required_dimensions
 from tests.integration.dremio.conftest import OBSL_MODEL_NAME
 
 pytestmark = pytest.mark.dremio
@@ -50,12 +51,14 @@ SOURCE_MODEL_YAML = REPO_ROOT / "examples" / "orionbelt_1_commerce.yaml"
 _MODEL_NOT_SERVED = ("not found", "does not exist", "no such", "unknown model", "no model")
 
 
-def _load() -> tuple[list[str], dict[str, Any]]:
+def _load() -> tuple[list[tuple[str, list[str]]], dict[str, Any]]:
     """Resolve the model and return its full queryable measure namespace.
 
     Uses ``SemanticModel.effective_measures`` so *synthesised* row-count
     measures (``Sales Count`` etc.) are swept too, not just declared measures.
-    Falls back to the declared list if resolution is unavailable at collection.
+    Each measure carries the dimensions it cannot be queried without, which for
+    a grain-fixed measure is its own grain. Falls back to the declared list if
+    resolution is unavailable at collection.
     """
     if not SOURCE_MODEL_YAML.exists():
         return [], {}
@@ -65,10 +68,13 @@ def _load() -> tuple[list[str], dict[str, Any]]:
         raw, source_map = TrackedLoader().load(SOURCE_MODEL_YAML)
         model, result = ReferenceResolver().resolve(raw, source_map)
         if result.valid:
-            return list(model.effective_measures.keys()), metrics
+            return [
+                (name, required_dimensions(measure))
+                for name, measure in model.effective_measures.items()
+            ], metrics
     except Exception:  # noqa: BLE001 -- fall back to declared measures at collection time
         pass
-    return list((raw_dict.get("measures") or {}).keys()), metrics
+    return [(name, []) for name in (raw_dict.get("measures") or {})], metrics
 
 
 _MEASURES, _METRICS = _load()
@@ -111,7 +117,7 @@ def pgwire_cursor():  # type: ignore[no-untyped-def]
         # error must fail loudly rather than masquerade as a skip (that is the
         # regression coverage this suite exists to provide).
         try:
-            cur.execute(_sql(_MEASURES[0], []))
+            cur.execute(_sql(_MEASURES[0][0], _MEASURES[0][1]))
             cur.fetchall()
         except Exception as exc:
             conn.rollback()
@@ -124,10 +130,15 @@ def pgwire_cursor():  # type: ignore[no-untyped-def]
         yield cur
 
 
-@pytest.mark.parametrize("measure", _MEASURES)
-def test_measure_executes_on_dremio(pgwire_cursor, measure: str) -> None:  # type: ignore[no-untyped-def]
-    """Every measure must execute (grand total) against live Dremio."""
-    pgwire_cursor.execute(_sql(measure, []))
+@pytest.mark.parametrize("measure,dims", _MEASURES, ids=[name for name, _ in _MEASURES])
+def test_measure_executes_on_dremio(pgwire_cursor, measure: str, dims: list[str]) -> None:  # type: ignore[no-untyped-def]
+    """Every measure must execute against live Dremio.
+
+    As a grand total, except for a measure whose grain is fixed to a dimension
+    list: that one is asked at its own grain, since a dimensionless query is a
+    question it cannot answer rather than one Dremio gets wrong.
+    """
+    pgwire_cursor.execute(_sql(measure, dims))
     pgwire_cursor.fetchall()  # raises on a Dremio execution error
 
 

--- a/tests/integration/drift/vendor_exec/test_vendor_measure_sweep.py
+++ b/tests/integration/drift/vendor_exec/test_vendor_measure_sweep.py
@@ -29,7 +29,7 @@ import yaml
 
 from orionbelt.compiler.pipeline import CompilationPipeline
 from orionbelt.models.query import QueryObject
-from orionbelt.models.semantic import SemanticModel
+from orionbelt.models.semantic import GrainMode, SemanticModel
 from orionbelt.parser.loader import TrackedLoader
 from orionbelt.parser.resolver import ReferenceResolver
 
@@ -44,11 +44,26 @@ _RAW = yaml.safe_load(COMMERCE_MODEL_YAML.read_text()) if COMMERCE_MODEL_YAML.ex
 _METRICS = _RAW.get("metrics") or {}
 
 
-def _measure_names() -> list[str]:
-    """Full queryable measure namespace via ``effective_measures``.
+def _required_dimensions(measure: Any) -> list[str]:
+    """The dimensions a measure cannot be queried without.
+
+    A grain fixed to a dimension list is one: resolution refuses to aggregate at
+    a grain the query does not group by, because that is what multiplies rows
+    (``grain ['Country Name'] is not a subset of query dimensions []``). Asking
+    for it as a grand total is therefore a bad question, not a vendor bug, so
+    the sweep asks the right one instead of skipping the measure.
+    """
+    grain = getattr(measure, "grain", None)
+    if grain is None or grain.mode != GrainMode.FIXED:
+        return []
+    return [*grain.include, *grain.keep_only]
+
+
+def _measure_items() -> list[tuple[str, str, list[str]]]:
+    """``(kind, name, dimensions)`` for the full queryable measure namespace.
 
     Includes synthesised row-count measures (``Sales Count`` etc.), not just
-    declared measures. Falls back to the declared list at collection time.
+    declared ones. Falls back to the declared list at collection time.
     """
     if not COMMERCE_MODEL_YAML.exists():
         return []
@@ -56,13 +71,13 @@ def _measure_names() -> list[str]:
         raw, source_map = TrackedLoader().load(COMMERCE_MODEL_YAML)
         model, result = ReferenceResolver().resolve(raw, source_map)
         if result.valid:
-            return list(model.effective_measures.keys())
+            return [
+                ("measure", name, _required_dimensions(measure))
+                for name, measure in model.effective_measures.items()
+            ]
     except Exception:  # noqa: BLE001 -- fall back to declared measures at collection time
         pass
-    return list((_RAW.get("measures") or {}).keys())
-
-
-_MEASURES = _measure_names()
+    return [("measure", name, []) for name in (_RAW.get("measures") or {})]
 
 
 def _time_dimension(spec: dict[str, Any]) -> str | None:
@@ -73,7 +88,7 @@ def _time_dimension(spec: dict[str, Any]) -> str | None:
 # metrics with their required time dimension; derived metrics grouped by a
 # plain dimension.
 def _sweep_items() -> list[tuple[str, str, list[str]]]:
-    items: list[tuple[str, str, list[str]]] = [("measure", m, []) for m in _MEASURES]
+    items: list[tuple[str, str, list[str]]] = _measure_items()
     for name, spec in _METRICS.items():
         time_dim = _time_dimension(spec)
         items.append(("metric", name, [time_dim] if time_dim else ["Product Category"]))

--- a/tests/integration/drift/vendor_exec/test_vendor_measure_sweep.py
+++ b/tests/integration/drift/vendor_exec/test_vendor_measure_sweep.py
@@ -29,9 +29,10 @@ import yaml
 
 from orionbelt.compiler.pipeline import CompilationPipeline
 from orionbelt.models.query import QueryObject
-from orionbelt.models.semantic import GrainMode, SemanticModel
+from orionbelt.models.semantic import SemanticModel
 from orionbelt.parser.loader import TrackedLoader
 from orionbelt.parser.resolver import ReferenceResolver
+from tests.integration._measure_dimensions import required_dimensions
 
 from .conftest import VendorTarget
 
@@ -42,21 +43,6 @@ COMMERCE_MODEL_YAML = REPO_ROOT / "examples" / "orionbelt_1_commerce.yaml"
 
 _RAW = yaml.safe_load(COMMERCE_MODEL_YAML.read_text()) if COMMERCE_MODEL_YAML.exists() else {}
 _METRICS = _RAW.get("metrics") or {}
-
-
-def _required_dimensions(measure: Any) -> list[str]:
-    """The dimensions a measure cannot be queried without.
-
-    A grain fixed to a dimension list is one: resolution refuses to aggregate at
-    a grain the query does not group by, because that is what multiplies rows
-    (``grain ['Country Name'] is not a subset of query dimensions []``). Asking
-    for it as a grand total is therefore a bad question, not a vendor bug, so
-    the sweep asks the right one instead of skipping the measure.
-    """
-    grain = getattr(measure, "grain", None)
-    if grain is None or grain.mode != GrainMode.FIXED:
-        return []
-    return [*grain.include, *grain.keep_only]
 
 
 def _measure_items() -> list[tuple[str, str, list[str]]]:
@@ -72,7 +58,7 @@ def _measure_items() -> list[tuple[str, str, list[str]]]:
         model, result = ReferenceResolver().resolve(raw, source_map)
         if result.valid:
             return [
-                ("measure", name, _required_dimensions(measure))
+                ("measure", name, required_dimensions(measure))
                 for name, measure in model.effective_measures.items()
             ]
     except Exception:  # noqa: BLE001 -- fall back to declared measures at collection time


### PR DESCRIPTION
## The failure

`test_vendor_measure_sweep[measure:Sales by Country]` fails on all four local vendors:

```
Measure 'Sales by Country' grain ['Country Name'] is not a subset of query
dimensions []. This would cause row multiplication.
```

Found while running the docker-gated suites for #302, and **not caused by it**: reproduced at `8eefd0e`, before the function-catalog work started. It has been failing since the grain-override measure was added to the commerce model, invisible because the vendor-exec suites are docker-gated and CI never runs them.

## Why it is the test that is wrong

The sweep asks every measure for a grand total. A measure whose grain is fixed to a dimension list cannot answer one, by design: aggregating at a grain the query does not group by is precisely what multiplies rows, and resolution refuses it. So the query was a bad question, not a vendor bug.

The sweep already handles the analogous case for metrics, giving a cumulative or period-over-period metric its required time dimension. This does the same for measures: a `FIXED` grain contributes its `include` and `keepOnly` dimensions to the query.

Skipping the measure was the other option and the worse one. The grain path is exactly the kind of SQL this sweep exists to execute against a real engine, so it should run, not be excluded.

## Verification

- 176 sweep tests pass across DuckDB, Postgres, MySQL and ClickHouse (was 172 passing, 4 failing).
- The compiled SQL for that measure now groups by `Country Name` instead of refusing.
- `uv run pytest`: 3698 passed, 815 skipped. `ruff`, `mypy` clean.

Independent of #302; either can merge first.