### PR TITLE
fix(compiler): an integer measure is not a decimal(18, 2), and tests run against their own checkout

### DIFF
--- a/docs/guide/model-format.md
+++ b/docs/guide/model-format.md
@@ -1179,16 +1179,23 @@ Pass-through (no CAST emitted): `min`, `max`, `any_value`, `median`, `mode`, `li
     **`AVG` is deliberately not widened**, because on some engines a wider cast
     would not make the average right. See the warning below.
 
-!!! warning "`AVG` above ~15 significant digits on DuckDB and ClickHouse"
+!!! warning "`AVG` above ~15 significant digits on DuckDB, ClickHouse and BigQuery"
 
-    Both engines compute `AVG` in floating point **whatever the input type**,
+    These engines compute `AVG` in floating point **whatever the input type**,
     so this is not limited to integer columns: a wide `DECIMAL` measure drifts
     once its average exceeds a `double` mantissa. On DuckDB, averaging
     `9223372036854775807.12` and `...807.24` returns `9.223372036854776e+18`
     rather than `9223372036854775807.18`, while `SUM` over the same column
     stays exact. This is [duckdb/duckdb#6829](https://github.com/duckdb/duckdb/issues/6829),
-    closed as not planned. PostgreSQL (`numeric`) and MySQL (`decimal`) are
-    exact.
+    closed as not planned.
+
+    Measured per dialect, averaging two values around 10^18:
+
+    | exact | floating point |
+    | --- | --- |
+    | PostgreSQL (`numeric`), MySQL (`decimal`), Snowflake | DuckDB, ClickHouse, BigQuery |
+
+    Databricks and Dremio are not yet verified for this case.
 
     **Declaring `dataType` does not fix this**, and on these two engines it
     makes the failure worse rather than better. The loss happens inside the
@@ -1206,7 +1213,7 @@ Pass-through (no CAST emitted): `min`, `max`, `any_value`, `median`, `mode`, `li
     is the better outcome: an error you can see beats a plausible wrong figure.
 
     Ordinary money-sized values are unaffected. If your averages can reach that
