### PR TITLE
fix(compiler): a selecting aggregate's CFL leg carries the stored value (#311)

### DIFF
--- a/src/orionbelt/compiler/cfl.py
+++ b/src/orionbelt/compiler/cfl.py
@@ -338,6 +338,11 @@ class CFLPlanner:
         return cfl_projection.is_multi_field(measure)
 
     @staticmethod
+    def _leaves_union_untyped(measure: ResolvedMeasure, model: SemanticModel) -> bool:
+        """Whether both sides of the union carry *measure* with no cast."""
+        return cfl_projection.leaves_union_untyped(measure, model)
+
+    @staticmethod
     def _resolve_union_alignment_type(
         measure: ResolvedMeasure,
         model: SemanticModel,
@@ -594,9 +599,10 @@ class CFLPlanner:
                     # every one before the outer SUM sees it. The NULL pads
                     # below use the same resolver, so the legs still agree,
                     # which is what the cast was for.
-                    own_type_name = self._resolve_union_alignment_type(m, model, dialect)
-                    if own_type_name:
-                        own_expr = Cast(expr=own_expr, type_name=own_type_name)
+                    if not self._leaves_union_untyped(m, model):
+                        own_type_name = self._resolve_union_alignment_type(m, model, dialect)
+                        if own_type_name:
+                            own_expr = Cast(expr=own_expr, type_name=own_type_name)
                     leg_builder.select(AliasedExpr(expr=own_expr, alias=m.name))
                     # An ordered aggregate's sort key rides along as its own
                     # column so the outer re-aggregation can order by it.
@@ -607,9 +613,11 @@ class CFLPlanner:
                         )
                 elif not union_by_name:
                     model_measure = model.measures.get(m.name)
