### PR TITLE
fix(compiler): CFL legs align on a type that preserves the input (#305)

### DIFF
--- a/src/orionbelt/compiler/cfl.py
+++ b/src/orionbelt/compiler/cfl.py
@@ -338,6 +338,15 @@ class CFLPlanner:
         return cfl_projection.is_multi_field(measure)
 
     @staticmethod
+    def _resolve_union_alignment_type(
+        measure: ResolvedMeasure,
+        model: SemanticModel,
+        dialect: Dialect | None = None,
+    ) -> str | None:
+        """The type every UNION leg agrees on for *measure*'s column."""
+        return cfl_projection.resolve_union_alignment_type(measure, model, dialect)
+
+    @staticmethod
     def _resolve_null_type_for_field(
         measure: ResolvedMeasure,
         field_idx: int,
@@ -579,7 +588,13 @@ class CFLPlanner:
                         if m.name in conformed_exprs
                         else m
                     )
-                    own_type_name = self._resolve_null_type_for_field(m, 0, model, dialect)
+                    # Align on a type that preserves the input, not on the
+                    # measure's declared *output* type: these are
+                    # pre-aggregation rows, and narrowing them here rounds
+                    # every one before the outer SUM sees it. The NULL pads
+                    # below use the same resolver, so the legs still agree,
+                    # which is what the cast was for.
+                    own_type_name = self._resolve_union_alignment_type(m, model, dialect)
                     if own_type_name:
                         own_expr = Cast(expr=own_expr, type_name=own_type_name)
                     leg_builder.select(AliasedExpr(expr=own_expr, alias=m.name))
@@ -592,7 +607,7 @@ class CFLPlanner:
                         )
                 elif not union_by_name:
                     model_measure = model.measures.get(m.name)
