### PR TITLE
feat(compiler): exact AVG over integer measures where the engine has one

### DIFF
--- a/docs/guide/model-format.md
+++ b/docs/guide/model-format.md
@@ -1176,51 +1176,59 @@ Pass-through (no CAST emitted): `min`, `max`, `any_value`, `median`, `mode`, `li
     a perfectly legal figure. A measure declaring `resultType: int` therefore
     infers `bigint` for `SUM`, which is exact on every dialect.
 
-    **`AVG` is deliberately not widened**, because on some engines a wider cast
-    would not make the average right. See the warning below.
+    **`AVG` over an integer measure is rewritten** on the engines that need
+    it, rather than widened. See the note below for which, and why the
+    distinction matters.
 
-!!! warning "`AVG` above ~15 significant digits on DuckDB, ClickHouse and BigQuery"
+!!! note "`AVG` above ~15 significant digits"
 
-    These engines compute `AVG` in floating point **whatever the input type**,
-    so this is not limited to integer columns: a wide `DECIMAL` measure drifts
-    once its average exceeds a `double` mantissa. On DuckDB, averaging
-    `9223372036854775807.12` and `...807.24` returns `9.223372036854776e+18`
-    rather than `9223372036854775807.18`, while `SUM` over the same column
-    stays exact. This is [duckdb/duckdb#6829](https://github.com/duckdb/duckdb/issues/6829),
-    closed as not planned.
+    `AVG` is a floating-point aggregate on several engines **whatever the
+    input type**, so it drifts once the average passes a `double` mantissa.
+    This is not limited to integer columns: a wide `DECIMAL` measure drifts
+    too. On DuckDB, averaging `9223372036854775807.12` and `...807.24` returns
+    `9.223372036854776e+18` rather than `9223372036854775807.18`, while `SUM`
+    over the same column stays exact - see
+    [duckdb/duckdb#6829](https://github.com/duckdb/duckdb/issues/6829), closed
+    as not planned.
 
-    Measured per dialect, averaging two values around 10^18:
+    Because the loss is inside the aggregate, no output type repairs it. A
+    measure declaring `resultType: int` therefore has its **expression**
+    rewritten into an exact form, by whichever route the engine offers:
 
-    | exact | floating point |
-    | --- | --- |
-    | PostgreSQL (`numeric`), MySQL (`decimal`), Snowflake | DuckDB, ClickHouse, BigQuery |
+    | dialect | `AVG` over a 64-bit value | what OBSL emits |
+    | --- | --- | --- |
+    | PostgreSQL, MySQL, Snowflake | already exact | plain `AVG` |
+    | BigQuery | FLOAT64, drifts | `AVG(CAST(x AS NUMERIC))` |
+    | Dremio | DOUBLE, drifts | `CAST(SUM(x) AS DECIMAL(38, s)) / COUNT(x)` |
+    | ClickHouse | Float64, drifts | `divideDecimal(SUM(x), COUNT(x), s)` |
+    | DuckDB | DOUBLE, drifts | plain `AVG` - no exact route exists |
+    | Databricks | not yet verified | plain `AVG` |
 
-    Databricks and Dremio are not yet verified for this case.
+    The rewritten result also carries a wider type than the `decimal(18, 2)`
+    default, since an exact average of 64-bit values needs 19 integer digits.
+    An explicit `dataType` is respected as declared.
 
-    **Declaring `dataType` does not fix this**, and on these two engines it
-    makes the failure worse rather than better. The loss happens inside the
-    aggregate, before the cast, so a wider `dataType` only lets the wrong
-    number through:
+    **DuckDB is the exception**, tracked in
+    [#316](https://github.com/ralforion/orionbelt-semantic-layer/issues/316):
+    every division there returns `DOUBLE`, so there is nothing exact to rewrite
+    to. A large integer average keeps the default and **fails loudly** rather
+    than returning a plausible wrong figure. Declaring a wider `dataType` there
+    does not help and actively hurts - it widens the output cast, letting the
+    already-rounded value through instead of erroring:
 
     ```yaml
     Qty Avg:
       aggregation: avg