-                    null_type_name = self._resolve_union_alignment_type(m, model, dialect)
-                    if null_type_name is None and model_measure:
-                        null_type_name = model_measure.result_type.value
+                    null_type_name = None
+                    if not self._leaves_union_untyped(m, model):
+                        null_type_name = self._resolve_union_alignment_type(m, model, dialect)
+                        if null_type_name is None and model_measure:
+                            null_type_name = model_measure.result_type.value
                     null_expr = (
                         Cast(Literal.null(), type_name=null_type_name)
                         if null_type_name

--- a/src/orionbelt/compiler/cfl_projection.py
+++ b/src/orionbelt/compiler/cfl_projection.py
@@ -206,6 +206,44 @@ _ACCUMULATING_AGGREGATIONS = frozenset(
 )
 
 
+# These pick a value out of the rows rather than combining them, so the leg
+# should hand the outer aggregate the stored value untouched.
+_SELECTING_AGGREGATIONS = frozenset({"min", "max", "any_value", "median", "mode"})
+
+
+def leaves_union_untyped(measure: ResolvedMeasure, model: SemanticModel) -> bool:
+    """Whether both sides of the union should carry *measure* with no cast.
+
+    A selecting aggregate hands the outer ``MIN``/``MAX``/... a value to choose
+    from, so any cast on the leg is applied to the stored value itself. Casting
+    to the measure's ``result_type`` meant a ``DECIMAL(38, 15)`` column reached
+    the aggregate as ``FLOAT``, and ``MIN`` then selected from already-degraded
+    values: 1.000000000000400 became 1.0 the moment a measure from another fact
+    joined the query. Issue #311.
+
+    Leaving both sides untyped works because the *padding* is what forced the
+    cast in the first place. A typed NULL that disagrees with the own column is
+    what builds ClickHouse's ``Variant(Decimal, Float64)``; an untyped ``NULL``
+    unifies with whatever the column is. Measured on ClickHouse, Postgres,
+    MySQL, DuckDB, BigQuery and Snowflake, each returning the exact stored
+    value where the cast returned a degraded one.
+
+    Restricted to numeric sources. A text or temporal column is not damaged by
+    its abstract type, and the existing padding for those is well covered.
+    """
+    model_measure = model.effective_measures.get(measure.name)
+    if not model_measure:
+        return False
+    if (model_measure.aggregation or "").lower() not in _SELECTING_AGGREGATIONS:
+        return False
+    if len(model_measure.columns) != 1:
+        return False
+    ref = model_measure.columns[0]
+    obj = model.data_objects.get(ref.view) if ref.view else None
+    column = obj.columns.get(ref.column) if obj and ref.column else None
+    return column is not None and column.abstract_type.value in ("int", "float")
+
+
 def resolve_union_alignment_type(
     measure: ResolvedMeasure,
     model: SemanticModel,

--- a/tests/unit/test_cfl_union_alignment.py
+++ b/tests/unit/test_cfl_union_alignment.py
@@ -54,6 +54,7 @@ dataObjects:
     columns:
       Day: {code: day, abstractType: int}
       Amount: {code: amount, abstractType: float}
+      Label: {code: label, abstractType: string}
     joins:
       - joinType: many-to-one
         joinTo: Days
@@ -90,6 +91,10 @@ measures:
     columns: [{dataObject: Charges, column: Amount}]
     resultType: float
     aggregation: min
+  Charged Label Min:
+    columns: [{dataObject: Charges, column: Label}]
+    resultType: string
+    aggregation: min
   Charged:
     columns: [{dataObject: Charges, column: Amount}]
     resultType: float
@@ -118,11 +123,11 @@ def _model() -> SemanticModel:
 def _seeded() -> duckdb.DuckDBPyConnection:
     con = duckdb.connect(":memory:")
     con.execute("CREATE TABLE days (day INTEGER)")
-    con.execute("CREATE TABLE charges (day INTEGER, amount DECIMAL(18, 6))")
+    con.execute("CREATE TABLE charges (day INTEGER, amount DECIMAL(18, 6), label VARCHAR)")
     con.execute("CREATE TABLE invoices (day INTEGER, amount DECIMAL(18, 6))")
     con.execute(f"INSERT INTO days SELECT * FROM range(1, {ROWS + 1})")
-    for table in ("charges", "invoices"):
-        con.execute(f"INSERT INTO {table} SELECT r, 1 + {FRACTION} FROM range(1, {ROWS + 1}) t(r)")
+    con.execute(f"INSERT INTO charges SELECT r, 1 + {FRACTION}, 'x' FROM range(1, {ROWS + 1}) t(r)")
+    con.execute(f"INSERT INTO invoices SELECT r, 1 + {FRACTION} FROM range(1, {ROWS + 1}) t(r)")
     return con
 
 
@@ -229,10 +234,9 @@ class TestWhatIsAndIsNotWidened:
         from 1.000000000000400 to 1.000000000000 - so they keep the existing
         alignment.
 
-        This asserts the leg is not widened rather than asserting a value:
-        those aggregates have a separate, older precision problem of their own
-        (the leg casts a wide decimal to FLOAT), which this change neither
-        causes nor fixes.
+        They are also not narrowed: a selecting aggregate hands the outer
+        ``MIN`` a value to choose from, so the leg carries the stored value
+        with no cast at all. See ``TestSelectingAggregatesKeepTheStoredValue``.
         """
         sql = PIPELINE.compile(
             QueryObject(select=QuerySelect(dimensions=[], measures=["Charged Min", "Invoiced"])),
@@ -270,3 +274,74 @@ class TestWhatIsAndIsNotWidened:
         assert "DECIMAL(18, 3)" not in leg, (
             f"a statistical aggregate narrowed its rows to the result scale: {leg}"
         )
+
+
+class TestSelectingAggregatesKeepTheStoredValue:
+    """A leg hands MIN/MAX a value to choose from, so it must not touch it.
+
+    Casting the leg to the measure's ``result_type`` meant a wide decimal
+    reached the aggregate as ``FLOAT``, and ``MIN`` selected from already
+    degraded values. Issue #311.
+    """
+
+    def test_a_min_answers_the_same_multi_fact_as_alone(self) -> None:
+        con = duckdb.connect(":memory:")
+        try:
+            con.execute("CREATE TABLE days (day INTEGER)")
+            con.execute("CREATE TABLE charges (day INTEGER, amount DECIMAL(38, 15), label VARCHAR)")
+            con.execute("CREATE TABLE invoices (day INTEGER, amount DECIMAL(18, 6))")
+            con.execute("INSERT INTO days VALUES (1), (2)")
+            con.execute("INSERT INTO charges VALUES (1, 1.000000000000400, 'x'), (2, 2.5, 'y')")
+            con.execute("INSERT INTO invoices VALUES (1, 3.5), (2, 4.5)")
+            star = _run(con, ["Charged Min"])[0][0]
+            cfl = _run(con, ["Charged Min", "Invoiced"])[0][0]
+        finally:
+            con.close()
+        assert Decimal(str(star)) == Decimal("1.000000000000400")
+        assert Decimal(str(cfl)) == Decimal(str(star)), (
+            "MIN selected from values the leg had already degraded"
+        )
+
+    def test_the_leg_carries_the_column_uncast(self) -> None:
+        sql = PIPELINE.compile(
+            QueryObject(select=QuerySelect(dimensions=[], measures=["Charged Min", "Invoiced"])),
+            _model(),
+            "duckdb",
+        ).sql
+        assert '"Charges"."amount" AS "Charged Min"' in sql, (
+            f"the leg should hand MIN the stored value, uncast:\n{sql}"
+        )
+
+    def test_the_padding_is_an_untyped_null(self) -> None:
+        """A typed NULL is what forced the cast; an untyped one unifies.
+
+        ClickHouse builds a ``Variant(Decimal, Float64)`` from a typed pad that
+        disagrees with the own column and then refuses to aggregate it. A bare
+        ``NULL`` takes whatever type the column has, measured on ClickHouse,
+        Postgres, MySQL, DuckDB, BigQuery and Snowflake.
+        """
+        sql = PIPELINE.compile(
+            QueryObject(
+                select=QuerySelect(dimensions=["Day"], measures=["Charged Min", "Invoiced"])
+            ),
+            _model(),
+            "clickhouse",
+        ).sql
+        assert 'NULL AS "Charged Min"' in sql, f"expected an untyped pad:\n{sql}"
+
+    def test_a_non_numeric_source_is_left_as_it_was(self) -> None:
+        """Only numeric sources were being damaged.
+
+        A text column is not degraded by its abstract type, and the existing
+        padding for those is well covered, so the change is scoped to where the
+        harm was rather than applied on principle.
+        """
+        sql = PIPELINE.compile(
+            QueryObject(
+                select=QuerySelect(dimensions=[], measures=["Charged Label Min", "Invoiced"])
+            ),
+            _model(),
+            "duckdb",
+        ).sql
+        leg = next(line for line in sql.splitlines() if '"Charged Label Min"' in line)
+        assert "CAST" in leg, f"a text source should keep its existing padding:\n{leg}"


### PR DESCRIPTION
Closes #311.

## The defect

`MIN`, `MAX`, `ANY_VALUE`, `MEDIAN` and `MODE` hand the outer aggregate a value to **choose from**, so a cast on the leg lands on the stored value itself. Casting to the measure's `result_type` meant a `DECIMAL(38, 15)` column reached `MIN` as `FLOAT`:

| Path | Result |
|---|---|
| Star (`MIN` alone) | `1.000000000000400` |
| CFL (`MIN` + another fact's measure) | `1.0` |

Sibling of #305, different cause. That one applied the declared **output** `dataType` to pre-aggregation rows; this applies the column's **abstract** type to them.

## Why not the #305 fix

#305 deliberately left these alone, and widening them was tried and rejected in that review: it changed both the value and its type, turning `1.000000000000400` into `1.000000000000`. The answer is a third thing - **not casting at all**:

```sql
-- before                                   -- after
CAST("Charges"."amount" AS FLOAT) AS "Min"  "Charges"."amount" AS "Min"
CAST(NULL AS FLOAT)              AS "Min"   NULL                AS "Min"
```

That works because **the padding is what forced the cast in the first place**. A typed NULL disagreeing with the own column is what builds ClickHouse's `Variant(Decimal, Float64)`; an untyped `NULL` takes whatever type the column has.

## Measured, in the shape the planner emits

Two legs, each padding the other's measure, on every reachable engine:

| Engine | Result |
|---|---|
| ClickHouse | `1.000000000000400` |
| Postgres | `1.000000000000400` |
| MySQL 8.0 | `1.000000000000400` |
| DuckDB | `1.000000000000400` |
| BigQuery | `1.0000000000004` |
| Snowflake | `1.000000000000400` |

Each returns the exact stored value where the cast returned a degraded one, and none errors on the untyped pad.

## Scope

**Numeric sources only.** A text or temporal column is not damaged by its abstract type and the existing padding for those is well covered, so this changes where the harm was rather than everywhere the pattern appears. `test_a_non_numeric_source_is_left_as_it_was` pins that a text `MIN` keeps its cast.

## Verification

- 4062 tests, plus 518 vendor-exec against containers and live warehouses
- **No drift snapshots move**: no existing CFL fixture uses a selecting aggregate, which is also why the suite never covered this
- The three new behavioural tests fail on main with `MIN selected from values the leg had already degraded`
- The FinOps showcase reproduces its documented figures unchanged
- `ruff`, `mypy` clean