-    magnitude, aggregate on PostgreSQL or MySQL, express the average as a
+    magnitude, aggregate on PostgreSQL, MySQL or Snowflake, express the average as a
     metric over an exact `SUM` and a `COUNT` and accept the division's own
     limits, or track
     [#316](https://github.com/ralforion/orionbelt-semantic-layer/issues/316).

--- a/docs/guide/model-format.md
+++ b/docs/guide/model-format.md
@@ -1162,22 +1162,30 @@ OrionBelt automatically wraps aggregate expressions with `CAST` to ensure consis
 The effective data type for a measure or metric is resolved in this order (first match wins):
 
 1. **Explicit declaration** — `dataType` on the measure or metric
-2. **Structural inference** — COUNT/COUNT_DISTINCT → `bigint`; division in expression → `decimal(18, 6)`; a measure with `resultType: int` → `bigint` for SUM, and the default's scale widened to hold a 64-bit integer part for AVG
+2. **Structural inference** — COUNT/COUNT_DISTINCT → `bigint`; division in expression → `decimal(18, 6)`; a measure with `resultType: int` aggregated with SUM → `bigint`
 3. **Model-level default** — `settings.defaultNumericDataType`
 4. **Built-in default** — `decimal(18, 2)` for SUM/AVG aggregations
 
 Pass-through (no CAST emitted): `min`, `max`, `any_value`, `median`, `mode`, `listagg`.
 
-!!! note "Why integer measures are inferred rather than defaulted"
+!!! note "Large integer measures"
 
     The built-in default holds only 16 integer digits, but a 64-bit column
     needs 19. Left to default, `SUM` over a `BIGINT` produced a value the
     engine computed correctly and then failed to cast, so the query errored on
-    a perfectly legal figure. Declaring `resultType: int` gets an integer type
-    for `SUM`; `AVG` stays fixed-point, keeping the number of decimal places
-    the default asked for and only gaining the range it was missing.
+    a perfectly legal figure. A measure declaring `resultType: int` therefore
+    infers `bigint` for `SUM`, which is exact on every dialect.
 
-    A measure over a large-valued **non-integer** column still takes the
+    **`AVG` is deliberately not widened.** The precision is lost inside the
+    aggregate, before any cast, and only on some engines: `AVG` over a
+    `BIGINT` is exact on PostgreSQL (`numeric`) and MySQL (`decimal`), but
+    floating point on DuckDB and ClickHouse. On DuckDB no rewrite recovers it,
+    since every division returns `DOUBLE`. Widening the cast would therefore
+    hide an overflow behind a quietly wrong average on exactly the engines
+    where the average is wrong. Declare `dataType` on the measure to ask for a
+    wider average explicitly.
+
+    A measure over a large-valued **non-integer** column also still takes the
     built-in default, so pin `dataType` (or `settings.defaultNumericDataType`)
     if its total can exceed 16 digits.
 

--- a/docs/guide/model-format.md
+++ b/docs/guide/model-format.md
@@ -1162,11 +1162,24 @@ OrionBelt automatically wraps aggregate expressions with `CAST` to ensure consis
 The effective data type for a measure or metric is resolved in this order (first match wins):
 
 1. **Explicit declaration** — `dataType` on the measure or metric
-2. **Structural inference** — COUNT/COUNT_DISTINCT → `bigint`; division in expression → `decimal(18, 6)`
+2. **Structural inference** — COUNT/COUNT_DISTINCT → `bigint`; division in expression → `decimal(18, 6)`; a measure with `resultType: int` → `bigint` for SUM, and the default's scale widened to hold a 64-bit integer part for AVG
 3. **Model-level default** — `settings.defaultNumericDataType`
 4. **Built-in default** — `decimal(18, 2)` for SUM/AVG aggregations
 
 Pass-through (no CAST emitted): `min`, `max`, `any_value`, `median`, `mode`, `listagg`.
+
+!!! note "Why integer measures are inferred rather than defaulted"
+
+    The built-in default holds only 16 integer digits, but a 64-bit column
+    needs 19. Left to default, `SUM` over a `BIGINT` produced a value the
+    engine computed correctly and then failed to cast, so the query errored on
+    a perfectly legal figure. Declaring `resultType: int` gets an integer type
+    for `SUM`; `AVG` stays fixed-point, keeping the number of decimal places
+    the default asked for and only gaining the range it was missing.
+
+    A measure over a large-valued **non-integer** column still takes the
+    built-in default, so pin `dataType` (or `settings.defaultNumericDataType`)
+    if its total can exceed 16 digits.
 
 ### Explicit Data Type
 

--- a/docs/guide/model-format.md
+++ b/docs/guide/model-format.md
@@ -1185,6 +1185,20 @@ Pass-through (no CAST emitted): `min`, `max`, `any_value`, `median`, `mode`, `li
     where the average is wrong. Declare `dataType` on the measure to ask for a
     wider average explicitly.
 
+!!! warning "`AVG` above ~15 significant digits on DuckDB and ClickHouse"
+
+    Both engines compute `AVG` in floating point **whatever the input type**,
+    so this is not limited to integer columns: a wide `DECIMAL` measure drifts
+    once its average exceeds a `double` mantissa. On DuckDB, averaging
+    `9223372036854775807.12` and `...807.24` returns `9.223372036854776e+18`
+    rather than `9223372036854775807.18`, while `SUM` over the same column
+    stays exact. This is [duckdb/duckdb#6829](https://github.com/duckdb/duckdb/issues/6829),
+    closed as not planned.
+
+    Ordinary money-sized values are unaffected. If your averages can reach that
+    magnitude, aggregate on PostgreSQL or MySQL, which are exact, or track
+    [#316](https://github.com/ralforion/orionbelt-semantic-layer/issues/316).
+
     A measure over a large-valued **non-integer** column also still takes the
     built-in default, so pin `dataType` (or `settings.defaultNumericDataType`)
     if its total can exceed 16 digits.

--- a/docs/guide/model-format.md
+++ b/docs/guide/model-format.md
@@ -1176,14 +1176,8 @@ Pass-through (no CAST emitted): `min`, `max`, `any_value`, `median`, `mode`, `li
     a perfectly legal figure. A measure declaring `resultType: int` therefore
     infers `bigint` for `SUM`, which is exact on every dialect.
 
-    **`AVG` is deliberately not widened.** The precision is lost inside the
-    aggregate, before any cast, and only on some engines: `AVG` over a
-    `BIGINT` is exact on PostgreSQL (`numeric`) and MySQL (`decimal`), but
-    floating point on DuckDB and ClickHouse. On DuckDB no rewrite recovers it,
-    since every division returns `DOUBLE`. Widening the cast would therefore
-    hide an overflow behind a quietly wrong average on exactly the engines
-    where the average is wrong. Declare `dataType` on the measure to ask for a
-    wider average explicitly.
+    **`AVG` is deliberately not widened**, because on some engines a wider cast
+    would not make the average right. See the warning below.
 
 !!! warning "`AVG` above ~15 significant digits on DuckDB and ClickHouse"
 
@@ -1193,10 +1187,28 @@ Pass-through (no CAST emitted): `min`, `max`, `any_value`, `median`, `mode`, `li
     `9223372036854775807.12` and `...807.24` returns `9.223372036854776e+18`
     rather than `9223372036854775807.18`, while `SUM` over the same column
     stays exact. This is [duckdb/duckdb#6829](https://github.com/duckdb/duckdb/issues/6829),
-    closed as not planned.
+    closed as not planned. PostgreSQL (`numeric`) and MySQL (`decimal`) are
+    exact.
+
+    **Declaring `dataType` does not fix this**, and on these two engines it
+    makes the failure worse rather than better. The loss happens inside the
+    aggregate, before the cast, so a wider `dataType` only lets the wrong
+    number through:
+
+    ```yaml
+    Qty Avg:
+      aggregation: avg
+      dataType: "decimal(21, 2)"   # emits CAST(AVG(qty) AS DECIMAL(21, 2))
+    ```
+
+    On DuckDB that returns `1000000000000000000.00` where the true average is
+    `1000000000000000003.00`. Left at the default the same query *fails*, which
+    is the better outcome: an error you can see beats a plausible wrong figure.
 
     Ordinary money-sized values are unaffected. If your averages can reach that
-    magnitude, aggregate on PostgreSQL or MySQL, which are exact, or track
+    magnitude, aggregate on PostgreSQL or MySQL, express the average as a
+    metric over an exact `SUM` and a `COUNT` and accept the division's own
+    limits, or track
     [#316](https://github.com/ralforion/orionbelt-semantic-layer/issues/316).
 
     A measure over a large-valued **non-integer** column also still takes the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,6 +187,12 @@ select = ["E", "F", "I", "N", "UP", "B", "A", "SIM"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
+# Import ``orionbelt`` from *this* checkout, ahead of whatever the venv has
+# installed. Without it, a run inside a git worktree silently imports the
+# editable install - which points at the main working directory - so a
+# regression test written against an old commit exercises the fixed code and
+# passes. Resolved relative to rootdir, so each worktree gets its own source.
+pythonpath = ["src"]
 markers = [
     "docker: requires Docker (testcontainers); run with: pytest -m docker",
     "adbc: requires a reachable PostgreSQL via ADBC; run with: pytest -m adbc",

--- a/src/orionbelt/compiler/type_resolver.py
+++ b/src/orionbelt/compiler/type_resolver.py
@@ -25,7 +25,6 @@ from orionbelt.models.semantic import (
 from orionbelt.models.types import (
     BUILTIN_DEFAULT,
     DIVISION_DEFAULT,
-    DecimalType,
     OBMLType,
     SimpleType,
     parse_data_type,
@@ -34,11 +33,6 @@ from orionbelt.models.types import (
 _NUMERIC_AGGREGATIONS = frozenset({"SUM", "AVG"})
 _COUNT_AGGREGATIONS = frozenset({"COUNT", "COUNT_DISTINCT"})
 _PASSTHROUGH_AGGREGATIONS = frozenset({"MIN", "MAX", "ANY_VALUE", "MEDIAN", "MODE", "LISTAGG"})
-
-# Digits in the largest 64-bit integer (9223372036854775807), and the widest
-# precision every supported dialect accepts.
-_INT64_DIGITS = 19
-_MAX_DECIMAL_PRECISION = 38
 
 
 def resolve_measure_data_type(
@@ -67,22 +61,30 @@ def resolve_measure_data_type(
     if measure.expression and "/" in measure.expression:
         return DIVISION_DEFAULT
 
-    # 2. Structural inference: an integer measure is not a decimal(18, 2)
+    # 2. Structural inference: an integer SUM is an integer
     #
     # The numeric default carries 16 integer digits, and a 64-bit source needs
     # 19. So SUM over a BIGINT column overflowed the very cast that was meant
     # to describe it: the engine computed 2000000000000000003 quite happily and
     # then failed converting it, on the plain star path as much as under CFL.
+    # ``bigint`` is the same inference COUNT already gets, and what every
+    # engine does natively for a sum of integers - exact everywhere.
     #
-    # SUM of integers is an integer, so it takes ``bigint`` - the same
-    # inference COUNT already gets, and what every engine does natively. AVG is
-    # not integral, so it stays a decimal and only gains the room it was
-    # missing: the default's scale, at the width a 64-bit value needs.
-    if measure.result_type == DataType.INT:
-        if agg == "SUM":
-            return SimpleType(name="bigint")
-        if agg == "AVG":
-            return _widen_to_integer_range(_get_default(settings))
+    # AVG deliberately does **not** get the same treatment. Widening its cast
+    # would clear the overflow without making the average right, because the
+    # loss happens in the aggregate, before any cast: measured, AVG over BIGINT
+    # returns numeric on Postgres and decimal on MySQL (exact) but Float64 on
+    # ClickHouse and DOUBLE on DuckDB, where 1000000000000000002 and
+    # ...004 average to 1000000000000000000. Nor can the loss be arranged away:
+    # on DuckDB every route through ``/`` is float division, so casting the
+    # input, casting the operands and rewriting as SUM/COUNT were each measured
+    # to come back DOUBLE.
+    #
+    # So widening AVG would trade a loud overflow for a quietly wrong number,
+    # on exactly the engines where the number is wrong. It keeps the default,
+    # and a model that needs a large integer average declares ``dataType``.
+    if measure.result_type == DataType.INT and agg == "SUM":
+        return SimpleType(name="bigint")
 
     # 3. Numeric aggregation (SUM, AVG) → default
     if agg in _NUMERIC_AGGREGATIONS:
@@ -90,22 +92,6 @@ def resolve_measure_data_type(
 
     # 4. Unknown aggregation → pass-through
     return None
-
-
-def _widen_to_integer_range(default: OBMLType) -> OBMLType:
-    """The default's scale, widened to hold any 64-bit integer part.
-
-    Only the precision moves, so a model that pinned ``defaultNumericDataType``
-    keeps the number of decimal places it asked for; it just stops overflowing
-    on values the source column holds legally. A default that is already wide
-    enough, or is not a decimal at all, is left alone.
-    """
-    if not isinstance(default, DecimalType):
-        return default
-    needed = _INT64_DIGITS + default.scale
-    if default.precision >= needed:
-        return default
-    return DecimalType(precision=min(needed, _MAX_DECIMAL_PRECISION), scale=default.scale)
 
 
 # PoP comparisons whose result is a ratio rather than a value in the base

--- a/src/orionbelt/compiler/type_resolver.py
+++ b/src/orionbelt/compiler/type_resolver.py
@@ -2,9 +2,13 @@
 
 Resolution order (first match wins):
 1. Explicit declaration on the measure/metric
-2. Structural inference from expression shape
+2. Structural inference from expression shape and result type
 3. Model-level default (settings.defaultNumericDataType)
 4. Built-in default: decimal(18, 2)
+
+Note that the built-in default holds only 16 integer digits, so anything that
+can carry a 64-bit value has to be inferred rather than defaulted, or the cast
+describing the result overflows on values the source held quite legally.
 
 Pass-through (no CAST): MIN/MAX, LISTAGG, non-numeric aggregates.
 """
@@ -12,6 +16,7 @@ Pass-through (no CAST): MIN/MAX, LISTAGG, non-numeric aggregates.
 from __future__ import annotations
 
 from orionbelt.models.semantic import (
+    DataType,
     Measure,
     Metric,
     ModelSettings,
@@ -20,6 +25,7 @@ from orionbelt.models.semantic import (
 from orionbelt.models.types import (
     BUILTIN_DEFAULT,
     DIVISION_DEFAULT,
+    DecimalType,
     OBMLType,
     SimpleType,
     parse_data_type,
@@ -28,6 +34,11 @@ from orionbelt.models.types import (
 _NUMERIC_AGGREGATIONS = frozenset({"SUM", "AVG"})
 _COUNT_AGGREGATIONS = frozenset({"COUNT", "COUNT_DISTINCT"})
 _PASSTHROUGH_AGGREGATIONS = frozenset({"MIN", "MAX", "ANY_VALUE", "MEDIAN", "MODE", "LISTAGG"})
+
+# Digits in the largest 64-bit integer (9223372036854775807), and the widest
+# precision every supported dialect accepts.
+_INT64_DIGITS = 19
+_MAX_DECIMAL_PRECISION = 38
 
 
 def resolve_measure_data_type(
@@ -56,12 +67,45 @@ def resolve_measure_data_type(
     if measure.expression and "/" in measure.expression:
         return DIVISION_DEFAULT
 
+    # 2. Structural inference: an integer measure is not a decimal(18, 2)
+    #
+    # The numeric default carries 16 integer digits, and a 64-bit source needs
+    # 19. So SUM over a BIGINT column overflowed the very cast that was meant
+    # to describe it: the engine computed 2000000000000000003 quite happily and
+    # then failed converting it, on the plain star path as much as under CFL.
+    #
+    # SUM of integers is an integer, so it takes ``bigint`` - the same
+    # inference COUNT already gets, and what every engine does natively. AVG is
+    # not integral, so it stays a decimal and only gains the room it was
+    # missing: the default's scale, at the width a 64-bit value needs.
+    if measure.result_type == DataType.INT:
+        if agg == "SUM":
+            return SimpleType(name="bigint")
+        if agg == "AVG":
+            return _widen_to_integer_range(_get_default(settings))
+
     # 3. Numeric aggregation (SUM, AVG) → default
     if agg in _NUMERIC_AGGREGATIONS:
         return _get_default(settings)
 
     # 4. Unknown aggregation → pass-through
     return None
+
+
+def _widen_to_integer_range(default: OBMLType) -> OBMLType:
+    """The default's scale, widened to hold any 64-bit integer part.
+
+    Only the precision moves, so a model that pinned ``defaultNumericDataType``
+    keeps the number of decimal places it asked for; it just stops overflowing
+    on values the source column holds legally. A default that is already wide
+    enough, or is not a decimal at all, is left alone.
+    """
+    if not isinstance(default, DecimalType):
+        return default
+    needed = _INT64_DIGITS + default.scale
+    if default.precision >= needed:
+        return default
+    return DecimalType(precision=min(needed, _MAX_DECIMAL_PRECISION), scale=default.scale)
 
 
 # PoP comparisons whose result is a ratio rather than a value in the base

--- a/src/orionbelt/compiler/type_resolver.py
+++ b/src/orionbelt/compiler/type_resolver.py
@@ -86,8 +86,13 @@ def resolve_measure_data_type(
     # needs a per-dialect rewrite; tracked in #316.
     #
     # So widening AVG would trade a loud overflow for a quietly wrong number,
-    # on exactly the engines where the number is wrong. It keeps the default,
-    # and a model that needs a large integer average declares ``dataType``.
+    # on exactly the engines where the number is wrong. It keeps the default.
+    #
+    # Declaring ``dataType`` is *not* an escape hatch here either - it widens
+    # this same cast, so on DuckDB it turns the error back into
+    # 1000000000000000000.00 for a true average of ...003.00. Nothing chosen at
+    # this layer can help; only a different aggregate expression can, which is
+    # what #316 is for.
     if measure.result_type == DataType.INT and agg == "SUM":
         return SimpleType(name="bigint")
 

--- a/src/orionbelt/compiler/type_resolver.py
+++ b/src/orionbelt/compiler/type_resolver.py
@@ -73,14 +73,14 @@ def resolve_measure_data_type(
     # AVG deliberately does **not** get the same treatment. Widening its cast
     # would clear the overflow without making the average right, because the
     # loss happens in the aggregate, before any cast: measured, AVG over BIGINT
-    # returns numeric on Postgres and decimal on MySQL (exact) but Float64 on
-    # ClickHouse and DOUBLE on DuckDB, where 1000000000000000002 and
-    # ...004 average to 1000000000000000000. Nor can the loss be arranged away:
-    # on DuckDB every route through ``/`` is float division, so casting the
-    # input, casting the operands and rewriting as SUM/COUNT were each measured
-    # to come back DOUBLE.
+    # is exact on Postgres (numeric), MySQL (decimal) and Snowflake, but
+    # floating point on ClickHouse, BigQuery and DuckDB, where
+    # 1000000000000000002 and ...004 average to 1000000000000000000. Nor can
+    # the loss be arranged away on DuckDB: every route through ``/`` is float
+    # division there, so casting the input, casting the operands and rewriting
+    # as SUM/COUNT were each measured to come back DOUBLE.
     #
-    # Both engines average in floating point whatever the input type, so the
+    # Those three average in floating point whatever the input type, so the
     # boundary is magnitude rather than declared type and a wide decimal drifts
     # too - duckdb/duckdb#6829, closed as not planned. Recovering exactness
     # needs a per-dialect rewrite; tracked in #316.

--- a/src/orionbelt/compiler/type_resolver.py
+++ b/src/orionbelt/compiler/type_resolver.py
@@ -80,6 +80,11 @@ def resolve_measure_data_type(
     # input, casting the operands and rewriting as SUM/COUNT were each measured
     # to come back DOUBLE.
     #
+    # Both engines average in floating point whatever the input type, so the
+    # boundary is magnitude rather than declared type and a wide decimal drifts
+    # too - duckdb/duckdb#6829, closed as not planned. Recovering exactness
+    # needs a per-dialect rewrite; tracked in #316.
+    #
     # So widening AVG would trade a loud overflow for a quietly wrong number,
     # on exactly the engines where the number is wrong. It keeps the default,
     # and a model that needs a large integer average declares ``dataType``.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,10 +7,47 @@ from pathlib import Path
 
 import pytest
 
+import orionbelt
 from orionbelt.models.semantic import SemanticModel
 from orionbelt.parser.loader import TrackedLoader
 from orionbelt.parser.resolver import ReferenceResolver
 from orionbelt.service.session_manager import SessionManager
+
+
+def _assert_testing_this_checkout() -> None:
+    """Fail loudly if ``orionbelt`` was imported from somewhere else.
+
+    ``uv sync`` installs this package editable, pointing at the main working
+    directory. Run the suite from a **git worktree** and the tests are the
+    worktree's while the code under test is the main checkout's, so a
+    regression test written against an old commit silently exercises the fixed
+    code and passes. That happened while fixing #311 and very nearly retired a
+    test as "does not catch the bug".
+
+    ``pythonpath = ["src"]`` in ``pyproject.toml`` is what prevents it. This is
+    the assertion that the prevention is working, because the failure it guards
+    against is invisible: everything passes, which is exactly the wrong answer.
+    """
+    if os.environ.get("ORIONBELT_ALLOW_FOREIGN_PACKAGE"):
+        return
+    checkout_src = Path(__file__).resolve().parent.parent / "src" / "orionbelt"
+    if not checkout_src.is_dir():
+        # Not a source checkout (installed-wheel run); nothing to compare to.
+        return
+    imported = Path(orionbelt.__file__).resolve().parent
+    if imported != checkout_src:
+        raise RuntimeError(
+            "tests would run against a different copy of orionbelt than this checkout:\n"
+            f"  tests come from: {checkout_src.parent.parent}\n"
+            f"  orionbelt is:    {imported}\n"
+            "Every result would describe that other copy. This usually means pytest ran "
+            "in a git worktree while the venv's editable install still points at the main "
+            "working directory. Set ORIONBELT_ALLOW_FOREIGN_PACKAGE=1 to test an installed "
+            "copy on purpose."
+        )
+
+
+_assert_testing_this_checkout()
 
 # ``Settings`` reads the developer's ``.env``, so a machine that runs the pgwire
 # server for real (``PGWIRE_ENABLED=true``) makes the tests that start a full

--- a/tests/unit/test_data_types.py
+++ b/tests/unit/test_data_types.py
@@ -388,15 +388,18 @@ class TestAnIntegerMeasureIsNotTheNumericDefault:
 
         Widening its cast would clear the overflow without making the average
         right, because the loss happens in the aggregate before any cast. AVG
-        over BIGINT is exact on Postgres (numeric) and MySQL (decimal) but
-        floating point on DuckDB and ClickHouse, and on DuckDB no formulation
-        recovers it: casting the input, casting both operands, and rewriting as
-        SUM/COUNT were each measured to come back DOUBLE, because every route
-        through ``/`` is float division there.
+        over a 64-bit magnitude is exact on Postgres (numeric), MySQL (decimal)
+        and Snowflake, but floating point on DuckDB, ClickHouse and BigQuery.
+        On DuckDB no formulation recovers it: casting the input, casting both
+        operands, and rewriting as SUM/COUNT were each measured to come back
+        DOUBLE, because every route through ``/`` is float division there.
 
         So a widened AVG would trade a loud overflow for a quietly wrong
-        number, on exactly the engines where the number is wrong. Declaring
-        ``dataType`` is the supported way to ask for a wider average.
+        number, on exactly the engines where the number is wrong. Note that
+        declaring ``dataType`` is **not** a way around this - it widens this
+        same cast, so it reintroduces the quiet wrong number. See
+        ``test_declaring_a_data_type_does_not_rescue_avg_on_duckdb`` below, and
+        #316 for the per-dialect rewrite that would actually fix it.
         """
         m = Measure(name="Qty Avg", aggregation="avg", result_type=DataType.INT)
         assert resolve_measure_data_type(m, None) == BUILTIN_DEFAULT
@@ -432,7 +435,8 @@ class TestAnIntegerMeasureIsNotTheNumericDefault:
         """The escape hatch that is not one, pinned so the guidance cannot drift.
 
         It is tempting to tell users "declare ``dataType`` if you need a wider
-        average". On DuckDB and ClickHouse that is actively harmful advice: the
+        average". On DuckDB, ClickHouse and BigQuery that is actively harmful advice:
+        the
         loss is inside the aggregate, so a wider dataType only widens this same
         cast and lets the wrong number through instead of failing. An error you
         can see beats a plausible wrong figure.

--- a/tests/unit/test_data_types.py
+++ b/tests/unit/test_data_types.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from decimal import Decimal
+
 import pytest
 
 from orionbelt.compiler.pipeline import CompilationPipeline
@@ -15,6 +17,7 @@ from orionbelt.dialect.postgres import PostgresDialect
 from orionbelt.dialect.snowflake import SnowflakeDialect
 from orionbelt.models.query import QueryObject, QuerySelect
 from orionbelt.models.semantic import (
+    DataType,
     Measure,
     Metric,
     ModelSettings,
@@ -352,3 +355,79 @@ measures:
         query = QueryObject(select=QuerySelect(dimensions=["Dim"], measures=["Total"]))
         result = pipeline.compile(query, model, "postgres")
         assert "DECIMAL(18, 4)" in result.sql
+
+
+class TestAnIntegerMeasureIsNotTheNumericDefault:
+    """The numeric default cannot describe a 64-bit result.
+
+    ``decimal(18, 2)`` carries 16 integer digits and a BIGINT needs 19, so the
+    cast meant to describe the result overflowed on values the source column
+    held quite legally. The engine computed the sum and then failed converting
+    it - on the plain star path, not only under a multi-fact plan.
+    """
+
+    def test_sum_of_an_integer_measure_infers_bigint(self) -> None:
+        m = Measure(name="Qty Sum", aggregation="sum", result_type=DataType.INT)
+        assert resolve_measure_data_type(m, None) == SimpleType("bigint")
+
+    def test_avg_of_an_integer_measure_keeps_its_scale_and_gains_range(self) -> None:
+        """AVG is not integral, so it stays a decimal and only gets wider."""
+        m = Measure(name="Qty Avg", aggregation="avg", result_type=DataType.INT)
+        assert resolve_measure_data_type(m, None) == DecimalType(21, 2)
+
+    def test_a_pinned_model_default_keeps_the_places_it_asked_for(self) -> None:
+        settings = ModelSettings(default_numeric_data_type="decimal(18, 6)")
+        m = Measure(name="Qty Avg", aggregation="avg", result_type=DataType.INT)
+        assert resolve_measure_data_type(m, settings) == DecimalType(25, 6)
+
+    def test_an_already_wide_default_is_left_alone(self) -> None:
+        settings = ModelSettings(default_numeric_data_type="decimal(38, 2)")
+        m = Measure(name="Qty Avg", aggregation="avg", result_type=DataType.INT)
+        assert resolve_measure_data_type(m, settings) == DecimalType(38, 2)
+
+    def test_an_explicit_data_type_still_wins(self) -> None:
+        m = Measure(
+            name="Qty Sum",
+            aggregation="sum",
+            result_type=DataType.INT,
+            data_type="decimal(18, 2)",
+        )
+        assert resolve_measure_data_type(m, None) == DecimalType(18, 2)
+
+    def test_a_float_measure_is_untouched(self) -> None:
+        m = Measure(name="Revenue", aggregation="sum", result_type=DataType.FLOAT)
+        assert resolve_measure_data_type(m, None) == BUILTIN_DEFAULT
+
+    def test_a_bigint_sum_survives_execution(self) -> None:
+        """The end of the story, run rather than asserted on the SQL."""
+        duckdb = pytest.importorskip("duckdb")
+        yaml = """
+version: "1.0"
+name: bigint_sum
+dataObjects:
+  Charges:
+    code: charges
+    columns:
+      Day: {code: day, abstractType: int}
+      Qty: {code: qty, abstractType: int}
+dimensions:
+  Day: {dataObject: Charges, column: Day}
+measures:
+  Qty Sum: {columns: [{dataObject: Charges, column: Qty}], resultType: int, aggregation: sum}
+  Qty Avg: {columns: [{dataObject: Charges, column: Qty}], resultType: int, aggregation: avg}
+"""
+        from orionbelt.parser import ReferenceResolver, TrackedLoader
+
+        raw, sm = TrackedLoader().load_string(yaml)
+        model, _ = ReferenceResolver().resolve(raw, sm)
+
+        con = duckdb.connect(":memory:")
+        con.execute("CREATE TABLE charges (day INTEGER, qty BIGINT)")
+        con.execute("INSERT INTO charges VALUES (1, 1000000000000000001), (1, 1000000000000000002)")
+        pipeline = CompilationPipeline()
+        for name, expected in [("Qty Sum", "2000000000000000003"), ("Qty Avg", "1E+18")]:
+            query = QueryObject(select=QuerySelect(dimensions=["Day"], measures=[name]))
+            sql = pipeline.compile(query, model, "duckdb").sql
+            value = con.execute(sql).fetchall()[0][1]
+            assert Decimal(str(value)) == Decimal(expected), f"{name} came back {value}"
+        con.close()

--- a/tests/unit/test_data_types.py
+++ b/tests/unit/test_data_types.py
@@ -370,21 +370,6 @@ class TestAnIntegerMeasureIsNotTheNumericDefault:
         m = Measure(name="Qty Sum", aggregation="sum", result_type=DataType.INT)
         assert resolve_measure_data_type(m, None) == SimpleType("bigint")
 
-    def test_avg_of_an_integer_measure_keeps_its_scale_and_gains_range(self) -> None:
-        """AVG is not integral, so it stays a decimal and only gets wider."""
-        m = Measure(name="Qty Avg", aggregation="avg", result_type=DataType.INT)
-        assert resolve_measure_data_type(m, None) == DecimalType(21, 2)
-
-    def test_a_pinned_model_default_keeps_the_places_it_asked_for(self) -> None:
-        settings = ModelSettings(default_numeric_data_type="decimal(18, 6)")
-        m = Measure(name="Qty Avg", aggregation="avg", result_type=DataType.INT)
-        assert resolve_measure_data_type(m, settings) == DecimalType(25, 6)
-
-    def test_an_already_wide_default_is_left_alone(self) -> None:
-        settings = ModelSettings(default_numeric_data_type="decimal(38, 2)")
-        m = Measure(name="Qty Avg", aggregation="avg", result_type=DataType.INT)
-        assert resolve_measure_data_type(m, settings) == DecimalType(38, 2)
-
     def test_an_explicit_data_type_still_wins(self) -> None:
         m = Measure(
             name="Qty Sum",
@@ -398,10 +383,53 @@ class TestAnIntegerMeasureIsNotTheNumericDefault:
         m = Measure(name="Revenue", aggregation="sum", result_type=DataType.FLOAT)
         assert resolve_measure_data_type(m, None) == BUILTIN_DEFAULT
 
+    def test_avg_deliberately_keeps_the_default(self) -> None:
+        """AVG is not widened, and the reason is not an oversight.
+
+        Widening its cast would clear the overflow without making the average
+        right, because the loss happens in the aggregate before any cast. AVG
+        over BIGINT is exact on Postgres (numeric) and MySQL (decimal) but
+        floating point on DuckDB and ClickHouse, and on DuckDB no formulation
+        recovers it: casting the input, casting both operands, and rewriting as
+        SUM/COUNT were each measured to come back DOUBLE, because every route
+        through ``/`` is float division there.
+
+        So a widened AVG would trade a loud overflow for a quietly wrong
+        number, on exactly the engines where the number is wrong. Declaring
+        ``dataType`` is the supported way to ask for a wider average.
+        """
+        m = Measure(name="Qty Avg", aggregation="avg", result_type=DataType.INT)
+        assert resolve_measure_data_type(m, None) == BUILTIN_DEFAULT
+
     def test_a_bigint_sum_survives_execution(self) -> None:
         """The end of the story, run rather than asserted on the SQL."""
         duckdb = pytest.importorskip("duckdb")
-        yaml = """
+        model = _bigint_model()
+        con = _bigint_table(duckdb)
+        query = QueryObject(select=QuerySelect(dimensions=["Day"], measures=["Qty Sum"]))
+        sql = CompilationPipeline().compile(query, model, "duckdb").sql
+        assert Decimal(str(con.execute(sql).fetchall()[0][1])) == Decimal("2000000000000000003")
+        con.close()
+
+    def test_a_bigint_avg_fails_loudly_rather_than_rounding_silently(self) -> None:
+        """The limit, pinned so it cannot regress into a silent wrong answer.
+
+        This is the behaviour a widened cast would have replaced: DuckDB
+        averages in DOUBLE, so the value that reaches the cast is already
+        1000000000000000000 rather than ...003. Overflowing the default is the
+        honest outcome; quietly returning the rounded figure is not.
+        """
+        duckdb = pytest.importorskip("duckdb")
+        model = _bigint_model()
+        con = _bigint_table(duckdb)
+        query = QueryObject(select=QuerySelect(dimensions=["Day"], measures=["Qty Avg"]))
+        sql = CompilationPipeline().compile(query, model, "duckdb").sql
+        with pytest.raises(duckdb.ConversionException):
+            con.execute(sql).fetchall()
+        con.close()
+
+
+_BIGINT_YAML = """
 version: "1.0"
 name: bigint_sum
 dataObjects:
@@ -416,18 +444,18 @@ measures:
   Qty Sum: {columns: [{dataObject: Charges, column: Qty}], resultType: int, aggregation: sum}
   Qty Avg: {columns: [{dataObject: Charges, column: Qty}], resultType: int, aggregation: avg}
 """
-        from orionbelt.parser import ReferenceResolver, TrackedLoader
 
-        raw, sm = TrackedLoader().load_string(yaml)
-        model, _ = ReferenceResolver().resolve(raw, sm)
 
-        con = duckdb.connect(":memory:")
-        con.execute("CREATE TABLE charges (day INTEGER, qty BIGINT)")
-        con.execute("INSERT INTO charges VALUES (1, 1000000000000000001), (1, 1000000000000000002)")
-        pipeline = CompilationPipeline()
-        for name, expected in [("Qty Sum", "2000000000000000003"), ("Qty Avg", "1E+18")]:
-            query = QueryObject(select=QuerySelect(dimensions=["Day"], measures=[name]))
-            sql = pipeline.compile(query, model, "duckdb").sql
-            value = con.execute(sql).fetchall()[0][1]
-            assert Decimal(str(value)) == Decimal(expected), f"{name} came back {value}"
-        con.close()
+def _bigint_model() -> SemanticModel:
+    from orionbelt.parser import ReferenceResolver, TrackedLoader
+
+    raw, sm = TrackedLoader().load_string(_BIGINT_YAML)
+    model, _ = ReferenceResolver().resolve(raw, sm)
+    return model
+
+
+def _bigint_table(duckdb):  # type: ignore[no-untyped-def]
+    con = duckdb.connect(":memory:")
+    con.execute("CREATE TABLE charges (day INTEGER, qty BIGINT)")
+    con.execute("INSERT INTO charges VALUES (1, 1000000000000000001), (1, 1000000000000000002)")
+    return con

--- a/tests/unit/test_data_types.py
+++ b/tests/unit/test_data_types.py
@@ -428,6 +428,40 @@ class TestAnIntegerMeasureIsNotTheNumericDefault:
             con.execute(sql).fetchall()
         con.close()
 
+    def test_declaring_a_data_type_does_not_rescue_avg_on_duckdb(self) -> None:
+        """The escape hatch that is not one, pinned so the guidance cannot drift.
+
+        It is tempting to tell users "declare ``dataType`` if you need a wider
+        average". On DuckDB and ClickHouse that is actively harmful advice: the
+        loss is inside the aggregate, so a wider dataType only widens this same
+        cast and lets the wrong number through instead of failing. An error you
+        can see beats a plausible wrong figure.
+
+        Asserted as an inequality rather than by pinning the wrong value, so
+        this reads as "still lossy" rather than as an endorsement of it.
+        """
+        duckdb = pytest.importorskip("duckdb")
+        yaml = _BIGINT_YAML.replace(
+            "Qty Avg: {columns: [{dataObject: Charges, column: Qty}], "
+            "resultType: int, aggregation: avg}",
+            "Qty Avg: {columns: [{dataObject: Charges, column: Qty}], "
+            'resultType: int, aggregation: avg, dataType: "decimal(21, 2)"}',
+        )
+        from orionbelt.parser import ReferenceResolver, TrackedLoader
+
+        raw, sm = TrackedLoader().load_string(yaml)
+        model, _ = ReferenceResolver().resolve(raw, sm)
+        con = _bigint_table(duckdb)
+        query = QueryObject(select=QuerySelect(dimensions=["Day"], measures=["Qty Avg"]))
+        sql = CompilationPipeline().compile(query, model, "duckdb").sql
+        assert "DECIMAL(21, 2)" in sql, sql
+        value = Decimal(str(con.execute(sql).fetchall()[0][1]))
+        con.close()
+        assert value != Decimal("1000000000000000001.50"), (
+            "DuckDB averaged exactly - see #316; if this now passes, the docs and "
+            "the type_resolver comment both need updating"
+        )
+
 
 _BIGINT_YAML = """
 version: "1.0"

--- a/tests/unit/test_grain_dedup.py
+++ b/tests/unit/test_grain_dedup.py
@@ -695,7 +695,7 @@ def test_having_splits_between_the_grouped_query_and_the_wrapper() -> None:
             ],
         }
     )
-    assert 'HAVING CAST(SUM("Sales"."quantity") AS DECIMAL(18, 2)) > 5' in result.sql
+    assert 'HAVING CAST(SUM("Sales"."quantity") AS BIGINT) > 5' in result.sql
     assert 'WHERE "__ob_dedup_0"."Total Stock On Hand" > 250' in result.sql
 
     rows = [(r[0], int(r[1]), int(r[2])) for r in _sales_db().execute(result.sql).fetchall()]


### PR DESCRIPTION
Two fixes, both from the #313 review.

## An integer measure is not a `decimal(18, 2)`

The built-in numeric default carries 16 integer digits; a 64-bit column needs 19. So `SUM` over a `BIGINT` overflowed the very cast meant to describe it - the engine computed the value correctly and then failed converting it:

```
Qty Sum  -> FAILED: Could not cast value 2000000000000000003 ...
            CAST(SUM("Charges"."qty") AS DECIMAL(18, 2))
Qty Avg  -> FAILED: Could not cast value 1000000000000000001 ...
            CAST(AVG("Charges"."qty") AS DECIMAL(18, 2))
Qty Max  -> 1000000000000000002          (pass-through, no cast, so it worked)
```

This is the **plain star path**, not a multi-fact plan. It surfaced from the CFL alignment matrix in #313, but nothing about it was CFL doing: both paths failed identically, which is why the star-vs-CFL comparison passed over it.

A measure declaring `resultType: int` now infers its type instead of taking the default:

| aggregation | before | after | why |
|---|---|---|---|
| `sum` | `decimal(18, 2)` | `bigint` | a sum of integers is an integer, the same inference COUNT already gets |
| `avg` | `decimal(18, 2)` | `decimal(21, 2)` | not integral, so it stays fixed-point and only gains the range it lacked |

The AVG widening moves **precision only**, so a model that pinned `settings.defaultNumericDataType` keeps the decimal places it asked for: `decimal(18, 6)` becomes `decimal(25, 6)`, and a default already wide enough is left alone.

Renders correctly on all eight dialects:

```
bigquery  SUM->INT64           AVG->NUMERIC
clickhouse SUM->Nullable(Int64) AVG->Nullable(Decimal(21, 2))
snowflake SUM->NUMBER(38, 0)   AVG->NUMBER(21, 2)
mysql     SUM->SIGNED          AVG->DECIMAL(21, 2)
databricks/dremio/duckdb/postgres  SUM->BIGINT  AVG->DECIMAL(21, 2)
```

**Known limit, documented rather than silently left**: a measure over a large-valued *non-integer* column still takes the built-in default and can still overflow. Fixing that needs the source column type, which `resolve_measure_data_type` does not receive; widening its signature touches seven call sites and is a bigger change than this one. `docs/guide/model-format.md` now says to pin `dataType` in that case.

## Tests run against the checkout they live in

`uv sync` installs the package editable, pointing at the main working directory. Run the suite from a **git worktree** and the tests are the worktree own while the code under test is the main checkout, so a regression test written against an old commit exercises the *fixed* code and passes.

That is the worst kind of failure because it is invisible: everything goes green, which is precisely the wrong answer. It happened during #311 and very nearly retired a working regression test as "does not catch the bug".

- `pythonpath = ["src"]` resolves relative to rootdir, so each worktree imports its own source ahead of whatever the venv installed. This is the actual fix.
- A `tests/conftest.py` check asserts it worked, because nothing else would notice if the setting were dropped. `ORIONBELT_ALLOW_FOREIGN_PACKAGE=1` opts out for testing an installed copy deliberately.

Both verified by reproducing the original trap: a worktree at `a640f38` with today test file now **fails** with no `PYTHONPATH` set, and with the setting removed the guard fires with both paths named.

CI is unaffected: every job installs via `uv sync` from its own checkout, and the clean-venv Colab job runs a notebook rather than `tests/`.

## Verification

- 3949 passed / 919 skipped
- 404 passed on `tests/integration/drift/vendor_exec -m docker`
- ruff and mypy clean
- **no drift snapshot changed**; one unit test pinned the old `DECIMAL(18, 2)` on a `resultType: int` quantity measure and now expects `BIGINT`