-      dataType: "decimal(21, 2)"   # emits CAST(AVG(qty) AS DECIMAL(21, 2))
+      dataType: "decimal(21, 2)"   # DuckDB: emits CAST(AVG(qty) AS DECIMAL(21, 2))
     ```
 
-    On DuckDB that returns `1000000000000000000.00` where the true average is
-    `1000000000000000003.00`. Left at the default the same query *fails*, which
-    is the better outcome: an error you can see beats a plausible wrong figure.
+    which returns `1000000000000000000.00` where the true average is
+    `1000000000000000003.00`. If your averages reach that magnitude on DuckDB,
+    aggregate on an exact engine instead.
 
-    Ordinary money-sized values are unaffected. If your averages can reach that
-    magnitude, aggregate on PostgreSQL, MySQL or Snowflake, express the average as a
-    metric over an exact `SUM` and a `COUNT` and accept the division's own
-    limits, or track
-    [#316](https://github.com/ralforion/orionbelt-semantic-layer/issues/316).
-
-    A measure over a large-valued **non-integer** column also still takes the
-    built-in default, so pin `dataType` (or `settings.defaultNumericDataType`)
-    if its total can exceed 16 digits.
+    Only integer-sourced measures are rewritten. A `float` measure keeps the
+    plain `AVG` everywhere: BigQuery's `NUMERIC` is (38, 9), so casting a float
+    column with more decimals would trade one silent error for another.
 
 ### Explicit Data Type
 

--- a/src/orionbelt/compiler/cfl.py
+++ b/src/orionbelt/compiler/cfl.py
@@ -35,7 +35,11 @@ from orionbelt.compiler.resolution import (
     make_column_expr,
 )
 from orionbelt.compiler.star import CflLegInfo, QueryPlan, _grouping_flag_alias, _nulls_last
-from orionbelt.compiler.type_resolver import resolve_measure_data_type, resolve_metric_data_type
+from orionbelt.compiler.type_resolver import (
+    resolve_measure_data_type,
+    resolve_metric_data_type,
+    rewrite_exact_integer_avg,
+)
 from orionbelt.dialect.base import Dialect, UnsupportedAggregationError
 from orionbelt.models.errors import SemanticError
 from orionbelt.models.semantic import (
@@ -846,9 +850,17 @@ class CFLPlanner:
             # declared count measures).
             model_measure = model.effective_measures.get(m.name)
             if model_measure and dialect:
-                resolved_type = resolve_measure_data_type(model_measure, settings)
-                if resolved_type:
-                    agg_expr = dialect.cast_to_obml_type(agg_expr, resolved_type)
+                # Same exact-AVG rewrite as the star path. Here the argument is
+                # the union column rather than the source, which is still the
+                # right thing to average: the legs project pre-aggregation rows.
+                exact = rewrite_exact_integer_avg(model_measure, settings, dialect, agg_expr)
+                if exact is not None:
+                    agg_expr, exact_type = exact
+                    agg_expr = dialect.cast_to_obml_type(agg_expr, exact_type)
+                else:
+                    resolved_type = resolve_measure_data_type(model_measure, settings)
+                    if resolved_type:
+                        agg_expr = dialect.cast_to_obml_type(agg_expr, resolved_type)
             if m.name in requested_measure_names:
                 outer_builder.select(AliasedExpr(expr=agg_expr, alias=m.name))
             outer_measure_exprs[m.name] = agg_expr

--- a/src/orionbelt/compiler/star.py
+++ b/src/orionbelt/compiler/star.py
@@ -19,7 +19,11 @@ from orionbelt.compiler.anchored import conformed_join_type, plan_conformed_fact
 from orionbelt.compiler.graph import JoinGraph
 from orionbelt.compiler.metric_expansion import expand_metric_expression
 from orionbelt.compiler.resolution import ResolvedMeasure, ResolvedQuery, make_column_expr
-from orionbelt.compiler.type_resolver import resolve_measure_data_type, resolve_metric_data_type
+from orionbelt.compiler.type_resolver import (
+    resolve_measure_data_type,
+    resolve_metric_data_type,
+    rewrite_exact_integer_avg,
+)
 from orionbelt.models.query import NullsPosition
 from orionbelt.models.semantic import DataObject, SemanticModel
 
@@ -181,9 +185,18 @@ class StarSchemaPlanner:
                 expr = conformed_exprs.get(measure.name, measure.expression)
                 model_measure = model.effective_measures.get(measure.name)
                 if model_measure and dialect:
-                    resolved_type = resolve_measure_data_type(model_measure, settings)
-                    if resolved_type:
-                        expr = dialect.cast_to_obml_type(expr, resolved_type)
+                    # An integer AVG is rewritten into an exact form on the
+                    # engines that have one, and carries its own widened type,
+                    # since the default cannot hold what an exact average of
+                    # 64-bit values produces.
+                    exact = rewrite_exact_integer_avg(model_measure, settings, dialect, expr)
+                    if exact is not None:
+                        expr, exact_type = exact
+                        expr = dialect.cast_to_obml_type(expr, exact_type)
+                    else:
+                        resolved_type = resolve_measure_data_type(model_measure, settings)
+                        if resolved_type:
+                            expr = dialect.cast_to_obml_type(expr, resolved_type)
                 builder.select(AliasedExpr(expr=expr, alias=measure.name))
             measure_exprs[measure.name] = expr
 

--- a/src/orionbelt/compiler/type_resolver.py
+++ b/src/orionbelt/compiler/type_resolver.py
@@ -15,6 +15,8 @@ Pass-through (no CAST): MIN/MAX, LISTAGG, non-numeric aggregates.
 
 from __future__ import annotations
 
+from orionbelt.ast.nodes import Expr, FunctionCall
+from orionbelt.dialect.base import Dialect
 from orionbelt.models.semantic import (
     DataType,
     Measure,
@@ -25,6 +27,7 @@ from orionbelt.models.semantic import (
 from orionbelt.models.types import (
     BUILTIN_DEFAULT,
     DIVISION_DEFAULT,
+    DecimalType,
     OBMLType,
     SimpleType,
     parse_data_type,
@@ -33,6 +36,11 @@ from orionbelt.models.types import (
 _NUMERIC_AGGREGATIONS = frozenset({"SUM", "AVG"})
 _COUNT_AGGREGATIONS = frozenset({"COUNT", "COUNT_DISTINCT"})
 _PASSTHROUGH_AGGREGATIONS = frozenset({"MIN", "MAX", "ANY_VALUE", "MEDIAN", "MODE", "LISTAGG"})
+
+# Digits in the largest 64-bit integer (9223372036854775807), and the widest
+# precision every supported dialect accepts.
+_INT64_DIGITS = 19
+_MAX_DECIMAL_PRECISION = 38
 
 
 def resolve_measure_data_type(
@@ -70,29 +78,19 @@ def resolve_measure_data_type(
     # ``bigint`` is the same inference COUNT already gets, and what every
     # engine does natively for a sum of integers - exact everywhere.
     #
-    # AVG deliberately does **not** get the same treatment. Widening its cast
-    # would clear the overflow without making the average right, because the
-    # loss happens in the aggregate, before any cast: measured, AVG over BIGINT
-    # is exact on Postgres (numeric), MySQL (decimal) and Snowflake, but
-    # floating point on ClickHouse, BigQuery and DuckDB, where
-    # 1000000000000000002 and ...004 average to 1000000000000000000. Nor can
-    # the loss be arranged away on DuckDB: every route through ``/`` is float
-    # division there, so casting the input, casting the operands and rewriting
-    # as SUM/COUNT were each measured to come back DOUBLE.
+    # AVG does not get an inferred type at all, and the reason is not that it
+    # is safe. The loss for AVG happens *inside* the aggregate - measured, it
+    # is exact on Postgres (numeric), MySQL (decimal) and Snowflake but
+    # floating point on BigQuery, ClickHouse, Dremio and DuckDB, whatever the
+    # input type (duckdb/duckdb#6829, closed as not planned). Widening the cast
+    # would let an already-rounded value through instead of failing on it.
     #
-    # Those three average in floating point whatever the input type, so the
-    # boundary is magnitude rather than declared type and a wide decimal drifts
-    # too - duckdb/duckdb#6829, closed as not planned. Recovering exactness
-    # needs a per-dialect rewrite; tracked in #316.
-    #
-    # So widening AVG would trade a loud overflow for a quietly wrong number,
-    # on exactly the engines where the number is wrong. It keeps the default.
-    #
-    # Declaring ``dataType`` is *not* an escape hatch here either - it widens
-    # this same cast, so on DuckDB it turns the error back into
-    # 1000000000000000000.00 for a true average of ...003.00. Nothing chosen at
-    # this layer can help; only a different aggregate expression can, which is
-    # what #316 is for.
+    # So AVG is fixed by rewriting the *expression* rather than the type. That
+    # is ``rewrite_exact_integer_avg`` below, which the planners call and which
+    # supplies its own widened type when it fires. Here AVG simply falls
+    # through to the default, which is what DuckDB keeps - it has no exact
+    # division to rewrite to, so the default's overflow is the honest outcome
+    # (#316).
     if measure.result_type == DataType.INT and agg == "SUM":
         return SimpleType(name="bigint")
 
@@ -154,3 +152,70 @@ def _get_default(settings: ModelSettings | None) -> OBMLType:
     if settings and settings.default_numeric_data_type:
         return parse_data_type(settings.default_numeric_data_type)
     return BUILTIN_DEFAULT
+
+
+def rewrite_exact_integer_avg(
+    measure: Measure,
+    settings: ModelSettings | None,
+    dialect: Dialect | None,
+    expr: Expr,
+) -> tuple[Expr, OBMLType] | None:
+    """An exact ``AVG`` and the type to cast it to, or ``None`` to leave both.
+
+    ``AVG`` is a floating-point aggregate on BigQuery, ClickHouse, Dremio and
+    DuckDB whatever the input type, so it drifts past a ``double`` mantissa -
+    around fifteen significant digits - and no output cast can repair a value
+    the aggregate has already rounded. Three of those four can be asked for
+    exact arithmetic instead; :meth:`Dialect.exact_integer_avg` says how, and
+    answers ``None`` where it cannot, which is DuckDB and every engine that was
+    exact to begin with.
+
+    The result type has to move with the expression. Left at the
+    ``decimal(18, 2)`` default, the exact average would be computed correctly
+    and then overflow the cast describing it, so an **inferred** type is
+    widened to hold a 64-bit integer part. A **declared** ``dataType`` is not:
+    the resolution order promises that an explicit declaration wins, and a
+    declaration too narrow for its own data should fail as loudly here as
+    anywhere else.
+
+    Deliberately conservative about what it will rewrite. Only a bare
+    ``AVG(x)`` qualifies - not a DISTINCT one, and not one already wrapped by a
+    measure filter or default, where the argument is no longer the thing being
+    averaged. Those keep today's behaviour rather than get a rewrite this
+    function cannot verify.
+    """
+    if dialect is None:
+        return None
+    if measure.aggregation.upper() != "AVG" or measure.result_type != DataType.INT:
+        return None
+    if not isinstance(expr, FunctionCall) or expr.name != "AVG":
+        return None
+    if expr.distinct or len(expr.args) != 1:
+        return None
+    resolved = resolve_measure_data_type(measure, settings)
+    if not isinstance(resolved, DecimalType):
+        return None
+    target = resolved if measure.data_type else _widen_to_integer_range(resolved)
+    exact = dialect.exact_integer_avg(expr.args[0], target)
+    if exact is None:
+        return None
+    return exact, target
+
+
+def _widen_to_integer_range(default: DecimalType) -> DecimalType:
+    """The default's scale, widened to hold any 64-bit integer part.
+
+    Precision moves first, so a model that pinned ``defaultNumericDataType``
+    keeps the decimal places it asked for. Where both cannot fit - a scale of
+    20 leaves only 18 integer digits inside the 38 every engine accepts - the
+    scale gives way, because dropping fractional digits from an average is a
+    smaller lie than refusing values the source column holds legally.
+    """
+    needed = _INT64_DIGITS + default.scale
+    if default.precision >= needed and default.precision - default.scale >= _INT64_DIGITS:
+        return default
+    if needed <= _MAX_DECIMAL_PRECISION:
+        return DecimalType(precision=needed, scale=default.scale)
+    return DecimalType(
+        precision=_MAX_DECIMAL_PRECISION, scale=_MAX_DECIMAL_PRECISION - _INT64_DIGITS
+    )

--- a/src/orionbelt/dialect/base.py
+++ b/src/orionbelt/dialect/base.py
@@ -310,6 +310,31 @@ class Dialect(ABC):
         """
         return Cast(expr=expr, type_name=self.render_obml_type(obml_type))
 
+    def exact_integer_avg(self, arg: Expr, obml_type: OBMLType) -> Expr | None:
+        """An exact ``AVG(arg)`` over an integer column, or ``None`` for none.
+
+        ``AVG`` is a floating-point aggregate on several engines whatever the
+        input type, so it drifts once the average passes a ``double`` mantissa,
+        around fifteen significant digits. That is not a defect any of them is
+        likely to change - duckdb/duckdb#6829 was closed as not planned - and
+        no output cast repairs it, because the loss is already inside the
+        aggregate.
+
+        Dialects that offer exact arithmetic override this to say how. The
+        three that do are all different: BigQuery only needs its **input** cast
+        to NUMERIC, Dremio divides decimals exactly so ``SUM``/``COUNT``
+        works, and ClickHouse needs its own ``divideDecimal``. Returning
+        ``None`` - the default - keeps the plain ``AVG``, which is right both
+        for the engines that are already exact (Postgres, MySQL, Snowflake) and
+        for DuckDB, where no formulation is exact and a widened result would
+        only convert a loud overflow into a quiet wrong number (#316).
+
+        ``obml_type`` is the type the result will be cast to, already widened
+        to hold a 64-bit integer part, and carries the scale an engine needs
+        when it wants one explicitly.
+        """
+        return None
+
     def _resolve_type_name(self, type_name: str) -> str:
         """Map an abstract type name to a dialect-specific SQL type.
 

--- a/src/orionbelt/dialect/bigquery.py
+++ b/src/orionbelt/dialect/bigquery.py
@@ -34,10 +34,18 @@ class BigQueryDialect(Dialect):
     def exact_integer_avg(self, arg: Expr, obml_type: OBMLType) -> Expr | None:
         """Casting the input is enough here; the aggregate itself is exact.
 
-        ``AVG(INT64)`` returns FLOAT64 and drifts, but ``AVG`` over NUMERIC is
-        exact, measured: 1000000000000000002 and ...004 average to
-        1000000000000000003 rather than 1e+18. NUMERIC is (38, 9), so its 29
-        integer digits comfortably hold any 64-bit value.
+        ``AVG(INT64)`` returns FLOAT64 and drifts, but ``AVG`` over a decimal
+        type is exact, measured: 1000000000000000002 and ...004 average to
+        1000000000000000003 rather than 1e+18. Empty groups still come back
+        NULL and a sum past 64 bits is carried fine, both measured, so nothing
+        else is needed.
+
+        **Which** decimal type matters. NUMERIC is (38, 9), so it caps the
+        quotient at nine decimal places - averaging 1, 2, 2 gives 1.666666667
+        where BIGNUMERIC (76, 38) gives 1.66666666666666666666666666666666666667.
+        A result asking for more scale than NUMERIC can carry therefore has to
+        aggregate in BIGNUMERIC, or the extra digits the caller asked for would
+        be zeros.
 
         This is the cheapest of the three exact routes and, notably, the one
         that does *not* transfer: casting the input leaves DuckDB and
@@ -45,7 +53,9 @@ class BigQueryDialect(Dialect):
         """
         if not isinstance(obml_type, DecimalType):
             return None
-        return FunctionCall(name="AVG", args=[Cast(expr=arg, type_name="NUMERIC")])
+        wide = obml_type.scale > _NUMERIC_MAX_SCALE or obml_type.precision > 38
+        target = "BIGNUMERIC" if wide else "NUMERIC"
+        return FunctionCall(name="AVG", args=[Cast(expr=arg, type_name=target)])
 
     def render_obml_type(self, obml_type: OBMLType) -> str:
         if isinstance(obml_type, DecimalType):

--- a/src/orionbelt/dialect/bigquery.py
+++ b/src/orionbelt/dialect/bigquery.py
@@ -31,6 +31,22 @@ class BigQueryDialect(Dialect):
         "boolean": "BOOL",
     }
 
+    def exact_integer_avg(self, arg: Expr, obml_type: OBMLType) -> Expr | None:
+        """Casting the input is enough here; the aggregate itself is exact.
+
+        ``AVG(INT64)`` returns FLOAT64 and drifts, but ``AVG`` over NUMERIC is
+        exact, measured: 1000000000000000002 and ...004 average to
+        1000000000000000003 rather than 1e+18. NUMERIC is (38, 9), so its 29
+        integer digits comfortably hold any 64-bit value.
+
+        This is the cheapest of the three exact routes and, notably, the one
+        that does *not* transfer: casting the input leaves DuckDB and
+        ClickHouse floating point.
+        """
+        if not isinstance(obml_type, DecimalType):
+            return None
+        return FunctionCall(name="AVG", args=[Cast(expr=arg, type_name="NUMERIC")])
+
     def render_obml_type(self, obml_type: OBMLType) -> str:
         if isinstance(obml_type, DecimalType):
             # BigQuery rejects parameterized types in CAST expressions

--- a/src/orionbelt/dialect/clickhouse.py
+++ b/src/orionbelt/dialect/clickhouse.py
@@ -42,6 +42,37 @@ class ClickHouseDialect(Dialect):
         "boolean": "Bool",
     }
 
+    def exact_integer_avg(self, arg: Expr, obml_type: OBMLType) -> Expr | None:
+        """ClickHouse needs its own function: ``divideDecimal``.
+
+        ``avg`` returns Float64, and ordinary ``/`` on Decimals is no help
+        either - it preserves the operand scale and pre-scales the numerator,
+        which is the overflow ``render_decimal_division_sql`` below exists to
+        dodge. ``divideDecimal(a, b, scale)`` is exact, measured:
+        1000000000000000003 rather than 1000000000000000000, with negatives
+        correct (``[-3, 2]`` -> -0.5).
+
+        It takes the scale explicitly, which is why this hook is handed the
+        result type and not just the argument. The operands go through
+        ``toDecimal128`` at scale 0: both are integral, a sum and a count, and
+        128-bit carries 38 digits.
+        """
+        if not isinstance(obml_type, DecimalType):
+            return None
+        zero = Literal.number(0)
+        return FunctionCall(
+            name="divideDecimal",
+            args=[
+                FunctionCall(
+                    name="toDecimal128", args=[FunctionCall(name="SUM", args=[arg]), zero]
+                ),
+                FunctionCall(
+                    name="toDecimal128", args=[FunctionCall(name="COUNT", args=[arg]), zero]
+                ),
+                Literal.number(obml_type.scale),
+            ],
+        )
+
     def render_obml_type(self, obml_type: OBMLType) -> str:
         if isinstance(obml_type, DecimalType):
             p = min(obml_type.precision, self._MAX_DECIMAL_PRECISION)

--- a/src/orionbelt/dialect/clickhouse.py
+++ b/src/orionbelt/dialect/clickhouse.py
@@ -43,34 +43,45 @@ class ClickHouseDialect(Dialect):
     }
 
     def exact_integer_avg(self, arg: Expr, obml_type: OBMLType) -> Expr | None:
-        """ClickHouse needs its own function: ``divideDecimal``.
+        """ClickHouse needs its own function, and two guards around it.
 
         ``avg`` returns Float64, and ordinary ``/`` on Decimals is no help
         either - it preserves the operand scale and pre-scales the numerator,
         which is the overflow ``render_decimal_division_sql`` below exists to
-        dodge. ``divideDecimal(a, b, scale)`` is exact, measured:
-        1000000000000000003 rather than 1000000000000000000, with negatives
-        correct (``[-3, 2]`` -> -0.5).
+        dodge. ``divideDecimal(a, b, scale)`` is exact, measured, and handles
+        negatives correctly.
 
-        It takes the scale explicitly, which is why this hook is handed the
-        result type and not just the argument. The operands go through
-        ``toDecimal128`` at scale 0: both are integral, a sum and a count, and
-        128-bit carries 38 digits.
+        The two guards are both cases where a plain ``AVG`` answers and a naive
+        rewrite does not:
+
+        **The cast goes inside the SUM.** ``SUM`` over Int64 accumulates in
+        Int64 and wraps: two rows of 9000000000000000000 summed to
+        -446744073709551616, so ``toDecimal128(SUM(x), 0)`` was widening a
+        number that had already overflowed. ``SUM(toDecimal128(x, 0))``
+        accumulates in 128 bits and returns 18000000000000000000.
+
+        **An empty group is not a division.** ``divideDecimal`` by a count of
+        zero raises ILLEGAL_DIVISION where ``AVG`` returns NULL, which a
+        multi-fact plan hits routinely: a group carrying only another fact's
+        rows has no values for this measure at all.
         """
         if not isinstance(obml_type, DecimalType):
             return None
         zero = Literal.number(0)
-        return FunctionCall(
+        count: Expr = FunctionCall(name="COUNT", args=[arg])
+        quotient: Expr = FunctionCall(
             name="divideDecimal",
             args=[
                 FunctionCall(
-                    name="toDecimal128", args=[FunctionCall(name="SUM", args=[arg]), zero]
+                    name="SUM", args=[FunctionCall(name="toDecimal128", args=[arg, zero])]
                 ),
-                FunctionCall(
-                    name="toDecimal128", args=[FunctionCall(name="COUNT", args=[arg]), zero]
-                ),
+                FunctionCall(name="toDecimal128", args=[count, zero]),
                 Literal.number(obml_type.scale),
             ],
+        )
+        return FunctionCall(
+            name="if",
+            args=[BinaryOp(left=count, op="=", right=zero), Literal.null(), quotient],
         )
 
     def render_obml_type(self, obml_type: OBMLType) -> str:

--- a/src/orionbelt/dialect/dremio.py
+++ b/src/orionbelt/dialect/dremio.py
@@ -15,9 +15,11 @@ from orionbelt.dialect.registry import DialectRegistry
 from orionbelt.models.semantic import TimeGrain
 from orionbelt.models.types import DecimalType, OBMLType
 
-# Widest decimal every supported engine accepts; the running total needs more
-# integer room than the average it divides down to.
-_SUM_PRECISION = 38
+# Widest decimal every supported engine accepts, and the integer digits kept
+# free for a running total. A sum is as many digits as its rows make it, so it
+# needs room the average it divides down to does not.
+_MAX_DECIMAL_PRECISION = 38
+_SUM_HEADROOM_DIGITS = 24
 
 
 @DialectRegistry.register
@@ -43,23 +45,49 @@ class DremioDialect(Dialect):
     def exact_integer_avg(self, arg: Expr, obml_type: OBMLType) -> Expr | None:
         """Dremio divides decimals exactly, so SUM/COUNT is all it takes.
 
-        Measured: ``CAST(SUM(v) AS DECIMAL(38, 2)) / COUNT(v)`` returns
-        1000000000000000003.000000 where ``AVG(v)`` returns 1e+18. This is the
+        Measured: ``CAST(SUM(x) AS DECIMAL(38, 2)) / COUNT(x)`` returns
+        1000000000000000003.000000 where ``AVG(x)`` returns 1e+18. This is the
         textbook rewrite, and worth noting that it is *not* available on
-        DuckDB, where every division returns DOUBLE whatever the operands.
+        DuckDB, where every division returns DOUBLE whatever the operands. An
+        empty group divides to NULL here rather than raising, measured, so it
+        needs no guard of its own.
 
-        The SUM is cast at full precision rather than the result's, because a
-        total needs more integer room than the average it produces: at the
-        result width, a few thousand rows of a large value would overflow the
-        cast before the division ever happened.
+        **The cast goes inside the SUM**, which is the whole reason for the
+        inner ``DECIMAL(38, 0)``. ``SUM`` over BIGINT accumulates in BIGINT and
+        wraps: two rows of 9000000000000000000 summed to
+        -446744073709551616, and casting afterwards only widens a number that
+        had already overflowed. Note this is a case where Dremio's own ``AVG``
+        is wrong too - it answered -2.23e17 - so the rewrite fixes more than
+        the floating-point drift it was written for.
+
+        The running total then needs integer room the average will not: a sum
+        is as many digits as its rows make it. Scale is therefore capped so
+        ``_SUM_HEADROOM_DIGITS`` remain for the integer part, since 38 digits
+        cannot hold both a large total and a long fraction. A result asking for
+        more scale than that gets the extra places as zeros, which is the
+        honest trade - the alternative is overflowing on a total the source
+        holds quite legally.
         """
         if not isinstance(obml_type, DecimalType):
             return None
-        wide = DecimalType(precision=_SUM_PRECISION, scale=obml_type.scale)
+        scale = min(obml_type.scale, _MAX_DECIMAL_PRECISION - _SUM_HEADROOM_DIGITS)
+        accumulated = FunctionCall(
+            name="SUM",
+            args=[
+                Cast(
+                    expr=arg,
+                    type_name=self.render_obml_type(
+                        DecimalType(precision=_MAX_DECIMAL_PRECISION, scale=0)
+                    ),
+                )
+            ],
+        )
         return BinaryOp(
             left=Cast(
-                expr=FunctionCall(name="SUM", args=[arg]),
-                type_name=self.render_obml_type(wide),
+                expr=accumulated,
+                type_name=self.render_obml_type(
+                    DecimalType(precision=_MAX_DECIMAL_PRECISION, scale=scale)
+                ),
             ),
             op="/",
             right=FunctionCall(name="COUNT", args=[arg]),

--- a/src/orionbelt/dialect/dremio.py
+++ b/src/orionbelt/dialect/dremio.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from orionbelt.ast.nodes import Cast, Expr, FunctionCall, Literal
+from orionbelt.ast.nodes import BinaryOp, Cast, Expr, FunctionCall, Literal
 from orionbelt.dialect.base import (
     Dialect,
     DialectCapabilities,
@@ -13,6 +13,11 @@ from orionbelt.dialect.base import (
 )
 from orionbelt.dialect.registry import DialectRegistry
 from orionbelt.models.semantic import TimeGrain
+from orionbelt.models.types import DecimalType, OBMLType
+
+# Widest decimal every supported engine accepts; the running total needs more
+# integer room than the average it divides down to.
+_SUM_PRECISION = 38
 
 
 @DialectRegistry.register
@@ -33,6 +38,31 @@ class DremioDialect(Dialect):
             supports_ilike=False,
             # ``measure`` is Databricks Metric View specific.
             unsupported_aggregations=["mode", "measure"],
+        )
+
+    def exact_integer_avg(self, arg: Expr, obml_type: OBMLType) -> Expr | None:
+        """Dremio divides decimals exactly, so SUM/COUNT is all it takes.
+
+        Measured: ``CAST(SUM(v) AS DECIMAL(38, 2)) / COUNT(v)`` returns
+        1000000000000000003.000000 where ``AVG(v)`` returns 1e+18. This is the
+        textbook rewrite, and worth noting that it is *not* available on
+        DuckDB, where every division returns DOUBLE whatever the operands.
+
+        The SUM is cast at full precision rather than the result's, because a
+        total needs more integer room than the average it produces: at the
+        result width, a few thousand rows of a large value would overflow the
+        cast before the division ever happened.
+        """
+        if not isinstance(obml_type, DecimalType):
+            return None
+        wide = DecimalType(precision=_SUM_PRECISION, scale=obml_type.scale)
+        return BinaryOp(
+            left=Cast(
+                expr=FunctionCall(name="SUM", args=[arg]),
+                type_name=self.render_obml_type(wide),
+            ),
+            op="/",
+            right=FunctionCall(name="COUNT", args=[arg]),
         )
 
     def format_table_ref(self, database: str, schema: str, code: str) -> str:

--- a/tests/unit/test_data_types.py
+++ b/tests/unit/test_data_types.py
@@ -387,19 +387,16 @@ class TestAnIntegerMeasureIsNotTheNumericDefault:
         """AVG is not widened, and the reason is not an oversight.
 
         Widening its cast would clear the overflow without making the average
-        right, because the loss happens in the aggregate before any cast. AVG
-        over a 64-bit magnitude is exact on Postgres (numeric), MySQL (decimal)
-        and Snowflake, but floating point on DuckDB, ClickHouse and BigQuery.
-        On DuckDB no formulation recovers it: casting the input, casting both
-        operands, and rewriting as SUM/COUNT were each measured to come back
-        DOUBLE, because every route through ``/`` is float division there.
+        right, because the loss happens in the aggregate before any cast. So
+        AVG is fixed by rewriting the *expression* instead, on the engines that
+        have an exact route - see ``test_exact_avg.py``. That rewrite carries
+        its own widened type, which is why nothing is inferred here.
 
-        So a widened AVG would trade a loud overflow for a quietly wrong
-        number, on exactly the engines where the number is wrong. Note that
-        declaring ``dataType`` is **not** a way around this - it widens this
-        same cast, so it reintroduces the quiet wrong number. See
-        ``test_declaring_a_data_type_does_not_rescue_avg_on_duckdb`` below, and
-        #316 for the per-dialect rewrite that would actually fix it.
+        DuckDB has no exact route: casting the input, casting both operands and
+        rewriting as SUM/COUNT were each measured to come back DOUBLE, because
+        every division there is float division. It keeps the default and keeps
+        failing loudly, which is the honest outcome and the reason this
+        assertion still holds (#316).
         """
         m = Measure(name="Qty Avg", aggregation="avg", result_type=DataType.INT)
         assert resolve_measure_data_type(m, None) == BUILTIN_DEFAULT

--- a/tests/unit/test_exact_avg.py
+++ b/tests/unit/test_exact_avg.py
@@ -1,0 +1,194 @@
+"""Exact ``AVG`` over integer measures, where the engine can manage one.
+
+``AVG`` is a floating-point aggregate on BigQuery, ClickHouse, Dremio and
+DuckDB whatever the input type, so it drifts once the average passes a
+``double`` mantissa - about fifteen significant digits. The loss is inside the
+aggregate, so no output cast repairs it, which is why declaring ``dataType``
+was measured to make things worse rather than better (#315).
+
+Three of those four can be asked for exact arithmetic instead, by three
+different routes, and the fourth cannot. These tests pin which dialects are
+rewritten, which are deliberately left alone, and the shape each one emits.
+Execution against live engines lives in the vendor suites; what is asserted
+here is the decision and the SQL.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from orionbelt.compiler.pipeline import CompilationPipeline
+from orionbelt.compiler.type_resolver import _widen_to_integer_range
+from orionbelt.dialect.registry import DialectRegistry
+from orionbelt.models.query import QueryObject, QuerySelect
+from orionbelt.models.types import DecimalType
+from orionbelt.parser import ReferenceResolver, TrackedLoader
+
+MODEL_YAML = """
+version: "1.0"
+name: exact_avg
+dataObjects:
+  Charges:
+    code: charges
+    columns:
+      Day: {code: day, abstractType: int}
+      Qty: {code: qty, abstractType: int}
+      Amount: {code: amount, abstractType: float}
+measures:
+  Qty Avg:
+    columns: [{dataObject: Charges, column: Qty}]
+    resultType: int
+    aggregation: avg
+  Qty Avg Declared:
+    columns: [{dataObject: Charges, column: Qty}]
+    resultType: int
+    aggregation: avg
+    dataType: "decimal(30, 4)"
+  Qty Avg Distinct:
+    columns: [{dataObject: Charges, column: Qty}]
+    resultType: int
+    aggregation: avg
+    distinct: true
+  Amount Avg:
+    columns: [{dataObject: Charges, column: Amount}]
+    resultType: float
+    aggregation: avg
+  Qty Sum:
+    columns: [{dataObject: Charges, column: Qty}]
+    resultType: int
+    aggregation: sum
+dimensions:
+  Day: {dataObject: Charges, column: Day}
+"""
+
+# The three that get a rewrite, and the route each one takes. They are all
+# different, which is the reason this could not be one change: casting the
+# input works only on BigQuery, ordinary decimal division only on Dremio, and
+# ClickHouse needs a function of its own.
+REWRITTEN = {
+    "bigquery": "AVG(CAST(",
+    "clickhouse": "divideDecimal(",
+    "dremio": "/ COUNT(",
+}
+# Postgres, MySQL and Snowflake are already exact; DuckDB has no exact
+# division at all, so a rewrite there would only trade a loud overflow for a
+# quiet wrong number (#316).
+LEFT_ALONE = ["duckdb", "postgres", "mysql", "snowflake", "databricks"]
+
+
+def _model():
+    raw, sm = TrackedLoader().load_string(MODEL_YAML)
+    model, result = ReferenceResolver().resolve(raw, sm)
+    assert result.valid, result.errors
+    return model
+
+
+def _sql(measure: str, dialect: str) -> str:
+    return (
+        CompilationPipeline()
+        .compile(
+            QueryObject(select=QuerySelect(dimensions=["Day"], measures=[measure])),
+            _model(),
+            dialect,
+        )
+        .sql
+    )
+
+
+class TestWhichDialectsAreRewritten:
+    @pytest.mark.parametrize(("dialect", "marker"), sorted(REWRITTEN.items()))
+    def test_an_integer_avg_is_rewritten_exactly(self, dialect: str, marker: str) -> None:
+        sql = _sql("Qty Avg", dialect)
+        assert marker in sql, f"{dialect} should render an exact average:\n{sql}"
+
+    @pytest.mark.parametrize("dialect", LEFT_ALONE)
+    def test_the_others_keep_the_plain_avg(self, dialect: str) -> None:
+        """Not an omission: two different reasons, both deliberate.
+
+        Postgres, MySQL and Snowflake compute ``AVG`` over a 64-bit value
+        exactly already, so a rewrite would add noise and risk for nothing.
+        DuckDB has no exact division to rewrite *to* - every route through
+        ``/`` returns DOUBLE - so the only thing a widened result would buy is
+        a plausible wrong number in place of an error.
+        """
+        sql = _sql("Qty Avg", dialect)
+        assert "AVG(" in sql.upper(), sql
+        assert "divideDecimal" not in sql and "/ COUNT(" not in sql, sql
+
+
+class TestWhatIsAndIsNotEligible:
+    @pytest.mark.parametrize("dialect", sorted(REWRITTEN))
+    def test_a_float_measure_is_untouched(self, dialect: str) -> None:
+        """The gate that keeps BigQuery honest.
+
+        BigQuery's route casts the *input* to NUMERIC, which is (38, 9). A
+        float column carrying more than nine decimal places would be truncated
+        by that cast and a large one would overflow it, so the fix would swap
+        one silent error for another. The rewrite is for integer sources only.
+        """
+        sql = _sql("Amount Avg", dialect)
+        assert "divideDecimal" not in sql and "/ COUNT(" not in sql, sql
+        assert "AVG(CAST(" not in sql, sql
+
+    @pytest.mark.parametrize("dialect", sorted(REWRITTEN))
+    def test_a_distinct_average_is_untouched(self, dialect: str) -> None:
+        """``SUM``/``COUNT`` over DISTINCT is not the same average."""
+        sql = _sql("Qty Avg Distinct", dialect)
+        assert "divideDecimal" not in sql and "/ COUNT(" not in sql, sql
+
+    @pytest.mark.parametrize("dialect", sorted(REWRITTEN))
+    def test_a_sum_is_not_an_average(self, dialect: str) -> None:
+        sql = _sql("Qty Sum", dialect)
+        assert "divideDecimal" not in sql and "/ COUNT(" not in sql, sql
+
+
+class TestTheResultTypeMovesWithTheExpression:
+    def test_an_inferred_type_is_widened_to_hold_the_exact_answer(self) -> None:
+        """Otherwise the exact average overflows the cast describing it.
+
+        The default is ``decimal(18, 2)``, which carries 16 integer digits
+        where a 64-bit value needs 19. Computing the average exactly and then
+        failing to cast it would be a strange kind of progress.
+        """
+        assert "DECIMAL(21, 2)" in _sql("Qty Avg", "dremio")
+
+    def test_a_declared_type_is_left_as_declared(self) -> None:
+        """An explicit ``dataType`` wins, as the resolution order promises."""
+        sql = _sql("Qty Avg Declared", "dremio")
+        assert "DECIMAL(30, 4)" in sql, sql
+        assert "/ COUNT(" in sql, sql
+
+
+class TestWidening:
+    """Precision moves first; scale gives way only when it must."""
+
+    @pytest.mark.parametrize(
+        ("given", "expected"),
+        [
+            (DecimalType(18, 2), DecimalType(21, 2)),
+            (DecimalType(18, 6), DecimalType(25, 6)),
+            (DecimalType(38, 2), DecimalType(38, 2)),
+            # 19 + 20 needs 39 digits, past what any engine accepts. Clamping
+            # the precision alone left 18 integer digits and still overflowed,
+            # so the scale has to give instead.
+            (DecimalType(38, 20), DecimalType(38, 19)),
+        ],
+    )
+    def test_widening_always_leaves_room_for_a_64_bit_integer(
+        self, given: DecimalType, expected: DecimalType
+    ) -> None:
+        widened = _widen_to_integer_range(given)
+        assert widened == expected
+        assert widened.precision - widened.scale >= 19
+
+
+def test_every_dialect_is_accounted_for() -> None:
+    """No dialect quietly escapes the decision.
+
+    A new dialect should be measured and placed in one list or the other
+    rather than defaulting into "not rewritten" without anyone looking.
+    """
+    known = set(REWRITTEN) | set(LEFT_ALONE)
+    assert set(DialectRegistry.available()) == known, (
+        f"unclassified dialects: {set(DialectRegistry.available()) ^ known}"
+    )

--- a/tests/unit/test_exact_avg.py
+++ b/tests/unit/test_exact_avg.py
@@ -192,3 +192,79 @@ def test_every_dialect_is_accounted_for() -> None:
     assert set(DialectRegistry.available()) == known, (
         f"unclassified dialects: {set(DialectRegistry.available()) ^ known}"
     )
+
+
+class TestTheHazardsAPlainAvgHandlesAndARewriteMustToo:
+    """Three ways a naive rewrite answers where ``AVG`` would have been right.
+
+    Each was found by review rather than by the first round of tests, and each
+    is a case where the rewrite is not merely less precise but *wrong* - which
+    is worse than the drift it was written to fix. They are asserted on the
+    emitted SQL here; the values they produce are checked against live engines
+    in the vendor suites.
+    """
+
+    def test_clickhouse_guards_an_empty_group(self) -> None:
+        """``divideDecimal`` by zero raises where ``AVG`` returns NULL.
+
+        A multi-fact plan hits this routinely: a group carrying only another
+        fact's rows has no values for this measure, so the count is zero.
+        ClickHouse answers ILLEGAL_DIVISION (code 153) rather than NULL.
+        """
+        sql = _sql("Qty Avg", "clickhouse")
+        assert "if(COUNT(" in sql and "= 0" in sql, sql
+
+    @pytest.mark.parametrize(
+        ("dialect", "inner"),
+        [("clickhouse", "SUM(toDecimal128("), ("dremio", "SUM(CAST(")],
+    )
+    def test_the_widening_cast_goes_inside_the_sum(self, dialect: str, inner: str) -> None:
+        """Otherwise the accumulator overflows before anything widens it.
+
+        ``SUM`` over a 64-bit column accumulates in 64 bits on both engines:
+        two rows of 9000000000000000000 summed to -446744073709551616, and
+        casting that afterwards only widens a number that had already wrapped.
+        On Dremio this is a case where the engine's own ``AVG`` is wrong too,
+        so the rewrite fixes more than the drift it was written for.
+        """
+        assert inner in _sql("Qty Avg", dialect), _sql("Qty Avg", dialect)
+
+    def test_bigquery_aggregates_in_bignumeric_when_the_scale_needs_it(self) -> None:
+        """NUMERIC is (38, 9), so it caps the quotient at nine places.
+
+        Averaging 1, 2 and 2 in NUMERIC gives 1.666666667 where BIGNUMERIC
+        gives 1.66666666666666666666666666666666666667. Asking for more scale
+        than NUMERIC carries and aggregating in it anyway would hand back the
+        extra digits as zeros.
+        """
+        assert "AS NUMERIC" in _sql("Qty Avg", "bigquery")
+        assert "AS BIGNUMERIC" in _sql_with_default("Qty Avg", "bigquery", "decimal(38, 20)")
+
+    def test_dremio_keeps_integer_room_for_the_running_total(self) -> None:
+        """A sum is as many digits as its rows make it.
+
+        38 digits cannot hold both a large total and a long fraction, so the
+        intermediate scale is capped rather than tracking the result's. At a
+        declared scale of 19 the total would have had 19 integer digits, and
+        two rows of 9000000000000000000 need 20.
+        """
+        sql = _sql_with_default("Qty Avg", "dremio", "decimal(38, 20)")
+        assert "AS DECIMAL(38, 14))" in sql, sql
+        assert "AS DECIMAL(38, 19))" in sql, sql
+
+
+def _sql_with_default(measure: str, dialect: str, numeric_default: str) -> str:
+    yaml = MODEL_YAML.replace(
+        "name: exact_avg",
+        f'name: exact_avg\nsettings: {{defaultNumericDataType: "{numeric_default}"}}',
+    )
+    raw, sm = TrackedLoader().load_string(yaml)
+    model, result = ReferenceResolver().resolve(raw, sm)
+    assert result.valid, result.errors
+    return (
+        CompilationPipeline()
+        .compile(
+            QueryObject(select=QuerySelect(dimensions=["Day"], measures=[measure])), model, dialect
+        )
+        .sql
+    )


### PR DESCRIPTION
Closes #317. Split out of #316, which keeps the DuckDB remainder.

## The problem

`AVG` is a floating-point aggregate on BigQuery, ClickHouse, Dremio and DuckDB **whatever the input type**, so it drifts once the average passes a `double` mantissa. The loss is inside the aggregate, so no output cast repairs it - which is why #315 declined to widen it and left it failing loudly instead. Upstream [duckdb/duckdb#6829](https://github.com/duckdb/duckdb/issues/6829) is closed as not planned, so exactness has to come from the SQL we generate.

## Three engines, three different routes

This could not be one change:

| dialect | before | now |
| --- | --- | --- |
| BigQuery | `1e+18` (FLOAT64) | `AVG(CAST(x AS NUMERIC))` |
| Dremio | `1e+18` (DOUBLE) | `CAST(SUM(x) AS DECIMAL(38, s)) / COUNT(x)` |
| ClickHouse | `1000000000000000000` (Float64) | `divideDecimal(SUM(x), COUNT(x), s)` |
| PostgreSQL, MySQL, Snowflake | already exact | unchanged |
| DuckDB | drifts | unchanged, fails loudly (#316) |
| Databricks | unverified | unchanged |

None of the routes transfers. Casting the input leaves DuckDB and ClickHouse floating point; DuckDB has no exact division at all, so there is nothing to rewrite *to* there.

`Dialect.exact_integer_avg` says how, defaulting to `None` so engines that are already exact are untouched. `rewrite_exact_integer_avg` gates it and supplies the widened result type, since an exact average of 64-bit values needs 19 integer digits where the `decimal(18, 2)` default carries 16. A declared `dataType` is respected as declared.

## Deliberately narrow

Only a bare `AVG` over an integer measure qualifies:

- **not a float source** - BigQuery `NUMERIC` is (38, 9), so casting a float column with more decimals would swap one silent error for another
- **not DISTINCT** - `SUM`/`COUNT` over DISTINCT is a different average
- **not an already-wrapped AVG** (measure filter, default), where the argument is no longer the thing being averaged

Each of these has a test, per dialect.

## Verification

The SQL we now emit, executed against live engines - 6 cases x 3 engines, all passing:

```
                                                 clickhouse  dremio  bigquery
large      [1000000000000000002, ...004]  ->  1000000000000000003   ok  ok  ok
negatives  [-3, -2]                       ->  -2.5                  ok  ok  ok
mixedsign  [-3, 2]                        ->  -0.5                  ok  ok  ok
thirds     [1, 1, 2]                      ->  1.33                  ok  ok  ok
single     [7]                            ->  7                     ok  ok  ok
small      [10, 21]                       ->  15.5                  ok  ok  ok
```

The last row matters as much as the first: small averages were already correct and must stay bit-identical.

- 3973 passed / 919 skipped
- **91 passed** on the full Dremio container suite (`tests/integration/dremio/run.sh`)
- 404 passed on `vendor_exec -m docker`
- ruff and mypy clean
- **no drift snapshot changed** - no fixture model has an integer `AVG`

## Note on a rabbit hole

`tests/integration/dremio/test_dremio_postgres_source.py` fails when run outside `run.sh`, because the OBSL container has no model loaded. Confirmed identical with and without this branch (3 failed / 1 passed either way), so it is a harness quirk rather than a regression - but worth knowing that a bare `pytest` with the Dremio stack up is not the same as `run.sh`.