-                    null_type_name = self._resolve_null_type_for_field(m, 0, model, dialect)
+                    null_type_name = self._resolve_union_alignment_type(m, model, dialect)
                     if null_type_name is None and model_measure:
                         null_type_name = model_measure.result_type.value
                     null_expr = (

--- a/src/orionbelt/compiler/cfl_projection.py
+++ b/src/orionbelt/compiler/cfl_projection.py
@@ -192,6 +192,11 @@ def resolve_null_type_for_field(
 _ALIGNMENT_SCALE = 12
 _ALIGNMENT_PRECISION = 38
 
+# Only these combine values across rows, so only these compound a
+# pre-aggregation rounding error. Everything else either selects a value
+# (MIN/MAX/ANY_VALUE/MEDIAN/MODE) or projects the raw column (COUNT, LISTAGG).
+_ACCUMULATING_AGGREGATIONS = frozenset({"sum", "avg"})
+
 
 def resolve_union_alignment_type(
     measure: ResolvedMeasure,
@@ -205,38 +210,48 @@ def resolve_union_alignment_type(
     is right for the outer ``CAST(SUM(...) AS ...)`` and wrong here: the legs
     carry **pre-aggregation rows**, so aligning them on the declared output
     type rounds every row before it is summed. A measure declared
-    ``decimal(18, 2)`` over a ``DECIMAL(18, 6)`` column lost up to 0.005 per
-    row, which is invisible on one row and material on fifteen thousand.
+    ``decimal(18, 2)`` over a six-decimal column lost up to 0.005 per row.
 
     The alignment still has to be a single concrete type, because a strict
     engine will not union columns whose types disagree: ClickHouse produces
-    ``Variant(Decimal, Float64)`` and then refuses to ``SUM`` it. So the answer
-    is a type that is common across legs *and* preserves the input, rather than
-    the narrower of the two.
+    ``Variant(Decimal, Float64)`` and then refuses to ``SUM`` it.
+
+    Widening applies only to the aggregations that **accumulate** across rows,
+    which is where pre-aggregation rounding compounds. ``MIN``, ``MAX``,
+    ``ANY_VALUE``, ``MEDIAN`` and ``MODE`` select a value rather than combining
+    values, and ``resolve_measure_data_type`` treats them as no-cast
+    pass-through; widening them changed both the value and its type, turning
+    ``MIN`` over a fifteen-decimal column from 1.000000000000400 into
+    1.000000000000. ``COUNT`` and ``LISTAGG`` project the raw column, whose own
+    type is already the right alignment.
+
+    An **expression** measure has no ``columns`` and is covered: it projects a
+    pre-aggregation expression exactly as a column measure projects a column,
+    so it suffered the same rounding and was missed by an earlier version of
+    this that keyed on having exactly one column.
 
     A model that declares the source column's ``sqlPrecision``/``sqlScale`` is
-    taken at its word. Otherwise the fallback widens to
-    ``decimal(38, 12)``, which carries any realistic money or rate column
-    exactly and still leaves 26 integer digits.
-
-    Non-numeric aggregates keep the existing behaviour: COUNT and LISTAGG
-    project the raw column, whose type is already the right alignment.
+    taken at its word. Otherwise the fallback widens to ``decimal(38, 12)``,
+    which carries any realistic money or rate column exactly and still leaves
+    26 integer digits.
     """
     model_measure = model.effective_measures.get(measure.name)
-    if not model_measure:
-        return None
-    agg = (model_measure.aggregation or "").lower()
-    if agg in ("count", "count_distinct", "listagg") or len(model_measure.columns) != 1:
+    if not model_measure or dialect is None:
         return resolve_null_type_for_field(measure, 0, model, dialect)
-    if dialect is None:
+    if (model_measure.aggregation or "").lower() not in _ACCUMULATING_AGGREGATIONS:
+        return resolve_null_type_for_field(measure, 0, model, dialect)
+    # A multi-field aggregate pads per slot; each slot keeps its own type.
+    if len(model_measure.columns) > 1:
         return resolve_null_type_for_field(measure, 0, model, dialect)
 
-    ref = model_measure.columns[0]
-    obj = model.data_objects.get(ref.view) if ref.view else None
-    column = obj.columns.get(ref.column) if obj and ref.column else None
-    if column is not None and column.abstract_type.value not in ("int", "float"):
-        # A non-numeric source keeps its own type; widening it makes no sense.
-        return resolve_null_type_for_field(measure, 0, model, dialect)
+    column = None
+    if len(model_measure.columns) == 1:
+        ref = model_measure.columns[0]
+        obj = model.data_objects.get(ref.view) if ref.view else None
+        column = obj.columns.get(ref.column) if obj and ref.column else None
+        if column is not None and column.abstract_type.value not in ("int", "float"):
+            # A non-numeric source keeps its own type; widening it is nonsense.
+            return resolve_null_type_for_field(measure, 0, model, dialect)
 
     if column is not None and column.sql_precision is not None:
         precision = column.sql_precision

--- a/src/orionbelt/compiler/cfl_projection.py
+++ b/src/orionbelt/compiler/cfl_projection.py
@@ -195,7 +195,15 @@ _ALIGNMENT_PRECISION = 38
 # Only these combine values across rows, so only these compound a
 # pre-aggregation rounding error. Everything else either selects a value
 # (MIN/MAX/ANY_VALUE/MEDIAN/MODE) or projects the raw column (COUNT, LISTAGG).
-_ACCUMULATING_AGGREGATIONS = frozenset({"sum", "avg"})
+#
+# The statistical aggregates belong here for the same reason SUM does, and were
+# missed by a first cut that listed only the obvious two: STDDEV over 1.0004 and
+# 1.0005 declared decimal(18, 3) answered 0.000 alone and 0.001 beside a measure
+# from another fact. The two-column ones (CORR, COVAR_*, REGR_*) never reach
+# this path - a multi-field measure pads per slot and keeps each slot's type.
+_ACCUMULATING_AGGREGATIONS = frozenset(
+    {"sum", "avg", "stddev", "stddev_pop", "variance", "var_pop"}
+)
 
 
 def resolve_union_alignment_type(

--- a/src/orionbelt/compiler/cfl_projection.py
+++ b/src/orionbelt/compiler/cfl_projection.py
@@ -39,6 +39,7 @@ from orionbelt.models.semantic import (
     TWO_COLUMN_AGGREGATIONS,
     SemanticModel,
 )
+from orionbelt.models.types import DecimalType
 
 if TYPE_CHECKING:
     from orionbelt.compiler.cfl import CFLPlanner
@@ -183,6 +184,66 @@ def resolve_null_type_for_field(
             return dialect.render_obml_type(resolved)
     # Fallback to measure result_type.
     return model_measure.result_type.value
+
+
+# Scale used to align a numeric aggregate's UNION legs when the model has not
+# declared the source column's own scale. Wide enough that a money column is
+# carried exactly, while leaving 26 integer digits at precision 38.
+_ALIGNMENT_SCALE = 12
+_ALIGNMENT_PRECISION = 38
+
+
+def resolve_union_alignment_type(
+    measure: ResolvedMeasure,
+    model: SemanticModel,
+    dialect: Dialect | None = None,
+) -> str | None:
+    """The type every UNION leg agrees on for *measure*'s column.
+
+    Distinct from :func:`resolve_null_type_for_field`, and the distinction is
+    the whole point. That one answers "what type does the *result* have", which
+    is right for the outer ``CAST(SUM(...) AS ...)`` and wrong here: the legs
+    carry **pre-aggregation rows**, so aligning them on the declared output
+    type rounds every row before it is summed. A measure declared
+    ``decimal(18, 2)`` over a ``DECIMAL(18, 6)`` column lost up to 0.005 per
+    row, which is invisible on one row and material on fifteen thousand.
+
+    The alignment still has to be a single concrete type, because a strict
+    engine will not union columns whose types disagree: ClickHouse produces
+    ``Variant(Decimal, Float64)`` and then refuses to ``SUM`` it. So the answer
+    is a type that is common across legs *and* preserves the input, rather than
+    the narrower of the two.
+
+    A model that declares the source column's ``sqlPrecision``/``sqlScale`` is
+    taken at its word. Otherwise the fallback widens to
+    ``decimal(38, 12)``, which carries any realistic money or rate column
+    exactly and still leaves 26 integer digits.
+
+    Non-numeric aggregates keep the existing behaviour: COUNT and LISTAGG
+    project the raw column, whose type is already the right alignment.
+    """
+    model_measure = model.effective_measures.get(measure.name)
+    if not model_measure:
+        return None
+    agg = (model_measure.aggregation or "").lower()
+    if agg in ("count", "count_distinct", "listagg") or len(model_measure.columns) != 1:
+        return resolve_null_type_for_field(measure, 0, model, dialect)
+    if dialect is None:
+        return resolve_null_type_for_field(measure, 0, model, dialect)
+
+    ref = model_measure.columns[0]
+    obj = model.data_objects.get(ref.view) if ref.view else None
+    column = obj.columns.get(ref.column) if obj and ref.column else None
+    if column is not None and column.abstract_type.value not in ("int", "float"):
+        # A non-numeric source keeps its own type; widening it makes no sense.
+        return resolve_null_type_for_field(measure, 0, model, dialect)
+
+    if column is not None and column.sql_precision is not None:
+        precision = column.sql_precision
+        scale = column.sql_scale if column.sql_scale is not None else 0
+    else:
+        precision, scale = _ALIGNMENT_PRECISION, _ALIGNMENT_SCALE
+    return dialect.render_obml_type(DecimalType(precision=precision, scale=scale))
 
 
 def outer_aggregation(measure: ResolvedMeasure) -> tuple[str, bool]:

--- a/src/orionbelt/dialect/bigquery.py
+++ b/src/orionbelt/dialect/bigquery.py
@@ -12,6 +12,9 @@ from orionbelt.dialect.registry import DialectRegistry
 from orionbelt.models.semantic import TimeGrain
 from orionbelt.models.types import DecimalType, OBMLType
 
+# BigQuery NUMERIC is (38, 9); anything wider needs BIGNUMERIC.
+_NUMERIC_MAX_SCALE = 9
+
 
 @DialectRegistry.register
 class BigQueryDialect(Dialect):
@@ -33,11 +36,17 @@ class BigQueryDialect(Dialect):
             # BigQuery rejects parameterized types in CAST expressions
             # ("Parameterized types are not allowed in CAST expressions"),
             # so emit a bare NUMERIC / BIGNUMERIC and let BigQuery default
-            # the precision/scale. NUMERIC covers precision ≤ 38; spill
-            # over to BIGNUMERIC for higher precision OBML decimals. The
-            # user-specified scale is honoured separately by
-            # ``cast_to_obml_type`` which wraps the CAST in ROUND.
-            if obml_type.precision > 38:
+            # the precision/scale. The user-specified scale is honoured
+            # separately by ``cast_to_obml_type``, which wraps the CAST in
+            # ROUND.
+            #
+            # NUMERIC is (38, 9) and BIGNUMERIC is (76, 38), so *scale* decides
+            # as much as precision does: a request for scale 12 came back as
+            # NUMERIC and silently dropped the digits, measured on BigQuery as
+            # ``CAST(1.000000000004 AS NUMERIC)`` returning 1 where BIGNUMERIC
+            # returns the value. A model declaring the usual two decimal places
+            # is unaffected.
+            if obml_type.precision > 38 or obml_type.scale > _NUMERIC_MAX_SCALE:
                 return "BIGNUMERIC"
             return "NUMERIC"
         return self._OBML_SIMPLE_TYPE_MAP.get(obml_type.name, obml_type.name.upper())

--- a/tests/integration/drift/compile_only/bigquery/04_sales_returns_cfl_by_country.sql
+++ b/tests/integration/drift/compile_only/bigquery/04_sales_returns_cfl_by_country.sql
@@ -1,10 +1,10 @@
 WITH `composite_01` AS (
-SELECT `Countries`.`countryname` AS `Sales Country Name`, CAST(`Sales`.`salesamount` AS NUMERIC) AS `Total Sales`, CAST(NULL AS NUMERIC) AS `Total Returns`
+SELECT `Countries`.`countryname` AS `Sales Country Name`, CAST(`Sales`.`salesamount` AS BIGNUMERIC) AS `Total Sales`, CAST(NULL AS BIGNUMERIC) AS `Total Returns`
 FROM `orionbelt_1`.`sales` AS `Sales`
 LEFT JOIN `orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`
 LEFT JOIN `orionbelt_1`.`countries` AS `Countries` ON `Clients`.`clientcountryid` = `Countries`.`countryid`
 UNION ALL
-SELECT `Countries`.`countryname` AS `Sales Country Name`, CAST(NULL AS NUMERIC) AS `Total Sales`, CAST(`Returns`.`returnamount` AS NUMERIC) AS `Total Returns`
+SELECT `Countries`.`countryname` AS `Sales Country Name`, CAST(NULL AS BIGNUMERIC) AS `Total Sales`, CAST(`Returns`.`returnamount` AS BIGNUMERIC) AS `Total Returns`
 FROM `orionbelt_1`.`returns` AS `Returns`
 LEFT JOIN `orionbelt_1`.`sales` AS `Sales` ON `Returns`.`returnsalesid` = `Sales`.`salesid`
 LEFT JOIN `orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`

--- a/tests/integration/drift/compile_only/bigquery/05_sales_purchases_cfl_ungrouped.sql
+++ b/tests/integration/drift/compile_only/bigquery/05_sales_purchases_cfl_ungrouped.sql
@@ -1,8 +1,8 @@
 WITH `composite_01` AS (
-SELECT CAST(`Sales`.`salesamount` AS NUMERIC) AS `Total Sales`, CAST(NULL AS NUMERIC) AS `Total Purchases`
+SELECT CAST(`Sales`.`salesamount` AS BIGNUMERIC) AS `Total Sales`, CAST(NULL AS BIGNUMERIC) AS `Total Purchases`
 FROM `orionbelt_1`.`sales` AS `Sales`
 UNION ALL
-SELECT CAST(NULL AS NUMERIC) AS `Total Sales`, CAST(`Purchases`.`purchaseamount` AS NUMERIC) AS `Total Purchases`
+SELECT CAST(NULL AS BIGNUMERIC) AS `Total Sales`, CAST(`Purchases`.`purchaseamount` AS BIGNUMERIC) AS `Total Purchases`
 FROM `orionbelt_1`.`purchases` AS `Purchases`
 )
 SELECT ROUND(CAST(SUM(`composite_01`.`Total Sales`) AS NUMERIC), 2) AS `Total Sales`, ROUND(CAST(SUM(`composite_01`.`Total Purchases`) AS NUMERIC), 2) AS `Total Purchases`

--- a/tests/integration/drift/compile_only/bigquery/07_total_sales_by_client_with_complaints.sql
+++ b/tests/integration/drift/compile_only/bigquery/07_total_sales_by_client_with_complaints.sql
@@ -1,9 +1,9 @@
 WITH `composite_01` AS (
-SELECT `Clients`.`clientname` AS `Sales Client Name`, CAST(NULL AS STRING) AS `Complaint Client Name`, CAST(`Sales`.`salesamount` AS NUMERIC) AS `Total Sales`, CAST(NULL AS INT64) AS `Client Complaints Count`
+SELECT `Clients`.`clientname` AS `Sales Client Name`, CAST(NULL AS STRING) AS `Complaint Client Name`, CAST(`Sales`.`salesamount` AS BIGNUMERIC) AS `Total Sales`, CAST(NULL AS INT64) AS `Client Complaints Count`
 FROM `orionbelt_1`.`sales` AS `Sales`
 LEFT JOIN `orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`
 UNION ALL
-SELECT CAST(NULL AS STRING) AS `Sales Client Name`, `Clients`.`clientname` AS `Complaint Client Name`, CAST(NULL AS NUMERIC) AS `Total Sales`, CAST(1 AS INT64) AS `Client Complaints Count`
+SELECT CAST(NULL AS STRING) AS `Sales Client Name`, `Clients`.`clientname` AS `Complaint Client Name`, CAST(NULL AS BIGNUMERIC) AS `Total Sales`, CAST(1 AS INT64) AS `Client Complaints Count`
 FROM `orionbelt_1`.`clientcomplaints` AS `Client Complaints`
 LEFT JOIN `orionbelt_1`.`clients` AS `Clients` ON `Client Complaints`.`complclientid` = `Clients`.`clientid`
 )

--- a/tests/integration/drift/compile_only/bigquery/09_return_rate.sql
+++ b/tests/integration/drift/compile_only/bigquery/09_return_rate.sql
@@ -1,8 +1,8 @@
 WITH `composite_01` AS (
-SELECT CAST(`Returns`.`returnamount` AS NUMERIC) AS `Total Returns`, CAST(NULL AS NUMERIC) AS `Total Sales`
+SELECT CAST(`Returns`.`returnamount` AS BIGNUMERIC) AS `Total Returns`, CAST(NULL AS BIGNUMERIC) AS `Total Sales`
 FROM `orionbelt_1`.`returns` AS `Returns`
 UNION ALL
-SELECT CAST(NULL AS NUMERIC) AS `Total Returns`, CAST(`Sales`.`salesamount` AS NUMERIC) AS `Total Sales`
+SELECT CAST(NULL AS BIGNUMERIC) AS `Total Returns`, CAST(`Sales`.`salesamount` AS BIGNUMERIC) AS `Total Sales`
 FROM `orionbelt_1`.`sales` AS `Sales`
 )
 SELECT ROUND(CAST(SUM(`composite_01`.`Total Returns`) / NULLIF(SUM(`composite_01`.`Total Sales`), 0) AS NUMERIC), 4) AS `Return Rate`

--- a/tests/integration/drift/compile_only/clickhouse/04_sales_returns_cfl_by_country.sql
+++ b/tests/integration/drift/compile_only/clickhouse/04_sales_returns_cfl_by_country.sql
@@ -1,10 +1,10 @@
 WITH "composite_01" AS (
-SELECT "Countries"."countryname" AS "Sales Country Name", CAST(round("Sales"."salesamount", 2) AS Nullable(Decimal(18, 2))) AS "Total Sales", CAST(round(NULL, 2) AS Nullable(Decimal(18, 2))) AS "Total Returns"
+SELECT "Countries"."countryname" AS "Sales Country Name", CAST(round("Sales"."salesamount", 12) AS Nullable(Decimal(38, 12))) AS "Total Sales", CAST(round(NULL, 12) AS Nullable(Decimal(38, 12))) AS "Total Returns"
 FROM "orionbelt_1"."sales" AS "Sales"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"
 LEFT JOIN "orionbelt_1"."countries" AS "Countries" ON "Clients"."clientcountryid" = "Countries"."countryid"
 UNION ALL
-SELECT "Countries"."countryname" AS "Sales Country Name", CAST(round(NULL, 2) AS Nullable(Decimal(18, 2))) AS "Total Sales", CAST(round("Returns"."returnamount", 2) AS Nullable(Decimal(18, 2))) AS "Total Returns"
+SELECT "Countries"."countryname" AS "Sales Country Name", CAST(round(NULL, 12) AS Nullable(Decimal(38, 12))) AS "Total Sales", CAST(round("Returns"."returnamount", 12) AS Nullable(Decimal(38, 12))) AS "Total Returns"
 FROM "orionbelt_1"."returns" AS "Returns"
 LEFT JOIN "orionbelt_1"."sales" AS "Sales" ON "Returns"."returnsalesid" = "Sales"."salesid"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"

--- a/tests/integration/drift/compile_only/clickhouse/05_sales_purchases_cfl_ungrouped.sql
+++ b/tests/integration/drift/compile_only/clickhouse/05_sales_purchases_cfl_ungrouped.sql
@@ -1,8 +1,8 @@
 WITH "composite_01" AS (
-SELECT CAST(round("Sales"."salesamount", 2) AS Nullable(Decimal(18, 2))) AS "Total Sales", CAST(round(NULL, 2) AS Nullable(Decimal(18, 2))) AS "Total Purchases"
+SELECT CAST(round("Sales"."salesamount", 12) AS Nullable(Decimal(38, 12))) AS "Total Sales", CAST(round(NULL, 12) AS Nullable(Decimal(38, 12))) AS "Total Purchases"
 FROM "orionbelt_1"."sales" AS "Sales"
 UNION ALL
-SELECT CAST(round(NULL, 2) AS Nullable(Decimal(18, 2))) AS "Total Sales", CAST(round("Purchases"."purchaseamount", 2) AS Nullable(Decimal(18, 2))) AS "Total Purchases"
+SELECT CAST(round(NULL, 12) AS Nullable(Decimal(38, 12))) AS "Total Sales", CAST(round("Purchases"."purchaseamount", 12) AS Nullable(Decimal(38, 12))) AS "Total Purchases"
 FROM "orionbelt_1"."purchases" AS "Purchases"
 )
 SELECT CAST(round(SUM("composite_01"."Total Sales"), 2) AS Nullable(Decimal(18, 2))) AS "Total Sales", CAST(round(SUM("composite_01"."Total Purchases"), 2) AS Nullable(Decimal(18, 2))) AS "Total Purchases"

--- a/tests/integration/drift/compile_only/clickhouse/07_total_sales_by_client_with_complaints.sql
+++ b/tests/integration/drift/compile_only/clickhouse/07_total_sales_by_client_with_complaints.sql
@@ -1,9 +1,9 @@
 WITH "composite_01" AS (
-SELECT "Clients"."clientname" AS "Sales Client Name", CAST(NULL AS Nullable(String)) AS "Complaint Client Name", CAST(round("Sales"."salesamount", 2) AS Nullable(Decimal(18, 2))) AS "Total Sales", CAST(NULL AS Nullable(Int32)) AS "Client Complaints Count"
+SELECT "Clients"."clientname" AS "Sales Client Name", CAST(NULL AS Nullable(String)) AS "Complaint Client Name", CAST(round("Sales"."salesamount", 12) AS Nullable(Decimal(38, 12))) AS "Total Sales", CAST(NULL AS Nullable(Int32)) AS "Client Complaints Count"
 FROM "orionbelt_1"."sales" AS "Sales"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"
 UNION ALL
-SELECT CAST(NULL AS Nullable(String)) AS "Sales Client Name", "Clients"."clientname" AS "Complaint Client Name", CAST(round(NULL, 2) AS Nullable(Decimal(18, 2))) AS "Total Sales", CAST(1 AS Nullable(Int32)) AS "Client Complaints Count"
+SELECT CAST(NULL AS Nullable(String)) AS "Sales Client Name", "Clients"."clientname" AS "Complaint Client Name", CAST(round(NULL, 12) AS Nullable(Decimal(38, 12))) AS "Total Sales", CAST(1 AS Nullable(Int32)) AS "Client Complaints Count"
 FROM "orionbelt_1"."clientcomplaints" AS "Client Complaints"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Client Complaints"."complclientid" = "Clients"."clientid"
 )

--- a/tests/integration/drift/compile_only/clickhouse/09_return_rate.sql
+++ b/tests/integration/drift/compile_only/clickhouse/09_return_rate.sql
@@ -1,8 +1,8 @@
 WITH "composite_01" AS (
-SELECT CAST(round("Returns"."returnamount", 2) AS Nullable(Decimal(18, 2))) AS "Total Returns", CAST(round(NULL, 2) AS Nullable(Decimal(18, 2))) AS "Total Sales"
+SELECT CAST(round("Returns"."returnamount", 12) AS Nullable(Decimal(38, 12))) AS "Total Returns", CAST(round(NULL, 12) AS Nullable(Decimal(38, 12))) AS "Total Sales"
 FROM "orionbelt_1"."returns" AS "Returns"
 UNION ALL
-SELECT CAST(round(NULL, 2) AS Nullable(Decimal(18, 2))) AS "Total Returns", CAST(round("Sales"."salesamount", 2) AS Nullable(Decimal(18, 2))) AS "Total Sales"
+SELECT CAST(round(NULL, 12) AS Nullable(Decimal(38, 12))) AS "Total Returns", CAST(round("Sales"."salesamount", 12) AS Nullable(Decimal(38, 12))) AS "Total Sales"
 FROM "orionbelt_1"."sales" AS "Sales"
 )
 SELECT CAST(round(CAST(SUM("composite_01"."Total Returns") AS Nullable(Decimal(38, 14))) / CAST(NULLIF(SUM("composite_01"."Total Sales"), 0) AS Nullable(Decimal(38, 14))), 4) AS Nullable(Decimal(18, 4))) AS "Return Rate"

--- a/tests/integration/drift/compile_only/databricks/04_sales_returns_cfl_by_country.sql
+++ b/tests/integration/drift/compile_only/databricks/04_sales_returns_cfl_by_country.sql
@@ -1,10 +1,10 @@
 WITH `composite_01` AS (
-SELECT `Countries`.`countryname` AS `Sales Country Name`, CAST(`Sales`.`salesamount` AS DECIMAL(18, 2)) AS `Total Sales`, CAST(NULL AS DECIMAL(18, 2)) AS `Total Returns`
+SELECT `Countries`.`countryname` AS `Sales Country Name`, CAST(`Sales`.`salesamount` AS DECIMAL(38, 12)) AS `Total Sales`, CAST(NULL AS DECIMAL(38, 12)) AS `Total Returns`
 FROM `orionbelt_1`.`sales` AS `Sales`
 LEFT JOIN `orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`
 LEFT JOIN `orionbelt_1`.`countries` AS `Countries` ON `Clients`.`clientcountryid` = `Countries`.`countryid`
 UNION ALL
-SELECT `Countries`.`countryname` AS `Sales Country Name`, CAST(NULL AS DECIMAL(18, 2)) AS `Total Sales`, CAST(`Returns`.`returnamount` AS DECIMAL(18, 2)) AS `Total Returns`
+SELECT `Countries`.`countryname` AS `Sales Country Name`, CAST(NULL AS DECIMAL(38, 12)) AS `Total Sales`, CAST(`Returns`.`returnamount` AS DECIMAL(38, 12)) AS `Total Returns`
 FROM `orionbelt_1`.`returns` AS `Returns`
 LEFT JOIN `orionbelt_1`.`sales` AS `Sales` ON `Returns`.`returnsalesid` = `Sales`.`salesid`
 LEFT JOIN `orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`

--- a/tests/integration/drift/compile_only/databricks/05_sales_purchases_cfl_ungrouped.sql
+++ b/tests/integration/drift/compile_only/databricks/05_sales_purchases_cfl_ungrouped.sql
@@ -1,8 +1,8 @@
 WITH `composite_01` AS (
-SELECT CAST(`Sales`.`salesamount` AS DECIMAL(18, 2)) AS `Total Sales`, CAST(NULL AS DECIMAL(18, 2)) AS `Total Purchases`
+SELECT CAST(`Sales`.`salesamount` AS DECIMAL(38, 12)) AS `Total Sales`, CAST(NULL AS DECIMAL(38, 12)) AS `Total Purchases`
 FROM `orionbelt_1`.`sales` AS `Sales`
 UNION ALL
-SELECT CAST(NULL AS DECIMAL(18, 2)) AS `Total Sales`, CAST(`Purchases`.`purchaseamount` AS DECIMAL(18, 2)) AS `Total Purchases`
+SELECT CAST(NULL AS DECIMAL(38, 12)) AS `Total Sales`, CAST(`Purchases`.`purchaseamount` AS DECIMAL(38, 12)) AS `Total Purchases`
 FROM `orionbelt_1`.`purchases` AS `Purchases`
 )
 SELECT CAST(SUM(`composite_01`.`Total Sales`) AS DECIMAL(18, 2)) AS `Total Sales`, CAST(SUM(`composite_01`.`Total Purchases`) AS DECIMAL(18, 2)) AS `Total Purchases`

--- a/tests/integration/drift/compile_only/databricks/07_total_sales_by_client_with_complaints.sql
+++ b/tests/integration/drift/compile_only/databricks/07_total_sales_by_client_with_complaints.sql
@@ -1,9 +1,9 @@
 WITH `composite_01` AS (
-SELECT `Clients`.`clientname` AS `Sales Client Name`, CAST(NULL AS STRING) AS `Complaint Client Name`, CAST(`Sales`.`salesamount` AS DECIMAL(18, 2)) AS `Total Sales`, CAST(NULL AS INT) AS `Client Complaints Count`
+SELECT `Clients`.`clientname` AS `Sales Client Name`, CAST(NULL AS STRING) AS `Complaint Client Name`, CAST(`Sales`.`salesamount` AS DECIMAL(38, 12)) AS `Total Sales`, CAST(NULL AS INT) AS `Client Complaints Count`
 FROM `orionbelt_1`.`sales` AS `Sales`
 LEFT JOIN `orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`
 UNION ALL
-SELECT CAST(NULL AS STRING) AS `Sales Client Name`, `Clients`.`clientname` AS `Complaint Client Name`, CAST(NULL AS DECIMAL(18, 2)) AS `Total Sales`, CAST(1 AS INT) AS `Client Complaints Count`
+SELECT CAST(NULL AS STRING) AS `Sales Client Name`, `Clients`.`clientname` AS `Complaint Client Name`, CAST(NULL AS DECIMAL(38, 12)) AS `Total Sales`, CAST(1 AS INT) AS `Client Complaints Count`
 FROM `orionbelt_1`.`clientcomplaints` AS `Client Complaints`
 LEFT JOIN `orionbelt_1`.`clients` AS `Clients` ON `Client Complaints`.`complclientid` = `Clients`.`clientid`
 )

--- a/tests/integration/drift/compile_only/databricks/09_return_rate.sql
+++ b/tests/integration/drift/compile_only/databricks/09_return_rate.sql
@@ -1,8 +1,8 @@
 WITH `composite_01` AS (
-SELECT CAST(`Returns`.`returnamount` AS DECIMAL(18, 2)) AS `Total Returns`, CAST(NULL AS DECIMAL(18, 2)) AS `Total Sales`
+SELECT CAST(`Returns`.`returnamount` AS DECIMAL(38, 12)) AS `Total Returns`, CAST(NULL AS DECIMAL(38, 12)) AS `Total Sales`
 FROM `orionbelt_1`.`returns` AS `Returns`
 UNION ALL
-SELECT CAST(NULL AS DECIMAL(18, 2)) AS `Total Returns`, CAST(`Sales`.`salesamount` AS DECIMAL(18, 2)) AS `Total Sales`
+SELECT CAST(NULL AS DECIMAL(38, 12)) AS `Total Returns`, CAST(`Sales`.`salesamount` AS DECIMAL(38, 12)) AS `Total Sales`
 FROM `orionbelt_1`.`sales` AS `Sales`
 )
 SELECT CAST(SUM(`composite_01`.`Total Returns`) / NULLIF(SUM(`composite_01`.`Total Sales`), 0) AS DECIMAL(18, 4)) AS `Return Rate`

--- a/tests/integration/drift/compile_only/dremio/04_sales_returns_cfl_by_country.sql
+++ b/tests/integration/drift/compile_only/dremio/04_sales_returns_cfl_by_country.sql
@@ -1,10 +1,10 @@
 WITH "composite_01" AS (
-SELECT "Countries"."countryname" AS "Sales Country Name", CAST("Sales"."salesamount" AS DECIMAL(18, 2)) AS "Total Sales", CAST(NULL AS DECIMAL(18, 2)) AS "Total Returns"
+SELECT "Countries"."countryname" AS "Sales Country Name", CAST("Sales"."salesamount" AS DECIMAL(38, 12)) AS "Total Sales", CAST(NULL AS DECIMAL(38, 12)) AS "Total Returns"
 FROM "orionbelt_1"."sales" AS "Sales"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"
 LEFT JOIN "orionbelt_1"."countries" AS "Countries" ON "Clients"."clientcountryid" = "Countries"."countryid"
 UNION ALL
-SELECT "Countries"."countryname" AS "Sales Country Name", CAST(NULL AS DECIMAL(18, 2)) AS "Total Sales", CAST("Returns"."returnamount" AS DECIMAL(18, 2)) AS "Total Returns"
+SELECT "Countries"."countryname" AS "Sales Country Name", CAST(NULL AS DECIMAL(38, 12)) AS "Total Sales", CAST("Returns"."returnamount" AS DECIMAL(38, 12)) AS "Total Returns"
 FROM "orionbelt_1"."returns" AS "Returns"
 LEFT JOIN "orionbelt_1"."sales" AS "Sales" ON "Returns"."returnsalesid" = "Sales"."salesid"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"

--- a/tests/integration/drift/compile_only/dremio/05_sales_purchases_cfl_ungrouped.sql
+++ b/tests/integration/drift/compile_only/dremio/05_sales_purchases_cfl_ungrouped.sql
@@ -1,8 +1,8 @@
 WITH "composite_01" AS (
-SELECT CAST("Sales"."salesamount" AS DECIMAL(18, 2)) AS "Total Sales", CAST(NULL AS DECIMAL(18, 2)) AS "Total Purchases"
+SELECT CAST("Sales"."salesamount" AS DECIMAL(38, 12)) AS "Total Sales", CAST(NULL AS DECIMAL(38, 12)) AS "Total Purchases"
 FROM "orionbelt_1"."sales" AS "Sales"
 UNION ALL
-SELECT CAST(NULL AS DECIMAL(18, 2)) AS "Total Sales", CAST("Purchases"."purchaseamount" AS DECIMAL(18, 2)) AS "Total Purchases"
+SELECT CAST(NULL AS DECIMAL(38, 12)) AS "Total Sales", CAST("Purchases"."purchaseamount" AS DECIMAL(38, 12)) AS "Total Purchases"
 FROM "orionbelt_1"."purchases" AS "Purchases"
 )
 SELECT CAST(SUM("composite_01"."Total Sales") AS DECIMAL(18, 2)) AS "Total Sales", CAST(SUM("composite_01"."Total Purchases") AS DECIMAL(18, 2)) AS "Total Purchases"

--- a/tests/integration/drift/compile_only/dremio/07_total_sales_by_client_with_complaints.sql
+++ b/tests/integration/drift/compile_only/dremio/07_total_sales_by_client_with_complaints.sql
@@ -1,9 +1,9 @@
 WITH "composite_01" AS (
-SELECT "Clients"."clientname" AS "Sales Client Name", CAST(NULL AS VARCHAR) AS "Complaint Client Name", CAST("Sales"."salesamount" AS DECIMAL(18, 2)) AS "Total Sales", CAST(NULL AS INTEGER) AS "Client Complaints Count"
+SELECT "Clients"."clientname" AS "Sales Client Name", CAST(NULL AS VARCHAR) AS "Complaint Client Name", CAST("Sales"."salesamount" AS DECIMAL(38, 12)) AS "Total Sales", CAST(NULL AS INTEGER) AS "Client Complaints Count"
 FROM "orionbelt_1"."sales" AS "Sales"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"
 UNION ALL
-SELECT CAST(NULL AS VARCHAR) AS "Sales Client Name", "Clients"."clientname" AS "Complaint Client Name", CAST(NULL AS DECIMAL(18, 2)) AS "Total Sales", CAST(1 AS INTEGER) AS "Client Complaints Count"
+SELECT CAST(NULL AS VARCHAR) AS "Sales Client Name", "Clients"."clientname" AS "Complaint Client Name", CAST(NULL AS DECIMAL(38, 12)) AS "Total Sales", CAST(1 AS INTEGER) AS "Client Complaints Count"
 FROM "orionbelt_1"."clientcomplaints" AS "Client Complaints"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Client Complaints"."complclientid" = "Clients"."clientid"
 )

--- a/tests/integration/drift/compile_only/dremio/09_return_rate.sql
+++ b/tests/integration/drift/compile_only/dremio/09_return_rate.sql
@@ -1,8 +1,8 @@
 WITH "composite_01" AS (
-SELECT CAST("Returns"."returnamount" AS DECIMAL(18, 2)) AS "Total Returns", CAST(NULL AS DECIMAL(18, 2)) AS "Total Sales"
+SELECT CAST("Returns"."returnamount" AS DECIMAL(38, 12)) AS "Total Returns", CAST(NULL AS DECIMAL(38, 12)) AS "Total Sales"
 FROM "orionbelt_1"."returns" AS "Returns"
 UNION ALL
-SELECT CAST(NULL AS DECIMAL(18, 2)) AS "Total Returns", CAST("Sales"."salesamount" AS DECIMAL(18, 2)) AS "Total Sales"
+SELECT CAST(NULL AS DECIMAL(38, 12)) AS "Total Returns", CAST("Sales"."salesamount" AS DECIMAL(38, 12)) AS "Total Sales"
 FROM "orionbelt_1"."sales" AS "Sales"
 )
 SELECT CAST(SUM("composite_01"."Total Returns") / NULLIF(SUM("composite_01"."Total Sales"), 0) AS DECIMAL(18, 4)) AS "Return Rate"

--- a/tests/integration/drift/compile_only/duckdb/04_sales_returns_cfl_by_country.sql
+++ b/tests/integration/drift/compile_only/duckdb/04_sales_returns_cfl_by_country.sql
@@ -1,10 +1,10 @@
 WITH "composite_01" AS (
-SELECT "Countries"."countryname" AS "Sales Country Name", CAST("Sales"."salesamount" AS DECIMAL(18, 2)) AS "Total Sales"
+SELECT "Countries"."countryname" AS "Sales Country Name", CAST("Sales"."salesamount" AS DECIMAL(38, 12)) AS "Total Sales"
 FROM "orionbelt_1"."sales" AS "Sales"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"
 LEFT JOIN "orionbelt_1"."countries" AS "Countries" ON "Clients"."clientcountryid" = "Countries"."countryid"
 UNION ALL BY NAME
-SELECT "Countries"."countryname" AS "Sales Country Name", CAST("Returns"."returnamount" AS DECIMAL(18, 2)) AS "Total Returns"
+SELECT "Countries"."countryname" AS "Sales Country Name", CAST("Returns"."returnamount" AS DECIMAL(38, 12)) AS "Total Returns"
 FROM "orionbelt_1"."returns" AS "Returns"
 LEFT JOIN "orionbelt_1"."sales" AS "Sales" ON "Returns"."returnsalesid" = "Sales"."salesid"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"

--- a/tests/integration/drift/compile_only/duckdb/05_sales_purchases_cfl_ungrouped.sql
+++ b/tests/integration/drift/compile_only/duckdb/05_sales_purchases_cfl_ungrouped.sql
@@ -1,8 +1,8 @@
 WITH "composite_01" AS (
-SELECT CAST("Sales"."salesamount" AS DECIMAL(18, 2)) AS "Total Sales"
+SELECT CAST("Sales"."salesamount" AS DECIMAL(38, 12)) AS "Total Sales"
 FROM "orionbelt_1"."sales" AS "Sales"
 UNION ALL BY NAME
-SELECT CAST("Purchases"."purchaseamount" AS DECIMAL(18, 2)) AS "Total Purchases"
+SELECT CAST("Purchases"."purchaseamount" AS DECIMAL(38, 12)) AS "Total Purchases"
 FROM "orionbelt_1"."purchases" AS "Purchases"
 )
 SELECT CAST(SUM("composite_01"."Total Sales") AS DECIMAL(18, 2)) AS "Total Sales", CAST(SUM("composite_01"."Total Purchases") AS DECIMAL(18, 2)) AS "Total Purchases"

--- a/tests/integration/drift/compile_only/duckdb/07_total_sales_by_client_with_complaints.sql
+++ b/tests/integration/drift/compile_only/duckdb/07_total_sales_by_client_with_complaints.sql
@@ -1,5 +1,5 @@
 WITH "composite_01" AS (
-SELECT "Clients"."clientname" AS "Sales Client Name", CAST("Sales"."salesamount" AS DECIMAL(18, 2)) AS "Total Sales"
+SELECT "Clients"."clientname" AS "Sales Client Name", CAST("Sales"."salesamount" AS DECIMAL(38, 12)) AS "Total Sales"
 FROM "orionbelt_1"."sales" AS "Sales"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"
 UNION ALL BY NAME

--- a/tests/integration/drift/compile_only/duckdb/09_return_rate.sql
+++ b/tests/integration/drift/compile_only/duckdb/09_return_rate.sql
@@ -1,8 +1,8 @@
 WITH "composite_01" AS (
-SELECT CAST("Returns"."returnamount" AS DECIMAL(18, 2)) AS "Total Returns"
+SELECT CAST("Returns"."returnamount" AS DECIMAL(38, 12)) AS "Total Returns"
 FROM "orionbelt_1"."returns" AS "Returns"
 UNION ALL BY NAME
-SELECT CAST("Sales"."salesamount" AS DECIMAL(18, 2)) AS "Total Sales"
+SELECT CAST("Sales"."salesamount" AS DECIMAL(38, 12)) AS "Total Sales"
 FROM "orionbelt_1"."sales" AS "Sales"
 )
 SELECT CAST(SUM("composite_01"."Total Returns") / NULLIF(SUM("composite_01"."Total Sales"), 0) AS DECIMAL(18, 4)) AS "Return Rate"

--- a/tests/integration/drift/compile_only/mysql/04_sales_returns_cfl_by_country.sql
+++ b/tests/integration/drift/compile_only/mysql/04_sales_returns_cfl_by_country.sql
@@ -1,10 +1,10 @@
 WITH `composite_01` AS (
-SELECT `Countries`.`countryname` AS `Sales Country Name`, CAST(`Sales`.`salesamount` AS DECIMAL(18, 2)) AS `Total Sales`, CAST(NULL AS DECIMAL(18, 2)) AS `Total Returns`
+SELECT `Countries`.`countryname` AS `Sales Country Name`, CAST(`Sales`.`salesamount` AS DECIMAL(38, 12)) AS `Total Sales`, CAST(NULL AS DECIMAL(38, 12)) AS `Total Returns`
 FROM `orionbelt_1`.`sales` AS `Sales`
 LEFT JOIN `orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`
 LEFT JOIN `orionbelt_1`.`countries` AS `Countries` ON `Clients`.`clientcountryid` = `Countries`.`countryid`
 UNION ALL
-SELECT `Countries`.`countryname` AS `Sales Country Name`, CAST(NULL AS DECIMAL(18, 2)) AS `Total Sales`, CAST(`Returns`.`returnamount` AS DECIMAL(18, 2)) AS `Total Returns`
+SELECT `Countries`.`countryname` AS `Sales Country Name`, CAST(NULL AS DECIMAL(38, 12)) AS `Total Sales`, CAST(`Returns`.`returnamount` AS DECIMAL(38, 12)) AS `Total Returns`
 FROM `orionbelt_1`.`returns` AS `Returns`
 LEFT JOIN `orionbelt_1`.`sales` AS `Sales` ON `Returns`.`returnsalesid` = `Sales`.`salesid`
 LEFT JOIN `orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`

--- a/tests/integration/drift/compile_only/mysql/05_sales_purchases_cfl_ungrouped.sql
+++ b/tests/integration/drift/compile_only/mysql/05_sales_purchases_cfl_ungrouped.sql
@@ -1,8 +1,8 @@
 WITH `composite_01` AS (
-SELECT CAST(`Sales`.`salesamount` AS DECIMAL(18, 2)) AS `Total Sales`, CAST(NULL AS DECIMAL(18, 2)) AS `Total Purchases`
+SELECT CAST(`Sales`.`salesamount` AS DECIMAL(38, 12)) AS `Total Sales`, CAST(NULL AS DECIMAL(38, 12)) AS `Total Purchases`
 FROM `orionbelt_1`.`sales` AS `Sales`
 UNION ALL
-SELECT CAST(NULL AS DECIMAL(18, 2)) AS `Total Sales`, CAST(`Purchases`.`purchaseamount` AS DECIMAL(18, 2)) AS `Total Purchases`
+SELECT CAST(NULL AS DECIMAL(38, 12)) AS `Total Sales`, CAST(`Purchases`.`purchaseamount` AS DECIMAL(38, 12)) AS `Total Purchases`
 FROM `orionbelt_1`.`purchases` AS `Purchases`
 )
 SELECT CAST(SUM(`composite_01`.`Total Sales`) AS DECIMAL(18, 2)) AS `Total Sales`, CAST(SUM(`composite_01`.`Total Purchases`) AS DECIMAL(18, 2)) AS `Total Purchases`

--- a/tests/integration/drift/compile_only/mysql/07_total_sales_by_client_with_complaints.sql
+++ b/tests/integration/drift/compile_only/mysql/07_total_sales_by_client_with_complaints.sql
@@ -1,9 +1,9 @@
 WITH `composite_01` AS (
-SELECT `Clients`.`clientname` AS `Sales Client Name`, CAST(NULL AS CHAR(255)) AS `Complaint Client Name`, CAST(`Sales`.`salesamount` AS DECIMAL(18, 2)) AS `Total Sales`, CAST(NULL AS SIGNED) AS `Client Complaints Count`
+SELECT `Clients`.`clientname` AS `Sales Client Name`, CAST(NULL AS CHAR(255)) AS `Complaint Client Name`, CAST(`Sales`.`salesamount` AS DECIMAL(38, 12)) AS `Total Sales`, CAST(NULL AS SIGNED) AS `Client Complaints Count`
 FROM `orionbelt_1`.`sales` AS `Sales`
 LEFT JOIN `orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`
 UNION ALL
-SELECT CAST(NULL AS CHAR(255)) AS `Sales Client Name`, `Clients`.`clientname` AS `Complaint Client Name`, CAST(NULL AS DECIMAL(18, 2)) AS `Total Sales`, CAST(1 AS SIGNED) AS `Client Complaints Count`
+SELECT CAST(NULL AS CHAR(255)) AS `Sales Client Name`, `Clients`.`clientname` AS `Complaint Client Name`, CAST(NULL AS DECIMAL(38, 12)) AS `Total Sales`, CAST(1 AS SIGNED) AS `Client Complaints Count`
 FROM `orionbelt_1`.`clientcomplaints` AS `Client Complaints`
 LEFT JOIN `orionbelt_1`.`clients` AS `Clients` ON `Client Complaints`.`complclientid` = `Clients`.`clientid`
 )

--- a/tests/integration/drift/compile_only/mysql/09_return_rate.sql
+++ b/tests/integration/drift/compile_only/mysql/09_return_rate.sql
@@ -1,8 +1,8 @@
 WITH `composite_01` AS (
-SELECT CAST(`Returns`.`returnamount` AS DECIMAL(18, 2)) AS `Total Returns`, CAST(NULL AS DECIMAL(18, 2)) AS `Total Sales`
+SELECT CAST(`Returns`.`returnamount` AS DECIMAL(38, 12)) AS `Total Returns`, CAST(NULL AS DECIMAL(38, 12)) AS `Total Sales`
 FROM `orionbelt_1`.`returns` AS `Returns`
 UNION ALL
-SELECT CAST(NULL AS DECIMAL(18, 2)) AS `Total Returns`, CAST(`Sales`.`salesamount` AS DECIMAL(18, 2)) AS `Total Sales`
+SELECT CAST(NULL AS DECIMAL(38, 12)) AS `Total Returns`, CAST(`Sales`.`salesamount` AS DECIMAL(38, 12)) AS `Total Sales`
 FROM `orionbelt_1`.`sales` AS `Sales`
 )
 SELECT CAST(SUM(`composite_01`.`Total Returns`) / NULLIF(SUM(`composite_01`.`Total Sales`), 0) AS DECIMAL(18, 4)) AS `Return Rate`

--- a/tests/integration/drift/compile_only/postgres/04_sales_returns_cfl_by_country.sql
+++ b/tests/integration/drift/compile_only/postgres/04_sales_returns_cfl_by_country.sql
@@ -1,10 +1,10 @@
 WITH "composite_01" AS (
-SELECT "Countries"."countryname" AS "Sales Country Name", CAST("Sales"."salesamount" AS DECIMAL(18, 2)) AS "Total Sales", CAST(NULL AS DECIMAL(18, 2)) AS "Total Returns"
+SELECT "Countries"."countryname" AS "Sales Country Name", CAST("Sales"."salesamount" AS DECIMAL(38, 12)) AS "Total Sales", CAST(NULL AS DECIMAL(38, 12)) AS "Total Returns"
 FROM "orionbelt_1"."sales" AS "Sales"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"
 LEFT JOIN "orionbelt_1"."countries" AS "Countries" ON "Clients"."clientcountryid" = "Countries"."countryid"
 UNION ALL
-SELECT "Countries"."countryname" AS "Sales Country Name", CAST(NULL AS DECIMAL(18, 2)) AS "Total Sales", CAST("Returns"."returnamount" AS DECIMAL(18, 2)) AS "Total Returns"
+SELECT "Countries"."countryname" AS "Sales Country Name", CAST(NULL AS DECIMAL(38, 12)) AS "Total Sales", CAST("Returns"."returnamount" AS DECIMAL(38, 12)) AS "Total Returns"
 FROM "orionbelt_1"."returns" AS "Returns"
 LEFT JOIN "orionbelt_1"."sales" AS "Sales" ON "Returns"."returnsalesid" = "Sales"."salesid"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"

--- a/tests/integration/drift/compile_only/postgres/05_sales_purchases_cfl_ungrouped.sql
+++ b/tests/integration/drift/compile_only/postgres/05_sales_purchases_cfl_ungrouped.sql
@@ -1,8 +1,8 @@
 WITH "composite_01" AS (
-SELECT CAST("Sales"."salesamount" AS DECIMAL(18, 2)) AS "Total Sales", CAST(NULL AS DECIMAL(18, 2)) AS "Total Purchases"
+SELECT CAST("Sales"."salesamount" AS DECIMAL(38, 12)) AS "Total Sales", CAST(NULL AS DECIMAL(38, 12)) AS "Total Purchases"
 FROM "orionbelt_1"."sales" AS "Sales"
 UNION ALL
-SELECT CAST(NULL AS DECIMAL(18, 2)) AS "Total Sales", CAST("Purchases"."purchaseamount" AS DECIMAL(18, 2)) AS "Total Purchases"
+SELECT CAST(NULL AS DECIMAL(38, 12)) AS "Total Sales", CAST("Purchases"."purchaseamount" AS DECIMAL(38, 12)) AS "Total Purchases"
 FROM "orionbelt_1"."purchases" AS "Purchases"
 )
 SELECT CAST(SUM("composite_01"."Total Sales") AS DECIMAL(18, 2)) AS "Total Sales", CAST(SUM("composite_01"."Total Purchases") AS DECIMAL(18, 2)) AS "Total Purchases"

--- a/tests/integration/drift/compile_only/postgres/07_total_sales_by_client_with_complaints.sql
+++ b/tests/integration/drift/compile_only/postgres/07_total_sales_by_client_with_complaints.sql
@@ -1,9 +1,9 @@
 WITH "composite_01" AS (
-SELECT "Clients"."clientname" AS "Sales Client Name", CAST(NULL AS VARCHAR) AS "Complaint Client Name", CAST("Sales"."salesamount" AS DECIMAL(18, 2)) AS "Total Sales", CAST(NULL AS INTEGER) AS "Client Complaints Count"
+SELECT "Clients"."clientname" AS "Sales Client Name", CAST(NULL AS VARCHAR) AS "Complaint Client Name", CAST("Sales"."salesamount" AS DECIMAL(38, 12)) AS "Total Sales", CAST(NULL AS INTEGER) AS "Client Complaints Count"
 FROM "orionbelt_1"."sales" AS "Sales"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"
 UNION ALL
-SELECT CAST(NULL AS VARCHAR) AS "Sales Client Name", "Clients"."clientname" AS "Complaint Client Name", CAST(NULL AS DECIMAL(18, 2)) AS "Total Sales", CAST(1 AS INTEGER) AS "Client Complaints Count"
+SELECT CAST(NULL AS VARCHAR) AS "Sales Client Name", "Clients"."clientname" AS "Complaint Client Name", CAST(NULL AS DECIMAL(38, 12)) AS "Total Sales", CAST(1 AS INTEGER) AS "Client Complaints Count"
 FROM "orionbelt_1"."clientcomplaints" AS "Client Complaints"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Client Complaints"."complclientid" = "Clients"."clientid"
 )

--- a/tests/integration/drift/compile_only/postgres/09_return_rate.sql
+++ b/tests/integration/drift/compile_only/postgres/09_return_rate.sql
@@ -1,8 +1,8 @@
 WITH "composite_01" AS (
-SELECT CAST("Returns"."returnamount" AS DECIMAL(18, 2)) AS "Total Returns", CAST(NULL AS DECIMAL(18, 2)) AS "Total Sales"
+SELECT CAST("Returns"."returnamount" AS DECIMAL(38, 12)) AS "Total Returns", CAST(NULL AS DECIMAL(38, 12)) AS "Total Sales"
 FROM "orionbelt_1"."returns" AS "Returns"
 UNION ALL
-SELECT CAST(NULL AS DECIMAL(18, 2)) AS "Total Returns", CAST("Sales"."salesamount" AS DECIMAL(18, 2)) AS "Total Sales"
+SELECT CAST(NULL AS DECIMAL(38, 12)) AS "Total Returns", CAST("Sales"."salesamount" AS DECIMAL(38, 12)) AS "Total Sales"
 FROM "orionbelt_1"."sales" AS "Sales"
 )
 SELECT CAST(SUM("composite_01"."Total Returns") / NULLIF(SUM("composite_01"."Total Sales"), 0) AS DECIMAL(18, 4)) AS "Return Rate"

--- a/tests/integration/drift/compile_only/snowflake/04_sales_returns_cfl_by_country.sql
+++ b/tests/integration/drift/compile_only/snowflake/04_sales_returns_cfl_by_country.sql
@@ -1,10 +1,10 @@
 WITH "composite_01" AS (
-SELECT "Countries"."countryname" AS "Sales Country Name", CAST("Sales"."salesamount" AS NUMBER(18, 2)) AS "Total Sales"
+SELECT "Countries"."countryname" AS "Sales Country Name", CAST("Sales"."salesamount" AS NUMBER(38, 12)) AS "Total Sales"
 FROM "orionbelt_1"."sales" AS "Sales"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"
 LEFT JOIN "orionbelt_1"."countries" AS "Countries" ON "Clients"."clientcountryid" = "Countries"."countryid"
 UNION ALL BY NAME
-SELECT "Countries"."countryname" AS "Sales Country Name", CAST("Returns"."returnamount" AS NUMBER(18, 2)) AS "Total Returns"
+SELECT "Countries"."countryname" AS "Sales Country Name", CAST("Returns"."returnamount" AS NUMBER(38, 12)) AS "Total Returns"
 FROM "orionbelt_1"."returns" AS "Returns"
 LEFT JOIN "orionbelt_1"."sales" AS "Sales" ON "Returns"."returnsalesid" = "Sales"."salesid"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"

--- a/tests/integration/drift/compile_only/snowflake/05_sales_purchases_cfl_ungrouped.sql
+++ b/tests/integration/drift/compile_only/snowflake/05_sales_purchases_cfl_ungrouped.sql
@@ -1,8 +1,8 @@
 WITH "composite_01" AS (
-SELECT CAST("Sales"."salesamount" AS NUMBER(18, 2)) AS "Total Sales"
+SELECT CAST("Sales"."salesamount" AS NUMBER(38, 12)) AS "Total Sales"
 FROM "orionbelt_1"."sales" AS "Sales"
 UNION ALL BY NAME
-SELECT CAST("Purchases"."purchaseamount" AS NUMBER(18, 2)) AS "Total Purchases"
+SELECT CAST("Purchases"."purchaseamount" AS NUMBER(38, 12)) AS "Total Purchases"
 FROM "orionbelt_1"."purchases" AS "Purchases"
 )
 SELECT CAST(SUM("composite_01"."Total Sales") AS NUMBER(18, 2)) AS "Total Sales", CAST(SUM("composite_01"."Total Purchases") AS NUMBER(18, 2)) AS "Total Purchases"

--- a/tests/integration/drift/compile_only/snowflake/07_total_sales_by_client_with_complaints.sql
+++ b/tests/integration/drift/compile_only/snowflake/07_total_sales_by_client_with_complaints.sql
@@ -1,5 +1,5 @@
 WITH "composite_01" AS (
-SELECT "Clients"."clientname" AS "Sales Client Name", CAST("Sales"."salesamount" AS NUMBER(18, 2)) AS "Total Sales"
+SELECT "Clients"."clientname" AS "Sales Client Name", CAST("Sales"."salesamount" AS NUMBER(38, 12)) AS "Total Sales"
 FROM "orionbelt_1"."sales" AS "Sales"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"
 UNION ALL BY NAME

--- a/tests/integration/drift/compile_only/snowflake/09_return_rate.sql
+++ b/tests/integration/drift/compile_only/snowflake/09_return_rate.sql
@@ -1,8 +1,8 @@
 WITH "composite_01" AS (
-SELECT CAST("Returns"."returnamount" AS NUMBER(18, 2)) AS "Total Returns"
+SELECT CAST("Returns"."returnamount" AS NUMBER(38, 12)) AS "Total Returns"
 FROM "orionbelt_1"."returns" AS "Returns"
 UNION ALL BY NAME
-SELECT CAST("Sales"."salesamount" AS NUMBER(18, 2)) AS "Total Sales"
+SELECT CAST("Sales"."salesamount" AS NUMBER(38, 12)) AS "Total Sales"
 FROM "orionbelt_1"."sales" AS "Sales"
 )
 SELECT CAST(SUM("composite_01"."Total Returns") / NULLIF(SUM("composite_01"."Total Sales"), 0) AS NUMBER(18, 4)) AS "Return Rate"

--- a/tests/integration/drift/duckdb/04_sales_returns_cfl_by_country.yaml
+++ b/tests/integration/drift/duckdb/04_sales_returns_cfl_by_country.yaml
@@ -1,7 +1,7 @@
 last_verified_by: tests/integration/correctness/test_cfl_split.py::test_sales_returns_cfl_split_by_country
 sql: 'WITH "composite_01" AS (
 
-  SELECT "Countries"."countryname" AS "Sales Country Name", CAST("Sales"."salesamount" AS DECIMAL(18, 2)) AS "Total Sales"
+  SELECT "Countries"."countryname" AS "Sales Country Name", CAST("Sales"."salesamount" AS DECIMAL(38, 12)) AS "Total Sales"
 
   FROM "orionbelt_1"."sales" AS "Sales"
 
@@ -11,7 +11,7 @@ sql: 'WITH "composite_01" AS (
 
   UNION ALL BY NAME
 
-  SELECT "Countries"."countryname" AS "Sales Country Name", CAST("Returns"."returnamount" AS DECIMAL(18, 2)) AS "Total Returns"
+  SELECT "Countries"."countryname" AS "Sales Country Name", CAST("Returns"."returnamount" AS DECIMAL(38, 12)) AS "Total Returns"
 
   FROM "orionbelt_1"."returns" AS "Returns"
 

--- a/tests/integration/drift/duckdb/05_sales_purchases_cfl_ungrouped.yaml
+++ b/tests/integration/drift/duckdb/05_sales_purchases_cfl_ungrouped.yaml
@@ -1,13 +1,13 @@
 last_verified_by: tests/integration/correctness/test_cfl_split.py::test_sales_purchases_cfl_split_ungrouped
 sql: 'WITH "composite_01" AS (
 
-  SELECT CAST("Sales"."salesamount" AS DECIMAL(18, 2)) AS "Total Sales"
+  SELECT CAST("Sales"."salesamount" AS DECIMAL(38, 12)) AS "Total Sales"
 
   FROM "orionbelt_1"."sales" AS "Sales"
 
   UNION ALL BY NAME
 
-  SELECT CAST("Purchases"."purchaseamount" AS DECIMAL(18, 2)) AS "Total Purchases"
+  SELECT CAST("Purchases"."purchaseamount" AS DECIMAL(38, 12)) AS "Total Purchases"
 
   FROM "orionbelt_1"."purchases" AS "Purchases"
 

--- a/tests/integration/drift/duckdb/07_total_sales_by_client_with_complaints.yaml
+++ b/tests/integration/drift/duckdb/07_total_sales_by_client_with_complaints.yaml
@@ -1,7 +1,7 @@
 last_verified_by: tests/integration/correctness/test_hand_sql_reference.py::test_obsl_matches_hand_sql[07_total_sales_by_client_with_complaints]
 sql: 'WITH "composite_01" AS (
 
-  SELECT "Clients"."clientname" AS "Sales Client Name", CAST("Sales"."salesamount" AS DECIMAL(18, 2)) AS "Total Sales"
+  SELECT "Clients"."clientname" AS "Sales Client Name", CAST("Sales"."salesamount" AS DECIMAL(38, 12)) AS "Total Sales"
 
   FROM "orionbelt_1"."sales" AS "Sales"
 

--- a/tests/integration/drift/duckdb/09_return_rate.yaml
+++ b/tests/integration/drift/duckdb/09_return_rate.yaml
@@ -1,13 +1,13 @@
 last_verified_by: tests/integration/correctness/test_metric_algebra.py::test_return_rate_equals_returns_over_sales
 sql: 'WITH "composite_01" AS (
 
-  SELECT CAST("Returns"."returnamount" AS DECIMAL(18, 2)) AS "Total Returns"
+  SELECT CAST("Returns"."returnamount" AS DECIMAL(38, 12)) AS "Total Returns"
 
   FROM "orionbelt_1"."returns" AS "Returns"
 
   UNION ALL BY NAME
 
-  SELECT CAST("Sales"."salesamount" AS DECIMAL(18, 2)) AS "Total Sales"
+  SELECT CAST("Sales"."salesamount" AS DECIMAL(38, 12)) AS "Total Sales"
 
   FROM "orionbelt_1"."sales" AS "Sales"
 

--- a/tests/unit/test_cfl_union_alignment.py
+++ b/tests/unit/test_cfl_union_alignment.py
@@ -1,0 +1,186 @@
+"""What type a CFL UNION leg carries a measure's rows in.
+
+A leg projects **pre-aggregation rows** and the outer query aggregates them, so
+the type the legs agree on is not the type the result has. Aligning them on the
+measure's declared ``dataType`` conflated the two and rounded every row before
+it was summed: a measure declared ``decimal(18, 2)`` over a six-decimal column
+lost up to 0.005 per row, which is invisible on one row and material on fifteen
+thousand.
+
+That made the same measure answer differently depending on whether the query
+happened to be multi-fact, which for a semantic layer is the cardinal sin: a
+measure means one thing regardless of what is selected alongside it. Issue #305.
+
+The alignment cast itself has to stay. A strict engine will not union columns
+whose types disagree - ClickHouse builds a ``Variant(Decimal, Float64)`` and
+then refuses to ``SUM`` it, measured as error code 43 - so the fix is the type
+chosen, not the casting.
+"""
+
+from __future__ import annotations
+
+import re
+from decimal import Decimal
+
+import duckdb
+
+from orionbelt.compiler.pipeline import CompilationPipeline
+from orionbelt.models.query import QueryObject, QuerySelect
+from orionbelt.models.semantic import SemanticModel
+from orionbelt.parser.loader import TrackedLoader
+from orionbelt.parser.resolver import ReferenceResolver
+
+PIPELINE = CompilationPipeline()
+
+# Two independent facts meeting only at a conformed dimension, each carrying a
+# money column with more scale than the measure declares. That gap is the whole
+# subject: without it the rounding has nothing to round away.
+MODEL_YAML = """\
+version: 1.0
+
+settings:
+  defaultDialect: duckdb
+
+dataObjects:
+  Days:
+    code: days
+    schema: main
+    columns:
+      Day: {code: day, abstractType: int, primaryKey: true}
+
+  Charges:
+    code: charges
+    schema: main
+    columns:
+      Day: {code: day, abstractType: int}
+      Amount: {code: amount, abstractType: float}
+    joins:
+      - joinType: many-to-one
+        joinTo: Days
+        columnsFrom: [Day]
+        columnsTo: [Day]
+
+  Invoices:
+    code: invoices
+    schema: main
+    columns:
+      Day: {code: day, abstractType: int}
+      Amount: {code: amount, abstractType: float}
+    joins:
+      - joinType: many-to-one
+        joinTo: Days
+        columnsFrom: [Day]
+        columnsTo: [Day]
+
+dimensions:
+  Day: {dataObject: Days, column: Day, resultType: int}
+
+measures:
+  Charged:
+    columns: [{dataObject: Charges, column: Amount}]
+    resultType: float
+    aggregation: sum
+    dataType: "decimal(18, 2)"
+  Invoiced:
+    columns: [{dataObject: Invoices, column: Amount}]
+    resultType: float
+    aggregation: sum
+    dataType: "decimal(18, 2)"
+"""
+
+# Every row is a third of a cent away from a clean value, so per-row rounding
+# is both certain and cumulative rather than luck of the data.
+ROWS = 300
+FRACTION = Decimal("0.004")
+
+
+def _model() -> SemanticModel:
+    raw, source_map = TrackedLoader().load_string(MODEL_YAML)
+    model, result = ReferenceResolver().resolve(raw, source_map)
+    assert result.valid, result.errors
+    return model
+
+
+def _seeded() -> duckdb.DuckDBPyConnection:
+    con = duckdb.connect(":memory:")
+    con.execute("CREATE TABLE days (day INTEGER)")
+    con.execute("CREATE TABLE charges (day INTEGER, amount DECIMAL(18, 6))")
+    con.execute("CREATE TABLE invoices (day INTEGER, amount DECIMAL(18, 6))")
+    con.execute(f"INSERT INTO days SELECT * FROM range(1, {ROWS + 1})")
+    for table in ("charges", "invoices"):
+        con.execute(f"INSERT INTO {table} SELECT r, 1 + {FRACTION} FROM range(1, {ROWS + 1}) t(r)")
+    return con
+
+
+def _run(con: duckdb.DuckDBPyConnection, measures: list[str]) -> list[tuple]:
+    sql = PIPELINE.compile(
+        QueryObject(select=QuerySelect(dimensions=[], measures=measures)),
+        _model(),
+        "duckdb",
+    ).sql
+    return con.execute(sql).fetchall()
+
+
+class TestUnionAlignmentPreservesInput:
+    def test_a_measure_answers_the_same_multi_fact_as_alone(self) -> None:
+        """The regression #305 describes, stated as the property it violates.
+
+        ``Charged`` alone takes the star path and casts after ``SUM``; asking
+        for it beside a measure from an independent fact takes the CFL path.
+        The two must agree, and did not: over 300 rows of 1.004 the multi-fact
+        answer came back 1.20 short.
+        """
+        con = _seeded()
+        try:
+            star = _run(con, ["Charged"])[0][0]
+            cfl = _run(con, ["Charged", "Invoiced"])[0][0]
+        finally:
+            con.close()
+        expected = (Decimal(1) + FRACTION) * ROWS
+        assert Decimal(str(star)) == expected.quantize(Decimal("0.01"))
+        assert Decimal(str(cfl)) == Decimal(str(star)), (
+            "the same measure answered differently under a multi-fact plan"
+        )
+
+    def test_the_legs_align_on_a_wider_type_than_the_result(self) -> None:
+        """Rows are carried wide; only the aggregate narrows to the declared type.
+
+        Asserted on the shape rather than the exact spelling, since the width
+        is a fallback the model can override with ``sqlPrecision``/``sqlScale``.
+        """
+        sql = PIPELINE.compile(
+            QueryObject(select=QuerySelect(dimensions=[], measures=["Charged", "Invoiced"])),
+            _model(),
+            "duckdb",
+        ).sql
+        leg_casts = re.findall(r'CAST\("(?:Charges|Invoices)"\."amount" AS ([A-Z0-9_(), ]+)\)', sql)
+        assert leg_casts, f"expected a leg cast on the source column:\n{sql}"
+        for rendered in leg_casts:
+            scale = int(re.search(r",\s*(\d+)\)", rendered).group(1))
+            assert scale > 2, f"leg narrowed rows to the result's scale: {rendered}"
+        assert re.search(r"CAST\(SUM\(.*?\) AS DECIMAL\(18, 2\)\)", sql), (
+            f"the aggregate should still narrow to the declared dataType:\n{sql}"
+        )
+
+    def test_every_leg_agrees_on_one_type(self) -> None:
+        """The reason the cast exists at all.
+
+        ClickHouse will not union columns whose types disagree: it builds a
+        ``Variant(Decimal, Float64)`` and refuses to ``SUM`` it. Widening the
+        own-measure cast without widening the NULL padding to match would trade
+        this bug for that one.
+        """
+        sql = PIPELINE.compile(
+            QueryObject(select=QuerySelect(dimensions=["Day"], measures=["Charged", "Invoiced"])),
+            _model(),
+            "clickhouse",
+        ).sql
+        # Only the union legs, not the outer aggregate: the whole point is that
+        # those two carry different types, so searching the statement as a
+        # whole would find the difference the fix introduces on purpose.
+        legs = sql[sql.index("WITH ") : sql.rindex(")\nSELECT")]
+        types = set(re.findall(r"AS (Nullable\(Decimal\(\d+, \d+\)\))", legs))
+        assert len(types) == 1, f"legs disagree on the union type: {types}\n{legs}"
+        assert re.search(r"CAST\(round\(SUM\(.*?\), 2\) AS Nullable\(Decimal\(18, 2\)\)\)", sql), (
+            f"the outer aggregate should still narrow to the declared type:\n{sql}"
+        )

--- a/tests/unit/test_cfl_union_alignment.py
+++ b/tests/unit/test_cfl_union_alignment.py
@@ -76,6 +76,15 @@ dimensions:
   Day: {dataObject: Days, column: Day, resultType: int}
 
 measures:
+  Charged Expr:
+    expression: "{[Charges].[Amount]} * 1"
+    resultType: float
+    aggregation: sum
+    dataType: "decimal(18, 2)"
+  Charged Min:
+    columns: [{dataObject: Charges, column: Amount}]
+    resultType: float
+    aggregation: min
   Charged:
     columns: [{dataObject: Charges, column: Amount}]
     resultType: float
@@ -183,4 +192,51 @@ class TestUnionAlignmentPreservesInput:
         assert len(types) == 1, f"legs disagree on the union type: {types}\n{legs}"
         assert re.search(r"CAST\(round\(SUM\(.*?\), 2\) AS Nullable\(Decimal\(18, 2\)\)\)", sql), (
             f"the outer aggregate should still narrow to the declared type:\n{sql}"
+        )
+
+
+class TestWhatIsAndIsNotWidened:
+    """Widening follows what an aggregation *does*, not what it is over."""
+
+    def test_an_expression_measure_is_covered_too(self) -> None:
+        """It has no ``columns``, and projects a pre-aggregation expression.
+
+        An earlier version keyed on having exactly one column, so every
+        ``expression:`` measure kept the original bug while the tests, which
+        only covered ``columns:`` measures, stayed green.
+        """
+        con = _seeded()
+        try:
+            star = _run(con, ["Charged Expr"])[0][0]
+            cfl = _run(con, ["Charged Expr", "Invoiced"])[0][0]
+        finally:
+            con.close()
+        assert Decimal(str(cfl)) == Decimal(str(star)), (
+            "an expression measure answered differently under a multi-fact plan"
+        )
+
+    def test_a_selecting_aggregate_is_left_alone(self) -> None:
+        """MIN picks a value rather than combining values, so nothing compounds.
+
+        ``resolve_measure_data_type`` treats MIN, MAX, ANY_VALUE, MEDIAN and
+        MODE as no-cast pass-through. Routing them through the widening changed
+        both the value and its type - MIN over a fifteen-decimal column went
+        from 1.000000000000400 to 1.000000000000 - so they keep the existing
+        alignment.
+
+        This asserts the leg is not widened rather than asserting a value:
+        those aggregates have a separate, older precision problem of their own
+        (the leg casts a wide decimal to FLOAT), which this change neither
+        causes nor fixes.
+        """
+        sql = PIPELINE.compile(
+            QueryObject(select=QuerySelect(dimensions=[], measures=["Charged Min", "Invoiced"])),
+            _model(),
+            "duckdb",
+        ).sql
+        min_leg = next(
+            line for line in sql.splitlines() if '"Charged Min"' in line and "CAST" in line
+        )
+        assert "DECIMAL(38, 12)" not in min_leg, (
+            f"a selecting aggregate was widened as though it accumulated: {min_leg}"
         )

--- a/tests/unit/test_cfl_union_alignment.py
+++ b/tests/unit/test_cfl_union_alignment.py
@@ -76,6 +76,11 @@ dimensions:
   Day: {dataObject: Days, column: Day, resultType: int}
 
 measures:
+  Charged Stddev:
+    columns: [{dataObject: Charges, column: Amount}]
+    resultType: float
+    aggregation: stddev
+    dataType: "decimal(18, 3)"
   Charged Expr:
     expression: "{[Charges].[Amount]} * 1"
     resultType: float
@@ -239,4 +244,29 @@ class TestWhatIsAndIsNotWidened:
         )
         assert "DECIMAL(38, 12)" not in min_leg, (
             f"a selecting aggregate was widened as though it accumulated: {min_leg}"
+        )
+
+    def test_a_statistical_aggregate_accumulates_too(self) -> None:
+        """STDDEV combines values across rows, so it rounds the same way SUM does.
+
+        A first cut listed only SUM and AVG, on the reasoning that they were
+        the obvious accumulating pair. STDDEV, STDDEV_POP, VARIANCE and VAR_POP
+        are single-column aggregates over the same pre-aggregation rows and
+        compound the same error: over 1.0004 and 1.0005 declared
+        ``decimal(18, 3)``, STDDEV answered 0.000 alone and 0.001 beside a
+        measure from another fact.
+
+        The two-column statistics (CORR, COVAR_*, REGR_*) never reach this
+        path: a multi-field measure pads per slot and keeps each slot's type.
+        """
+        sql = PIPELINE.compile(
+            QueryObject(select=QuerySelect(dimensions=[], measures=["Charged Stddev", "Invoiced"])),
+            _model(),
+            "duckdb",
+        ).sql
+        leg = next(
+            line for line in sql.splitlines() if '"Charged Stddev"' in line and "CAST" in line
+        )
+        assert "DECIMAL(18, 3)" not in leg, (
+            f"a statistical aggregate narrowed its rows to the result scale: {leg}"
         )

--- a/tests/unit/test_data_types.py
+++ b/tests/unit/test_data_types.py
@@ -191,6 +191,15 @@ class TestDialectRendering:
         # spill to BIGNUMERIC above precision 38.
         assert d.render_obml_type(DecimalType(18, 2)) == "NUMERIC"
         assert d.render_obml_type(DecimalType(76, 10)) == "BIGNUMERIC"
+        # Scale decides as much as precision does. NUMERIC is (38, 9), so a
+        # request for more scale than that has to spill too: measured on
+        # BigQuery, CAST(1.000000000004 AS NUMERIC) returns 1 while BIGNUMERIC
+        # returns the value, so answering NUMERIC here dropped the digits
+        # silently for every caller, not only the CFL leg alignment that
+        # surfaced it.
+        assert d.render_obml_type(DecimalType(38, 9)) == "NUMERIC"
+        assert d.render_obml_type(DecimalType(38, 12)) == "BIGNUMERIC"
+        assert d.render_obml_type(DecimalType(18, 12)) == "BIGNUMERIC"
 
     def test_precision_clamping(self) -> None:
         d = SnowflakeDialect()

--- a/tests/unit/test_grain_dedup.py
+++ b/tests/unit/test_grain_dedup.py
@@ -13,6 +13,7 @@ data where the two answers differ.
 
 from __future__ import annotations
 
+import re
 from decimal import Decimal
 
 import duckdb
@@ -2126,8 +2127,13 @@ def test_cfl_sort_key_alias_steps_aside_for_a_measure_that_owns_the_name() -> No
         {"select": {"dimensions": ["Year"], "measures": ["Return List__wg", "Return List"]}},
         CFL_ALIAS_CLASH_YAML,
     )
-    # The declared measure keeps the name it asked for...
-    assert '"Sales"."amount" AS DECIMAL(18, 2)) AS "Return List__wg"' in result.sql
+    # The declared measure keeps the name it asked for. The cast width is
+    # deliberately not pinned here: a CFL leg aligns on a type that preserves
+    # the input rather than the declared result type, and that is the subject
+    # of test_cfl_union_alignment, not of this test.
+    assert re.search(
+        r'CAST\("Sales"\."amount" AS [A-Z0-9_(), ]+\) AS "Return List__wg"', result.sql
+    ), result.sql
     # ...and the sort key moves out of its way, in the leg and in the outer ORDER BY.
     assert '"Calendar"."month" AS "Return List__wg_"' in result.sql
     assert 'ORDER BY "composite_01"."Return List__wg_"' in result.sql
@@ -2362,7 +2368,9 @@ def test_cfl_multi_field_alias_steps_aside_for_a_measure_that_owns_the_name() ->
         {"select": {"dimensions": ["Year"], "measures": ["Return Pairs__f0", "Return Pairs"]}},
         CFL_FIELD_CLASH_YAML,
     )
-    assert '"Sales"."amount" AS DECIMAL(18, 2)) AS "Return Pairs__f0"' in result.sql
+    assert re.search(
+        r'CAST\("Sales"\."amount" AS [A-Z0-9_(), ]+\) AS "Return Pairs__f0"', result.sql
+    ), result.sql
     assert '"Returns"."id" AS "Return Pairs__f0_"' in result.sql
     assert '"composite_01"."Return Pairs__f0_"' in result.sql
 


### PR DESCRIPTION
Closes #305.

## The defect

A CFL leg projects **pre-aggregation rows**; the outer query aggregates them. So the type the legs agree on is not the type the result has. Both came from `resolve_null_type_for_field`, which answers the second question, and using it for the first rounded every row before it was summed.

```sql
-- before: rows narrowed to the declared output type, then summed
CAST("Charges"."BilledCost" AS DECIMAL(18, 2)) AS "Billed Cost"
...
CAST(SUM("composite_01"."Billed Cost") AS DECIMAL(18, 2))
```

A measure declared `decimal(18, 2)` over a six-decimal column lost up to 0.005 per row: **1.06 across 15,224 rows**.

The consequence is worse than the magnitude. The same measure answered differently depending on whether the query happened to be multi-fact, so a report correct for months went wrong the moment someone added a measure from another fact, silently and always under-reporting.

## The fix

`resolve_union_alignment_type` is now separate, and is used for **both** the own-measure cast and the NULL padding, so the legs still agree:

```sql
-- after: rows carried wide, only the aggregate narrows
CAST("Charges"."BilledCost" AS DECIMAL(38, 12)) AS "Billed Cost"
...
CAST(SUM("composite_01"."Billed Cost") AS DECIMAL(18, 2))
```

That agreement is not optional. ClickHouse builds a `Variant(Decimal, Float64)` from mismatched legs and refuses to `SUM` it, still reproducible as **error code 43**, so the fix is the type *chosen*, not the casting. Widening the own cast without widening the padding would have traded this bug for that one.

A model declaring `sqlPrecision`/`sqlScale` is taken at its word. Otherwise the fallback is `decimal(38, 12)` - exact for any realistic money or rate column, with 26 integer digits left over.

**Non-numeric aggregates are untouched.** COUNT and LISTAGG project the raw column, whose own type is already the right alignment; widening a text column would be nonsense.

## Why the suite never caught it

The 32 drift snapshots that moved changed only their `sql` field. All four *execution* snapshots return **byte-identical rows**, because the existing fixtures carry no sub-cent precision to lose. The same reason the bug survived: any check comparing totals on that data would pass either way.

The new regression test uses 300 rows of `1.004`, so the rounding is certain and cumulative rather than luck of the data. It fails on the previous code with `the same measure answered differently under a multi-fact plan`.

## Verification

Executed, not just compiled. The wide alignment sums `1.005 + NULL + 2.004`:

| Engine | Rendered type | Result | Old alignment |
|---|---|---|---|
| BigQuery | `NUMERIC` | 3.009 | 3.00 |
| Snowflake | `NUMBER(38, 12)` | 3.009 | 3.00 |
| Postgres | `DECIMAL(38, 12)` | 3.009 | 3.00 |
| DuckDB | `DECIMAL(38, 12)` | 3.009 | 3.00 |
| ClickHouse | `Nullable(Decimal(38, 12))` | 3.009 | 3.00 |

- 3937 tests pass, plus 518 vendor-exec against containers and live warehouses
- The shipped FinOps showcase reproduces its documented figures unchanged
- `ruff`, `mypy` clean
