### PR TITLE
feat(examples): FinOps semantic model on the FOCUS specification

### DIFF
--- a/docs/examples/finops-focus.md
+++ b/docs/examples/finops-focus.md
@@ -1,0 +1,219 @@
+---
+description: "FinOps cloud cost analysis on the FOCUS specification: a multi-fact OBML model over charges, invoices and commitments, with invoice reconciliation through the composite fact layer."
+---
+
+# FinOps on FOCUS
+
+[FOCUS](https://focus.finops.org) — the FinOps Open Cost and Usage Specification — is the FinOps Foundation's vendor-neutral schema for technology cost and usage data. AWS, Microsoft Azure, Google Cloud and OCI all publish FOCUS exports, so one model can read any of their bills.
+
+FOCUS standardises the **physical** schema: column names, data types, allowed values, and requirement levels (MUST / SHOULD / MAY). It deliberately stops there. It does not define:
+
+- metrics — no effective savings rate, no unit cost, no amortisation rule
+- dimensional hierarchies — no provider → service → SKU
+- how its datasets join
+
+That is the semantic layer's job, and it is what this example supplies.
+
+## Why this is a multi-fact model
+
+Since version 1.4 FOCUS is a multi-dataset specification. This example reproduces the shape that matters:
+
+```
+                Billing Periods        Providers
+                   ^      ^             ^     ^
+                   |      |             |     |
+              Charges     +--- Invoice Details
+                 |
+            Commitments
+```
+
+**Charges** (daily usage) and **Invoice Details** (invoice lines) are independent facts. Nothing joins one to the other — they meet only at the conformed dimensions. So asking for cost and invoiced amount side by side is a genuine multi-fact query, and OrionBelt answers it through the [composite fact layer](../guide/compilation.md) rather than by joining the two.
+
+That question has a name in FinOps: **invoice reconciliation**, the headline use case for FOCUS 1.4. "Does what we were charged match what we were invoiced?"
+
+## Build the data
+
+The example ships a generator rather than a checked-in database file:
+
+```bash
+uv run python scripts/build_finops_duckdb.py
+```
+
+This writes `examples/finops.duckdb` with five tables in a `focus` schema — `charges`, `invoice_details`, `commitments`, `providers`, `billing_periods` — holding six months of synthetic multi-cloud billing that conforms to FOCUS column names and allowed values. The database is named for the domain, the schema for the specification its tables conform to.
+
+```bash
+export DUCKDB_DATABASE=$PWD/examples/finops.duckdb
+export DB_VENDOR=duckdb
+```
+
+## Invoice reconciliation
+
+```yaml title="reconciliation.yml"
+select:
+  dimensions: [Billing Period, Provider]
+  measures: [Billed Cost, Invoiced Amount, Invoice Variance]
+orderBy:
+  - field: Billing Period
+    direction: asc
+```
+
+```bash
+uv run obsl execute examples/finops.obml.yml -q reconciliation.yml
+```
+
+| Billing Period | Provider | Billed Cost | Invoiced Amount | Invoice Variance |
+|---|---|---|---|---|
+| March 2026 | Amazon Web Services | 34,875.23 | 34,908.06 | -32.83 |
+| March 2026 | Google Cloud | 24,395.02 | 24,400.78 | -5.76 |
+| March 2026 | Microsoft Azure | 30,173.82 | 30,139.68 | 34.14 |
+
+`Invoice Variance` is a metric spanning two measures that live on different facts:
+
+```yaml
+Invoice Variance:
+  expression: "{[Billed Cost]} - {[Invoiced Amount]}"
+```
+
+The compiled SQL unions the two legs and pads the missing columns, so each fact is aggregated at its own grain:
+
+```sql
+WITH "composite_01" AS (
+  SELECT
+    "Billing Periods"."BillingPeriodLabel" AS "Billing Period",
+    "Providers"."ProviderName" AS "Provider",
+    CAST("Charges"."BilledCost" AS DECIMAL(18, 2)) AS "Billed Cost"
+  FROM "focus"."charges" AS "Charges"
+  LEFT JOIN "focus"."billing_periods" AS "Billing Periods" ON ...
+  LEFT JOIN "focus"."providers" AS "Providers" ON ...
+  UNION ALL BY NAME
+  SELECT
+    "Billing Periods"."BillingPeriodLabel" AS "Billing Period",
+    "Providers"."ProviderName" AS "Provider",
+    CAST("Invoice Details"."InvoicedAmount" AS DECIMAL(18, 2)) AS "Invoiced Amount"
+  FROM "focus"."invoice_details" AS "Invoice Details"
+  LEFT JOIN ...
+)
+SELECT
+  "Billing Period",
+  "Provider",
+  SUM("composite_01"."Billed Cost")     AS "Billed Cost",
+  SUM("composite_01"."Invoiced Amount") AS "Invoiced Amount",
+  SUM("composite_01"."Billed Cost") - SUM("composite_01"."Invoiced Amount")
+    AS "Invoice Variance"
+FROM "composite_01"
+GROUP BY ALL
+```
+
+### What the naive join does instead
+
+Joining both facts to the billing period in one query is the obvious move, and it is wrong. Against this dataset:
+
+| Approach | Billed Cost | Invoiced Amount |
+|---|---|---|
+| Truth | 518,167.94 | 517,944.37 |
+| Composite fact layer | 518,167.94 | 517,944.37 |
+| `charges JOIN invoice_details` | 1,730,132.52 | 435,865,817.48 |
+
+Every one of the 14,979 charge rows is multiplied by every invoice line for its provider and period. Invoiced amount inflates roughly **842x**. Nothing errors; the dashboard just quietly reports a number that is three orders of magnitude wrong.
+
+## Conformed dimensions matter
+
+`Provider` is a separate data object rather than a column on each fact, and that is not a stylistic choice. A dimension used in a cross-fact query has to be reachable from **both** facts. Left as a plain column on `Charges`, the `Provider` value would populate on the charges leg and come back `NULL` on the invoice leg, splitting every reconciliation row in two.
+
+The same applies to `Billing Periods`. These two objects are the entire reason a common root exists for the union.
+
+## Rate optimisation
+
+FOCUS separates three costs, and the gaps between them are where FinOps savings live:
+
+| Measure | Meaning |
+|---|---|
+| `List Cost` | What the usage would cost at published on-demand rates |
+| `Contracted Cost` | Cost at negotiated rates |
+| `Effective Cost` | Cost with commitment purchases amortised over the period they cover |
+
+```yaml
+select:
+  dimensions: [Provider, Service Category]
+  measures: [Effective Cost, List Cost, Effective Savings Rate, Negotiated Discount Rate]
+orderBy: [{field: Effective Cost, direction: desc}]
+```
+
+| Provider | Service Category | Effective Cost | List Cost | Effective Savings Rate | Negotiated Discount Rate |
+|---|---|---|---|---|---|
+| Amazon Web Services | Compute | 62,043.78 | 76,623.62 | 19.03% | 5.88% |
+| Microsoft Azure | Compute | 62,038.48 | 74,547.62 | 16.78% | 6.19% |
+| Microsoft Azure | Databases | 61,375.00 | 74,522.11 | 17.64% | 6.09% |
+
+Splitting the two rates answers a question a single "savings" number cannot: how much came from negotiating, and how much from committing.
+
+## Commitment utilisation
+
+```yaml
+select:
+  dimensions: [Commitment, Commitment Type]
+  measures: [Effective Cost, Committed Amount, Commitment Utilization]
+```
+
+| Commitment | Commitment Type | Effective Cost | Committed Amount | Commitment Utilization |
+|---|---|---|---|---|
+| Amazon Web Services Reserved Instance 2 | Reserved Instance | 17,389.32 | 21,650.10 | 80.32% |
+| Amazon Web Services Savings Plan 1 | Savings Plan | 30,341.10 | 46,993.56 | 64.56% |
+| Microsoft Azure Savings Plan 4 | Savings Plan | 25,541.75 | 28,336.98 | 90.14% |
+
+This query emits a warning:
+
+```
+warning: Measure(s) 'Committed Amount' are sourced from an object whose rows
+this query's joins replicate. Each was aggregated over rows deduplicated on
+that object's key, so per-group values are correct - but one row can belong to
+several groups, so the values do not add up to that object's grand total.
+```
+
+That is the intended behaviour, not a defect. `Committed Amount` lives on the *one* side of a many-to-one join: one commitment covers thousands of charge rows. Summing it naively across the joined result multiplies the contract value by the number of charges it covered. OrionBelt [deduplicates on the commitment key](../guide/compilation.md) so each group is right, and tells you the column will not cross-foot.
+
+## Trend and anomaly detection
+
+Cumulative and period-over-period metrics come from the same model:
+
+```yaml
+select:
+  dimensions: [Charge Date]
+  measures: [Effective Cost, Running Effective Cost, Effective Cost MoM Growth]
+```
+
+| Charge Date | Effective Cost | Running Effective Cost | Effective Cost MoM Growth |
+|---|---|---|---|
+| 2026-03-01 | 79,379.49 | 79,379.49 | |
+| 2026-04-01 | 70,085.54 | 149,465.03 | -11.71% |
+| 2026-05-01 | 70,058.03 | 219,523.06 | -0.04% |
+| 2026-06-01 | 89,843.52 | 309,366.57 | 28.24% |
+| 2026-07-01 | 75,150.27 | 384,516.85 | -16.35% |
+
+`Effective Cost MoM Growth` is the metric a cost-anomaly alert fires on.
+
+## Using a real cloud export
+
+The model targets standard FOCUS columns only, so it ports to a real export by changing `code` and `schema` on the data objects and the `defaultDialect` setting.
+
+One caveat for Google Cloud. Its FOCUS export puts every standard FOCUS column in a scalar type, but carries labels, credits, tags and project ancestry as `REPEATED RECORD` extension columns prefixed `x_`:
+
+| Column | Type |
+|---|---|
+| `x_Credits`, `x_Labels`, `x_Tags`, `x_SystemLabels`, `x_ProjectLabels` | `REPEATED RECORD` |
+| `x_Project` | `RECORD` (with a repeated `Ancestors`) |
+
+OBML models relational columns, so reach those through a flattening BigQuery view and point `code` at the view. Note that `x_Credits` being repeated means credits are a *second fact at a different grain* inside the same table, not a labels convenience — model it as its own data object.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `examples/finops.obml.yml` | The semantic model |
+| `scripts/build_finops_duckdb.py` | Generates `examples/finops.duckdb` |
+
+## See also
+
+- [FOCUS specification](https://focus.finops.org/focus-specification/)
+- [Multi-fact queries and the composite fact layer](../guide/compilation.md)
+- [TPC-DS Benchmark](tpcds.md) — the other multi-fact example

--- a/examples/finops.obml.yml
+++ b/examples/finops.obml.yml
@@ -1,0 +1,698 @@
+# yaml-language-server: $schema=../schema/obml-schema.json
+#
+# FOCUS FinOps Semantic Model for OrionBelt
+#
+# FOCUS is the FinOps Open Cost and Usage Specification (https://focus.finops.org),
+# the FinOps Foundation's vendor-neutral schema for technology cost and usage
+# data. AWS, Microsoft Azure, Google Cloud and OCI all publish FOCUS exports.
+#
+# FOCUS standardises the *physical* schema: column names, data types, allowed
+# values, requirement levels. It does not define metrics, dimensional
+# hierarchies, or how its datasets join. That semantic layer is what this model
+# supplies.
+#
+# Since FOCUS 1.4 the specification is multi-dataset. This model reproduces the
+# shape that matters:
+#
+#     Billing Periods  <-- Charges           (usage, daily grain)
+#           ^
+#           +---------- Invoice Details      (invoice lines, monthly grain)
+#
+# Charges and Invoice Details are independent facts. Nothing joins one to the
+# other; they only meet at Billing Periods. So asking for cost and invoiced
+# amount together is a genuine multi-fact query, and OrionBelt answers it
+# through the composite fact layer rather than fanning the rows out. That is
+# invoice reconciliation, FOCUS 1.4's headline use case.
+#
+# Build the data first:
+#     uv run python scripts/build_finops_duckdb.py
+#
+# Every column below is a standard FOCUS column, and every one is scalar - which
+# is true of the specification itself. Provider-specific extensions (the "x_"
+# columns in a real Google Cloud export) are nested and are deliberately out of
+# scope here.
+
+version: 1.0
+
+settings:
+  defaultNumericDataType: "decimal(18, 2)"
+  defaultDialect: duckdb
+
+dataObjects:
+  # ── Conformed root ─────────────────────────────────────────────────
+  # The only object both facts can reach. JoinGraph.find_common_root()
+  # resolves to this for any cross-fact query.
+
+  Billing Periods:
+    code: billing_periods
+    schema: focus
+    description: One row per billing account per billing period (month).
+    columns:
+      Period Start:
+        code: BillingPeriodStart
+        abstractType: timestamp
+        primaryKey: true
+      Period End:
+        code: BillingPeriodEnd
+        abstractType: timestamp
+      Period Key:
+        code: BillingPeriodKey
+        abstractType: string
+      Period Year:
+        code: BillingPeriodYear
+        abstractType: int
+        numClass: categorical
+      Period Month:
+        code: BillingPeriodMonth
+        abstractType: int
+        numClass: categorical
+      Period Label:
+        code: BillingPeriodLabel
+        abstractType: string
+      Account Id:
+        code: BillingAccountId
+        abstractType: string
+      Account Name:
+        code: BillingAccountName
+        abstractType: string
+      Period Currency:
+        code: BillingCurrency
+        abstractType: string
+
+  # ── Second conformed dimension ─────────────────────────────────────
+  # Provider is the other thing both facts have in common. It has to be its own
+  # object for a cross-fact query to group by it: left as a plain column on each
+  # fact, it would populate on the Charges leg and come back NULL on the
+  # Invoice Details leg, quietly splitting every reconciliation row in two.
+
+  Providers:
+    code: providers
+    schema: focus
+    description: Cloud providers, conformed across both facts.
+    columns:
+      Provider Name:
+        code: ProviderName
+        abstractType: string
+        primaryKey: true
+      Provider Publisher:
+        code: PublisherName
+        abstractType: string
+      Provider Invoice Issuer:
+        code: InvoiceIssuerName
+        abstractType: string
+
+  # ── Contract Commitment dataset ────────────────────────────────────
+
+  Commitments:
+    code: commitments
+    schema: focus
+    description: >-
+      Savings plans, reserved instances and committed use discounts. FOCUS 1.4
+      grew this dataset from 13 to 30 columns; the subset here is what a
+      coverage or utilisation question actually needs.
+    columns:
+      Commitment Id:
+        code: CommitmentDiscountId
+        abstractType: string
+        primaryKey: true
+      Commitment Name:
+        code: CommitmentDiscountName
+        abstractType: string
+      Commitment Type Code:
+        code: CommitmentDiscountType
+        abstractType: string
+      Commitment Category Code:
+        code: CommitmentDiscountCategory
+        abstractType: string
+      Commitment Status Code:
+        code: CommitmentDiscountStatus
+        abstractType: string
+      Commitment Provider:
+        code: ProviderName
+        abstractType: string
+      Commitment Service Category:
+        code: ServiceCategory
+        abstractType: string
+      Commitment Start:
+        code: CommitmentStart
+        abstractType: timestamp
+      Commitment End:
+        code: CommitmentEnd
+        abstractType: timestamp
+      Committed Amount Value:
+        code: CommittedAmount
+        abstractType: float
+      Commitment Currency:
+        code: BillingCurrency
+        abstractType: string
+
+  # ── Charges dataset (fact 1) ───────────────────────────────────────
+
+  Charges:
+    code: charges
+    schema: focus
+    description: >-
+      One row per resource per SKU per charge period. The core FOCUS dataset.
+    columns:
+      Charge Account Id:
+        code: BillingAccountId
+        abstractType: string
+      Charge Account Name:
+        code: BillingAccountName
+        abstractType: string
+      Sub Account Id:
+        code: SubAccountId
+        abstractType: string
+      Sub Account Name:
+        code: SubAccountName
+        abstractType: string
+      Charge Billing Period Start:
+        code: BillingPeriodStart
+        abstractType: timestamp
+      Charge Billing Period End:
+        code: BillingPeriodEnd
+        abstractType: timestamp
+      Charge Period Start:
+        code: ChargePeriodStart
+        abstractType: timestamp
+      Charge Period End:
+        code: ChargePeriodEnd
+        abstractType: timestamp
+      Provider:
+        code: ProviderName
+        abstractType: string
+      Publisher:
+        code: PublisherName
+        abstractType: string
+      Charge Invoice Issuer:
+        code: InvoiceIssuerName
+        abstractType: string
+      Service:
+        code: ServiceName
+        abstractType: string
+      Service Category Code:
+        code: ServiceCategory
+        abstractType: string
+      Sku:
+        code: SkuId
+        abstractType: string
+      Sku Price Id:
+        code: SkuPriceId
+        abstractType: string
+      Resource Id:
+        code: ResourceId
+        abstractType: string
+      Resource Name:
+        code: ResourceName
+        abstractType: string
+      Resource Type Code:
+        code: ResourceType
+        abstractType: string
+      Region Id:
+        code: RegionId
+        abstractType: string
+      Region Name:
+        code: RegionName
+        abstractType: string
+      Availability Zone Code:
+        code: AvailabilityZone
+        abstractType: string
+      Charge Category Code:
+        code: ChargeCategory
+        abstractType: string
+      Charge Class Code:
+        code: ChargeClass
+        abstractType: string
+      Charge Description:
+        code: ChargeDescription
+        abstractType: string
+      Charge Frequency Code:
+        code: ChargeFrequency
+        abstractType: string
+      Pricing Category Code:
+        code: PricingCategory
+        abstractType: string
+      Pricing Quantity Value:
+        code: PricingQuantity
+        abstractType: float
+      Pricing Unit Code:
+        code: PricingUnit
+        abstractType: string
+      Consumed Quantity Value:
+        code: ConsumedQuantity
+        abstractType: float
+      Consumed Unit Code:
+        code: ConsumedUnit
+        abstractType: string
+      List Unit Price Value:
+        code: ListUnitPrice
+        abstractType: float
+        numClass: non-additive
+      Contracted Unit Price Value:
+        code: ContractedUnitPrice
+        abstractType: float
+        numClass: non-additive
+      List Cost Value:
+        code: ListCost
+        abstractType: float
+      Contracted Cost Value:
+        code: ContractedCost
+        abstractType: float
+      Billed Cost Value:
+        code: BilledCost
+        abstractType: float
+      Effective Cost Value:
+        code: EffectiveCost
+        abstractType: float
+      Charge Currency:
+        code: BillingCurrency
+        abstractType: string
+      Charge Commitment Id:
+        code: CommitmentDiscountId
+        abstractType: string
+      Charge Commitment Type:
+        code: CommitmentDiscountType
+        abstractType: string
+      Charge Commitment Category:
+        code: CommitmentDiscountCategory
+        abstractType: string
+      Charge Commitment Status:
+        code: CommitmentDiscountStatus
+        abstractType: string
+    joins:
+      - joinType: many-to-one
+        joinTo: Billing Periods
+        columnsFrom:
+          - Charge Billing Period Start
+        columnsTo:
+          - Period Start
+      - joinType: many-to-one
+        joinTo: Commitments
+        columnsFrom:
+          - Charge Commitment Id
+        columnsTo:
+          - Commitment Id
+      - joinType: many-to-one
+        joinTo: Providers
+        columnsFrom:
+          - Provider
+        columnsTo:
+          - Provider Name
+
+  # ── Invoice Detail dataset (fact 2) ────────────────────────────────
+
+  Invoice Details:
+    code: invoice_details
+    schema: focus
+    description: >-
+      One row per invoice line. Added in FOCUS 1.4 to close the loop from
+      commitment to consumption to invoice. Independent of Charges: it shares
+      only the billing period, which is precisely why reconciling the two is a
+      multi-fact query.
+    columns:
+      Invoice Id:
+        code: InvoiceId
+        abstractType: string
+      Invoice Line Number:
+        code: InvoiceLineNumber
+        abstractType: int
+        numClass: categorical
+      Invoice Issuer:
+        code: InvoiceIssuerName
+        abstractType: string
+      Invoice Provider:
+        code: ProviderName
+        abstractType: string
+      Invoice Account Id:
+        code: BillingAccountId
+        abstractType: string
+      Invoice Billing Period Start:
+        code: BillingPeriodStart
+        abstractType: timestamp
+      Invoice Billing Period End:
+        code: BillingPeriodEnd
+        abstractType: timestamp
+      Invoice Line Detail:
+        code: InvoiceLineDetail
+        abstractType: string
+      Invoiced Amount Value:
+        code: InvoicedAmount
+        abstractType: float
+      Invoice Tax Value:
+        code: InvoiceTaxAmount
+        abstractType: float
+      Invoice Total Value:
+        code: InvoiceTotalAmount
+        abstractType: float
+      Invoice Currency:
+        code: BillingCurrency
+        abstractType: string
+    joins:
+      - joinType: many-to-one
+        joinTo: Billing Periods
+        columnsFrom:
+          - Invoice Billing Period Start
+        columnsTo:
+          - Period Start
+      - joinType: many-to-one
+        joinTo: Providers
+        columnsFrom:
+          - Invoice Provider
+        columnsTo:
+          - Provider Name
+
+# ── Dimensions ───────────────────────────────────────────────────────
+
+dimensions:
+  Billing Period:
+    dataObject: Billing Periods
+    column: Period Label
+    resultType: string
+    description: Human-readable billing month, e.g. "March 2026".
+  Billing Month:
+    dataObject: Billing Periods
+    column: Period Start
+    resultType: timestamp
+    description: Billing period start, for time-series and period-over-period.
+  Billing Account:
+    dataObject: Billing Periods
+    column: Account Name
+    resultType: string
+
+  Charge Date:
+    dataObject: Charges
+    column: Charge Period Start
+    resultType: timestamp
+    description: Start of the charge period. Daily grain in this dataset.
+  Provider:
+    dataObject: Providers
+    column: Provider Name
+    resultType: string
+    synonyms: [cloud, vendor, cloud provider]
+    description: Conformed across Charges and Invoice Details, so it survives a cross-fact query.
+  Publisher:
+    dataObject: Providers
+    column: Provider Publisher
+    resultType: string
+  Service:
+    dataObject: Charges
+    column: Service
+    resultType: string
+  Service Category:
+    dataObject: Charges
+    column: Service Category Code
+    resultType: string
+    description: FOCUS ServiceCategory, e.g. Compute, Storage, Databases.
+  Sub Account:
+    dataObject: Charges
+    column: Sub Account Name
+    resultType: string
+    synonyms: [project, subscription, account]
+    description: The cost-allocation unit - AWS account, Azure subscription, Google Cloud project.
+  Region:
+    dataObject: Charges
+    column: Region Name
+    resultType: string
+  Resource:
+    dataObject: Charges
+    column: Resource Name
+    resultType: string
+  Resource Type:
+    dataObject: Charges
+    column: Resource Type Code
+    resultType: string
+  Sku Id:
+    dataObject: Charges
+    column: Sku
+    resultType: string
+  Charge Category:
+    dataObject: Charges
+    column: Charge Category Code
+    resultType: string
+    description: FOCUS ChargeCategory, e.g. Usage, Purchase, Tax, Credit.
+  Pricing Category:
+    dataObject: Charges
+    column: Pricing Category Code
+    resultType: string
+    description: FOCUS PricingCategory, e.g. Standard, Committed, Dynamic.
+  Consumed Unit:
+    dataObject: Charges
+    column: Consumed Unit Code
+    resultType: string
+
+  Commitment:
+    dataObject: Commitments
+    column: Commitment Name
+    resultType: string
+  Commitment Type:
+    dataObject: Commitments
+    column: Commitment Type Code
+    resultType: string
+    description: Savings Plan, Reserved Instance, Committed Use Discount.
+  Commitment Category:
+    dataObject: Commitments
+    column: Commitment Category Code
+    resultType: string
+    description: FOCUS CommitmentDiscountCategory - Spend or Usage.
+
+  Invoice:
+    dataObject: Invoice Details
+    column: Invoice Id
+    resultType: string
+  Invoice Issuer:
+    dataObject: Invoice Details
+    column: Invoice Issuer
+    resultType: string
+
+# ── Measures ─────────────────────────────────────────────────────────
+#
+# Monetary measures are declared at the source columns' precision,
+# decimal(18, 6), and rely on `format` for display. This is deliberate: cloud
+# billing has genuine sub-cent line items (AWS Lambda bills GB-seconds at
+# ~0.0000167 each), so rounding every row to 2dp before aggregating loses real
+# money at scale. Declare the compute precision here; round for the reader.
+
+measures:
+  # Charges fact
+  Billed Cost:
+    columns:
+      - dataObject: Charges
+        column: Billed Cost Value
+    resultType: float
+    aggregation: sum
+    dataType: "decimal(18, 6)"
+    format: "#,##0.00"
+    synonyms: [spend, cost, charges]
+    description: Cash cost as charged by the provider.
+
+  Effective Cost:
+    columns:
+      - dataObject: Charges
+        column: Effective Cost Value
+    resultType: float
+    aggregation: sum
+    dataType: "decimal(18, 6)"
+    format: "#,##0.00"
+    synonyms: [amortized cost, true cost]
+    description: >-
+      Cost with commitment purchases amortised over the period they cover. The
+      number a FinOps practitioner uses for showback and unit economics.
+
+  List Cost:
+    columns:
+      - dataObject: Charges
+        column: List Cost Value
+    resultType: float
+    aggregation: sum
+    dataType: "decimal(18, 6)"
+    format: "#,##0.00"
+    description: What the usage would have cost at published on-demand rates.
+
+  Contracted Cost:
+    columns:
+      - dataObject: Charges
+        column: Contracted Cost Value
+    resultType: float
+    aggregation: sum
+    dataType: "decimal(18, 6)"
+    format: "#,##0.00"
+    description: Cost at negotiated rates, before commitment amortisation.
+
+  Consumed Quantity:
+    columns:
+      - dataObject: Charges
+        column: Consumed Quantity Value
+    resultType: float
+    aggregation: sum
+    dataType: "decimal(18, 4)"
+    format: "#,##0.0000"
+
+  Resource Count:
+    columns:
+      - dataObject: Charges
+        column: Resource Id
+    resultType: int
+    aggregation: count_distinct
+    dataType: bigint
+    format: "#,##0"
+
+  Total Effective Cost:
+    columns:
+      - dataObject: Charges
+        column: Effective Cost Value
+    resultType: float
+    aggregation: sum
+    dataType: "decimal(18, 6)"
+    format: "#,##0.00"
+    grain:
+      mode: FIXED
+    description: Effective cost across all dimensions, for share-of-spend.
+
+  # Invoice Details fact
+  Invoiced Amount:
+    columns:
+      - dataObject: Invoice Details
+        column: Invoiced Amount Value
+    resultType: float
+    aggregation: sum
+    dataType: "decimal(18, 6)"
+    format: "#,##0.00"
+    description: Net amount on the invoice, before tax.
+
+  Invoice Tax:
+    columns:
+      - dataObject: Invoice Details
+        column: Invoice Tax Value
+    resultType: float
+    aggregation: sum
+    dataType: "decimal(18, 6)"
+    format: "#,##0.00"
+
+  Invoice Total:
+    columns:
+      - dataObject: Invoice Details
+        column: Invoice Total Value
+    resultType: float
+    aggregation: sum
+    dataType: "decimal(18, 6)"
+    format: "#,##0.00"
+
+  # Commitments
+  Committed Amount:
+    columns:
+      - dataObject: Commitments
+        column: Committed Amount Value
+    resultType: float
+    aggregation: sum
+    dataType: "decimal(18, 6)"
+    format: "#,##0.00"
+    description: Contract value of the commitment over its whole term.
+
+# ── Metrics ──────────────────────────────────────────────────────────
+
+metrics:
+  Effective Savings Rate:
+    expression: "1 - {[Effective Cost]} / {[List Cost]}"
+    dataType: "decimal(5, 4)"
+    format: "0.00%"
+    description: >-
+      Share of on-demand list price avoided through negotiated rates and
+      commitments. The headline FinOps rate-optimisation metric.
+
+  Commitment Savings Rate:
+    expression: "1 - {[Effective Cost]} / {[Contracted Cost]}"
+    dataType: "decimal(5, 4)"
+    format: "0.00%"
+    description: Savings attributable to commitments alone, excluding negotiated rates.
+
+  Negotiated Discount Rate:
+    expression: "1 - {[Contracted Cost]} / {[List Cost]}"
+    dataType: "decimal(5, 4)"
+    format: "0.00%"
+    description: Savings from negotiated rates alone, before commitments.
+
+  Unit Cost:
+    expression: "{[Effective Cost]} / {[Consumed Quantity]}"
+    dataType: "decimal(18, 6)"
+    format: "#,##0.000000"
+    description: Effective cost per consumed unit. Only meaningful within one Consumed Unit.
+
+  Cost per Resource:
+    expression: "{[Effective Cost]} / {[Resource Count]}"
+    dataType: "decimal(18, 2)"
+    format: "#,##0.00"
+
+  Pct of Total Spend:
+    expression: "{[Effective Cost]} / {[Total Effective Cost]}"
+    dataType: "decimal(5, 4)"
+    format: "0.00%"
+
+  Commitment Utilization:
+    expression: "{[Effective Cost]} / {[Committed Amount]}"
+    dataType: "decimal(5, 4)"
+    format: "0.00%"
+    description: >-
+      Amortised cost drawn against the commitment's contract value. Under 100%
+      means committed spend is going to waste.
+
+  # ── Cross-fact: the reconciliation pair ───────────────────────────
+  # Billed Cost lives on Charges, Invoiced Amount on Invoice Details. Nothing
+  # joins those two objects, so these metrics force the composite fact layer.
+  # A BI tool that joins both facts to the billing period in one query instead
+  # multiplies charge rows by invoice lines and silently overstates both.
+
+  Invoice Variance:
+    expression: "{[Billed Cost]} - {[Invoiced Amount]}"
+    dataType: "decimal(18, 2)"
+    format: "#,##0.00"
+    description: >-
+      Charged minus invoiced. Should be near zero; a drift means credits,
+      rounding or late-landing usage. FOCUS 1.4's invoice reconciliation case.
+
+  Invoice Variance Pct:
+    expression: "({[Billed Cost]} - {[Invoiced Amount]}) / {[Invoiced Amount]}"
+    dataType: "decimal(8, 6)"
+    format: "0.0000%"
+
+  # ── Cumulative ────────────────────────────────────────────────────
+  Running Effective Cost:
+    type: cumulative
+    measure: Effective Cost
+    timeDimension: Charge Date
+    dataType: "decimal(18, 2)"
+    format: "#,##0.00"
+    description: Running total of amortised cost over time.
+
+  Rolling 3m Effective Cost:
+    type: cumulative
+    measure: Effective Cost
+    timeDimension: Charge Date
+    cumulativeType: sum
+    window: 3
+    dataType: "decimal(18, 2)"
+    format: "#,##0.00"
+    description: Three-month rolling spend, the usual smoothing for a spend trend.
+
+  # ── Period over period ────────────────────────────────────────────
+  Effective Cost MoM Change:
+    type: period_over_period
+    expression: "{[Effective Cost]}"
+    periodOverPeriod:
+      timeDimension: Charge Date
+      grain: month
+      offsetGrain: month
+      comparison: difference
+    dataType: "decimal(18, 2)"
+    format: "#,##0.00"
+    description: Absolute month-over-month spend change. The anomaly-detection metric.
+
+  Effective Cost MoM Growth:
+    type: period_over_period
+    expression: "{[Effective Cost]}"
+    periodOverPeriod:
+      timeDimension: Charge Date
+      grain: month
+      offsetGrain: month
+      comparison: percentChange
+    dataType: "decimal(5, 4)"
+    format: "0.00%"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -156,6 +156,7 @@ nav:
       - Multi-Dialect Output: examples/multi-dialect.md
       - "Multi-Fact: Sales & Returns": examples/multi-fact.md
       - TPC-DS Benchmark: examples/tpcds.md
+      - "FinOps on FOCUS": examples/finops-focus.md
   - Comparison:
       - Overview: comparison/index.md
       - vs. dbt Semantic Layer: comparison/dbt.md

--- a/scripts/build_finops_duckdb.py
+++ b/scripts/build_finops_duckdb.py
@@ -1,0 +1,614 @@
+"""Build the FOCUS FinOps showcase DuckDB file.
+
+Creates ``examples/finops.duckdb`` with four tables that mirror the datasets
+defined by FOCUS (the FinOps Open Cost and Usage Specification, the FinOps
+Foundation's vendor-neutral schema for technology cost and usage data):
+
+    billing_periods   one row per billing account per month  (conformed root)
+    charges           one row per resource per SKU per day   (fact)
+    invoice_details   one row per invoice line               (fact)
+    commitments       one row per contract commitment        (dimension)
+
+``charges`` and ``invoice_details`` are deliberately *independent* facts that
+only meet at ``billing_periods``. That is what makes invoice reconciliation
+("does what we were charged match what we were invoiced?") a multi-fact
+question, and it is the case the composite fact layer exists to answer.
+
+Only standard FOCUS columns are generated - every column here is scalar, which
+is true of the specification itself. Provider-specific extensions (the ``x_``
+columns in a real Google Cloud export) are nested and are not modelled here.
+
+Run:
+    uv run python scripts/build_finops_duckdb.py
+
+The generated .duckdb file is gitignored and rebuilt on demand, matching how
+``build_demo_duckdb.py`` treats ``orionbelt_1_commerce.duckdb``.
+"""
+
+from __future__ import annotations
+
+import random
+from datetime import date, datetime, timedelta
+from pathlib import Path
+
+import duckdb
+
+# This script lives at <repo>/scripts/build_finops_duckdb.py, so the repo root is
+# its parent's parent. Anchoring on __file__ keeps it correct regardless of the
+# caller's working directory.
+REPO = Path(__file__).resolve().parents[1]
+OUT = REPO / "examples" / "finops.duckdb"
+# Database is the domain (finops), schema is the specification the tables
+# conform to (focus). Keeping them distinct also avoids DuckDB refusing a schema
+# whose name collides with the catalog name taken from the file.
+SCHEMA = "focus"
+
+SEED = 20260816
+random.seed(SEED)
+
+CURRENCY = "EUR"
+
+# ---------------------------------------------------------------------------
+# Reference data
+#
+# ServiceCategory values are the FOCUS-defined set; ChargeCategory and
+# PricingCategory likewise. Keeping to the specification's allowed values is
+# the point of the showcase, so they are not invented here.
+# ---------------------------------------------------------------------------
+
+# (ProviderName, PublisherName, InvoiceIssuerName)
+PROVIDERS = [
+    ("Amazon Web Services", "Amazon Web Services", "Amazon Web Services"),
+    ("Microsoft Azure", "Microsoft", "Microsoft"),
+    ("Google Cloud", "Google", "Google"),
+]
+
+# (ServiceName, ServiceCategory, ResourceType, ConsumedUnit, list price per unit)
+SERVICES = {
+    "Amazon Web Services": [
+        ("Amazon EC2", "Compute", "Instance", "Hours", 0.096),
+        ("Amazon S3", "Storage", "Bucket", "GB-Months", 0.023),
+        ("Amazon RDS", "Databases", "Database Instance", "Hours", 0.145),
+        ("AWS Lambda", "Compute", "Function", "GB-Seconds", 0.0000167),
+        ("Amazon CloudFront", "Networking", "Distribution", "GB", 0.085),
+        ("Amazon EKS", "Compute", "Cluster", "Hours", 0.10),
+    ],
+    "Microsoft Azure": [
+        ("Virtual Machines", "Compute", "Virtual Machine", "Hours", 0.104),
+        ("Blob Storage", "Storage", "Storage Account", "GB-Months", 0.0184),
+        ("Azure SQL Database", "Databases", "Database", "Hours", 0.152),
+        ("Azure Functions", "Compute", "Function App", "GB-Seconds", 0.000016),
+        ("Azure CDN", "Networking", "Endpoint", "GB", 0.081),
+        ("Azure Kubernetes Service", "Compute", "Cluster", "Hours", 0.10),
+    ],
+    "Google Cloud": [
+        ("Compute Engine", "Compute", "Instance", "Hours", 0.089),
+        ("Cloud Storage", "Storage", "Bucket", "GB-Months", 0.020),
+        ("Cloud SQL", "Databases", "Database Instance", "Hours", 0.138),
+        ("Cloud Run", "Compute", "Service", "vCPU-Seconds", 0.000024),
+        ("Cloud CDN", "Networking", "Backend", "GB", 0.080),
+        ("Google Kubernetes Engine", "Compute", "Cluster", "Hours", 0.10),
+    ],
+}
+
+# (RegionId, RegionName, AvailabilityZone)
+REGIONS = [
+    ("eu-west-1", "EU (Ireland)", "eu-west-1a"),
+    ("eu-central-1", "EU (Frankfurt)", "eu-central-1b"),
+    ("us-east-1", "US East (N. Virginia)", "us-east-1a"),
+    ("us-west-2", "US West (Oregon)", "us-west-2c"),
+    ("ap-southeast-1", "Asia Pacific (Singapore)", "ap-southeast-1a"),
+]
+
+# (SubAccountId, SubAccountName) - the cost-allocation unit (AWS account,
+# Azure subscription, Google Cloud project).
+SUB_ACCOUNTS = [
+    ("sub-1001", "platform-prod"),
+    ("sub-1002", "platform-staging"),
+    ("sub-1003", "data-analytics"),
+    ("sub-1004", "ml-research"),
+    ("sub-1005", "corp-shared-services"),
+]
+
+BILLING_ACCOUNT_ID = "acct-0001"
+BILLING_ACCOUNT_NAME = "Contoso Group"
+
+# Six months of billing periods.
+PERIODS = [(2026, m) for m in range(3, 9)]
+
+
+def month_bounds(year: int, month: int) -> tuple[date, date]:
+    """Return the first day of the month and the first day of the next month."""
+    start = date(year, month, 1)
+    end = date(year + 1, 1, 1) if month == 12 else date(year, month + 1, 1)
+    return start, end
+
+
+# ---------------------------------------------------------------------------
+# Commitments
+# ---------------------------------------------------------------------------
+
+
+def build_commitments() -> list[tuple]:
+    """One commitment per provider per category, spanning the whole window."""
+    rows = []
+    specs = [
+        ("Savings Plan", "Usage", "Amazon Web Services", 45000.0, "Compute"),
+        ("Reserved Instance", "Usage", "Amazon Web Services", 22000.0, "Databases"),
+        ("Reservation", "Usage", "Microsoft Azure", 38000.0, "Compute"),
+        ("Savings Plan", "Spend", "Microsoft Azure", 15000.0, "Databases"),
+        ("Committed Use Discount", "Spend", "Google Cloud", 41000.0, "Compute"),
+        ("Committed Use Discount", "Usage", "Google Cloud", 12000.0, "Databases"),
+    ]
+    start, _ = month_bounds(*PERIODS[0])
+    _, end = month_bounds(*PERIODS[-1])
+    for i, (ctype, category, provider, amount, service_category) in enumerate(specs, 1):
+        rows.append(
+            (
+                f"cd-{i:03d}",
+                f"{provider} {ctype} {i}",
+                ctype,
+                category,
+                "Active",
+                provider,
+                service_category,
+                datetime.combine(start, datetime.min.time()),
+                datetime.combine(end, datetime.min.time()),
+                round(amount, 2),
+                CURRENCY,
+            )
+        )
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Charges
+# ---------------------------------------------------------------------------
+
+
+def build_charges(commitments: list[tuple]) -> list[tuple]:
+    """Daily usage charges, plus a monthly tax/purchase charge per provider.
+
+    Discounting is modelled the way FOCUS intends it: ListCost is what the
+    published rate would have cost, ContractedCost applies the negotiated rate,
+    and EffectiveCost additionally amortises commitment coverage. Rows covered
+    by a commitment carry its CommitmentDiscountId, which is what lets a query
+    ask "how much of our committed spend did we actually use?".
+    """
+    # Commitments indexed by (provider, service category) so a charge can be
+    # matched to the commitment that would plausibly cover it.
+    by_provider: dict[tuple[str, str], str] = {(row[5], row[6]): row[0] for row in commitments}
+    commitment_meta = {row[0]: (row[2], row[3], row[4]) for row in commitments}
+
+    rows: list[tuple] = []
+    for year, month in PERIODS:
+        p_start, p_end = month_bounds(year, month)
+        n_days = (p_end - p_start).days
+
+        for provider, publisher, issuer in PROVIDERS:
+            for service_name, service_cat, resource_type, unit, list_rate in SERVICES[provider]:
+                # A stable handful of resources per service, so ResourceId is
+                # meaningful across periods rather than random noise.
+                n_resources = random.randint(3, 6)
+                for r in range(n_resources):
+                    sub_id, sub_name = random.choice(SUB_ACCOUNTS)
+                    region_id, region_name, az = random.choice(REGIONS)
+                    resource_id = (
+                        f"{provider[:3].lower()}-{service_name[:4].lower().strip()}"
+                        f"-{region_id}-{r:02d}"
+                    ).replace(" ", "")
+                    resource_name = f"{service_name} {r + 1}"
+                    sku_id = f"SKU-{abs(hash((provider, service_name, region_id))) % 90000 + 10000}"
+                    sku_price_id = f"{sku_id}-P{r % 3 + 1}"
+
+                    commitment_id = by_provider.get((provider, service_cat))
+                    # Only ~55% of eligible rows are actually covered.
+                    covered = commitment_id is not None and random.random() < 0.55
+
+                    # A gentle upward usage trend across the window, plus noise.
+                    trend = 1.0 + 0.06 * PERIODS.index((year, month))
+                    base = random.uniform(40, 900) * trend
+
+                    for d in range(n_days):
+                        day = p_start + timedelta(days=d)
+                        # Weekends are quieter for non-storage services.
+                        weekend = day.weekday() >= 5
+                        factor = 0.55 if (weekend and service_cat != "Storage") else 1.0
+                        qty = round(base * factor * random.uniform(0.85, 1.15), 4)
+                        if qty <= 0:
+                            continue
+
+                        list_cost = qty * list_rate
+                        # Negotiated rate: 0-12% off list.
+                        contracted_rate = list_rate * (1 - random.uniform(0.0, 0.12))
+                        contracted_cost = qty * contracted_rate
+                        # BilledCost is the cash that lands on the invoice for
+                        # this row; EffectiveCost additionally amortises the
+                        # benefit of any commitment covering it. They differ
+                        # only where a commitment applies, which is exactly the
+                        # distinction FOCUS draws between the two columns.
+                        billed_cost = contracted_cost
+                        if covered:
+                            effective_cost = contracted_cost * (1 - random.uniform(0.15, 0.35))
+                        else:
+                            effective_cost = contracted_cost
+
+                        ctype, ccat, cstatus = (
+                            commitment_meta[commitment_id] if covered else (None, None, None)
+                        )
+
+                        rows.append(
+                            (
+                                BILLING_ACCOUNT_ID,
+                                BILLING_ACCOUNT_NAME,
+                                sub_id,
+                                sub_name,
+                                datetime.combine(p_start, datetime.min.time()),
+                                datetime.combine(p_end, datetime.min.time()),
+                                datetime.combine(day, datetime.min.time()),
+                                datetime.combine(day + timedelta(days=1), datetime.min.time()),
+                                provider,
+                                publisher,
+                                issuer,
+                                service_name,
+                                service_cat,
+                                sku_id,
+                                sku_price_id,
+                                resource_id,
+                                resource_name,
+                                resource_type,
+                                region_id,
+                                region_name,
+                                az,
+                                "Usage",
+                                None,
+                                f"{service_name} {resource_type.lower()} usage",
+                                "Usage-Based",
+                                "Standard" if not covered else "Committed",
+                                round(qty, 4),
+                                unit,
+                                round(qty, 4),
+                                unit,
+                                round(list_rate, 8),
+                                round(contracted_rate, 8),
+                                round(list_cost, 6),
+                                round(contracted_cost, 6),
+                                round(billed_cost, 6),
+                                round(effective_cost, 6),
+                                CURRENCY,
+                                commitment_id if covered else None,
+                                ctype,
+                                ccat,
+                                cstatus,
+                            )
+                        )
+
+            # One tax charge per provider per period, so ChargeCategory has a
+            # non-Usage value and cost-vs-invoice reconciliation has something
+            # real to explain.
+            tax = round(random.uniform(400, 1800), 2)
+            rows.append(
+                (
+                    BILLING_ACCOUNT_ID,
+                    BILLING_ACCOUNT_NAME,
+                    SUB_ACCOUNTS[0][0],
+                    SUB_ACCOUNTS[0][1],
+                    datetime.combine(p_start, datetime.min.time()),
+                    datetime.combine(p_end, datetime.min.time()),
+                    datetime.combine(p_start, datetime.min.time()),
+                    datetime.combine(p_end, datetime.min.time()),
+                    provider,
+                    publisher,
+                    issuer,
+                    "Tax",
+                    "Other",
+                    "SKU-TAX",
+                    "SKU-TAX-P1",
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    "Tax",
+                    None,
+                    "Value added tax",
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    tax,
+                    tax,
+                    tax,
+                    tax,
+                    CURRENCY,
+                    None,
+                    None,
+                    None,
+                    None,
+                )
+            )
+    return rows
+
+
+def rightsize_commitments(commitments: list[tuple], charges: list[tuple]) -> list[tuple]:
+    """Set each commitment's contract value from the spend it actually covered.
+
+    Commitment amounts cannot be picked up front: they have to exceed the spend
+    drawn against them, or utilisation comes out above 100% and the metric reads
+    as nonsense. Working backwards from the generated charges gives every
+    commitment a plausible utilisation in the 62-94% band, which is also the
+    range where the "you are wasting committed spend" conversation happens.
+    """
+    i_effective, i_commitment = 35, 37
+
+    drawn: dict[str, float] = {}
+    for row in charges:
+        cid = row[i_commitment]
+        if cid:
+            drawn[cid] = drawn.get(cid, 0.0) + float(row[i_effective] or 0.0)
+
+    out = []
+    for row in commitments:
+        cid = row[0]
+        covered = drawn.get(cid, 0.0)
+        target_utilisation = random.uniform(0.62, 0.94)
+        amount = round(covered / target_utilisation, 2) if covered else row[9]
+        out.append(row[:9] + (amount,) + row[10:])
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Invoice details
+# ---------------------------------------------------------------------------
+
+
+def build_invoice_details(charges: list[tuple]) -> list[tuple]:
+    """Invoice lines, summarised from charges but deliberately not identical.
+
+    Real invoices differ from the usage export: they round, they land credits
+    and adjustments at invoice level, and they arrive late. Reproducing that
+    drift is the whole point - a reconciliation query that always returns zero
+    variance would demonstrate nothing.
+    """
+    # Index of charge columns used below, kept local so the tuple layout above
+    # stays the single source of truth. These must track the CREATE TABLE
+    # column order for finops.charges.
+    i_period_start, i_provider, i_billed = 4, 8, 34
+
+    totals: dict[tuple, float] = {}
+    for row in charges:
+        key = (row[i_period_start], row[i_provider])
+        totals[key] = totals.get(key, 0.0) + (row[i_billed] or 0.0)
+
+    rows = []
+    line_no = 0
+    for (period_start, provider), billed in sorted(
+        totals.items(), key=lambda kv: (kv[0][0], kv[0][1])
+    ):
+        issuer = next(p[2] for p in PROVIDERS if p[0] == provider)
+        period_end = (
+            date(period_start.year + 1, 1, 1)
+            if period_start.month == 12
+            else date(period_start.year, period_start.month + 1, 1)
+        )
+        invoice_id = f"INV-{provider[:3].upper()}-{period_start:%Y%m}"
+
+        # Split the provider's monthly total across a few invoice lines, then
+        # nudge it so reconciliation finds a small, explainable variance.
+        drift = billed * random.uniform(-0.004, 0.004)
+        invoiced_total = billed + drift
+        n_lines = random.randint(2, 4)
+        weights = [random.uniform(0.5, 1.5) for _ in range(n_lines)]
+        wsum = sum(weights)
+        for li, w in enumerate(weights, 1):
+            line_no += 1
+            amount = invoiced_total * (w / wsum)
+            tax = amount * 0.19
+            rows.append(
+                (
+                    invoice_id,
+                    li,
+                    issuer,
+                    provider,
+                    BILLING_ACCOUNT_ID,
+                    datetime.combine(period_start.date(), datetime.min.time())
+                    if isinstance(period_start, datetime)
+                    else datetime.combine(period_start, datetime.min.time()),
+                    datetime.combine(period_end, datetime.min.time()),
+                    f"{provider} services line {li}",
+                    round(amount, 2),
+                    round(tax, 2),
+                    round(amount + tax, 2),
+                    CURRENCY,
+                )
+            )
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Billing periods
+# ---------------------------------------------------------------------------
+
+
+def build_billing_periods() -> list[tuple]:
+    rows = []
+    for year, month in PERIODS:
+        start, end = month_bounds(year, month)
+        rows.append(
+            (
+                datetime.combine(start, datetime.min.time()),
+                datetime.combine(end, datetime.min.time()),
+                f"{year}-{month:02d}",
+                year,
+                month,
+                start.strftime("%B %Y"),
+                BILLING_ACCOUNT_ID,
+                BILLING_ACCOUNT_NAME,
+                CURRENCY,
+            )
+        )
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Build
+# ---------------------------------------------------------------------------
+
+DDL = f"""
+CREATE SCHEMA IF NOT EXISTS {SCHEMA};
+
+DROP TABLE IF EXISTS {SCHEMA}.charges;
+DROP TABLE IF EXISTS {SCHEMA}.invoice_details;
+DROP TABLE IF EXISTS {SCHEMA}.commitments;
+DROP TABLE IF EXISTS {SCHEMA}.billing_periods;
+DROP TABLE IF EXISTS {SCHEMA}.providers;
+
+CREATE TABLE {SCHEMA}.providers (
+    ProviderName        VARCHAR,
+    PublisherName       VARCHAR,
+    InvoiceIssuerName   VARCHAR
+);
+
+CREATE TABLE {SCHEMA}.billing_periods (
+    BillingPeriodStart   TIMESTAMP,
+    BillingPeriodEnd     TIMESTAMP,
+    BillingPeriodKey     VARCHAR,
+    BillingPeriodYear    INTEGER,
+    BillingPeriodMonth   INTEGER,
+    BillingPeriodLabel   VARCHAR,
+    BillingAccountId     VARCHAR,
+    BillingAccountName   VARCHAR,
+    BillingCurrency      VARCHAR
+);
+
+CREATE TABLE {SCHEMA}.commitments (
+    CommitmentDiscountId        VARCHAR,
+    CommitmentDiscountName      VARCHAR,
+    CommitmentDiscountType      VARCHAR,
+    CommitmentDiscountCategory  VARCHAR,
+    CommitmentDiscountStatus    VARCHAR,
+    ProviderName                VARCHAR,
+    ServiceCategory             VARCHAR,
+    CommitmentStart             TIMESTAMP,
+    CommitmentEnd               TIMESTAMP,
+    CommittedAmount             DECIMAL(18, 2),
+    BillingCurrency             VARCHAR
+);
+
+CREATE TABLE {SCHEMA}.charges (
+    BillingAccountId            VARCHAR,
+    BillingAccountName          VARCHAR,
+    SubAccountId                VARCHAR,
+    SubAccountName              VARCHAR,
+    BillingPeriodStart          TIMESTAMP,
+    BillingPeriodEnd            TIMESTAMP,
+    ChargePeriodStart           TIMESTAMP,
+    ChargePeriodEnd             TIMESTAMP,
+    ProviderName                VARCHAR,
+    PublisherName               VARCHAR,
+    InvoiceIssuerName           VARCHAR,
+    ServiceName                 VARCHAR,
+    ServiceCategory             VARCHAR,
+    SkuId                       VARCHAR,
+    SkuPriceId                  VARCHAR,
+    ResourceId                  VARCHAR,
+    ResourceName                VARCHAR,
+    ResourceType                VARCHAR,
+    RegionId                    VARCHAR,
+    RegionName                  VARCHAR,
+    AvailabilityZone            VARCHAR,
+    ChargeCategory              VARCHAR,
+    ChargeClass                 VARCHAR,
+    ChargeDescription           VARCHAR,
+    ChargeFrequency             VARCHAR,
+    PricingCategory             VARCHAR,
+    PricingQuantity             DECIMAL(18, 4),
+    PricingUnit                 VARCHAR,
+    ConsumedQuantity            DECIMAL(18, 4),
+    ConsumedUnit                VARCHAR,
+    ListUnitPrice               DECIMAL(18, 8),
+    ContractedUnitPrice         DECIMAL(18, 8),
+    ListCost                    DECIMAL(18, 6),
+    ContractedCost              DECIMAL(18, 6),
+    BilledCost                  DECIMAL(18, 6),
+    EffectiveCost               DECIMAL(18, 6),
+    BillingCurrency             VARCHAR,
+    CommitmentDiscountId        VARCHAR,
+    CommitmentDiscountType      VARCHAR,
+    CommitmentDiscountCategory  VARCHAR,
+    CommitmentDiscountStatus    VARCHAR
+);
+
+CREATE TABLE {SCHEMA}.invoice_details (
+    InvoiceId           VARCHAR,
+    InvoiceLineNumber   INTEGER,
+    InvoiceIssuerName   VARCHAR,
+    ProviderName        VARCHAR,
+    BillingAccountId    VARCHAR,
+    BillingPeriodStart  TIMESTAMP,
+    BillingPeriodEnd    TIMESTAMP,
+    InvoiceLineDetail   VARCHAR,
+    InvoicedAmount      DECIMAL(18, 2),
+    InvoiceTaxAmount    DECIMAL(18, 2),
+    InvoiceTotalAmount  DECIMAL(18, 2),
+    BillingCurrency     VARCHAR
+);
+"""
+
+
+def main() -> None:
+    OUT.parent.mkdir(parents=True, exist_ok=True)
+    if OUT.exists():
+        OUT.unlink()
+
+    con = duckdb.connect(str(OUT))
+    con.execute(DDL)
+
+    periods = build_billing_periods()
+    commitments = build_commitments()
+    charges = build_charges(commitments)
+    commitments = rightsize_commitments(commitments, charges)
+    invoices = build_invoice_details(charges)
+
+    # Provider is the one dimension both facts share besides the billing
+    # period. Giving it its own table makes it a conformed dimension, so a
+    # cross-fact query can group by it; left inline on each fact it would only
+    # populate on whichever leg happened to own the column.
+    con.executemany(f"INSERT INTO {SCHEMA}.providers VALUES (?,?,?)", list(PROVIDERS))
+    con.executemany(f"INSERT INTO {SCHEMA}.billing_periods VALUES ({','.join(['?'] * 9)})", periods)
+    con.executemany(
+        f"INSERT INTO {SCHEMA}.commitments VALUES ({','.join(['?'] * 11)})", commitments
+    )
+    con.executemany(f"INSERT INTO {SCHEMA}.charges VALUES ({','.join(['?'] * 41)})", charges)
+    con.executemany(
+        f"INSERT INTO {SCHEMA}.invoice_details VALUES ({','.join(['?'] * 12)})", invoices
+    )
+
+    print(f"providers       : {len(PROVIDERS):>8,}")
+    print(f"billing_periods : {len(periods):>8,}")
+    print(f"commitments     : {len(commitments):>8,}")
+    print(f"charges         : {len(charges):>8,}")
+    print(f"invoice_details : {len(invoices):>8,}")
+
+    billed, effective, listc = con.execute(
+        f"SELECT SUM(BilledCost), SUM(EffectiveCost), SUM(ListCost) FROM {SCHEMA}.charges"
+    ).fetchone()
+    invoiced = con.execute(f"SELECT SUM(InvoicedAmount) FROM {SCHEMA}.invoice_details").fetchone()[
+        0
+    ]
+    print(
+        f"\nbilled={billed:,.2f} effective={effective:,.2f} list={listc:,.2f} "
+        f"invoiced={invoiced:,.2f} variance={billed - invoiced:,.2f} {CURRENCY}"
+    )
+
+    con.close()
+    print(f"\nWrote {OUT}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

A FinOps semantic model built on [FOCUS](https://focus.finops.org), the FinOps Open Cost and Usage Specification, plus a generator for synthetic multi-cloud billing data and a docs walkthrough.

## Why FOCUS is a good fit for OBSL

FOCUS standardises the **physical** schema of cloud billing: column names, data types, allowed values, requirement levels. AWS, Azure, Google Cloud and OCI all publish conformant exports. It deliberately defines no metrics, no dimensional hierarchies, and no join semantics between its datasets.

Since FOCUS 1.4 it is multi-dataset (Charges, Contract Commitment, Invoice Detail, Billing Period), so the missing join semantics now matter. That is the layer this model supplies, and it is not a shape anyone has published as a portable semantic model.

## The multi-fact case is real, not contrived

`Charges` (daily usage) and `Invoice Details` (invoice lines) are independent facts. Nothing joins one to the other; they meet only at two conformed dimensions. So invoice reconciliation, FOCUS 1.4's headline use case, is a genuine cross-fact query and routes through the composite fact layer.

Against the generated data:

| Approach | Billed Cost | Invoiced Amount |
|---|---|---|
| Truth | 518,167.94 | 517,944.37 |
| Composite fact layer | 518,167.94 | 517,944.37 |
| `charges JOIN invoice_details` | 1,730,132.52 | 435,865,817.48 |

Each of the 14,979 charge rows is multiplied by every invoice line for its provider and period. Invoiced amount inflates 842x, silently.

## Notes for review

- **`Provider` is its own data object**, not a column on each fact. A dimension used across facts must be reachable from both, or it populates on one union leg and returns NULL on the other, splitting every reconciliation row in two.
- **Monetary measures are `decimal(18, 6)`**, matching the source columns, with `format` for display. Cloud billing has genuine sub-cent line items (Lambda bills GB-seconds at ~0.0000167), so rounding rows to 2dp before aggregating loses real money at scale. This also sidesteps #305.
- **Commitment amounts are derived from the spend drawn against them** in a second pass, so utilisation lands at 62-94% rather than exceeding 100%.
- **The generator ships, the .duckdb does not**, matching how `build_demo_duckdb.py` treats `orionbelt_1_commerce.duckdb`. `*.duckdb` is already gitignored.
- **Naming**: database `finops` (the domain), schema `focus` (the specification its tables conform to).
- Only standard FOCUS columns are modelled, and every one is scalar. Google Cloud's nested `x_` extension columns are called out in the docs as needing a flattening view.

## Found while building this

#305: the CFL planner casts a measure's declared output `dataType` onto pre-aggregation row values inside each UNION leg, so a multi-fact total disagrees with the star-path total for the same measure. Filed separately, not fixed here.

## Coverage

Derived, cumulative and period-over-period metrics, a FIXED-grain share-of-spend measure, cross-fact metrics, and the grain-dedup warning on a one-side measure.

## Verification

- `obsl validate` passes
- All four documented queries execute against DuckDB, values checked against hand-written ground-truth SQL
- `ruff format` and `ruff check` clean
- `mkdocs build --strict` clean
