### PR TITLE
fix(compiler): one CFL alignment, wide enough for the source (#311)

### DIFF
--- a/src/orionbelt/compiler/cfl.py
+++ b/src/orionbelt/compiler/cfl.py
@@ -346,6 +346,14 @@ class CFLPlanner:
         """The type every UNION leg agrees on for *measure*'s column."""
         return cfl_projection.resolve_union_alignment_type(measure, model, dialect)
 
+    def _resolve_owning_leg_cast_type(
+        self,
+        measure: ResolvedMeasure,
+        model: SemanticModel,
+        dialect: Dialect | None = None,
+    ) -> str | None:
+        return cfl_projection.resolve_owning_leg_cast_type(measure, model, dialect)
+
     @staticmethod
     def _resolve_null_type_for_field(
         measure: ResolvedMeasure,
@@ -588,13 +596,27 @@ class CFLPlanner:
                         if m.name in conformed_exprs
                         else m
                     )
-                    # Align on a type that preserves the input, not on the
-                    # measure's declared *output* type: these are
-                    # pre-aggregation rows, and narrowing them here rounds
-                    # every one before the outer SUM sees it. The NULL pads
-                    # below use the same resolver, so the legs still agree,
-                    # which is what the cast was for.
-                    own_type_name = self._resolve_union_alignment_type(m, model, dialect)
+                    # The leg that owns the measure projects it **uncast**, in
+                    # the source's own type, exactly as the star path does.
+                    #
+                    # Only the NULL pads below carry a declared type, and that
+                    # is enough to settle the union: measured on DuckDB,
+                    # Postgres and ClickHouse, a typed pad beside an uncast
+                    # column resolves to the *column's* type, in any leg order.
+                    # Casting this side as well is what rounded pre-aggregation
+                    # rows to the declared output type (#305), and then, once
+                    # the alignment was widened to carry the scale, overflowed
+                    # a value the source column held quite legally: a
+                    # DECIMAL(38, 20) leaves only 18 integer digits, so a
+                    # DECIMAL(38, 15) source failed on Postgres and DuckDB
+                    # under CFL while succeeding alone (#311). Not casting
+                    # cannot do either, because there is no second type.
+                    #
+                    # The exception is an alignment that *converts* rather than
+                    # widens - LISTAGG over an integer column pads with text -
+                    # where an uncast leg would meet a pad of another type and
+                    # Postgres would refuse the union.
+                    own_type_name = self._resolve_owning_leg_cast_type(m, model, dialect)
                     if own_type_name:
                         own_expr = Cast(expr=own_expr, type_name=own_type_name)
                     leg_builder.select(AliasedExpr(expr=own_expr, alias=m.name))

--- a/src/orionbelt/compiler/cfl_projection.py
+++ b/src/orionbelt/compiler/cfl_projection.py
@@ -37,6 +37,8 @@ from orionbelt.compiler.type_resolver import resolve_measure_data_type
 from orionbelt.dialect.base import Dialect
 from orionbelt.models.semantic import (
     TWO_COLUMN_AGGREGATIONS,
+    DataObjectColumn,
+    Measure,
     SemanticModel,
 )
 from orionbelt.models.types import DecimalType, parse_data_type
@@ -206,6 +208,40 @@ _ALIGNMENT_PRECISION = 38
 _RAW_COLUMN_AGGREGATIONS = frozenset({"count", "count_distinct", "listagg"})
 
 
+def _alignment_source(
+    model_measure: Measure, model: SemanticModel
+) -> tuple[str | None, DataObjectColumn | None]:
+    """The numeric kind a measure's legs carry, and its source column if any.
+
+    One place decides this for **both** shapes a measure can take. Keeping the
+    ``columns:`` and ``expression:`` cases in separate branches is what caused
+    this function to be wrong three times in a row, each time for expression
+    measures and each time in a different clause: they were missed by the
+    accumulating widening, then by an attempt to leave the union untyped, then
+    by the integer alignment. They project a pre-aggregation value exactly as a
+    column measure does, so they belong on the same path.
+
+    Returns ``("int" | "float", column | None)``, or ``(None, None)`` when the
+    measure's legs should keep whatever :func:`resolve_null_type_for_field`
+    gives them.
+    """
+    if len(model_measure.columns) > 1:
+        # A multi-field aggregate pads per slot; each slot keeps its own type.
+        return None, None
+    if not model_measure.columns:
+        # An expression has no source column, so its kind is the declared
+        # resultType.
+        kind = model_measure.result_type.value
+        return (kind if kind in ("int", "float") else None), None
+    ref = model_measure.columns[0]
+    obj = model.data_objects.get(ref.view) if ref.view else None
+    column = obj.columns.get(ref.column) if obj and ref.column else None
+    if column is None:
+        return None, None
+    kind = column.abstract_type.value
+    return (kind if kind in ("int", "float") else None), column
+
+
 def resolve_union_alignment_type(
     measure: ResolvedMeasure,
     model: SemanticModel,
@@ -217,71 +253,41 @@ def resolve_union_alignment_type(
     the whole point. That one answers "what type does the *result* have", which
     is right for the outer ``CAST(SUM(...) AS ...)`` and wrong here: the legs
     carry **pre-aggregation rows**, so aligning them on the declared output
-    type rounds every row before it is summed. A measure declared
+    type rounds every row before the aggregate sees it. A measure declared
     ``decimal(18, 2)`` over a six-decimal column lost up to 0.005 per row.
 
-    The alignment still has to be a single concrete type, because a strict
-    engine will not union columns whose types disagree: ClickHouse produces
-    ``Variant(Decimal, Float64)`` and then refuses to ``SUM`` it.
+    The alignment has to be a single concrete type. A strict engine will not
+    union columns whose types disagree - ClickHouse produces
+    ``Variant(Decimal, Float64)`` and refuses to ``SUM`` it - and leaving both
+    sides untyped instead was measured to break two more: Postgres resolves a
+    column whose first occurrences are untyped NULLs as text, and DuckDB
+    unifies to the pad's type rather than the column's. So the only question is
+    the width.
 
-    Widening applies only to the aggregations that **accumulate** across rows,
-    which is where pre-aggregation rounding compounds. ``MIN``, ``MAX``,
-    ``ANY_VALUE``, ``MEDIAN`` and ``MODE`` select a value rather than combining
-    values, and ``resolve_measure_data_type`` treats them as no-cast
-    pass-through; widening them changed both the value and its type, turning
-    ``MIN`` over a fifteen-decimal column from 1.000000000000400 into
-    1.000000000000. ``COUNT`` and ``LISTAGG`` project the raw column, whose own
-    type is already the right alignment.
+    **Fractional sources** align on a wide decimal. **Integer sources** align
+    on the 64-bit integer instead: an integer has no fractional digits to lose,
+    a ``DECIMAL(38, 20)`` leaves only 18 integer digits where a BIGINT needs
+    19, and ``abstractType: int`` renders as a 32-bit ``INTEGER`` that a BIGINT
+    column overflows on its own.
 
-    An **expression** measure has no ``columns`` and is covered: it projects a
-    pre-aggregation expression exactly as a column measure projects a column,
-    so it suffered the same rounding and was missed by an earlier version of
-    this that keyed on having exactly one column.
-
-    A model that declares the source column's ``sqlPrecision``/``sqlScale`` is
-    taken at its word. Otherwise the fallback widens to ``decimal(38, 12)``,
-    which carries any realistic money or rate column exactly and still leaves
-    26 integer digits.
+    ``COUNT`` and ``LISTAGG`` project the raw column, whose own type is already
+    the alignment, and text or temporal sources keep theirs for the same
+    reason.
     """
     model_measure = model.effective_measures.get(measure.name)
     if not model_measure or dialect is None:
         return resolve_null_type_for_field(measure, 0, model, dialect)
     if (model_measure.aggregation or "").lower() in _RAW_COLUMN_AGGREGATIONS:
-        # COUNT and LISTAGG project the raw column, whose own type is already
-        # the right alignment.
-        return resolve_null_type_for_field(measure, 0, model, dialect)
-    # A multi-field aggregate pads per slot; each slot keeps its own type.
-    if len(model_measure.columns) > 1:
         return resolve_null_type_for_field(measure, 0, model, dialect)
 
-    # An expression measure has no source column, so numeric-ness comes from
-    # the declared resultType. It projects a pre-aggregation expression exactly
-    # as a column measure projects a column, and was missed twice by cuts that
-    # keyed on having exactly one column.
-    if not model_measure.columns and model_measure.result_type.value != "float":
+    kind, column = _alignment_source(model_measure, model)
+    if kind is None:
         return resolve_null_type_for_field(measure, 0, model, dialect)
+    if kind == "int":
+        return dialect.render_obml_type(parse_data_type("bigint"))
 
-    column = None
-    if len(model_measure.columns) == 1:
-        ref = model_measure.columns[0]
-        obj = model.data_objects.get(ref.view) if ref.view else None
-        column = obj.columns.get(ref.column) if obj and ref.column else None
-        if column is not None and column.abstract_type.value == "int":
-            # An integer has no fractional digits to lose, so the decimal
-            # widening buys nothing and costs two things: DECIMAL(38, 20)
-            # leaves 18 integer digits, which a BIGINT can exceed outright -
-            # DuckDB refuses to cast 1000000000000000000 - and it changes an
-            # integer measure's type the moment another fact joins the query.
-            #
-            # It still needs widening of its own kind. ``abstractType: int``
-            # renders as a 32-bit INTEGER, so a BIGINT column reached the leg
-            # as CAST(qty AS INTEGER) and failed on any value past 2^31. The
-            # 64-bit integer is the alignment that cannot lose.
-            return dialect.render_obml_type(parse_data_type("bigint"))
-        if column is not None and column.abstract_type.value != "float":
-            # Text and temporal: their own type is already the alignment.
-            return resolve_null_type_for_field(measure, 0, model, dialect)
-
+    # A model that declares the source column's own precision is taken at its
+    # word; otherwise the fallback width applies.
     if column is not None and column.sql_precision is not None:
         precision = column.sql_precision
         scale = column.sql_scale if column.sql_scale is not None else 0

--- a/src/orionbelt/compiler/cfl_projection.py
+++ b/src/orionbelt/compiler/cfl_projection.py
@@ -187,23 +187,23 @@ def resolve_null_type_for_field(
 
 
 # Scale used to align a numeric aggregate's UNION legs when the model has not
-# declared the source column's own scale. Wide enough that a money column is
-# carried exactly, while leaving 26 integer digits at precision 38.
-_ALIGNMENT_SCALE = 12
+# declared the source column's own scale, leaving 18 integer digits at
+# precision 38.
+#
+# It is a guess, and unavoidably so: ``abstractType: float`` says nothing about
+# a DECIMAL(38, 15) column behind it, and every fixed width is wrong for some
+# source. A first cut used 12 and lost anything past twelve places, measured on
+# Postgres, DuckDB, ClickHouse and Snowflake alike. 20 carries realistic money
+# and rate columns exactly. A model that declares ``sqlPrecision``/``sqlScale``
+# is taken at its word and needs no guess at all, which is the only exact
+# answer available without introspecting the warehouse.
+_ALIGNMENT_SCALE = 20
 _ALIGNMENT_PRECISION = 38
 
-# Only these combine values across rows, so only these compound a
-# pre-aggregation rounding error. Everything else either selects a value
-# (MIN/MAX/ANY_VALUE/MEDIAN/MODE) or projects the raw column (COUNT, LISTAGG).
-#
-# The statistical aggregates belong here for the same reason SUM does, and were
-# missed by a first cut that listed only the obvious two: STDDEV over 1.0004 and
-# 1.0005 declared decimal(18, 3) answered 0.000 alone and 0.001 beside a measure
-# from another fact. The two-column ones (CORR, COVAR_*, REGR_*) never reach
-# this path - a multi-field measure pads per slot and keeps each slot's type.
-_ACCUMULATING_AGGREGATIONS = frozenset(
-    {"sum", "avg", "stddev", "stddev_pop", "variance", "var_pop"}
-)
+
+# These project the raw column rather than a value to be combined, so their
+# alignment is the column's own type.
+_RAW_COLUMN_AGGREGATIONS = frozenset({"count", "count_distinct", "listagg"})
 
 
 def resolve_union_alignment_type(
@@ -246,10 +246,19 @@ def resolve_union_alignment_type(
     model_measure = model.effective_measures.get(measure.name)
     if not model_measure or dialect is None:
         return resolve_null_type_for_field(measure, 0, model, dialect)
-    if (model_measure.aggregation or "").lower() not in _ACCUMULATING_AGGREGATIONS:
+    if (model_measure.aggregation or "").lower() in _RAW_COLUMN_AGGREGATIONS:
+        # COUNT and LISTAGG project the raw column, whose own type is already
+        # the right alignment.
         return resolve_null_type_for_field(measure, 0, model, dialect)
     # A multi-field aggregate pads per slot; each slot keeps its own type.
     if len(model_measure.columns) > 1:
+        return resolve_null_type_for_field(measure, 0, model, dialect)
+
+    # An expression measure has no source column, so numeric-ness comes from
+    # the declared resultType. It projects a pre-aggregation expression exactly
+    # as a column measure projects a column, and was missed twice by cuts that
+    # keyed on having exactly one column.
+    if not model_measure.columns and model_measure.result_type.value not in ("int", "float"):
         return resolve_null_type_for_field(measure, 0, model, dialect)
 
     column = None

--- a/src/orionbelt/compiler/cfl_projection.py
+++ b/src/orionbelt/compiler/cfl_projection.py
@@ -300,6 +300,39 @@ def resolve_union_alignment_type(
     return dialect.render_obml_type(DecimalType(precision=precision, scale=scale))
 
 
+def resolve_owning_leg_cast_type(
+    measure: ResolvedMeasure,
+    model: SemanticModel,
+    dialect: Dialect | None = None,
+) -> str | None:
+    """The cast for the leg that *owns* a measure, or ``None`` to leave it be.
+
+    The NULL pads always carry a type; this side usually should not. A typed
+    pad beside an uncast column resolves to the **column's** type on DuckDB,
+    Postgres and ClickHouse, in any leg order, so the union is already settled
+    and casting here can only lose: to the declared output type it rounded
+    pre-aggregation rows (#305), and to a fixed wide decimal it overflowed
+    values the source held legally, since ``DECIMAL(38, 20)`` keeps just 18
+    integer digits (#311).
+
+    It is kept where the alignment is a **conversion** rather than a widening.
+    ``LISTAGG`` over an integer column aligns the pads on text, and an uncast
+    integer leg meeting a text pad is a union Postgres refuses outright. Those
+    measures are exactly the ones :func:`resolve_union_alignment_type` answers
+    from the column's own type, so the rule is: cast when the alignment is not
+    the numeric widening.
+    """
+    model_measure = model.effective_measures.get(measure.name)
+    if (
+        model_measure is not None
+        and dialect is not None
+        and (model_measure.aggregation or "").lower() not in _RAW_COLUMN_AGGREGATIONS
+        and _alignment_source(model_measure, model)[0] is not None
+    ):
+        return None
+    return resolve_union_alignment_type(measure, model, dialect)
+
+
 def outer_aggregation(measure: ResolvedMeasure) -> tuple[str, bool]:
     """The SQL aggregate name and ``DISTINCT`` flag to re-apply outside the union.
 

--- a/src/orionbelt/compiler/cfl_projection.py
+++ b/src/orionbelt/compiler/cfl_projection.py
@@ -39,7 +39,7 @@ from orionbelt.models.semantic import (
     TWO_COLUMN_AGGREGATIONS,
     SemanticModel,
 )
-from orionbelt.models.types import DecimalType
+from orionbelt.models.types import DecimalType, parse_data_type
 
 if TYPE_CHECKING:
     from orionbelt.compiler.cfl import CFLPlanner
@@ -258,7 +258,7 @@ def resolve_union_alignment_type(
     # the declared resultType. It projects a pre-aggregation expression exactly
     # as a column measure projects a column, and was missed twice by cuts that
     # keyed on having exactly one column.
-    if not model_measure.columns and model_measure.result_type.value not in ("int", "float"):
+    if not model_measure.columns and model_measure.result_type.value != "float":
         return resolve_null_type_for_field(measure, 0, model, dialect)
 
     column = None
@@ -266,8 +266,20 @@ def resolve_union_alignment_type(
         ref = model_measure.columns[0]
         obj = model.data_objects.get(ref.view) if ref.view else None
         column = obj.columns.get(ref.column) if obj and ref.column else None
-        if column is not None and column.abstract_type.value not in ("int", "float"):
-            # A non-numeric source keeps its own type; widening it is nonsense.
+        if column is not None and column.abstract_type.value == "int":
+            # An integer has no fractional digits to lose, so the decimal
+            # widening buys nothing and costs two things: DECIMAL(38, 20)
+            # leaves 18 integer digits, which a BIGINT can exceed outright -
+            # DuckDB refuses to cast 1000000000000000000 - and it changes an
+            # integer measure's type the moment another fact joins the query.
+            #
+            # It still needs widening of its own kind. ``abstractType: int``
+            # renders as a 32-bit INTEGER, so a BIGINT column reached the leg
+            # as CAST(qty AS INTEGER) and failed on any value past 2^31. The
+            # 64-bit integer is the alignment that cannot lose.
+            return dialect.render_obml_type(parse_data_type("bigint"))
+        if column is not None and column.abstract_type.value != "float":
+            # Text and temporal: their own type is already the alignment.
             return resolve_null_type_for_field(measure, 0, model, dialect)
 
     if column is not None and column.sql_precision is not None:

--- a/src/orionbelt/compiler/cfl_projection.py
+++ b/src/orionbelt/compiler/cfl_projection.py
@@ -286,11 +286,15 @@ def resolve_union_alignment_type(
     if kind == "int":
         return dialect.render_obml_type(parse_data_type("bigint"))
 
-    # A model that declares the source column's own precision is taken at its
-    # word; otherwise the fallback width applies.
-    if column is not None and column.sql_precision is not None:
-        precision = column.sql_precision
-        scale = column.sql_scale if column.sql_scale is not None else 0
+    # A model that declares the source column's own width is taken at its word,
+    # but only when it declares **both** halves of it. sqlPrecision and sqlScale
+    # are independently optional, so defaulting a missing scale to 0 turned
+    # sqlPrecision: 18 over a DECIMAL(18, 6) source into DECIMAL(18, 0) and
+    # rounded every row before the aggregate - the original defect, reached
+    # through a different door. A precision alone says nothing about scale, so
+    # it is not enough to narrow on.
+    if column is not None and column.sql_precision is not None and column.sql_scale is not None:
+        precision, scale = column.sql_precision, column.sql_scale
     else:
         precision, scale = _ALIGNMENT_PRECISION, _ALIGNMENT_SCALE
     return dialect.render_obml_type(DecimalType(precision=precision, scale=scale))

--- a/tests/integration/drift/compile_only/bigquery/04_sales_returns_cfl_by_country.sql
+++ b/tests/integration/drift/compile_only/bigquery/04_sales_returns_cfl_by_country.sql
@@ -1,10 +1,10 @@
 WITH `composite_01` AS (
-SELECT `Countries`.`countryname` AS `Sales Country Name`, CAST(`Sales`.`salesamount` AS BIGNUMERIC) AS `Total Sales`, CAST(NULL AS BIGNUMERIC) AS `Total Returns`
+SELECT `Countries`.`countryname` AS `Sales Country Name`, `Sales`.`salesamount` AS `Total Sales`, CAST(NULL AS BIGNUMERIC) AS `Total Returns`
 FROM `orionbelt_1`.`sales` AS `Sales`
 LEFT JOIN `orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`
 LEFT JOIN `orionbelt_1`.`countries` AS `Countries` ON `Clients`.`clientcountryid` = `Countries`.`countryid`
 UNION ALL
-SELECT `Countries`.`countryname` AS `Sales Country Name`, CAST(NULL AS BIGNUMERIC) AS `Total Sales`, CAST(`Returns`.`returnamount` AS BIGNUMERIC) AS `Total Returns`
+SELECT `Countries`.`countryname` AS `Sales Country Name`, CAST(NULL AS BIGNUMERIC) AS `Total Sales`, `Returns`.`returnamount` AS `Total Returns`
 FROM `orionbelt_1`.`returns` AS `Returns`
 LEFT JOIN `orionbelt_1`.`sales` AS `Sales` ON `Returns`.`returnsalesid` = `Sales`.`salesid`
 LEFT JOIN `orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`

--- a/tests/integration/drift/compile_only/bigquery/05_sales_purchases_cfl_ungrouped.sql
+++ b/tests/integration/drift/compile_only/bigquery/05_sales_purchases_cfl_ungrouped.sql
@@ -1,8 +1,8 @@
 WITH `composite_01` AS (
-SELECT CAST(`Sales`.`salesamount` AS BIGNUMERIC) AS `Total Sales`, CAST(NULL AS BIGNUMERIC) AS `Total Purchases`
+SELECT `Sales`.`salesamount` AS `Total Sales`, CAST(NULL AS BIGNUMERIC) AS `Total Purchases`
 FROM `orionbelt_1`.`sales` AS `Sales`
 UNION ALL
-SELECT CAST(NULL AS BIGNUMERIC) AS `Total Sales`, CAST(`Purchases`.`purchaseamount` AS BIGNUMERIC) AS `Total Purchases`
+SELECT CAST(NULL AS BIGNUMERIC) AS `Total Sales`, `Purchases`.`purchaseamount` AS `Total Purchases`
 FROM `orionbelt_1`.`purchases` AS `Purchases`
 )
 SELECT ROUND(CAST(SUM(`composite_01`.`Total Sales`) AS NUMERIC), 2) AS `Total Sales`, ROUND(CAST(SUM(`composite_01`.`Total Purchases`) AS NUMERIC), 2) AS `Total Purchases`

--- a/tests/integration/drift/compile_only/bigquery/07_total_sales_by_client_with_complaints.sql
+++ b/tests/integration/drift/compile_only/bigquery/07_total_sales_by_client_with_complaints.sql
@@ -1,5 +1,5 @@
 WITH `composite_01` AS (
-SELECT `Clients`.`clientname` AS `Sales Client Name`, CAST(NULL AS STRING) AS `Complaint Client Name`, CAST(`Sales`.`salesamount` AS BIGNUMERIC) AS `Total Sales`, CAST(NULL AS INT64) AS `Client Complaints Count`
+SELECT `Clients`.`clientname` AS `Sales Client Name`, CAST(NULL AS STRING) AS `Complaint Client Name`, `Sales`.`salesamount` AS `Total Sales`, CAST(NULL AS INT64) AS `Client Complaints Count`
 FROM `orionbelt_1`.`sales` AS `Sales`
 LEFT JOIN `orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`
 UNION ALL

--- a/tests/integration/drift/compile_only/bigquery/09_return_rate.sql
+++ b/tests/integration/drift/compile_only/bigquery/09_return_rate.sql
@@ -1,8 +1,8 @@
 WITH `composite_01` AS (
-SELECT CAST(`Returns`.`returnamount` AS BIGNUMERIC) AS `Total Returns`, CAST(NULL AS BIGNUMERIC) AS `Total Sales`
+SELECT `Returns`.`returnamount` AS `Total Returns`, CAST(NULL AS BIGNUMERIC) AS `Total Sales`
 FROM `orionbelt_1`.`returns` AS `Returns`
 UNION ALL
-SELECT CAST(NULL AS BIGNUMERIC) AS `Total Returns`, CAST(`Sales`.`salesamount` AS BIGNUMERIC) AS `Total Sales`
+SELECT CAST(NULL AS BIGNUMERIC) AS `Total Returns`, `Sales`.`salesamount` AS `Total Sales`
 FROM `orionbelt_1`.`sales` AS `Sales`
 )
 SELECT ROUND(CAST(SUM(`composite_01`.`Total Returns`) / NULLIF(SUM(`composite_01`.`Total Sales`), 0) AS NUMERIC), 4) AS `Return Rate`

--- a/tests/integration/drift/compile_only/clickhouse/04_sales_returns_cfl_by_country.sql
+++ b/tests/integration/drift/compile_only/clickhouse/04_sales_returns_cfl_by_country.sql
@@ -1,10 +1,10 @@
 WITH "composite_01" AS (
-SELECT "Countries"."countryname" AS "Sales Country Name", CAST(round("Sales"."salesamount", 20) AS Nullable(Decimal(38, 20))) AS "Total Sales", CAST(round(NULL, 20) AS Nullable(Decimal(38, 20))) AS "Total Returns"
+SELECT "Countries"."countryname" AS "Sales Country Name", "Sales"."salesamount" AS "Total Sales", CAST(round(NULL, 20) AS Nullable(Decimal(38, 20))) AS "Total Returns"
 FROM "orionbelt_1"."sales" AS "Sales"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"
 LEFT JOIN "orionbelt_1"."countries" AS "Countries" ON "Clients"."clientcountryid" = "Countries"."countryid"
 UNION ALL
-SELECT "Countries"."countryname" AS "Sales Country Name", CAST(round(NULL, 20) AS Nullable(Decimal(38, 20))) AS "Total Sales", CAST(round("Returns"."returnamount", 20) AS Nullable(Decimal(38, 20))) AS "Total Returns"
+SELECT "Countries"."countryname" AS "Sales Country Name", CAST(round(NULL, 20) AS Nullable(Decimal(38, 20))) AS "Total Sales", "Returns"."returnamount" AS "Total Returns"
 FROM "orionbelt_1"."returns" AS "Returns"
 LEFT JOIN "orionbelt_1"."sales" AS "Sales" ON "Returns"."returnsalesid" = "Sales"."salesid"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"

--- a/tests/integration/drift/compile_only/clickhouse/04_sales_returns_cfl_by_country.sql
+++ b/tests/integration/drift/compile_only/clickhouse/04_sales_returns_cfl_by_country.sql
@@ -1,10 +1,10 @@
 WITH "composite_01" AS (
-SELECT "Countries"."countryname" AS "Sales Country Name", CAST(round("Sales"."salesamount", 12) AS Nullable(Decimal(38, 12))) AS "Total Sales", CAST(round(NULL, 12) AS Nullable(Decimal(38, 12))) AS "Total Returns"
+SELECT "Countries"."countryname" AS "Sales Country Name", CAST(round("Sales"."salesamount", 20) AS Nullable(Decimal(38, 20))) AS "Total Sales", CAST(round(NULL, 20) AS Nullable(Decimal(38, 20))) AS "Total Returns"
 FROM "orionbelt_1"."sales" AS "Sales"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"
 LEFT JOIN "orionbelt_1"."countries" AS "Countries" ON "Clients"."clientcountryid" = "Countries"."countryid"
 UNION ALL
-SELECT "Countries"."countryname" AS "Sales Country Name", CAST(round(NULL, 12) AS Nullable(Decimal(38, 12))) AS "Total Sales", CAST(round("Returns"."returnamount", 12) AS Nullable(Decimal(38, 12))) AS "Total Returns"
+SELECT "Countries"."countryname" AS "Sales Country Name", CAST(round(NULL, 20) AS Nullable(Decimal(38, 20))) AS "Total Sales", CAST(round("Returns"."returnamount", 20) AS Nullable(Decimal(38, 20))) AS "Total Returns"
 FROM "orionbelt_1"."returns" AS "Returns"
 LEFT JOIN "orionbelt_1"."sales" AS "Sales" ON "Returns"."returnsalesid" = "Sales"."salesid"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"

--- a/tests/integration/drift/compile_only/clickhouse/05_sales_purchases_cfl_ungrouped.sql
+++ b/tests/integration/drift/compile_only/clickhouse/05_sales_purchases_cfl_ungrouped.sql
@@ -1,8 +1,8 @@
 WITH "composite_01" AS (
-SELECT CAST(round("Sales"."salesamount", 12) AS Nullable(Decimal(38, 12))) AS "Total Sales", CAST(round(NULL, 12) AS Nullable(Decimal(38, 12))) AS "Total Purchases"
+SELECT CAST(round("Sales"."salesamount", 20) AS Nullable(Decimal(38, 20))) AS "Total Sales", CAST(round(NULL, 20) AS Nullable(Decimal(38, 20))) AS "Total Purchases"
 FROM "orionbelt_1"."sales" AS "Sales"
 UNION ALL
-SELECT CAST(round(NULL, 12) AS Nullable(Decimal(38, 12))) AS "Total Sales", CAST(round("Purchases"."purchaseamount", 12) AS Nullable(Decimal(38, 12))) AS "Total Purchases"
+SELECT CAST(round(NULL, 20) AS Nullable(Decimal(38, 20))) AS "Total Sales", CAST(round("Purchases"."purchaseamount", 20) AS Nullable(Decimal(38, 20))) AS "Total Purchases"
 FROM "orionbelt_1"."purchases" AS "Purchases"
 )
 SELECT CAST(round(SUM("composite_01"."Total Sales"), 2) AS Nullable(Decimal(18, 2))) AS "Total Sales", CAST(round(SUM("composite_01"."Total Purchases"), 2) AS Nullable(Decimal(18, 2))) AS "Total Purchases"

--- a/tests/integration/drift/compile_only/clickhouse/05_sales_purchases_cfl_ungrouped.sql
+++ b/tests/integration/drift/compile_only/clickhouse/05_sales_purchases_cfl_ungrouped.sql
@@ -1,8 +1,8 @@
 WITH "composite_01" AS (
-SELECT CAST(round("Sales"."salesamount", 20) AS Nullable(Decimal(38, 20))) AS "Total Sales", CAST(round(NULL, 20) AS Nullable(Decimal(38, 20))) AS "Total Purchases"
+SELECT "Sales"."salesamount" AS "Total Sales", CAST(round(NULL, 20) AS Nullable(Decimal(38, 20))) AS "Total Purchases"
 FROM "orionbelt_1"."sales" AS "Sales"
 UNION ALL
-SELECT CAST(round(NULL, 20) AS Nullable(Decimal(38, 20))) AS "Total Sales", CAST(round("Purchases"."purchaseamount", 20) AS Nullable(Decimal(38, 20))) AS "Total Purchases"
+SELECT CAST(round(NULL, 20) AS Nullable(Decimal(38, 20))) AS "Total Sales", "Purchases"."purchaseamount" AS "Total Purchases"
 FROM "orionbelt_1"."purchases" AS "Purchases"
 )
 SELECT CAST(round(SUM("composite_01"."Total Sales"), 2) AS Nullable(Decimal(18, 2))) AS "Total Sales", CAST(round(SUM("composite_01"."Total Purchases"), 2) AS Nullable(Decimal(18, 2))) AS "Total Purchases"

--- a/tests/integration/drift/compile_only/clickhouse/07_total_sales_by_client_with_complaints.sql
+++ b/tests/integration/drift/compile_only/clickhouse/07_total_sales_by_client_with_complaints.sql
@@ -1,9 +1,9 @@
 WITH "composite_01" AS (
-SELECT "Clients"."clientname" AS "Sales Client Name", CAST(NULL AS Nullable(String)) AS "Complaint Client Name", CAST(round("Sales"."salesamount", 12) AS Nullable(Decimal(38, 12))) AS "Total Sales", CAST(NULL AS Nullable(Int32)) AS "Client Complaints Count"
+SELECT "Clients"."clientname" AS "Sales Client Name", CAST(NULL AS Nullable(String)) AS "Complaint Client Name", CAST(round("Sales"."salesamount", 20) AS Nullable(Decimal(38, 20))) AS "Total Sales", CAST(NULL AS Nullable(Int32)) AS "Client Complaints Count"
 FROM "orionbelt_1"."sales" AS "Sales"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"
 UNION ALL
-SELECT CAST(NULL AS Nullable(String)) AS "Sales Client Name", "Clients"."clientname" AS "Complaint Client Name", CAST(round(NULL, 12) AS Nullable(Decimal(38, 12))) AS "Total Sales", CAST(1 AS Nullable(Int32)) AS "Client Complaints Count"
+SELECT CAST(NULL AS Nullable(String)) AS "Sales Client Name", "Clients"."clientname" AS "Complaint Client Name", CAST(round(NULL, 20) AS Nullable(Decimal(38, 20))) AS "Total Sales", CAST(1 AS Nullable(Int32)) AS "Client Complaints Count"
 FROM "orionbelt_1"."clientcomplaints" AS "Client Complaints"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Client Complaints"."complclientid" = "Clients"."clientid"
 )

--- a/tests/integration/drift/compile_only/clickhouse/07_total_sales_by_client_with_complaints.sql
+++ b/tests/integration/drift/compile_only/clickhouse/07_total_sales_by_client_with_complaints.sql
@@ -1,5 +1,5 @@
 WITH "composite_01" AS (
-SELECT "Clients"."clientname" AS "Sales Client Name", CAST(NULL AS Nullable(String)) AS "Complaint Client Name", CAST(round("Sales"."salesamount", 20) AS Nullable(Decimal(38, 20))) AS "Total Sales", CAST(NULL AS Nullable(Int32)) AS "Client Complaints Count"
+SELECT "Clients"."clientname" AS "Sales Client Name", CAST(NULL AS Nullable(String)) AS "Complaint Client Name", "Sales"."salesamount" AS "Total Sales", CAST(NULL AS Nullable(Int32)) AS "Client Complaints Count"
 FROM "orionbelt_1"."sales" AS "Sales"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"
 UNION ALL

--- a/tests/integration/drift/compile_only/clickhouse/09_return_rate.sql
+++ b/tests/integration/drift/compile_only/clickhouse/09_return_rate.sql
@@ -1,8 +1,8 @@
 WITH "composite_01" AS (
-SELECT CAST(round("Returns"."returnamount", 12) AS Nullable(Decimal(38, 12))) AS "Total Returns", CAST(round(NULL, 12) AS Nullable(Decimal(38, 12))) AS "Total Sales"
+SELECT CAST(round("Returns"."returnamount", 20) AS Nullable(Decimal(38, 20))) AS "Total Returns", CAST(round(NULL, 20) AS Nullable(Decimal(38, 20))) AS "Total Sales"
 FROM "orionbelt_1"."returns" AS "Returns"
 UNION ALL
-SELECT CAST(round(NULL, 12) AS Nullable(Decimal(38, 12))) AS "Total Returns", CAST(round("Sales"."salesamount", 12) AS Nullable(Decimal(38, 12))) AS "Total Sales"
+SELECT CAST(round(NULL, 20) AS Nullable(Decimal(38, 20))) AS "Total Returns", CAST(round("Sales"."salesamount", 20) AS Nullable(Decimal(38, 20))) AS "Total Sales"
 FROM "orionbelt_1"."sales" AS "Sales"
 )
 SELECT CAST(round(CAST(SUM("composite_01"."Total Returns") AS Nullable(Decimal(38, 14))) / CAST(NULLIF(SUM("composite_01"."Total Sales"), 0) AS Nullable(Decimal(38, 14))), 4) AS Nullable(Decimal(18, 4))) AS "Return Rate"

--- a/tests/integration/drift/compile_only/clickhouse/09_return_rate.sql
+++ b/tests/integration/drift/compile_only/clickhouse/09_return_rate.sql
@@ -1,8 +1,8 @@
 WITH "composite_01" AS (
-SELECT CAST(round("Returns"."returnamount", 20) AS Nullable(Decimal(38, 20))) AS "Total Returns", CAST(round(NULL, 20) AS Nullable(Decimal(38, 20))) AS "Total Sales"
+SELECT "Returns"."returnamount" AS "Total Returns", CAST(round(NULL, 20) AS Nullable(Decimal(38, 20))) AS "Total Sales"
 FROM "orionbelt_1"."returns" AS "Returns"
 UNION ALL
-SELECT CAST(round(NULL, 20) AS Nullable(Decimal(38, 20))) AS "Total Returns", CAST(round("Sales"."salesamount", 20) AS Nullable(Decimal(38, 20))) AS "Total Sales"
+SELECT CAST(round(NULL, 20) AS Nullable(Decimal(38, 20))) AS "Total Returns", "Sales"."salesamount" AS "Total Sales"
 FROM "orionbelt_1"."sales" AS "Sales"
 )
 SELECT CAST(round(CAST(SUM("composite_01"."Total Returns") AS Nullable(Decimal(38, 14))) / CAST(NULLIF(SUM("composite_01"."Total Sales"), 0) AS Nullable(Decimal(38, 14))), 4) AS Nullable(Decimal(18, 4))) AS "Return Rate"

--- a/tests/integration/drift/compile_only/databricks/04_sales_returns_cfl_by_country.sql
+++ b/tests/integration/drift/compile_only/databricks/04_sales_returns_cfl_by_country.sql
@@ -1,10 +1,10 @@
 WITH `composite_01` AS (
-SELECT `Countries`.`countryname` AS `Sales Country Name`, CAST(`Sales`.`salesamount` AS DECIMAL(38, 12)) AS `Total Sales`, CAST(NULL AS DECIMAL(38, 12)) AS `Total Returns`
+SELECT `Countries`.`countryname` AS `Sales Country Name`, CAST(`Sales`.`salesamount` AS DECIMAL(38, 20)) AS `Total Sales`, CAST(NULL AS DECIMAL(38, 20)) AS `Total Returns`
 FROM `orionbelt_1`.`sales` AS `Sales`
 LEFT JOIN `orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`
 LEFT JOIN `orionbelt_1`.`countries` AS `Countries` ON `Clients`.`clientcountryid` = `Countries`.`countryid`
 UNION ALL
-SELECT `Countries`.`countryname` AS `Sales Country Name`, CAST(NULL AS DECIMAL(38, 12)) AS `Total Sales`, CAST(`Returns`.`returnamount` AS DECIMAL(38, 12)) AS `Total Returns`
+SELECT `Countries`.`countryname` AS `Sales Country Name`, CAST(NULL AS DECIMAL(38, 20)) AS `Total Sales`, CAST(`Returns`.`returnamount` AS DECIMAL(38, 20)) AS `Total Returns`
 FROM `orionbelt_1`.`returns` AS `Returns`
 LEFT JOIN `orionbelt_1`.`sales` AS `Sales` ON `Returns`.`returnsalesid` = `Sales`.`salesid`
 LEFT JOIN `orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`

--- a/tests/integration/drift/compile_only/databricks/04_sales_returns_cfl_by_country.sql
+++ b/tests/integration/drift/compile_only/databricks/04_sales_returns_cfl_by_country.sql
@@ -1,10 +1,10 @@
 WITH `composite_01` AS (
-SELECT `Countries`.`countryname` AS `Sales Country Name`, CAST(`Sales`.`salesamount` AS DECIMAL(38, 20)) AS `Total Sales`, CAST(NULL AS DECIMAL(38, 20)) AS `Total Returns`
+SELECT `Countries`.`countryname` AS `Sales Country Name`, `Sales`.`salesamount` AS `Total Sales`, CAST(NULL AS DECIMAL(38, 20)) AS `Total Returns`
 FROM `orionbelt_1`.`sales` AS `Sales`
 LEFT JOIN `orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`
 LEFT JOIN `orionbelt_1`.`countries` AS `Countries` ON `Clients`.`clientcountryid` = `Countries`.`countryid`
 UNION ALL
-SELECT `Countries`.`countryname` AS `Sales Country Name`, CAST(NULL AS DECIMAL(38, 20)) AS `Total Sales`, CAST(`Returns`.`returnamount` AS DECIMAL(38, 20)) AS `Total Returns`
+SELECT `Countries`.`countryname` AS `Sales Country Name`, CAST(NULL AS DECIMAL(38, 20)) AS `Total Sales`, `Returns`.`returnamount` AS `Total Returns`
 FROM `orionbelt_1`.`returns` AS `Returns`
 LEFT JOIN `orionbelt_1`.`sales` AS `Sales` ON `Returns`.`returnsalesid` = `Sales`.`salesid`
 LEFT JOIN `orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`

--- a/tests/integration/drift/compile_only/databricks/05_sales_purchases_cfl_ungrouped.sql
+++ b/tests/integration/drift/compile_only/databricks/05_sales_purchases_cfl_ungrouped.sql
@@ -1,8 +1,8 @@
 WITH `composite_01` AS (
-SELECT CAST(`Sales`.`salesamount` AS DECIMAL(38, 12)) AS `Total Sales`, CAST(NULL AS DECIMAL(38, 12)) AS `Total Purchases`
+SELECT CAST(`Sales`.`salesamount` AS DECIMAL(38, 20)) AS `Total Sales`, CAST(NULL AS DECIMAL(38, 20)) AS `Total Purchases`
 FROM `orionbelt_1`.`sales` AS `Sales`
 UNION ALL
-SELECT CAST(NULL AS DECIMAL(38, 12)) AS `Total Sales`, CAST(`Purchases`.`purchaseamount` AS DECIMAL(38, 12)) AS `Total Purchases`
+SELECT CAST(NULL AS DECIMAL(38, 20)) AS `Total Sales`, CAST(`Purchases`.`purchaseamount` AS DECIMAL(38, 20)) AS `Total Purchases`
 FROM `orionbelt_1`.`purchases` AS `Purchases`
 )
 SELECT CAST(SUM(`composite_01`.`Total Sales`) AS DECIMAL(18, 2)) AS `Total Sales`, CAST(SUM(`composite_01`.`Total Purchases`) AS DECIMAL(18, 2)) AS `Total Purchases`

--- a/tests/integration/drift/compile_only/databricks/05_sales_purchases_cfl_ungrouped.sql
+++ b/tests/integration/drift/compile_only/databricks/05_sales_purchases_cfl_ungrouped.sql
@@ -1,8 +1,8 @@
 WITH `composite_01` AS (
-SELECT CAST(`Sales`.`salesamount` AS DECIMAL(38, 20)) AS `Total Sales`, CAST(NULL AS DECIMAL(38, 20)) AS `Total Purchases`
+SELECT `Sales`.`salesamount` AS `Total Sales`, CAST(NULL AS DECIMAL(38, 20)) AS `Total Purchases`
 FROM `orionbelt_1`.`sales` AS `Sales`
 UNION ALL
-SELECT CAST(NULL AS DECIMAL(38, 20)) AS `Total Sales`, CAST(`Purchases`.`purchaseamount` AS DECIMAL(38, 20)) AS `Total Purchases`
+SELECT CAST(NULL AS DECIMAL(38, 20)) AS `Total Sales`, `Purchases`.`purchaseamount` AS `Total Purchases`
 FROM `orionbelt_1`.`purchases` AS `Purchases`
 )
 SELECT CAST(SUM(`composite_01`.`Total Sales`) AS DECIMAL(18, 2)) AS `Total Sales`, CAST(SUM(`composite_01`.`Total Purchases`) AS DECIMAL(18, 2)) AS `Total Purchases`

--- a/tests/integration/drift/compile_only/databricks/07_total_sales_by_client_with_complaints.sql
+++ b/tests/integration/drift/compile_only/databricks/07_total_sales_by_client_with_complaints.sql
@@ -1,5 +1,5 @@
 WITH `composite_01` AS (
-SELECT `Clients`.`clientname` AS `Sales Client Name`, CAST(NULL AS STRING) AS `Complaint Client Name`, CAST(`Sales`.`salesamount` AS DECIMAL(38, 20)) AS `Total Sales`, CAST(NULL AS INT) AS `Client Complaints Count`
+SELECT `Clients`.`clientname` AS `Sales Client Name`, CAST(NULL AS STRING) AS `Complaint Client Name`, `Sales`.`salesamount` AS `Total Sales`, CAST(NULL AS INT) AS `Client Complaints Count`
 FROM `orionbelt_1`.`sales` AS `Sales`
 LEFT JOIN `orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`
 UNION ALL

--- a/tests/integration/drift/compile_only/databricks/07_total_sales_by_client_with_complaints.sql
+++ b/tests/integration/drift/compile_only/databricks/07_total_sales_by_client_with_complaints.sql
@@ -1,9 +1,9 @@
 WITH `composite_01` AS (
-SELECT `Clients`.`clientname` AS `Sales Client Name`, CAST(NULL AS STRING) AS `Complaint Client Name`, CAST(`Sales`.`salesamount` AS DECIMAL(38, 12)) AS `Total Sales`, CAST(NULL AS INT) AS `Client Complaints Count`
+SELECT `Clients`.`clientname` AS `Sales Client Name`, CAST(NULL AS STRING) AS `Complaint Client Name`, CAST(`Sales`.`salesamount` AS DECIMAL(38, 20)) AS `Total Sales`, CAST(NULL AS INT) AS `Client Complaints Count`
 FROM `orionbelt_1`.`sales` AS `Sales`
 LEFT JOIN `orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`
 UNION ALL
-SELECT CAST(NULL AS STRING) AS `Sales Client Name`, `Clients`.`clientname` AS `Complaint Client Name`, CAST(NULL AS DECIMAL(38, 12)) AS `Total Sales`, CAST(1 AS INT) AS `Client Complaints Count`
+SELECT CAST(NULL AS STRING) AS `Sales Client Name`, `Clients`.`clientname` AS `Complaint Client Name`, CAST(NULL AS DECIMAL(38, 20)) AS `Total Sales`, CAST(1 AS INT) AS `Client Complaints Count`
 FROM `orionbelt_1`.`clientcomplaints` AS `Client Complaints`
 LEFT JOIN `orionbelt_1`.`clients` AS `Clients` ON `Client Complaints`.`complclientid` = `Clients`.`clientid`
 )

--- a/tests/integration/drift/compile_only/databricks/09_return_rate.sql
+++ b/tests/integration/drift/compile_only/databricks/09_return_rate.sql
@@ -1,8 +1,8 @@
 WITH `composite_01` AS (
-SELECT CAST(`Returns`.`returnamount` AS DECIMAL(38, 12)) AS `Total Returns`, CAST(NULL AS DECIMAL(38, 12)) AS `Total Sales`
+SELECT CAST(`Returns`.`returnamount` AS DECIMAL(38, 20)) AS `Total Returns`, CAST(NULL AS DECIMAL(38, 20)) AS `Total Sales`
 FROM `orionbelt_1`.`returns` AS `Returns`
 UNION ALL
-SELECT CAST(NULL AS DECIMAL(38, 12)) AS `Total Returns`, CAST(`Sales`.`salesamount` AS DECIMAL(38, 12)) AS `Total Sales`
+SELECT CAST(NULL AS DECIMAL(38, 20)) AS `Total Returns`, CAST(`Sales`.`salesamount` AS DECIMAL(38, 20)) AS `Total Sales`
 FROM `orionbelt_1`.`sales` AS `Sales`
 )
 SELECT CAST(SUM(`composite_01`.`Total Returns`) / NULLIF(SUM(`composite_01`.`Total Sales`), 0) AS DECIMAL(18, 4)) AS `Return Rate`

--- a/tests/integration/drift/compile_only/databricks/09_return_rate.sql
+++ b/tests/integration/drift/compile_only/databricks/09_return_rate.sql
@@ -1,8 +1,8 @@
 WITH `composite_01` AS (
-SELECT CAST(`Returns`.`returnamount` AS DECIMAL(38, 20)) AS `Total Returns`, CAST(NULL AS DECIMAL(38, 20)) AS `Total Sales`
+SELECT `Returns`.`returnamount` AS `Total Returns`, CAST(NULL AS DECIMAL(38, 20)) AS `Total Sales`
 FROM `orionbelt_1`.`returns` AS `Returns`
 UNION ALL
-SELECT CAST(NULL AS DECIMAL(38, 20)) AS `Total Returns`, CAST(`Sales`.`salesamount` AS DECIMAL(38, 20)) AS `Total Sales`
+SELECT CAST(NULL AS DECIMAL(38, 20)) AS `Total Returns`, `Sales`.`salesamount` AS `Total Sales`
 FROM `orionbelt_1`.`sales` AS `Sales`
 )
 SELECT CAST(SUM(`composite_01`.`Total Returns`) / NULLIF(SUM(`composite_01`.`Total Sales`), 0) AS DECIMAL(18, 4)) AS `Return Rate`

--- a/tests/integration/drift/compile_only/dremio/04_sales_returns_cfl_by_country.sql
+++ b/tests/integration/drift/compile_only/dremio/04_sales_returns_cfl_by_country.sql
@@ -1,10 +1,10 @@
 WITH "composite_01" AS (
-SELECT "Countries"."countryname" AS "Sales Country Name", CAST("Sales"."salesamount" AS DECIMAL(38, 20)) AS "Total Sales", CAST(NULL AS DECIMAL(38, 20)) AS "Total Returns"
+SELECT "Countries"."countryname" AS "Sales Country Name", "Sales"."salesamount" AS "Total Sales", CAST(NULL AS DECIMAL(38, 20)) AS "Total Returns"
 FROM "orionbelt_1"."sales" AS "Sales"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"
 LEFT JOIN "orionbelt_1"."countries" AS "Countries" ON "Clients"."clientcountryid" = "Countries"."countryid"
 UNION ALL
-SELECT "Countries"."countryname" AS "Sales Country Name", CAST(NULL AS DECIMAL(38, 20)) AS "Total Sales", CAST("Returns"."returnamount" AS DECIMAL(38, 20)) AS "Total Returns"
+SELECT "Countries"."countryname" AS "Sales Country Name", CAST(NULL AS DECIMAL(38, 20)) AS "Total Sales", "Returns"."returnamount" AS "Total Returns"
 FROM "orionbelt_1"."returns" AS "Returns"
 LEFT JOIN "orionbelt_1"."sales" AS "Sales" ON "Returns"."returnsalesid" = "Sales"."salesid"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"

--- a/tests/integration/drift/compile_only/dremio/04_sales_returns_cfl_by_country.sql
+++ b/tests/integration/drift/compile_only/dremio/04_sales_returns_cfl_by_country.sql
@@ -1,10 +1,10 @@
 WITH "composite_01" AS (
-SELECT "Countries"."countryname" AS "Sales Country Name", CAST("Sales"."salesamount" AS DECIMAL(38, 12)) AS "Total Sales", CAST(NULL AS DECIMAL(38, 12)) AS "Total Returns"
+SELECT "Countries"."countryname" AS "Sales Country Name", CAST("Sales"."salesamount" AS DECIMAL(38, 20)) AS "Total Sales", CAST(NULL AS DECIMAL(38, 20)) AS "Total Returns"
 FROM "orionbelt_1"."sales" AS "Sales"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"
 LEFT JOIN "orionbelt_1"."countries" AS "Countries" ON "Clients"."clientcountryid" = "Countries"."countryid"
 UNION ALL
-SELECT "Countries"."countryname" AS "Sales Country Name", CAST(NULL AS DECIMAL(38, 12)) AS "Total Sales", CAST("Returns"."returnamount" AS DECIMAL(38, 12)) AS "Total Returns"
+SELECT "Countries"."countryname" AS "Sales Country Name", CAST(NULL AS DECIMAL(38, 20)) AS "Total Sales", CAST("Returns"."returnamount" AS DECIMAL(38, 20)) AS "Total Returns"
 FROM "orionbelt_1"."returns" AS "Returns"
 LEFT JOIN "orionbelt_1"."sales" AS "Sales" ON "Returns"."returnsalesid" = "Sales"."salesid"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"

--- a/tests/integration/drift/compile_only/dremio/05_sales_purchases_cfl_ungrouped.sql
+++ b/tests/integration/drift/compile_only/dremio/05_sales_purchases_cfl_ungrouped.sql
@@ -1,8 +1,8 @@
 WITH "composite_01" AS (
-SELECT CAST("Sales"."salesamount" AS DECIMAL(38, 20)) AS "Total Sales", CAST(NULL AS DECIMAL(38, 20)) AS "Total Purchases"
+SELECT "Sales"."salesamount" AS "Total Sales", CAST(NULL AS DECIMAL(38, 20)) AS "Total Purchases"
 FROM "orionbelt_1"."sales" AS "Sales"
 UNION ALL
-SELECT CAST(NULL AS DECIMAL(38, 20)) AS "Total Sales", CAST("Purchases"."purchaseamount" AS DECIMAL(38, 20)) AS "Total Purchases"
+SELECT CAST(NULL AS DECIMAL(38, 20)) AS "Total Sales", "Purchases"."purchaseamount" AS "Total Purchases"
 FROM "orionbelt_1"."purchases" AS "Purchases"
 )
 SELECT CAST(SUM("composite_01"."Total Sales") AS DECIMAL(18, 2)) AS "Total Sales", CAST(SUM("composite_01"."Total Purchases") AS DECIMAL(18, 2)) AS "Total Purchases"

--- a/tests/integration/drift/compile_only/dremio/05_sales_purchases_cfl_ungrouped.sql
+++ b/tests/integration/drift/compile_only/dremio/05_sales_purchases_cfl_ungrouped.sql
@@ -1,8 +1,8 @@
 WITH "composite_01" AS (
-SELECT CAST("Sales"."salesamount" AS DECIMAL(38, 12)) AS "Total Sales", CAST(NULL AS DECIMAL(38, 12)) AS "Total Purchases"
+SELECT CAST("Sales"."salesamount" AS DECIMAL(38, 20)) AS "Total Sales", CAST(NULL AS DECIMAL(38, 20)) AS "Total Purchases"
 FROM "orionbelt_1"."sales" AS "Sales"
 UNION ALL
-SELECT CAST(NULL AS DECIMAL(38, 12)) AS "Total Sales", CAST("Purchases"."purchaseamount" AS DECIMAL(38, 12)) AS "Total Purchases"
+SELECT CAST(NULL AS DECIMAL(38, 20)) AS "Total Sales", CAST("Purchases"."purchaseamount" AS DECIMAL(38, 20)) AS "Total Purchases"
 FROM "orionbelt_1"."purchases" AS "Purchases"
 )
 SELECT CAST(SUM("composite_01"."Total Sales") AS DECIMAL(18, 2)) AS "Total Sales", CAST(SUM("composite_01"."Total Purchases") AS DECIMAL(18, 2)) AS "Total Purchases"

--- a/tests/integration/drift/compile_only/dremio/07_total_sales_by_client_with_complaints.sql
+++ b/tests/integration/drift/compile_only/dremio/07_total_sales_by_client_with_complaints.sql
@@ -1,5 +1,5 @@
 WITH "composite_01" AS (
-SELECT "Clients"."clientname" AS "Sales Client Name", CAST(NULL AS VARCHAR) AS "Complaint Client Name", CAST("Sales"."salesamount" AS DECIMAL(38, 20)) AS "Total Sales", CAST(NULL AS INTEGER) AS "Client Complaints Count"
+SELECT "Clients"."clientname" AS "Sales Client Name", CAST(NULL AS VARCHAR) AS "Complaint Client Name", "Sales"."salesamount" AS "Total Sales", CAST(NULL AS INTEGER) AS "Client Complaints Count"
 FROM "orionbelt_1"."sales" AS "Sales"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"
 UNION ALL

--- a/tests/integration/drift/compile_only/dremio/07_total_sales_by_client_with_complaints.sql
+++ b/tests/integration/drift/compile_only/dremio/07_total_sales_by_client_with_complaints.sql
@@ -1,9 +1,9 @@
 WITH "composite_01" AS (
-SELECT "Clients"."clientname" AS "Sales Client Name", CAST(NULL AS VARCHAR) AS "Complaint Client Name", CAST("Sales"."salesamount" AS DECIMAL(38, 12)) AS "Total Sales", CAST(NULL AS INTEGER) AS "Client Complaints Count"
+SELECT "Clients"."clientname" AS "Sales Client Name", CAST(NULL AS VARCHAR) AS "Complaint Client Name", CAST("Sales"."salesamount" AS DECIMAL(38, 20)) AS "Total Sales", CAST(NULL AS INTEGER) AS "Client Complaints Count"
 FROM "orionbelt_1"."sales" AS "Sales"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"
 UNION ALL
-SELECT CAST(NULL AS VARCHAR) AS "Sales Client Name", "Clients"."clientname" AS "Complaint Client Name", CAST(NULL AS DECIMAL(38, 12)) AS "Total Sales", CAST(1 AS INTEGER) AS "Client Complaints Count"
+SELECT CAST(NULL AS VARCHAR) AS "Sales Client Name", "Clients"."clientname" AS "Complaint Client Name", CAST(NULL AS DECIMAL(38, 20)) AS "Total Sales", CAST(1 AS INTEGER) AS "Client Complaints Count"
 FROM "orionbelt_1"."clientcomplaints" AS "Client Complaints"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Client Complaints"."complclientid" = "Clients"."clientid"
 )

--- a/tests/integration/drift/compile_only/dremio/09_return_rate.sql
+++ b/tests/integration/drift/compile_only/dremio/09_return_rate.sql
@@ -1,8 +1,8 @@
 WITH "composite_01" AS (
-SELECT CAST("Returns"."returnamount" AS DECIMAL(38, 12)) AS "Total Returns", CAST(NULL AS DECIMAL(38, 12)) AS "Total Sales"
+SELECT CAST("Returns"."returnamount" AS DECIMAL(38, 20)) AS "Total Returns", CAST(NULL AS DECIMAL(38, 20)) AS "Total Sales"
 FROM "orionbelt_1"."returns" AS "Returns"
 UNION ALL
-SELECT CAST(NULL AS DECIMAL(38, 12)) AS "Total Returns", CAST("Sales"."salesamount" AS DECIMAL(38, 12)) AS "Total Sales"
+SELECT CAST(NULL AS DECIMAL(38, 20)) AS "Total Returns", CAST("Sales"."salesamount" AS DECIMAL(38, 20)) AS "Total Sales"
 FROM "orionbelt_1"."sales" AS "Sales"
 )
 SELECT CAST(SUM("composite_01"."Total Returns") / NULLIF(SUM("composite_01"."Total Sales"), 0) AS DECIMAL(18, 4)) AS "Return Rate"

--- a/tests/integration/drift/compile_only/dremio/09_return_rate.sql
+++ b/tests/integration/drift/compile_only/dremio/09_return_rate.sql
@@ -1,8 +1,8 @@
 WITH "composite_01" AS (
-SELECT CAST("Returns"."returnamount" AS DECIMAL(38, 20)) AS "Total Returns", CAST(NULL AS DECIMAL(38, 20)) AS "Total Sales"
+SELECT "Returns"."returnamount" AS "Total Returns", CAST(NULL AS DECIMAL(38, 20)) AS "Total Sales"
 FROM "orionbelt_1"."returns" AS "Returns"
 UNION ALL
-SELECT CAST(NULL AS DECIMAL(38, 20)) AS "Total Returns", CAST("Sales"."salesamount" AS DECIMAL(38, 20)) AS "Total Sales"
+SELECT CAST(NULL AS DECIMAL(38, 20)) AS "Total Returns", "Sales"."salesamount" AS "Total Sales"
 FROM "orionbelt_1"."sales" AS "Sales"
 )
 SELECT CAST(SUM("composite_01"."Total Returns") / NULLIF(SUM("composite_01"."Total Sales"), 0) AS DECIMAL(18, 4)) AS "Return Rate"

--- a/tests/integration/drift/compile_only/duckdb/04_sales_returns_cfl_by_country.sql
+++ b/tests/integration/drift/compile_only/duckdb/04_sales_returns_cfl_by_country.sql
@@ -1,10 +1,10 @@
 WITH "composite_01" AS (
-SELECT "Countries"."countryname" AS "Sales Country Name", CAST("Sales"."salesamount" AS DECIMAL(38, 12)) AS "Total Sales"
+SELECT "Countries"."countryname" AS "Sales Country Name", CAST("Sales"."salesamount" AS DECIMAL(38, 20)) AS "Total Sales"
 FROM "orionbelt_1"."sales" AS "Sales"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"
 LEFT JOIN "orionbelt_1"."countries" AS "Countries" ON "Clients"."clientcountryid" = "Countries"."countryid"
 UNION ALL BY NAME
-SELECT "Countries"."countryname" AS "Sales Country Name", CAST("Returns"."returnamount" AS DECIMAL(38, 12)) AS "Total Returns"
+SELECT "Countries"."countryname" AS "Sales Country Name", CAST("Returns"."returnamount" AS DECIMAL(38, 20)) AS "Total Returns"
 FROM "orionbelt_1"."returns" AS "Returns"
 LEFT JOIN "orionbelt_1"."sales" AS "Sales" ON "Returns"."returnsalesid" = "Sales"."salesid"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"

--- a/tests/integration/drift/compile_only/duckdb/04_sales_returns_cfl_by_country.sql
+++ b/tests/integration/drift/compile_only/duckdb/04_sales_returns_cfl_by_country.sql
@@ -1,10 +1,10 @@
 WITH "composite_01" AS (
-SELECT "Countries"."countryname" AS "Sales Country Name", CAST("Sales"."salesamount" AS DECIMAL(38, 20)) AS "Total Sales"
+SELECT "Countries"."countryname" AS "Sales Country Name", "Sales"."salesamount" AS "Total Sales"
 FROM "orionbelt_1"."sales" AS "Sales"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"
 LEFT JOIN "orionbelt_1"."countries" AS "Countries" ON "Clients"."clientcountryid" = "Countries"."countryid"
 UNION ALL BY NAME
-SELECT "Countries"."countryname" AS "Sales Country Name", CAST("Returns"."returnamount" AS DECIMAL(38, 20)) AS "Total Returns"
+SELECT "Countries"."countryname" AS "Sales Country Name", "Returns"."returnamount" AS "Total Returns"
 FROM "orionbelt_1"."returns" AS "Returns"
 LEFT JOIN "orionbelt_1"."sales" AS "Sales" ON "Returns"."returnsalesid" = "Sales"."salesid"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"

--- a/tests/integration/drift/compile_only/duckdb/05_sales_purchases_cfl_ungrouped.sql
+++ b/tests/integration/drift/compile_only/duckdb/05_sales_purchases_cfl_ungrouped.sql
@@ -1,8 +1,8 @@
 WITH "composite_01" AS (
-SELECT CAST("Sales"."salesamount" AS DECIMAL(38, 20)) AS "Total Sales"
+SELECT "Sales"."salesamount" AS "Total Sales"
 FROM "orionbelt_1"."sales" AS "Sales"
 UNION ALL BY NAME
-SELECT CAST("Purchases"."purchaseamount" AS DECIMAL(38, 20)) AS "Total Purchases"
+SELECT "Purchases"."purchaseamount" AS "Total Purchases"
 FROM "orionbelt_1"."purchases" AS "Purchases"
 )
 SELECT CAST(SUM("composite_01"."Total Sales") AS DECIMAL(18, 2)) AS "Total Sales", CAST(SUM("composite_01"."Total Purchases") AS DECIMAL(18, 2)) AS "Total Purchases"

--- a/tests/integration/drift/compile_only/duckdb/05_sales_purchases_cfl_ungrouped.sql
+++ b/tests/integration/drift/compile_only/duckdb/05_sales_purchases_cfl_ungrouped.sql
@@ -1,8 +1,8 @@
 WITH "composite_01" AS (
-SELECT CAST("Sales"."salesamount" AS DECIMAL(38, 12)) AS "Total Sales"
+SELECT CAST("Sales"."salesamount" AS DECIMAL(38, 20)) AS "Total Sales"
 FROM "orionbelt_1"."sales" AS "Sales"
 UNION ALL BY NAME
-SELECT CAST("Purchases"."purchaseamount" AS DECIMAL(38, 12)) AS "Total Purchases"
+SELECT CAST("Purchases"."purchaseamount" AS DECIMAL(38, 20)) AS "Total Purchases"
 FROM "orionbelt_1"."purchases" AS "Purchases"
 )
 SELECT CAST(SUM("composite_01"."Total Sales") AS DECIMAL(18, 2)) AS "Total Sales", CAST(SUM("composite_01"."Total Purchases") AS DECIMAL(18, 2)) AS "Total Purchases"

--- a/tests/integration/drift/compile_only/duckdb/07_total_sales_by_client_with_complaints.sql
+++ b/tests/integration/drift/compile_only/duckdb/07_total_sales_by_client_with_complaints.sql
@@ -1,5 +1,5 @@
 WITH "composite_01" AS (
-SELECT "Clients"."clientname" AS "Sales Client Name", CAST("Sales"."salesamount" AS DECIMAL(38, 20)) AS "Total Sales"
+SELECT "Clients"."clientname" AS "Sales Client Name", "Sales"."salesamount" AS "Total Sales"
 FROM "orionbelt_1"."sales" AS "Sales"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"
 UNION ALL BY NAME

--- a/tests/integration/drift/compile_only/duckdb/07_total_sales_by_client_with_complaints.sql
+++ b/tests/integration/drift/compile_only/duckdb/07_total_sales_by_client_with_complaints.sql
@@ -1,5 +1,5 @@
 WITH "composite_01" AS (
-SELECT "Clients"."clientname" AS "Sales Client Name", CAST("Sales"."salesamount" AS DECIMAL(38, 12)) AS "Total Sales"
+SELECT "Clients"."clientname" AS "Sales Client Name", CAST("Sales"."salesamount" AS DECIMAL(38, 20)) AS "Total Sales"
 FROM "orionbelt_1"."sales" AS "Sales"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"
 UNION ALL BY NAME

--- a/tests/integration/drift/compile_only/duckdb/09_return_rate.sql
+++ b/tests/integration/drift/compile_only/duckdb/09_return_rate.sql
@@ -1,8 +1,8 @@
 WITH "composite_01" AS (
-SELECT CAST("Returns"."returnamount" AS DECIMAL(38, 12)) AS "Total Returns"
+SELECT CAST("Returns"."returnamount" AS DECIMAL(38, 20)) AS "Total Returns"
 FROM "orionbelt_1"."returns" AS "Returns"
 UNION ALL BY NAME
-SELECT CAST("Sales"."salesamount" AS DECIMAL(38, 12)) AS "Total Sales"
+SELECT CAST("Sales"."salesamount" AS DECIMAL(38, 20)) AS "Total Sales"
 FROM "orionbelt_1"."sales" AS "Sales"
 )
 SELECT CAST(SUM("composite_01"."Total Returns") / NULLIF(SUM("composite_01"."Total Sales"), 0) AS DECIMAL(18, 4)) AS "Return Rate"

--- a/tests/integration/drift/compile_only/duckdb/09_return_rate.sql
+++ b/tests/integration/drift/compile_only/duckdb/09_return_rate.sql
@@ -1,8 +1,8 @@
 WITH "composite_01" AS (
-SELECT CAST("Returns"."returnamount" AS DECIMAL(38, 20)) AS "Total Returns"
+SELECT "Returns"."returnamount" AS "Total Returns"
 FROM "orionbelt_1"."returns" AS "Returns"
 UNION ALL BY NAME
-SELECT CAST("Sales"."salesamount" AS DECIMAL(38, 20)) AS "Total Sales"
+SELECT "Sales"."salesamount" AS "Total Sales"
 FROM "orionbelt_1"."sales" AS "Sales"
 )
 SELECT CAST(SUM("composite_01"."Total Returns") / NULLIF(SUM("composite_01"."Total Sales"), 0) AS DECIMAL(18, 4)) AS "Return Rate"

--- a/tests/integration/drift/compile_only/mysql/04_sales_returns_cfl_by_country.sql
+++ b/tests/integration/drift/compile_only/mysql/04_sales_returns_cfl_by_country.sql
@@ -1,10 +1,10 @@
 WITH `composite_01` AS (
-SELECT `Countries`.`countryname` AS `Sales Country Name`, CAST(`Sales`.`salesamount` AS DECIMAL(38, 12)) AS `Total Sales`, CAST(NULL AS DECIMAL(38, 12)) AS `Total Returns`
+SELECT `Countries`.`countryname` AS `Sales Country Name`, CAST(`Sales`.`salesamount` AS DECIMAL(38, 20)) AS `Total Sales`, CAST(NULL AS DECIMAL(38, 20)) AS `Total Returns`
 FROM `orionbelt_1`.`sales` AS `Sales`
 LEFT JOIN `orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`
 LEFT JOIN `orionbelt_1`.`countries` AS `Countries` ON `Clients`.`clientcountryid` = `Countries`.`countryid`
 UNION ALL
-SELECT `Countries`.`countryname` AS `Sales Country Name`, CAST(NULL AS DECIMAL(38, 12)) AS `Total Sales`, CAST(`Returns`.`returnamount` AS DECIMAL(38, 12)) AS `Total Returns`
+SELECT `Countries`.`countryname` AS `Sales Country Name`, CAST(NULL AS DECIMAL(38, 20)) AS `Total Sales`, CAST(`Returns`.`returnamount` AS DECIMAL(38, 20)) AS `Total Returns`
 FROM `orionbelt_1`.`returns` AS `Returns`
 LEFT JOIN `orionbelt_1`.`sales` AS `Sales` ON `Returns`.`returnsalesid` = `Sales`.`salesid`
 LEFT JOIN `orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`

--- a/tests/integration/drift/compile_only/mysql/04_sales_returns_cfl_by_country.sql
+++ b/tests/integration/drift/compile_only/mysql/04_sales_returns_cfl_by_country.sql
@@ -1,10 +1,10 @@
 WITH `composite_01` AS (
-SELECT `Countries`.`countryname` AS `Sales Country Name`, CAST(`Sales`.`salesamount` AS DECIMAL(38, 20)) AS `Total Sales`, CAST(NULL AS DECIMAL(38, 20)) AS `Total Returns`
+SELECT `Countries`.`countryname` AS `Sales Country Name`, `Sales`.`salesamount` AS `Total Sales`, CAST(NULL AS DECIMAL(38, 20)) AS `Total Returns`
 FROM `orionbelt_1`.`sales` AS `Sales`
 LEFT JOIN `orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`
 LEFT JOIN `orionbelt_1`.`countries` AS `Countries` ON `Clients`.`clientcountryid` = `Countries`.`countryid`
 UNION ALL
-SELECT `Countries`.`countryname` AS `Sales Country Name`, CAST(NULL AS DECIMAL(38, 20)) AS `Total Sales`, CAST(`Returns`.`returnamount` AS DECIMAL(38, 20)) AS `Total Returns`
+SELECT `Countries`.`countryname` AS `Sales Country Name`, CAST(NULL AS DECIMAL(38, 20)) AS `Total Sales`, `Returns`.`returnamount` AS `Total Returns`
 FROM `orionbelt_1`.`returns` AS `Returns`
 LEFT JOIN `orionbelt_1`.`sales` AS `Sales` ON `Returns`.`returnsalesid` = `Sales`.`salesid`
 LEFT JOIN `orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`

--- a/tests/integration/drift/compile_only/mysql/05_sales_purchases_cfl_ungrouped.sql
+++ b/tests/integration/drift/compile_only/mysql/05_sales_purchases_cfl_ungrouped.sql
@@ -1,8 +1,8 @@
 WITH `composite_01` AS (
-SELECT CAST(`Sales`.`salesamount` AS DECIMAL(38, 12)) AS `Total Sales`, CAST(NULL AS DECIMAL(38, 12)) AS `Total Purchases`
+SELECT CAST(`Sales`.`salesamount` AS DECIMAL(38, 20)) AS `Total Sales`, CAST(NULL AS DECIMAL(38, 20)) AS `Total Purchases`
 FROM `orionbelt_1`.`sales` AS `Sales`
 UNION ALL
-SELECT CAST(NULL AS DECIMAL(38, 12)) AS `Total Sales`, CAST(`Purchases`.`purchaseamount` AS DECIMAL(38, 12)) AS `Total Purchases`
+SELECT CAST(NULL AS DECIMAL(38, 20)) AS `Total Sales`, CAST(`Purchases`.`purchaseamount` AS DECIMAL(38, 20)) AS `Total Purchases`
 FROM `orionbelt_1`.`purchases` AS `Purchases`
 )
 SELECT CAST(SUM(`composite_01`.`Total Sales`) AS DECIMAL(18, 2)) AS `Total Sales`, CAST(SUM(`composite_01`.`Total Purchases`) AS DECIMAL(18, 2)) AS `Total Purchases`

--- a/tests/integration/drift/compile_only/mysql/05_sales_purchases_cfl_ungrouped.sql
+++ b/tests/integration/drift/compile_only/mysql/05_sales_purchases_cfl_ungrouped.sql
@@ -1,8 +1,8 @@
 WITH `composite_01` AS (
-SELECT CAST(`Sales`.`salesamount` AS DECIMAL(38, 20)) AS `Total Sales`, CAST(NULL AS DECIMAL(38, 20)) AS `Total Purchases`
+SELECT `Sales`.`salesamount` AS `Total Sales`, CAST(NULL AS DECIMAL(38, 20)) AS `Total Purchases`
 FROM `orionbelt_1`.`sales` AS `Sales`
 UNION ALL
-SELECT CAST(NULL AS DECIMAL(38, 20)) AS `Total Sales`, CAST(`Purchases`.`purchaseamount` AS DECIMAL(38, 20)) AS `Total Purchases`
+SELECT CAST(NULL AS DECIMAL(38, 20)) AS `Total Sales`, `Purchases`.`purchaseamount` AS `Total Purchases`
 FROM `orionbelt_1`.`purchases` AS `Purchases`
 )
 SELECT CAST(SUM(`composite_01`.`Total Sales`) AS DECIMAL(18, 2)) AS `Total Sales`, CAST(SUM(`composite_01`.`Total Purchases`) AS DECIMAL(18, 2)) AS `Total Purchases`

--- a/tests/integration/drift/compile_only/mysql/07_total_sales_by_client_with_complaints.sql
+++ b/tests/integration/drift/compile_only/mysql/07_total_sales_by_client_with_complaints.sql
@@ -1,9 +1,9 @@
 WITH `composite_01` AS (
-SELECT `Clients`.`clientname` AS `Sales Client Name`, CAST(NULL AS CHAR(255)) AS `Complaint Client Name`, CAST(`Sales`.`salesamount` AS DECIMAL(38, 12)) AS `Total Sales`, CAST(NULL AS SIGNED) AS `Client Complaints Count`
+SELECT `Clients`.`clientname` AS `Sales Client Name`, CAST(NULL AS CHAR(255)) AS `Complaint Client Name`, CAST(`Sales`.`salesamount` AS DECIMAL(38, 20)) AS `Total Sales`, CAST(NULL AS SIGNED) AS `Client Complaints Count`
 FROM `orionbelt_1`.`sales` AS `Sales`
 LEFT JOIN `orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`
 UNION ALL
-SELECT CAST(NULL AS CHAR(255)) AS `Sales Client Name`, `Clients`.`clientname` AS `Complaint Client Name`, CAST(NULL AS DECIMAL(38, 12)) AS `Total Sales`, CAST(1 AS SIGNED) AS `Client Complaints Count`
+SELECT CAST(NULL AS CHAR(255)) AS `Sales Client Name`, `Clients`.`clientname` AS `Complaint Client Name`, CAST(NULL AS DECIMAL(38, 20)) AS `Total Sales`, CAST(1 AS SIGNED) AS `Client Complaints Count`
 FROM `orionbelt_1`.`clientcomplaints` AS `Client Complaints`
 LEFT JOIN `orionbelt_1`.`clients` AS `Clients` ON `Client Complaints`.`complclientid` = `Clients`.`clientid`
 )

--- a/tests/integration/drift/compile_only/mysql/07_total_sales_by_client_with_complaints.sql
+++ b/tests/integration/drift/compile_only/mysql/07_total_sales_by_client_with_complaints.sql
@@ -1,5 +1,5 @@
 WITH `composite_01` AS (
-SELECT `Clients`.`clientname` AS `Sales Client Name`, CAST(NULL AS CHAR(255)) AS `Complaint Client Name`, CAST(`Sales`.`salesamount` AS DECIMAL(38, 20)) AS `Total Sales`, CAST(NULL AS SIGNED) AS `Client Complaints Count`
+SELECT `Clients`.`clientname` AS `Sales Client Name`, CAST(NULL AS CHAR(255)) AS `Complaint Client Name`, `Sales`.`salesamount` AS `Total Sales`, CAST(NULL AS SIGNED) AS `Client Complaints Count`
 FROM `orionbelt_1`.`sales` AS `Sales`
 LEFT JOIN `orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`
 UNION ALL

--- a/tests/integration/drift/compile_only/mysql/09_return_rate.sql
+++ b/tests/integration/drift/compile_only/mysql/09_return_rate.sql
@@ -1,8 +1,8 @@
 WITH `composite_01` AS (
-SELECT CAST(`Returns`.`returnamount` AS DECIMAL(38, 12)) AS `Total Returns`, CAST(NULL AS DECIMAL(38, 12)) AS `Total Sales`
+SELECT CAST(`Returns`.`returnamount` AS DECIMAL(38, 20)) AS `Total Returns`, CAST(NULL AS DECIMAL(38, 20)) AS `Total Sales`
 FROM `orionbelt_1`.`returns` AS `Returns`
 UNION ALL
-SELECT CAST(NULL AS DECIMAL(38, 12)) AS `Total Returns`, CAST(`Sales`.`salesamount` AS DECIMAL(38, 12)) AS `Total Sales`
+SELECT CAST(NULL AS DECIMAL(38, 20)) AS `Total Returns`, CAST(`Sales`.`salesamount` AS DECIMAL(38, 20)) AS `Total Sales`
 FROM `orionbelt_1`.`sales` AS `Sales`
 )
 SELECT CAST(SUM(`composite_01`.`Total Returns`) / NULLIF(SUM(`composite_01`.`Total Sales`), 0) AS DECIMAL(18, 4)) AS `Return Rate`

--- a/tests/integration/drift/compile_only/mysql/09_return_rate.sql
+++ b/tests/integration/drift/compile_only/mysql/09_return_rate.sql
@@ -1,8 +1,8 @@
 WITH `composite_01` AS (
-SELECT CAST(`Returns`.`returnamount` AS DECIMAL(38, 20)) AS `Total Returns`, CAST(NULL AS DECIMAL(38, 20)) AS `Total Sales`
+SELECT `Returns`.`returnamount` AS `Total Returns`, CAST(NULL AS DECIMAL(38, 20)) AS `Total Sales`
 FROM `orionbelt_1`.`returns` AS `Returns`
 UNION ALL
-SELECT CAST(NULL AS DECIMAL(38, 20)) AS `Total Returns`, CAST(`Sales`.`salesamount` AS DECIMAL(38, 20)) AS `Total Sales`
+SELECT CAST(NULL AS DECIMAL(38, 20)) AS `Total Returns`, `Sales`.`salesamount` AS `Total Sales`
 FROM `orionbelt_1`.`sales` AS `Sales`
 )
 SELECT CAST(SUM(`composite_01`.`Total Returns`) / NULLIF(SUM(`composite_01`.`Total Sales`), 0) AS DECIMAL(18, 4)) AS `Return Rate`

--- a/tests/integration/drift/compile_only/postgres/04_sales_returns_cfl_by_country.sql
+++ b/tests/integration/drift/compile_only/postgres/04_sales_returns_cfl_by_country.sql
@@ -1,10 +1,10 @@
 WITH "composite_01" AS (
-SELECT "Countries"."countryname" AS "Sales Country Name", CAST("Sales"."salesamount" AS DECIMAL(38, 20)) AS "Total Sales", CAST(NULL AS DECIMAL(38, 20)) AS "Total Returns"
+SELECT "Countries"."countryname" AS "Sales Country Name", "Sales"."salesamount" AS "Total Sales", CAST(NULL AS DECIMAL(38, 20)) AS "Total Returns"
 FROM "orionbelt_1"."sales" AS "Sales"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"
 LEFT JOIN "orionbelt_1"."countries" AS "Countries" ON "Clients"."clientcountryid" = "Countries"."countryid"
 UNION ALL
-SELECT "Countries"."countryname" AS "Sales Country Name", CAST(NULL AS DECIMAL(38, 20)) AS "Total Sales", CAST("Returns"."returnamount" AS DECIMAL(38, 20)) AS "Total Returns"
+SELECT "Countries"."countryname" AS "Sales Country Name", CAST(NULL AS DECIMAL(38, 20)) AS "Total Sales", "Returns"."returnamount" AS "Total Returns"
 FROM "orionbelt_1"."returns" AS "Returns"
 LEFT JOIN "orionbelt_1"."sales" AS "Sales" ON "Returns"."returnsalesid" = "Sales"."salesid"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"

--- a/tests/integration/drift/compile_only/postgres/04_sales_returns_cfl_by_country.sql
+++ b/tests/integration/drift/compile_only/postgres/04_sales_returns_cfl_by_country.sql
@@ -1,10 +1,10 @@
 WITH "composite_01" AS (
-SELECT "Countries"."countryname" AS "Sales Country Name", CAST("Sales"."salesamount" AS DECIMAL(38, 12)) AS "Total Sales", CAST(NULL AS DECIMAL(38, 12)) AS "Total Returns"
+SELECT "Countries"."countryname" AS "Sales Country Name", CAST("Sales"."salesamount" AS DECIMAL(38, 20)) AS "Total Sales", CAST(NULL AS DECIMAL(38, 20)) AS "Total Returns"
 FROM "orionbelt_1"."sales" AS "Sales"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"
 LEFT JOIN "orionbelt_1"."countries" AS "Countries" ON "Clients"."clientcountryid" = "Countries"."countryid"
 UNION ALL
-SELECT "Countries"."countryname" AS "Sales Country Name", CAST(NULL AS DECIMAL(38, 12)) AS "Total Sales", CAST("Returns"."returnamount" AS DECIMAL(38, 12)) AS "Total Returns"
+SELECT "Countries"."countryname" AS "Sales Country Name", CAST(NULL AS DECIMAL(38, 20)) AS "Total Sales", CAST("Returns"."returnamount" AS DECIMAL(38, 20)) AS "Total Returns"
 FROM "orionbelt_1"."returns" AS "Returns"
 LEFT JOIN "orionbelt_1"."sales" AS "Sales" ON "Returns"."returnsalesid" = "Sales"."salesid"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"

--- a/tests/integration/drift/compile_only/postgres/05_sales_purchases_cfl_ungrouped.sql
+++ b/tests/integration/drift/compile_only/postgres/05_sales_purchases_cfl_ungrouped.sql
@@ -1,8 +1,8 @@
 WITH "composite_01" AS (
-SELECT CAST("Sales"."salesamount" AS DECIMAL(38, 20)) AS "Total Sales", CAST(NULL AS DECIMAL(38, 20)) AS "Total Purchases"
+SELECT "Sales"."salesamount" AS "Total Sales", CAST(NULL AS DECIMAL(38, 20)) AS "Total Purchases"
 FROM "orionbelt_1"."sales" AS "Sales"
 UNION ALL
-SELECT CAST(NULL AS DECIMAL(38, 20)) AS "Total Sales", CAST("Purchases"."purchaseamount" AS DECIMAL(38, 20)) AS "Total Purchases"
+SELECT CAST(NULL AS DECIMAL(38, 20)) AS "Total Sales", "Purchases"."purchaseamount" AS "Total Purchases"
 FROM "orionbelt_1"."purchases" AS "Purchases"
 )
 SELECT CAST(SUM("composite_01"."Total Sales") AS DECIMAL(18, 2)) AS "Total Sales", CAST(SUM("composite_01"."Total Purchases") AS DECIMAL(18, 2)) AS "Total Purchases"

--- a/tests/integration/drift/compile_only/postgres/05_sales_purchases_cfl_ungrouped.sql
+++ b/tests/integration/drift/compile_only/postgres/05_sales_purchases_cfl_ungrouped.sql
@@ -1,8 +1,8 @@
 WITH "composite_01" AS (
-SELECT CAST("Sales"."salesamount" AS DECIMAL(38, 12)) AS "Total Sales", CAST(NULL AS DECIMAL(38, 12)) AS "Total Purchases"
+SELECT CAST("Sales"."salesamount" AS DECIMAL(38, 20)) AS "Total Sales", CAST(NULL AS DECIMAL(38, 20)) AS "Total Purchases"
 FROM "orionbelt_1"."sales" AS "Sales"
 UNION ALL
-SELECT CAST(NULL AS DECIMAL(38, 12)) AS "Total Sales", CAST("Purchases"."purchaseamount" AS DECIMAL(38, 12)) AS "Total Purchases"
+SELECT CAST(NULL AS DECIMAL(38, 20)) AS "Total Sales", CAST("Purchases"."purchaseamount" AS DECIMAL(38, 20)) AS "Total Purchases"
 FROM "orionbelt_1"."purchases" AS "Purchases"
 )
 SELECT CAST(SUM("composite_01"."Total Sales") AS DECIMAL(18, 2)) AS "Total Sales", CAST(SUM("composite_01"."Total Purchases") AS DECIMAL(18, 2)) AS "Total Purchases"

--- a/tests/integration/drift/compile_only/postgres/07_total_sales_by_client_with_complaints.sql
+++ b/tests/integration/drift/compile_only/postgres/07_total_sales_by_client_with_complaints.sql
@@ -1,5 +1,5 @@
 WITH "composite_01" AS (
-SELECT "Clients"."clientname" AS "Sales Client Name", CAST(NULL AS VARCHAR) AS "Complaint Client Name", CAST("Sales"."salesamount" AS DECIMAL(38, 20)) AS "Total Sales", CAST(NULL AS INTEGER) AS "Client Complaints Count"
+SELECT "Clients"."clientname" AS "Sales Client Name", CAST(NULL AS VARCHAR) AS "Complaint Client Name", "Sales"."salesamount" AS "Total Sales", CAST(NULL AS INTEGER) AS "Client Complaints Count"
 FROM "orionbelt_1"."sales" AS "Sales"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"
 UNION ALL

--- a/tests/integration/drift/compile_only/postgres/07_total_sales_by_client_with_complaints.sql
+++ b/tests/integration/drift/compile_only/postgres/07_total_sales_by_client_with_complaints.sql
@@ -1,9 +1,9 @@
 WITH "composite_01" AS (
-SELECT "Clients"."clientname" AS "Sales Client Name", CAST(NULL AS VARCHAR) AS "Complaint Client Name", CAST("Sales"."salesamount" AS DECIMAL(38, 12)) AS "Total Sales", CAST(NULL AS INTEGER) AS "Client Complaints Count"
+SELECT "Clients"."clientname" AS "Sales Client Name", CAST(NULL AS VARCHAR) AS "Complaint Client Name", CAST("Sales"."salesamount" AS DECIMAL(38, 20)) AS "Total Sales", CAST(NULL AS INTEGER) AS "Client Complaints Count"
 FROM "orionbelt_1"."sales" AS "Sales"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"
 UNION ALL
-SELECT CAST(NULL AS VARCHAR) AS "Sales Client Name", "Clients"."clientname" AS "Complaint Client Name", CAST(NULL AS DECIMAL(38, 12)) AS "Total Sales", CAST(1 AS INTEGER) AS "Client Complaints Count"
+SELECT CAST(NULL AS VARCHAR) AS "Sales Client Name", "Clients"."clientname" AS "Complaint Client Name", CAST(NULL AS DECIMAL(38, 20)) AS "Total Sales", CAST(1 AS INTEGER) AS "Client Complaints Count"
 FROM "orionbelt_1"."clientcomplaints" AS "Client Complaints"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Client Complaints"."complclientid" = "Clients"."clientid"
 )

--- a/tests/integration/drift/compile_only/postgres/09_return_rate.sql
+++ b/tests/integration/drift/compile_only/postgres/09_return_rate.sql
@@ -1,8 +1,8 @@
 WITH "composite_01" AS (
-SELECT CAST("Returns"."returnamount" AS DECIMAL(38, 12)) AS "Total Returns", CAST(NULL AS DECIMAL(38, 12)) AS "Total Sales"
+SELECT CAST("Returns"."returnamount" AS DECIMAL(38, 20)) AS "Total Returns", CAST(NULL AS DECIMAL(38, 20)) AS "Total Sales"
 FROM "orionbelt_1"."returns" AS "Returns"
 UNION ALL
-SELECT CAST(NULL AS DECIMAL(38, 12)) AS "Total Returns", CAST("Sales"."salesamount" AS DECIMAL(38, 12)) AS "Total Sales"
+SELECT CAST(NULL AS DECIMAL(38, 20)) AS "Total Returns", CAST("Sales"."salesamount" AS DECIMAL(38, 20)) AS "Total Sales"
 FROM "orionbelt_1"."sales" AS "Sales"
 )
 SELECT CAST(SUM("composite_01"."Total Returns") / NULLIF(SUM("composite_01"."Total Sales"), 0) AS DECIMAL(18, 4)) AS "Return Rate"

--- a/tests/integration/drift/compile_only/postgres/09_return_rate.sql
+++ b/tests/integration/drift/compile_only/postgres/09_return_rate.sql
@@ -1,8 +1,8 @@
 WITH "composite_01" AS (
-SELECT CAST("Returns"."returnamount" AS DECIMAL(38, 20)) AS "Total Returns", CAST(NULL AS DECIMAL(38, 20)) AS "Total Sales"
+SELECT "Returns"."returnamount" AS "Total Returns", CAST(NULL AS DECIMAL(38, 20)) AS "Total Sales"
 FROM "orionbelt_1"."returns" AS "Returns"
 UNION ALL
-SELECT CAST(NULL AS DECIMAL(38, 20)) AS "Total Returns", CAST("Sales"."salesamount" AS DECIMAL(38, 20)) AS "Total Sales"
+SELECT CAST(NULL AS DECIMAL(38, 20)) AS "Total Returns", "Sales"."salesamount" AS "Total Sales"
 FROM "orionbelt_1"."sales" AS "Sales"
 )
 SELECT CAST(SUM("composite_01"."Total Returns") / NULLIF(SUM("composite_01"."Total Sales"), 0) AS DECIMAL(18, 4)) AS "Return Rate"

--- a/tests/integration/drift/compile_only/snowflake/04_sales_returns_cfl_by_country.sql
+++ b/tests/integration/drift/compile_only/snowflake/04_sales_returns_cfl_by_country.sql
@@ -1,10 +1,10 @@
 WITH "composite_01" AS (
-SELECT "Countries"."countryname" AS "Sales Country Name", CAST("Sales"."salesamount" AS NUMBER(38, 12)) AS "Total Sales"
+SELECT "Countries"."countryname" AS "Sales Country Name", CAST("Sales"."salesamount" AS NUMBER(38, 20)) AS "Total Sales"
 FROM "orionbelt_1"."sales" AS "Sales"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"
 LEFT JOIN "orionbelt_1"."countries" AS "Countries" ON "Clients"."clientcountryid" = "Countries"."countryid"
 UNION ALL BY NAME
-SELECT "Countries"."countryname" AS "Sales Country Name", CAST("Returns"."returnamount" AS NUMBER(38, 12)) AS "Total Returns"
+SELECT "Countries"."countryname" AS "Sales Country Name", CAST("Returns"."returnamount" AS NUMBER(38, 20)) AS "Total Returns"
 FROM "orionbelt_1"."returns" AS "Returns"
 LEFT JOIN "orionbelt_1"."sales" AS "Sales" ON "Returns"."returnsalesid" = "Sales"."salesid"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"

--- a/tests/integration/drift/compile_only/snowflake/04_sales_returns_cfl_by_country.sql
+++ b/tests/integration/drift/compile_only/snowflake/04_sales_returns_cfl_by_country.sql
@@ -1,10 +1,10 @@
 WITH "composite_01" AS (
-SELECT "Countries"."countryname" AS "Sales Country Name", CAST("Sales"."salesamount" AS NUMBER(38, 20)) AS "Total Sales"
+SELECT "Countries"."countryname" AS "Sales Country Name", "Sales"."salesamount" AS "Total Sales"
 FROM "orionbelt_1"."sales" AS "Sales"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"
 LEFT JOIN "orionbelt_1"."countries" AS "Countries" ON "Clients"."clientcountryid" = "Countries"."countryid"
 UNION ALL BY NAME
-SELECT "Countries"."countryname" AS "Sales Country Name", CAST("Returns"."returnamount" AS NUMBER(38, 20)) AS "Total Returns"
+SELECT "Countries"."countryname" AS "Sales Country Name", "Returns"."returnamount" AS "Total Returns"
 FROM "orionbelt_1"."returns" AS "Returns"
 LEFT JOIN "orionbelt_1"."sales" AS "Sales" ON "Returns"."returnsalesid" = "Sales"."salesid"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"

--- a/tests/integration/drift/compile_only/snowflake/05_sales_purchases_cfl_ungrouped.sql
+++ b/tests/integration/drift/compile_only/snowflake/05_sales_purchases_cfl_ungrouped.sql
@@ -1,8 +1,8 @@
 WITH "composite_01" AS (
-SELECT CAST("Sales"."salesamount" AS NUMBER(38, 12)) AS "Total Sales"
+SELECT CAST("Sales"."salesamount" AS NUMBER(38, 20)) AS "Total Sales"
 FROM "orionbelt_1"."sales" AS "Sales"
 UNION ALL BY NAME
-SELECT CAST("Purchases"."purchaseamount" AS NUMBER(38, 12)) AS "Total Purchases"
+SELECT CAST("Purchases"."purchaseamount" AS NUMBER(38, 20)) AS "Total Purchases"
 FROM "orionbelt_1"."purchases" AS "Purchases"
 )
 SELECT CAST(SUM("composite_01"."Total Sales") AS NUMBER(18, 2)) AS "Total Sales", CAST(SUM("composite_01"."Total Purchases") AS NUMBER(18, 2)) AS "Total Purchases"

--- a/tests/integration/drift/compile_only/snowflake/05_sales_purchases_cfl_ungrouped.sql
+++ b/tests/integration/drift/compile_only/snowflake/05_sales_purchases_cfl_ungrouped.sql
@@ -1,8 +1,8 @@
 WITH "composite_01" AS (
-SELECT CAST("Sales"."salesamount" AS NUMBER(38, 20)) AS "Total Sales"
+SELECT "Sales"."salesamount" AS "Total Sales"
 FROM "orionbelt_1"."sales" AS "Sales"
 UNION ALL BY NAME
-SELECT CAST("Purchases"."purchaseamount" AS NUMBER(38, 20)) AS "Total Purchases"
+SELECT "Purchases"."purchaseamount" AS "Total Purchases"
 FROM "orionbelt_1"."purchases" AS "Purchases"
 )
 SELECT CAST(SUM("composite_01"."Total Sales") AS NUMBER(18, 2)) AS "Total Sales", CAST(SUM("composite_01"."Total Purchases") AS NUMBER(18, 2)) AS "Total Purchases"

--- a/tests/integration/drift/compile_only/snowflake/07_total_sales_by_client_with_complaints.sql
+++ b/tests/integration/drift/compile_only/snowflake/07_total_sales_by_client_with_complaints.sql
@@ -1,5 +1,5 @@
 WITH "composite_01" AS (
-SELECT "Clients"."clientname" AS "Sales Client Name", CAST("Sales"."salesamount" AS NUMBER(38, 20)) AS "Total Sales"
+SELECT "Clients"."clientname" AS "Sales Client Name", "Sales"."salesamount" AS "Total Sales"
 FROM "orionbelt_1"."sales" AS "Sales"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"
 UNION ALL BY NAME

--- a/tests/integration/drift/compile_only/snowflake/07_total_sales_by_client_with_complaints.sql
+++ b/tests/integration/drift/compile_only/snowflake/07_total_sales_by_client_with_complaints.sql
@@ -1,5 +1,5 @@
 WITH "composite_01" AS (
-SELECT "Clients"."clientname" AS "Sales Client Name", CAST("Sales"."salesamount" AS NUMBER(38, 12)) AS "Total Sales"
+SELECT "Clients"."clientname" AS "Sales Client Name", CAST("Sales"."salesamount" AS NUMBER(38, 20)) AS "Total Sales"
 FROM "orionbelt_1"."sales" AS "Sales"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"
 UNION ALL BY NAME

--- a/tests/integration/drift/compile_only/snowflake/09_return_rate.sql
+++ b/tests/integration/drift/compile_only/snowflake/09_return_rate.sql
@@ -1,8 +1,8 @@
 WITH "composite_01" AS (
-SELECT CAST("Returns"."returnamount" AS NUMBER(38, 20)) AS "Total Returns"
+SELECT "Returns"."returnamount" AS "Total Returns"
 FROM "orionbelt_1"."returns" AS "Returns"
 UNION ALL BY NAME
-SELECT CAST("Sales"."salesamount" AS NUMBER(38, 20)) AS "Total Sales"
+SELECT "Sales"."salesamount" AS "Total Sales"
 FROM "orionbelt_1"."sales" AS "Sales"
 )
 SELECT CAST(SUM("composite_01"."Total Returns") / NULLIF(SUM("composite_01"."Total Sales"), 0) AS NUMBER(18, 4)) AS "Return Rate"

--- a/tests/integration/drift/compile_only/snowflake/09_return_rate.sql
+++ b/tests/integration/drift/compile_only/snowflake/09_return_rate.sql
@@ -1,8 +1,8 @@
 WITH "composite_01" AS (
-SELECT CAST("Returns"."returnamount" AS NUMBER(38, 12)) AS "Total Returns"
+SELECT CAST("Returns"."returnamount" AS NUMBER(38, 20)) AS "Total Returns"
 FROM "orionbelt_1"."returns" AS "Returns"
 UNION ALL BY NAME
-SELECT CAST("Sales"."salesamount" AS NUMBER(38, 12)) AS "Total Sales"
+SELECT CAST("Sales"."salesamount" AS NUMBER(38, 20)) AS "Total Sales"
 FROM "orionbelt_1"."sales" AS "Sales"
 )
 SELECT CAST(SUM("composite_01"."Total Returns") / NULLIF(SUM("composite_01"."Total Sales"), 0) AS NUMBER(18, 4)) AS "Return Rate"

--- a/tests/integration/drift/duckdb/04_sales_returns_cfl_by_country.yaml
+++ b/tests/integration/drift/duckdb/04_sales_returns_cfl_by_country.yaml
@@ -1,7 +1,7 @@
 last_verified_by: tests/integration/correctness/test_cfl_split.py::test_sales_returns_cfl_split_by_country
 sql: 'WITH "composite_01" AS (
 
-  SELECT "Countries"."countryname" AS "Sales Country Name", CAST("Sales"."salesamount" AS DECIMAL(38, 12)) AS "Total Sales"
+  SELECT "Countries"."countryname" AS "Sales Country Name", CAST("Sales"."salesamount" AS DECIMAL(38, 20)) AS "Total Sales"
 
   FROM "orionbelt_1"."sales" AS "Sales"
 
@@ -11,7 +11,7 @@ sql: 'WITH "composite_01" AS (
 
   UNION ALL BY NAME
 
-  SELECT "Countries"."countryname" AS "Sales Country Name", CAST("Returns"."returnamount" AS DECIMAL(38, 12)) AS "Total Returns"
+  SELECT "Countries"."countryname" AS "Sales Country Name", CAST("Returns"."returnamount" AS DECIMAL(38, 20)) AS "Total Returns"
 
   FROM "orionbelt_1"."returns" AS "Returns"
 

--- a/tests/integration/drift/duckdb/04_sales_returns_cfl_by_country.yaml
+++ b/tests/integration/drift/duckdb/04_sales_returns_cfl_by_country.yaml
@@ -1,7 +1,7 @@
 last_verified_by: tests/integration/correctness/test_cfl_split.py::test_sales_returns_cfl_split_by_country
 sql: 'WITH "composite_01" AS (
 
-  SELECT "Countries"."countryname" AS "Sales Country Name", CAST("Sales"."salesamount" AS DECIMAL(38, 20)) AS "Total Sales"
+  SELECT "Countries"."countryname" AS "Sales Country Name", "Sales"."salesamount" AS "Total Sales"
 
   FROM "orionbelt_1"."sales" AS "Sales"
 
@@ -11,7 +11,7 @@ sql: 'WITH "composite_01" AS (
 
   UNION ALL BY NAME
 
-  SELECT "Countries"."countryname" AS "Sales Country Name", CAST("Returns"."returnamount" AS DECIMAL(38, 20)) AS "Total Returns"
+  SELECT "Countries"."countryname" AS "Sales Country Name", "Returns"."returnamount" AS "Total Returns"
 
   FROM "orionbelt_1"."returns" AS "Returns"
 

--- a/tests/integration/drift/duckdb/05_sales_purchases_cfl_ungrouped.yaml
+++ b/tests/integration/drift/duckdb/05_sales_purchases_cfl_ungrouped.yaml
@@ -1,13 +1,13 @@
 last_verified_by: tests/integration/correctness/test_cfl_split.py::test_sales_purchases_cfl_split_ungrouped
 sql: 'WITH "composite_01" AS (
 
-  SELECT CAST("Sales"."salesamount" AS DECIMAL(38, 12)) AS "Total Sales"
+  SELECT CAST("Sales"."salesamount" AS DECIMAL(38, 20)) AS "Total Sales"
 
   FROM "orionbelt_1"."sales" AS "Sales"
 
   UNION ALL BY NAME
 
-  SELECT CAST("Purchases"."purchaseamount" AS DECIMAL(38, 12)) AS "Total Purchases"
+  SELECT CAST("Purchases"."purchaseamount" AS DECIMAL(38, 20)) AS "Total Purchases"
 
   FROM "orionbelt_1"."purchases" AS "Purchases"
 

--- a/tests/integration/drift/duckdb/05_sales_purchases_cfl_ungrouped.yaml
+++ b/tests/integration/drift/duckdb/05_sales_purchases_cfl_ungrouped.yaml
@@ -1,13 +1,13 @@
 last_verified_by: tests/integration/correctness/test_cfl_split.py::test_sales_purchases_cfl_split_ungrouped
 sql: 'WITH "composite_01" AS (
 
-  SELECT CAST("Sales"."salesamount" AS DECIMAL(38, 20)) AS "Total Sales"
+  SELECT "Sales"."salesamount" AS "Total Sales"
 
   FROM "orionbelt_1"."sales" AS "Sales"
 
   UNION ALL BY NAME
 
-  SELECT CAST("Purchases"."purchaseamount" AS DECIMAL(38, 20)) AS "Total Purchases"
+  SELECT "Purchases"."purchaseamount" AS "Total Purchases"
 
   FROM "orionbelt_1"."purchases" AS "Purchases"
 

--- a/tests/integration/drift/duckdb/07_total_sales_by_client_with_complaints.yaml
+++ b/tests/integration/drift/duckdb/07_total_sales_by_client_with_complaints.yaml
@@ -1,7 +1,7 @@
 last_verified_by: tests/integration/correctness/test_hand_sql_reference.py::test_obsl_matches_hand_sql[07_total_sales_by_client_with_complaints]
 sql: 'WITH "composite_01" AS (
 
-  SELECT "Clients"."clientname" AS "Sales Client Name", CAST("Sales"."salesamount" AS DECIMAL(38, 20)) AS "Total Sales"
+  SELECT "Clients"."clientname" AS "Sales Client Name", "Sales"."salesamount" AS "Total Sales"
 
   FROM "orionbelt_1"."sales" AS "Sales"
 

--- a/tests/integration/drift/duckdb/07_total_sales_by_client_with_complaints.yaml
+++ b/tests/integration/drift/duckdb/07_total_sales_by_client_with_complaints.yaml
@@ -1,7 +1,7 @@
 last_verified_by: tests/integration/correctness/test_hand_sql_reference.py::test_obsl_matches_hand_sql[07_total_sales_by_client_with_complaints]
 sql: 'WITH "composite_01" AS (
 
-  SELECT "Clients"."clientname" AS "Sales Client Name", CAST("Sales"."salesamount" AS DECIMAL(38, 12)) AS "Total Sales"
+  SELECT "Clients"."clientname" AS "Sales Client Name", CAST("Sales"."salesamount" AS DECIMAL(38, 20)) AS "Total Sales"
 
   FROM "orionbelt_1"."sales" AS "Sales"
 

--- a/tests/integration/drift/duckdb/09_return_rate.yaml
+++ b/tests/integration/drift/duckdb/09_return_rate.yaml
@@ -1,13 +1,13 @@
 last_verified_by: tests/integration/correctness/test_metric_algebra.py::test_return_rate_equals_returns_over_sales
 sql: 'WITH "composite_01" AS (
 
-  SELECT CAST("Returns"."returnamount" AS DECIMAL(38, 20)) AS "Total Returns"
+  SELECT "Returns"."returnamount" AS "Total Returns"
 
   FROM "orionbelt_1"."returns" AS "Returns"
 
   UNION ALL BY NAME
 
-  SELECT CAST("Sales"."salesamount" AS DECIMAL(38, 20)) AS "Total Sales"
+  SELECT "Sales"."salesamount" AS "Total Sales"
 
   FROM "orionbelt_1"."sales" AS "Sales"
 

--- a/tests/integration/drift/duckdb/09_return_rate.yaml
+++ b/tests/integration/drift/duckdb/09_return_rate.yaml
@@ -1,13 +1,13 @@
 last_verified_by: tests/integration/correctness/test_metric_algebra.py::test_return_rate_equals_returns_over_sales
 sql: 'WITH "composite_01" AS (
 
-  SELECT CAST("Returns"."returnamount" AS DECIMAL(38, 12)) AS "Total Returns"
+  SELECT CAST("Returns"."returnamount" AS DECIMAL(38, 20)) AS "Total Returns"
 
   FROM "orionbelt_1"."returns" AS "Returns"
 
   UNION ALL BY NAME
 
-  SELECT CAST("Sales"."salesamount" AS DECIMAL(38, 12)) AS "Total Sales"
+  SELECT CAST("Sales"."salesamount" AS DECIMAL(38, 20)) AS "Total Sales"
 
   FROM "orionbelt_1"."sales" AS "Sales"
 

--- a/tests/unit/test_cfl_union_alignment.py
+++ b/tests/unit/test_cfl_union_alignment.py
@@ -54,6 +54,7 @@ dataObjects:
     columns:
       Day: {code: day, abstractType: int}
       Amount: {code: amount, abstractType: float}
+      Qty: {code: qty, abstractType: int}
     joins:
       - joinType: many-to-one
         joinTo: Days
@@ -76,6 +77,10 @@ dimensions:
   Day: {dataObject: Days, column: Day, resultType: int}
 
 measures:
+  Qty Min:
+    columns: [{dataObject: Charges, column: Qty}]
+    resultType: int
+    aggregation: min
   Charged Stddev:
     columns: [{dataObject: Charges, column: Amount}]
     resultType: float
@@ -267,10 +272,16 @@ class TestWhatIsAndIsNotWidened:
         con = duckdb.connect(":memory:")
         try:
             con.execute("CREATE TABLE days (day INTEGER)")
-            con.execute("CREATE TABLE charges (day INTEGER, amount DECIMAL(38, 15), label VARCHAR)")
+            con.execute(
+                "CREATE TABLE charges (day INTEGER, amount DECIMAL(38, 15), "
+                "label VARCHAR, qty BIGINT)"
+            )
             con.execute("CREATE TABLE invoices (day INTEGER, amount DECIMAL(18, 6))")
             con.execute("INSERT INTO days VALUES (1), (2)")
-            con.execute("INSERT INTO charges VALUES (1, 1.000000000000400, 'x'), (2, 2.5, 'y')")
+            con.execute(
+                "INSERT INTO charges VALUES "
+                "(1, 1.000000000000400, 'x', 1000000000000000001), (2, 2.5, 'y', 2)"
+            )
             con.execute("INSERT INTO invoices VALUES (1, 3.5), (2, 4.5)")
             star = _run(con, ["Charged Min"])[0][0]
             cfl = _run(con, ["Charged Min", "Invoiced"])[0][0]
@@ -373,3 +384,49 @@ class TestStarAndCflAgreeAcrossTheMatrix:
         assert not disagreements, (
             "a measure changed answer under a multi-fact plan:\n  " + "\n  ".join(disagreements)
         )
+
+
+class TestIntegersAreNotWidenedIntoDecimals:
+    """An integer has no fractional digits, so the decimal widening is all cost.
+
+    ``DECIMAL(38, 20)`` leaves 18 integer digits, which a BIGINT exceeds
+    outright: DuckDB refuses to cast 1000000000000000000. It would also change
+    an integer measure's type the moment another fact joined the query.
+
+    They still need an alignment of their own. ``abstractType: int`` renders as
+    a 32-bit INTEGER, so a BIGINT column reached the leg as
+    ``CAST(qty AS INTEGER)`` and failed on any value past 2^31 - a defect that
+    predates the widening and that a CFL query hit on its own.
+    """
+
+    def test_a_bigint_survives_a_multi_fact_query(self) -> None:
+        con = duckdb.connect(":memory:")
+        try:
+            con.execute("CREATE TABLE days (day INTEGER)")
+            con.execute(
+                "CREATE TABLE charges (day INTEGER, amount DECIMAL(18, 6), "
+                "label VARCHAR, qty BIGINT)"
+            )
+            con.execute("CREATE TABLE invoices (day INTEGER, amount DECIMAL(18, 6))")
+            con.execute("INSERT INTO days VALUES (1), (2)")
+            con.execute(
+                "INSERT INTO charges VALUES "
+                "(1, 1.5, 'x', 1000000000000000000), (2, 2.5, 'y', 2000000000000000000)"
+            )
+            con.execute("INSERT INTO invoices VALUES (1, 3.5), (2, 4.5)")
+            star = _run(con, ["Qty Min"])[0][0]
+            cfl = _run(con, ["Qty Min", "Invoiced"])[0][0]
+        finally:
+            con.close()
+        assert int(star) == 1000000000000000000
+        assert int(cfl) == int(star), "a BIGINT did not survive the CFL leg"
+
+    def test_the_leg_aligns_on_a_64_bit_integer(self) -> None:
+        sql = PIPELINE.compile(
+            QueryObject(select=QuerySelect(dimensions=[], measures=["Qty Min", "Invoiced"])),
+            _model(),
+            "duckdb",
+        ).sql
+        leg = next(line for line in sql.splitlines() if '"Qty Min"' in line and "CAST" in line)
+        assert "BIGINT" in leg, f"an integer column should align on the 64-bit integer: {leg}"
+        assert "DECIMAL" not in leg, f"an integer column should not be widened to a decimal: {leg}"

--- a/tests/unit/test_cfl_union_alignment.py
+++ b/tests/unit/test_cfl_union_alignment.py
@@ -126,6 +126,14 @@ def _seeded() -> duckdb.DuckDBPyConnection:
     return con
 
 
+def _first(con: duckdb.DuckDBPyConnection, model: SemanticModel, measures: list[str]) -> object:
+    """First cell of *measures* compiled against *model* and run on *con*."""
+    sql = PIPELINE.compile(
+        QueryObject(select=QuerySelect(dimensions=[], measures=measures)), model, "duckdb"
+    ).sql
+    return con.execute(sql).fetchall()[0][0]
+
+
 def _run(con: duckdb.DuckDBPyConnection, measures: list[str]) -> list[tuple]:
     sql = PIPELINE.compile(
         QueryObject(select=QuerySelect(dimensions=[], measures=measures)),
@@ -220,19 +228,21 @@ class TestWhatIsAndIsNotWidened:
             "an expression measure answered differently under a multi-fact plan"
         )
 
-    def test_a_selecting_aggregate_is_left_alone(self) -> None:
-        """MIN picks a value rather than combining values, so nothing compounds.
+    def test_a_selecting_aggregate_is_widened_too(self) -> None:
+        """One mechanism, not two: MIN aligns the same way SUM does.
 
-        ``resolve_measure_data_type`` treats MIN, MAX, ANY_VALUE, MEDIAN and
-        MODE as no-cast pass-through. Routing them through the widening changed
-        both the value and its type - MIN over a fifteen-decimal column went
-        from 1.000000000000400 to 1.000000000000 - so they keep the existing
-        alignment.
+        This asserted the opposite for a while. MIN was left unwidened because
+        widening it at scale 12 turned 1.000000000000400 into
+        1.000000000000, and an attempt to leave both sides of the union
+        untyped instead was measured to break two engines: Postgres resolves a
+        column whose first two occurrences are untyped NULLs as text and then
+        refuses to match numeric, and DuckDB unifies to the pad's type rather
+        than the column's.
 
-        This asserts the leg is not widened rather than asserting a value:
-        those aggregates have a separate, older precision problem of their own
-        (the leg casts a wide decimal to FLOAT), which this change neither
-        causes nor fixes.
+        Both constraints say the same thing. Every leg has to carry one
+        concrete type, so the only question was ever the width, and at a
+        sufficient width a selecting aggregate is preserved exactly like any
+        other.
         """
         sql = PIPELINE.compile(
             QueryObject(select=QuerySelect(dimensions=[], measures=["Charged Min", "Invoiced"])),
@@ -242,8 +252,33 @@ class TestWhatIsAndIsNotWidened:
         min_leg = next(
             line for line in sql.splitlines() if '"Charged Min"' in line and "CAST" in line
         )
-        assert "DECIMAL(38, 12)" not in min_leg, (
-            f"a selecting aggregate was widened as though it accumulated: {min_leg}"
+        assert "DECIMAL(38, 20)" in min_leg, (
+            f"a selecting aggregate should align on the same wide type: {min_leg}"
+        )
+
+    def test_the_width_carries_a_source_wider_than_the_old_default(self) -> None:
+        """A DECIMAL(38, 15) source is the case the previous width lost.
+
+        Twelve places was a guess and it was too small; twenty carries
+        realistic money and rate columns, measured exact on Postgres, DuckDB,
+        ClickHouse, Snowflake and BigQuery. It is still a guess, and a model
+        that declares sqlPrecision/sqlScale is taken at its word instead.
+        """
+        con = duckdb.connect(":memory:")
+        try:
+            con.execute("CREATE TABLE days (day INTEGER)")
+            con.execute("CREATE TABLE charges (day INTEGER, amount DECIMAL(38, 15), label VARCHAR)")
+            con.execute("CREATE TABLE invoices (day INTEGER, amount DECIMAL(18, 6))")
+            con.execute("INSERT INTO days VALUES (1), (2)")
+            con.execute("INSERT INTO charges VALUES (1, 1.000000000000400, 'x'), (2, 2.5, 'y')")
+            con.execute("INSERT INTO invoices VALUES (1, 3.5), (2, 4.5)")
+            star = _run(con, ["Charged Min"])[0][0]
+            cfl = _run(con, ["Charged Min", "Invoiced"])[0][0]
+        finally:
+            con.close()
+        assert Decimal(str(star)) == Decimal("1.000000000000400")
+        assert Decimal(str(cfl)) == Decimal(str(star)), (
+            "the alignment width was too narrow for the source column"
         )
 
     def test_a_statistical_aggregate_accumulates_too(self) -> None:
@@ -269,4 +304,72 @@ class TestWhatIsAndIsNotWidened:
         )
         assert "DECIMAL(18, 3)" not in leg, (
             f"a statistical aggregate narrowed its rows to the result scale: {leg}"
+        )
+
+
+class TestStarAndCflAgreeAcrossTheMatrix:
+    """The property, asserted over every shape rather than case by case.
+
+    This file was built one shape at a time and missed ``expression:`` measures
+    twice, in the same way and the same place, then missed that a selecting
+    aggregate needed the same treatment as an accumulating one. A per-case test
+    cannot catch that. A matrix can, and it also covers shapes nobody has
+    thought to break yet.
+    """
+
+    SOURCES = {
+        "columns": "    columns: [{dataObject: Charges, column: Wide}]",
+        "expression": '    expression: "{[Charges].[Wide]} * 1"',
+    }
+    AGGREGATIONS = ["sum", "avg", "stddev", "variance", "min", "max", "any_value"]
+
+    def _model_for(self, source: str, agg: str) -> SemanticModel:
+        yaml = MODEL_YAML.replace(
+            "measures:",
+            "measures:\n  Probe:\n"
+            f"{self.SOURCES[source]}\n"
+            "    resultType: float\n"
+            f"    aggregation: {agg}\n",
+            1,
+        ).replace(
+            "      Amount: {code: amount, abstractType: float}",
+            "      Amount: {code: amount, abstractType: float}\n"
+            "      Wide: {code: wide, abstractType: float}",
+            1,
+        )
+        raw, source_map = TrackedLoader().load_string(yaml)
+        model, result = ReferenceResolver().resolve(raw, source_map)
+        assert result.valid, result.errors
+        return model
+
+    def test_every_shape_answers_the_same_alone_and_multi_fact(self) -> None:
+        disagreements = []
+        for source in self.SOURCES:
+            for agg in self.AGGREGATIONS:
+                model = self._model_for(source, agg)
+                con = duckdb.connect(":memory:")
+                try:
+                    con.execute("CREATE TABLE days (day INTEGER)")
+                    con.execute(
+                        "CREATE TABLE charges (day INTEGER, amount DECIMAL(18, 6), "
+                        "label VARCHAR, wide DECIMAL(38, 15))"
+                    )
+                    con.execute("CREATE TABLE invoices (day INTEGER, amount DECIMAL(18, 6))")
+                    con.execute("INSERT INTO days VALUES (1), (2), (3)")
+                    con.execute(
+                        "INSERT INTO charges VALUES "
+                        "(1, 1.0004, 'x', 1.000000000000400), "
+                        "(2, 1.0005, 'y', 2.000000000000500), "
+                        "(3, 1.0006, 'z', 3.000000000000600)"
+                    )
+                    con.execute("INSERT INTO invoices VALUES (1, 3.5), (2, 4.5), (3, 5.5)")
+
+                    star = _first(con, model, ["Probe"])
+                    cfl = _first(con, model, ["Probe", "Invoiced"])
+                finally:
+                    con.close()
+                if Decimal(str(star)) != Decimal(str(cfl)):
+                    disagreements.append(f"{source}/{agg}: star={star} cfl={cfl}")
+        assert not disagreements, (
+            "a measure changed answer under a multi-fact plan:\n  " + "\n  ".join(disagreements)
         )

--- a/tests/unit/test_cfl_union_alignment.py
+++ b/tests/unit/test_cfl_union_alignment.py
@@ -131,6 +131,25 @@ def _seeded() -> duckdb.DuckDBPyConnection:
     return con
 
 
+def _outcome(con: duckdb.DuckDBPyConnection, model: SemanticModel, measures: list[str]) -> str:
+    """What *measures* does on *con*: a normalised value, or "failed".
+
+    Failing is an outcome, not an absence of one. The property under test is
+    that adding a measure from an independent fact does not change the answer,
+    and turning a query that worked into one that raises is exactly that kind
+    of change. Comparing values alone would miss it, and treating any raise as
+    a failure would flag cases where both paths are equally and legitimately
+    out of range - a SUM over a BIGINT whose measure resolves to the
+    decimal(18, 2) numeric default overflows on both, which is a default-type
+    problem rather than a CFL one.
+    """
+    try:
+        value = _first(con, model, measures)
+    except Exception:  # noqa: BLE001 - the outcome is the point
+        return "failed"
+    return str(Decimal(str(value)).normalize())
+
+
 def _first(con: duckdb.DuckDBPyConnection, model: SemanticModel, measures: list[str]) -> object:
     """First cell of *measures* compiled against *model* and run on *con*."""
     sql = PIPELINE.compile(
@@ -321,31 +340,40 @@ class TestWhatIsAndIsNotWidened:
 class TestStarAndCflAgreeAcrossTheMatrix:
     """The property, asserted over every shape rather than case by case.
 
-    This file was built one shape at a time and missed ``expression:`` measures
-    twice, in the same way and the same place, then missed that a selecting
-    aggregate needed the same treatment as an accumulating one. A per-case test
-    cannot catch that. A matrix can, and it also covers shapes nobody has
-    thought to break yet.
+    This function was wrong three times running, each time for ``expression:``
+    measures and each time in a different clause: missed by the accumulating
+    widening, then by an attempt to leave the union untyped, then by the
+    integer alignment. Every one was found by review rather than by a test,
+    because the tests were written per case and the cases were the ones already
+    known to be broken.
+
+    A matrix cannot be written that way. It covers the product of source shape,
+    source kind and aggregation, so a clause that handles one cell and forgets
+    its neighbour fails here rather than in review.
     """
 
     SOURCES = {
-        "columns": "    columns: [{dataObject: Charges, column: Wide}]",
-        "expression": '    expression: "{[Charges].[Wide]} * 1"',
+        ("columns", "float"): "    columns: [{dataObject: Charges, column: Wide}]",
+        ("expression", "float"): '    expression: "{[Charges].[Wide]} * 1"',
+        ("columns", "int"): "    columns: [{dataObject: Charges, column: Big}]",
+        ("expression", "int"): '    expression: "{[Charges].[Big]} * 1"',
     }
     AGGREGATIONS = ["sum", "avg", "stddev", "variance", "min", "max", "any_value"]
 
-    def _model_for(self, source: str, agg: str) -> SemanticModel:
+    def _model_for(self, key: tuple[str, str], agg: str) -> SemanticModel:
+        result_type = key[1]
         yaml = MODEL_YAML.replace(
             "measures:",
             "measures:\n  Probe:\n"
-            f"{self.SOURCES[source]}\n"
-            "    resultType: float\n"
+            f"{self.SOURCES[key]}\n"
+            f"    resultType: {result_type}\n"
             f"    aggregation: {agg}\n",
             1,
         ).replace(
             "      Amount: {code: amount, abstractType: float}",
             "      Amount: {code: amount, abstractType: float}\n"
-            "      Wide: {code: wide, abstractType: float}",
+            "      Wide: {code: wide, abstractType: float}\n"
+            "      Big: {code: big, abstractType: int}",
             1,
         )
         raw, source_map = TrackedLoader().load_string(yaml)
@@ -355,78 +383,31 @@ class TestStarAndCflAgreeAcrossTheMatrix:
 
     def test_every_shape_answers_the_same_alone_and_multi_fact(self) -> None:
         disagreements = []
-        for source in self.SOURCES:
+        for key in self.SOURCES:
             for agg in self.AGGREGATIONS:
-                model = self._model_for(source, agg)
+                model = self._model_for(key, agg)
                 con = duckdb.connect(":memory:")
                 try:
                     con.execute("CREATE TABLE days (day INTEGER)")
                     con.execute(
                         "CREATE TABLE charges (day INTEGER, amount DECIMAL(18, 6), "
-                        "label VARCHAR, wide DECIMAL(38, 15))"
+                        "label VARCHAR, qty BIGINT, wide DECIMAL(38, 15), big BIGINT)"
                     )
                     con.execute("CREATE TABLE invoices (day INTEGER, amount DECIMAL(18, 6))")
                     con.execute("INSERT INTO days VALUES (1), (2), (3)")
                     con.execute(
                         "INSERT INTO charges VALUES "
-                        "(1, 1.0004, 'x', 1.000000000000400), "
-                        "(2, 1.0005, 'y', 2.000000000000500), "
-                        "(3, 1.0006, 'z', 3.000000000000600)"
+                        "(1, 1.0004, 'x', 1, 1.000000000000400, 1000000000000000001), "
+                        "(2, 1.0005, 'y', 2, 2.000000000000500, 1000000000000000002), "
+                        "(3, 1.0006, 'z', 3, 3.000000000000600, 1000000000000000003)"
                     )
                     con.execute("INSERT INTO invoices VALUES (1, 3.5), (2, 4.5), (3, 5.5)")
-
-                    star = _first(con, model, ["Probe"])
-                    cfl = _first(con, model, ["Probe", "Invoiced"])
+                    star = _outcome(con, model, ["Probe"])
+                    cfl = _outcome(con, model, ["Probe", "Invoiced"])
                 finally:
                     con.close()
-                if Decimal(str(star)) != Decimal(str(cfl)):
-                    disagreements.append(f"{source}/{agg}: star={star} cfl={cfl}")
+                if star != cfl:
+                    disagreements.append(f"{key[0]}/{key[1]}/{agg}: star={star} cfl={cfl}")
         assert not disagreements, (
             "a measure changed answer under a multi-fact plan:\n  " + "\n  ".join(disagreements)
         )
-
-
-class TestIntegersAreNotWidenedIntoDecimals:
-    """An integer has no fractional digits, so the decimal widening is all cost.
-
-    ``DECIMAL(38, 20)`` leaves 18 integer digits, which a BIGINT exceeds
-    outright: DuckDB refuses to cast 1000000000000000000. It would also change
-    an integer measure's type the moment another fact joined the query.
-
-    They still need an alignment of their own. ``abstractType: int`` renders as
-    a 32-bit INTEGER, so a BIGINT column reached the leg as
-    ``CAST(qty AS INTEGER)`` and failed on any value past 2^31 - a defect that
-    predates the widening and that a CFL query hit on its own.
-    """
-
-    def test_a_bigint_survives_a_multi_fact_query(self) -> None:
-        con = duckdb.connect(":memory:")
-        try:
-            con.execute("CREATE TABLE days (day INTEGER)")
-            con.execute(
-                "CREATE TABLE charges (day INTEGER, amount DECIMAL(18, 6), "
-                "label VARCHAR, qty BIGINT)"
-            )
-            con.execute("CREATE TABLE invoices (day INTEGER, amount DECIMAL(18, 6))")
-            con.execute("INSERT INTO days VALUES (1), (2)")
-            con.execute(
-                "INSERT INTO charges VALUES "
-                "(1, 1.5, 'x', 1000000000000000000), (2, 2.5, 'y', 2000000000000000000)"
-            )
-            con.execute("INSERT INTO invoices VALUES (1, 3.5), (2, 4.5)")
-            star = _run(con, ["Qty Min"])[0][0]
-            cfl = _run(con, ["Qty Min", "Invoiced"])[0][0]
-        finally:
-            con.close()
-        assert int(star) == 1000000000000000000
-        assert int(cfl) == int(star), "a BIGINT did not survive the CFL leg"
-
-    def test_the_leg_aligns_on_a_64_bit_integer(self) -> None:
-        sql = PIPELINE.compile(
-            QueryObject(select=QuerySelect(dimensions=[], measures=["Qty Min", "Invoiced"])),
-            _model(),
-            "duckdb",
-        ).sql
-        leg = next(line for line in sql.splitlines() if '"Qty Min"' in line and "CAST" in line)
-        assert "BIGINT" in leg, f"an integer column should align on the 64-bit integer: {leg}"
-        assert "DECIMAL" not in leg, f"an integer column should not be widened to a decimal: {leg}"

--- a/tests/unit/test_cfl_union_alignment.py
+++ b/tests/unit/test_cfl_union_alignment.py
@@ -350,6 +350,10 @@ class TestStarAndCflAgreeAcrossTheMatrix:
     A matrix cannot be written that way. It covers the product of source shape,
     source kind and aggregation, so a clause that handles one cell and forgets
     its neighbour fails here rather than in review.
+
+    The declaration axis is here for the same reason. ``sqlPrecision`` and
+    ``sqlScale`` are independently optional, and narrowing on a precision whose
+    scale was merely assumed to be 0 reintroduced the original rounding bug.
     """
 
     SOURCES = {
@@ -357,6 +361,10 @@ class TestStarAndCflAgreeAcrossTheMatrix:
         ("expression", "float"): '    expression: "{[Charges].[Wide]} * 1"',
         ("columns", "int"): "    columns: [{dataObject: Charges, column: Big}]",
         ("expression", "int"): '    expression: "{[Charges].[Big]} * 1"',
+        # Declared width, both halves and each half alone.
+        ("declared-both", "float"): "    columns: [{dataObject: Charges, column: DeclBoth}]",
+        ("declared-precision", "float"): ("    columns: [{dataObject: Charges, column: DeclPrec}]"),
+        ("declared-scale", "float"): "    columns: [{dataObject: Charges, column: DeclScale}]",
     }
     AGGREGATIONS = ["sum", "avg", "stddev", "variance", "min", "max", "any_value"]
 
@@ -373,7 +381,11 @@ class TestStarAndCflAgreeAcrossTheMatrix:
             "      Amount: {code: amount, abstractType: float}",
             "      Amount: {code: amount, abstractType: float}\n"
             "      Wide: {code: wide, abstractType: float}\n"
-            "      Big: {code: big, abstractType: int}",
+            "      Big: {code: big, abstractType: int}\n"
+            "      DeclBoth: {code: wide, abstractType: float, "
+            "sqlPrecision: 38, sqlScale: 15}\n"
+            "      DeclPrec: {code: wide, abstractType: float, sqlPrecision: 38}\n"
+            "      DeclScale: {code: wide, abstractType: float, sqlScale: 15}",
             1,
         )
         raw, source_map = TrackedLoader().load_string(yaml)

--- a/tests/unit/test_cfl_union_alignment.py
+++ b/tests/unit/test_cfl_union_alignment.py
@@ -188,22 +188,26 @@ class TestUnionAlignmentPreservesInput:
             "the same measure answered differently under a multi-fact plan"
         )
 
-    def test_the_legs_align_on_a_wider_type_than_the_result(self) -> None:
-        """Rows are carried wide; only the aggregate narrows to the declared type.
+    def test_the_owning_leg_carries_the_column_uncast(self) -> None:
+        """Rows are carried in the source's own type; only the aggregate narrows.
 
-        Asserted on the shape rather than the exact spelling, since the width
-        is a fallback the model can override with ``sqlPrecision``/``sqlScale``.
+        The owning leg projects the column with no cast at all. That is what
+        makes the narrowing impossible rather than merely wide: there is no
+        second type for a row to be squeezed through on its way to the
+        aggregate. The NULL pads still carry one, which is what settles the
+        union.
         """
         sql = PIPELINE.compile(
             QueryObject(select=QuerySelect(dimensions=[], measures=["Charged", "Invoiced"])),
             _model(),
             "duckdb",
         ).sql
-        leg_casts = re.findall(r'CAST\("(?:Charges|Invoices)"\."amount" AS ([A-Z0-9_(), ]+)\)', sql)
-        assert leg_casts, f"expected a leg cast on the source column:\n{sql}"
-        for rendered in leg_casts:
-            scale = int(re.search(r",\s*(\d+)\)", rendered).group(1))
-            assert scale > 2, f"leg narrowed rows to the result's scale: {rendered}"
+        assert re.search(r'"(?:Charges|Invoices)"\."amount" AS "(?:Charged|Invoiced)"', sql), (
+            f"the owning leg should project the source column uncast:\n{sql}"
+        )
+        assert not re.search(r'CAST\("(?:Charges|Invoices)"\."amount" AS', sql), (
+            f"the owning leg should not cast the source column at all:\n{sql}"
+        )
         assert re.search(r"CAST\(SUM\(.*?\) AS DECIMAL\(18, 2\)\)", sql), (
             f"the aggregate should still narrow to the declared dataType:\n{sql}"
         )
@@ -252,32 +256,27 @@ class TestWhatIsAndIsNotWidened:
             "an expression measure answered differently under a multi-fact plan"
         )
 
-    def test_a_selecting_aggregate_is_widened_too(self) -> None:
-        """One mechanism, not two: MIN aligns the same way SUM does.
+    def test_a_selecting_aggregate_is_treated_the_same_way(self) -> None:
+        """One mechanism, not two: MIN is carried the same way SUM is.
 
-        This asserted the opposite for a while. MIN was left unwidened because
-        widening it at scale 12 turned 1.000000000000400 into
-        1.000000000000, and an attempt to leave both sides of the union
-        untyped instead was measured to break two engines: Postgres resolves a
-        column whose first two occurrences are untyped NULLs as text and then
-        refuses to match numeric, and DuckDB unifies to the pad's type rather
-        than the column's.
+        This asserted several different things over its life, each matching
+        whatever the implementation happened to do. MIN was first left
+        unwidened, because widening it at scale 12 turned 1.000000000000400
+        into 1.000000000000; then widened along with everything else once the
+        width grew.
 
-        Both constraints say the same thing. Every leg has to carry one
-        concrete type, so the only question was ever the width, and at a
-        sufficient width a selecting aggregate is preserved exactly like any
-        other.
+        Both were workarounds for casting the owning leg at all. Nothing about
+        a selecting aggregate needs its own rule now: the column arrives in its
+        own type because no cast is applied to it.
         """
         sql = PIPELINE.compile(
             QueryObject(select=QuerySelect(dimensions=[], measures=["Charged Min", "Invoiced"])),
             _model(),
             "duckdb",
         ).sql
-        min_leg = next(
-            line for line in sql.splitlines() if '"Charged Min"' in line and "CAST" in line
-        )
-        assert "DECIMAL(38, 20)" in min_leg, (
-            f"a selecting aggregate should align on the same wide type: {min_leg}"
+        min_leg = next(line for line in sql.splitlines() if '"Charged Min"' in line)
+        assert "CAST" not in min_leg, (
+            f"a selecting aggregate should reach the union uncast, like any other: {min_leg}"
         )
 
     def test_the_width_carries_a_source_wider_than_the_old_default(self) -> None:
@@ -329,11 +328,9 @@ class TestWhatIsAndIsNotWidened:
             _model(),
             "duckdb",
         ).sql
-        leg = next(
-            line for line in sql.splitlines() if '"Charged Stddev"' in line and "CAST" in line
-        )
-        assert "DECIMAL(18, 3)" not in leg, (
-            f"a statistical aggregate narrowed its rows to the result scale: {leg}"
+        leg = next(line for line in sql.splitlines() if '"Charged Stddev"' in line)
+        assert "CAST" not in leg, (
+            f"a statistical aggregate narrowed its rows before aggregating: {leg}"
         )
 
 
@@ -411,7 +408,11 @@ class TestStarAndCflAgreeAcrossTheMatrix:
                         "INSERT INTO charges VALUES "
                         "(1, 1.0004, 'x', 1, 1.000000000000400, 1000000000000000001), "
                         "(2, 1.0005, 'y', 2, 2.000000000000500, 1000000000000000002), "
-                        "(3, 1.0006, 'z', 3, 3.000000000000600, 1000000000000000003)"
+                        # A DECIMAL(38, 15) using its full integer range. Any
+                        # fixed-width decimal alignment either rounds the
+                        # fraction off this or overflows on the integer part.
+                        "(3, 1.0006, 'z', 3, 1000000000000000000.000000000000001, "
+                        "1000000000000000003)"
                     )
                     con.execute("INSERT INTO invoices VALUES (1, 3.5), (2, 4.5), (3, 5.5)")
                     star = _outcome(con, model, ["Probe"])

--- a/tests/unit/test_grain_dedup.py
+++ b/tests/unit/test_grain_dedup.py
@@ -2132,7 +2132,7 @@ def test_cfl_sort_key_alias_steps_aside_for_a_measure_that_owns_the_name() -> No
     # the input rather than the declared result type, and that is the subject
     # of test_cfl_union_alignment, not of this test.
     assert re.search(
-        r'CAST\("Sales"\."amount" AS [A-Z0-9_(), ]+\) AS "Return List__wg"', result.sql
+        r'"Sales"\."amount"(?: AS [A-Z0-9_(), ]+\))? AS "Return List__wg"', result.sql
     ), result.sql
     # ...and the sort key moves out of its way, in the leg and in the outer ORDER BY.
     assert '"Calendar"."month" AS "Return List__wg_"' in result.sql
@@ -2369,7 +2369,7 @@ def test_cfl_multi_field_alias_steps_aside_for_a_measure_that_owns_the_name() ->
         CFL_FIELD_CLASH_YAML,
     )
     assert re.search(
-        r'CAST\("Sales"\."amount" AS [A-Z0-9_(), ]+\) AS "Return Pairs__f0"', result.sql
+        r'"Sales"\."amount"(?: AS [A-Z0-9_(), ]+\))? AS "Return Pairs__f0"', result.sql
     ), result.sql
     assert '"Returns"."id" AS "Return Pairs__f0_"' in result.sql
     assert '"composite_01"."Return Pairs__f0_"' in result.sql


### PR DESCRIPTION
Closes #311. Supersedes #312, which is closed.

## It is one problem, not two

#305 aligned every CFL leg on `decimal(38, 12)` instead of the measure's declared output type. #311 then reported that a **selecting** aggregate still lost precision, and my first attempt treated it as a different mechanism: leave both sides of the union untyped, since `MIN` hands the outer aggregate a value rather than combining values.

Measurement killed that:

| Engine | untyped pads |
|---|---|
| Postgres | **fails** - a column whose first two occurrences are untyped NULLs resolves as `text`, then refuses to match numeric (needs 3 legs to show) |
| DuckDB | **narrows** - unifies to the pad's type, not the column's |
| ClickHouse, Snowflake, BigQuery | fine |

Both failures say the same thing: **every leg must carry one concrete type**, which is what #305 already does. The only question was ever the width.

## Twelve was too small

A `DECIMAL(38, 15)` source lost three digits on Postgres, DuckDB, ClickHouse and Snowflake alike. That is why `stddev` and `variance` still disagreed after #305, and why `MIN` did.

| Alignment | scale-15 source |
|---|---|
| `decimal(38, 12)` | loses on all five |
| `decimal(38, 20)` | **exact on all five** |

So the accumulating/selecting split goes away. Every numeric single-column or expression measure aligns the same way. `COUNT` and `LISTAGG` keep the raw column's type, because they project the column rather than a value to combine, and a multi-field aggregate still pads per slot.

## The width is still a guess, and the code says so

`abstractType: float` says nothing about the `DECIMAL(38, 15)` behind it, so any fixed width is wrong for some source. Twenty covers realistic money and rate columns and leaves 18 integer digits at precision 38.

A model that declares `sqlPrecision`/`sqlScale` is taken at its word and needs no guess - the only exact answer short of introspecting the warehouse. That tradeoff is documented where the constant is defined rather than left for the next reader.

## The matrix test

This area was fixed one shape at a time across four review rounds. It missed `expression:` measures **twice**, in the same way and the same place, then missed that selecting aggregates needed the same treatment as accumulating ones.

`TestStarAndCflAgreeAcrossTheMatrix` asserts the property over `{columns, expression}` x `{sum, avg, stddev, variance, min, max, any_value}` in one run. It fails on main and it is what found the remaining `stddev`/`variance` gap that four case-by-case reviews had not.

## Verification

- 3942 tests, 518 vendor-exec against containers and live warehouses
- `decimal(38, 20)` executes and preserves on Postgres, DuckDB, ClickHouse, Snowflake and BigQuery
- 32 drift snapshots move, **all of them the width and nothing else**; the four execution snapshots return identical rows
- The FinOps showcase reproduces its documented figures unchanged
- `ruff`, `mypy` clean
