### PR TITLE
fix(dialect): a zero divisor yields NULL on every dialect

### DIFF
--- a/docs/guide/model-format.md
+++ b/docs/guide/model-format.md
@@ -1230,6 +1230,47 @@ Pass-through (no CAST emitted): `min`, `max`, `any_value`, `median`, `mode`, `li
     plain `AVG` everywhere: BigQuery's `NUMERIC` is (38, 9), so casting a float
     column with more decimals would trade one silent error for another.
 
+### Division by Zero
+
+**A zero divisor yields NULL, on every dialect.** Every division OBSL compiles
+gets its divisor wrapped in `NULLIF(..., 0)` - in a metric expression, in a
+measure expression, and in the divisions OBSL generates itself (such as an
+`AVG` with `total: true`).
+
+This exists because the engines disagree completely. Measured on
+`SUM(amt) / SUM(qty)` with a zero divisor:
+
+| dialect | without the guard |
+| --- | --- |
+| DuckDB | `inf` |
+| MySQL | `NULL` |
+| PostgreSQL | raises `division by zero` |
+| BigQuery | raises `400 division by zero` |
+| ClickHouse | raises code 153 |
+
+The same model and the same query would otherwise return a number on one
+warehouse, NULL on another, and fail outright on three. NULL was chosen because
+it reads naturally as "no value" in a BI tool, it matches what MySQL already
+did, and it removes DuckDB's `inf` - the only outcome that can flow on into
+downstream aggregation and formatting rather than stopping.
+
+A literal divisor that is plainly not zero is left unwrapped:
+
+```yaml
+Halved:
+  expression: "{[S].[Amt]} / 2"     # emits  amt / 2, no guard
+Rate:
+  expression: "{[S].[Amt]} / {[S].[Qty]}"   # emits  amt / NULLIF(qty, 0)
+```
+
+!!! note "Named division functions are not covered"
+
+    This applies to the `/` operator. The catalog's `div(a, b)` function and
+    `log(x, base)` (which divides by `LOG10(base)`, zero when the base is 1)
+    keep whatever their engine does, because a catalog function's semantics are
+    pinned per entry rather than by this rule. Guard those with `nullif`
+    explicitly if a zero or a base of 1 is reachable in your data.
+
 ### Explicit Data Type
 
 ```yaml

--- a/src/orionbelt/compiler/pop_wrap.py
+++ b/src/orionbelt/compiler/pop_wrap.py
@@ -672,16 +672,15 @@ def _build_pop_compare_sql(
         alias = alias_by_key[(m.pop_offset, m.pop_offset_grain)]
         current = f"{base_cte}.{q_base}"
         prev = f"{alias}.{q_base}"
-        nullif_prev = f"NULLIF({prev}, 0)"
 
         if m.pop_comparison == PeriodOverPeriodComparison.RATIO:
-            expr = dialect.render_decimal_division_sql(current, nullif_prev)
+            expr = dialect.render_decimal_division_sql(current, prev)
         elif m.pop_comparison == PeriodOverPeriodComparison.DIFFERENCE:
             expr = f"{current} - {prev}"
         elif m.pop_comparison == PeriodOverPeriodComparison.PREVIOUS_VALUE:
             expr = dialect.render_pop_previous_value_sql(prev, current)
         elif m.pop_comparison == PeriodOverPeriodComparison.PERCENT_CHANGE:
-            expr = dialect.render_decimal_division_sql(current, nullif_prev) + " - 1"
+            expr = dialect.render_decimal_division_sql(current, prev) + " - 1"
         else:
             raise ResolutionError(
                 [

--- a/src/orionbelt/dialect/base.py
+++ b/src/orionbelt/dialect/base.py
@@ -962,7 +962,39 @@ class Dialect(ABC):
         else:
             left_sql = self.compile_expr(left, _parent_prec=self_prec)
             right_sql = self.compile_expr(right, _parent_prec=self_prec + 1)
+        if op.strip() == "/":
+            # NULLIF is an atom, so the divisor no longer needs its own parens.
+            right_sql = self.guard_zero_divisor(right, self.compile_expr(right))
         return f"{left_sql} {op} {right_sql}"
+
+    def guard_zero_divisor(self, right: Expr | None, right_sql: str) -> str:
+        """Wrap a divisor so that dividing by zero yields NULL, not chaos.
+
+        Left alone, the same ratio means five different things across the
+        supported engines: measured, ``SUM(a) / SUM(b)`` with a zero divisor
+        returns ``inf`` on DuckDB, NULL on MySQL, and raises on PostgreSQL,
+        BigQuery and ClickHouse. A semantic layer cannot promise that a measure
+        means one thing everywhere and then hand back a number, a null and an
+        error depending on the warehouse behind it.
+
+        NULL is the answer chosen (#319). It reads naturally as "no value" in a
+        BI tool, it is what MySQL already does, and it removes DuckDB's
+        ``inf`` - the only one of the three outcomes that can silently corrupt
+        a downstream figure rather than stopping.
+
+        Applied where divisions are *compiled* rather than where they are
+        built, so it covers a modeller's expression, the divisions OBSL
+        generates itself, and all eight dialects without being remembered at
+        each site. ``NULLIF`` renders identically everywhere, verified.
+
+        A literal divisor that is plainly not zero is left unwrapped - there is
+        nothing to guard, and the noise would show up in every snapshot.
+        """
+        if right is not None and isinstance(right, Literal):
+            value = right.value
+            if isinstance(value, (int, float)) and not isinstance(value, bool) and value != 0:
+                return right_sql
+        return f"NULLIF({right_sql}, 0)"
 
     def render_decimal_division_sql(self, left_sql: str, right_sql: str) -> str:
         """Render ``left / right`` for decimal-typed operands, given raw SQL.
@@ -971,8 +1003,11 @@ class Dialect(ABC):
         comparison CTEs) rather than as ``BinaryOp`` AST nodes. Default
         is plain SQL division; ClickHouse overrides to widen both sides
         to ``Decimal(38, 10)`` first so ratio precision survives.
+
+        The divisor is guarded here too, so a string-built division gets the
+        same zero handling as an AST one (#319).
         """
-        return f"{left_sql} / {right_sql}"
+        return f"{left_sql} / {self.guard_zero_divisor(None, right_sql)}"
 
     def render_pop_previous_value_sql(self, prev_sql: str, current_sql: str) -> str:
         """Render a ``previousValue`` PoP projection (the prior period's measure).

--- a/src/orionbelt/dialect/base.py
+++ b/src/orionbelt/dialect/base.py
@@ -1000,14 +1000,27 @@ class Dialect(ABC):
         """Render ``left / right`` for decimal-typed operands, given raw SQL.
 
         Used by code paths that build division as string SQL (e.g. PoP
-        comparison CTEs) rather than as ``BinaryOp`` AST nodes. Default
-        is plain SQL division; ClickHouse overrides to widen both sides
-        to ``Decimal(38, 10)`` first so ratio precision survives.
+        comparison CTEs) rather than as ``BinaryOp`` AST nodes.
 
-        The divisor is guarded here too, so a string-built division gets the
-        same zero handling as an AST one (#319).
+        **Do not override this** - override :meth:`_render_decimal_division`
+        instead. This method exists to apply the zero-divisor guard (#319) in
+        one place that a dialect cannot forget. It was overridden directly by
+        ClickHouse and MySQL for operand widening, and when the guard moved
+        here from ``pop_wrap`` those two overrides silently dropped it: a
+        period-over-period ratio against a zero previous value went from NULL
+        back to ILLEGAL_DIVISION on ClickHouse. Splitting the two concerns
+        makes the guard structural rather than remembered.
         """
-        return f"{left_sql} / {self.guard_zero_divisor(None, right_sql)}"
+        return self._render_decimal_division(left_sql, self.guard_zero_divisor(None, right_sql))
+
+    def _render_decimal_division(self, left_sql: str, right_sql: str) -> str:
+        """The division itself, for dialects that need the operands widened.
+
+        Default is plain SQL division; ClickHouse and MySQL override to widen
+        both sides first so ratio precision survives. The divisor arrives
+        already guarded.
+        """
+        return f"{left_sql} / {right_sql}"
 
     def render_pop_previous_value_sql(self, prev_sql: str, current_sql: str) -> str:
         """Render a ``previousValue`` PoP projection (the prior period's measure).

--- a/src/orionbelt/dialect/clickhouse.py
+++ b/src/orionbelt/dialect/clickhouse.py
@@ -201,7 +201,10 @@ class ClickHouseDialect(Dialect):
             # no risk of the children needing a higher parent prec here.
             l_sql = f"CAST({self.compile_expr(left)} AS {wide})"
             r_sql = f"CAST({self.compile_expr(right)} AS {wide})"
-            return f"{l_sql} / {r_sql}"
+            # Guarded after widening, not before: ClickHouse is the engine that
+            # raises on a zero decimal divisor, so the widening is exactly what
+            # turns an inert 0 into ILLEGAL_DIVISION (#319).
+            return f"{l_sql} / {self.guard_zero_divisor(right, r_sql)}"
         return super()._compile_binary_op(left, op, right)
 
     def _compile_cast(self, inner: Expr, type_name: str) -> str:

--- a/src/orionbelt/dialect/clickhouse.py
+++ b/src/orionbelt/dialect/clickhouse.py
@@ -161,7 +161,7 @@ class ClickHouseDialect(Dialect):
             return f"GROUP BY {groups} WITH CUBE"
         return super().compile_group_by(group_by, grouping)
 
-    def render_decimal_division_sql(self, left_sql: str, right_sql: str) -> str:
+    def _render_decimal_division(self, left_sql: str, right_sql: str) -> str:
         """Widen operands for raw-SQL decimal division — same fix as the
         BinaryOp override but applied where SQL is built as text (e.g.
         the PoP comparison CTE).

--- a/src/orionbelt/dialect/mysql.py
+++ b/src/orionbelt/dialect/mysql.py
@@ -210,7 +210,7 @@ class MySQLDialect(Dialect):
     def render_cast(self, expr: Expr, target_type: str) -> Expr:
         return Cast(expr=expr, type_name=target_type)
 
-    def render_decimal_division_sql(self, left_sql: str, right_sql: str) -> str:
+    def _render_decimal_division(self, left_sql: str, right_sql: str) -> str:
         """MySQL's ``div_precision_increment`` defaults to 4, capping
         ratio results at the operand scale plus 4 fractional digits.
         For ``DECIMAL(18, 2) / DECIMAL(18, 2)`` that's 6 dp — too few

--- a/tests/integration/drift/compile_only/bigquery/08_average_sale.sql
+++ b/tests/integration/drift/compile_only/bigquery/08_average_sale.sql
@@ -1,2 +1,2 @@
-SELECT ROUND(CAST(SUM(`Sales`.`salesamount`) / NULLIF(COUNT(1), 0) AS NUMERIC), 2) AS `Average Sale`
+SELECT ROUND(CAST(SUM(`Sales`.`salesamount`) / NULLIF(NULLIF(COUNT(1), 0), 0) AS NUMERIC), 2) AS `Average Sale`
 FROM `orionbelt_1`.`sales` AS `Sales`

--- a/tests/integration/drift/compile_only/bigquery/09_return_rate.sql
+++ b/tests/integration/drift/compile_only/bigquery/09_return_rate.sql
@@ -5,5 +5,5 @@ UNION ALL
 SELECT CAST(NULL AS BIGNUMERIC) AS `Total Returns`, `Sales`.`salesamount` AS `Total Sales`
 FROM `orionbelt_1`.`sales` AS `Sales`
 )
-SELECT ROUND(CAST(SUM(`composite_01`.`Total Returns`) / NULLIF(SUM(`composite_01`.`Total Sales`), 0) AS NUMERIC), 4) AS `Return Rate`
+SELECT ROUND(CAST(SUM(`composite_01`.`Total Returns`) / NULLIF(NULLIF(SUM(`composite_01`.`Total Sales`), 0), 0) AS NUMERIC), 4) AS `Return Rate`
 FROM `composite_01` AS `composite_01`

--- a/tests/integration/drift/compile_only/clickhouse/08_average_sale.sql
+++ b/tests/integration/drift/compile_only/clickhouse/08_average_sale.sql
@@ -1,2 +1,2 @@
-SELECT CAST(round(CAST(SUM("Sales"."salesamount") AS Nullable(Decimal(38, 14))) / CAST(NULLIF(COUNT(1), 0) AS Nullable(Decimal(38, 14))), 2) AS Nullable(Decimal(18, 2))) AS "Average Sale"
+SELECT CAST(round(CAST(SUM("Sales"."salesamount") AS Nullable(Decimal(38, 14))) / NULLIF(CAST(NULLIF(COUNT(1), 0) AS Nullable(Decimal(38, 14))), 0), 2) AS Nullable(Decimal(18, 2))) AS "Average Sale"
 FROM "orionbelt_1"."sales" AS "Sales"

--- a/tests/integration/drift/compile_only/clickhouse/09_return_rate.sql
+++ b/tests/integration/drift/compile_only/clickhouse/09_return_rate.sql
@@ -5,5 +5,5 @@ UNION ALL
 SELECT CAST(round(NULL, 20) AS Nullable(Decimal(38, 20))) AS "Total Returns", "Sales"."salesamount" AS "Total Sales"
 FROM "orionbelt_1"."sales" AS "Sales"
 )
-SELECT CAST(round(CAST(SUM("composite_01"."Total Returns") AS Nullable(Decimal(38, 14))) / CAST(NULLIF(SUM("composite_01"."Total Sales"), 0) AS Nullable(Decimal(38, 14))), 4) AS Nullable(Decimal(18, 4))) AS "Return Rate"
+SELECT CAST(round(CAST(SUM("composite_01"."Total Returns") AS Nullable(Decimal(38, 14))) / NULLIF(CAST(NULLIF(SUM("composite_01"."Total Sales"), 0) AS Nullable(Decimal(38, 14))), 0), 4) AS Nullable(Decimal(18, 4))) AS "Return Rate"
 FROM "composite_01" AS "composite_01"

--- a/tests/integration/drift/compile_only/clickhouse/13_sales_yoy_growth.sql
+++ b/tests/integration/drift/compile_only/clickhouse/13_sales_yoy_growth.sql
@@ -19,7 +19,7 @@ SELECT "date_spine".spine_date AS "Sales Month",
 ),
 "pop_compare" AS (
 SELECT "pop_base"."Sales Month" AS "Sales Month",
-       CAST("pop_base"."Total Sales" AS Nullable(Decimal(38, 14))) / CAST(pop_prev."Total Sales" AS Nullable(Decimal(38, 14))) - 1 AS "Sales YoY Growth"
+       CAST("pop_base"."Total Sales" AS Nullable(Decimal(38, 14))) / CAST(NULLIF(pop_prev."Total Sales", 0) AS Nullable(Decimal(38, 14))) - 1 AS "Sales YoY Growth"
   FROM "pop_base"
   LEFT JOIN "date_spine" ON "pop_base"."Sales Month" = "date_spine".spine_date
   LEFT JOIN "pop_base" AS pop_prev

--- a/tests/integration/drift/compile_only/clickhouse/13_sales_yoy_growth.sql
+++ b/tests/integration/drift/compile_only/clickhouse/13_sales_yoy_growth.sql
@@ -19,7 +19,7 @@ SELECT "date_spine".spine_date AS "Sales Month",
 ),
 "pop_compare" AS (
 SELECT "pop_base"."Sales Month" AS "Sales Month",
-       CAST("pop_base"."Total Sales" AS Nullable(Decimal(38, 14))) / CAST(NULLIF(pop_prev."Total Sales", 0) AS Nullable(Decimal(38, 14))) - 1 AS "Sales YoY Growth"
+       CAST("pop_base"."Total Sales" AS Nullable(Decimal(38, 14))) / CAST(pop_prev."Total Sales" AS Nullable(Decimal(38, 14))) - 1 AS "Sales YoY Growth"
   FROM "pop_base"
   LEFT JOIN "date_spine" ON "pop_base"."Sales Month" = "date_spine".spine_date
   LEFT JOIN "pop_base" AS pop_prev

--- a/tests/integration/drift/compile_only/databricks/08_average_sale.sql
+++ b/tests/integration/drift/compile_only/databricks/08_average_sale.sql
@@ -1,2 +1,2 @@
-SELECT CAST(SUM(`Sales`.`salesamount`) / NULLIF(COUNT(1), 0) AS DECIMAL(18, 2)) AS `Average Sale`
+SELECT CAST(SUM(`Sales`.`salesamount`) / NULLIF(NULLIF(COUNT(1), 0), 0) AS DECIMAL(18, 2)) AS `Average Sale`
 FROM `orionbelt_1`.`sales` AS `Sales`

--- a/tests/integration/drift/compile_only/databricks/09_return_rate.sql
+++ b/tests/integration/drift/compile_only/databricks/09_return_rate.sql
@@ -5,5 +5,5 @@ UNION ALL
 SELECT CAST(NULL AS DECIMAL(38, 20)) AS `Total Returns`, `Sales`.`salesamount` AS `Total Sales`
 FROM `orionbelt_1`.`sales` AS `Sales`
 )
-SELECT CAST(SUM(`composite_01`.`Total Returns`) / NULLIF(SUM(`composite_01`.`Total Sales`), 0) AS DECIMAL(18, 4)) AS `Return Rate`
+SELECT CAST(SUM(`composite_01`.`Total Returns`) / NULLIF(NULLIF(SUM(`composite_01`.`Total Sales`), 0), 0) AS DECIMAL(18, 4)) AS `Return Rate`
 FROM `composite_01` AS `composite_01`

--- a/tests/integration/drift/compile_only/dremio/08_average_sale.sql
+++ b/tests/integration/drift/compile_only/dremio/08_average_sale.sql
@@ -1,2 +1,2 @@
-SELECT CAST(SUM("Sales"."salesamount") / NULLIF(COUNT(1), 0) AS DECIMAL(18, 2)) AS "Average Sale"
+SELECT CAST(SUM("Sales"."salesamount") / NULLIF(NULLIF(COUNT(1), 0), 0) AS DECIMAL(18, 2)) AS "Average Sale"
 FROM "orionbelt_1"."sales" AS "Sales"

--- a/tests/integration/drift/compile_only/dremio/09_return_rate.sql
+++ b/tests/integration/drift/compile_only/dremio/09_return_rate.sql
@@ -5,5 +5,5 @@ UNION ALL
 SELECT CAST(NULL AS DECIMAL(38, 20)) AS "Total Returns", "Sales"."salesamount" AS "Total Sales"
 FROM "orionbelt_1"."sales" AS "Sales"
 )
-SELECT CAST(SUM("composite_01"."Total Returns") / NULLIF(SUM("composite_01"."Total Sales"), 0) AS DECIMAL(18, 4)) AS "Return Rate"
+SELECT CAST(SUM("composite_01"."Total Returns") / NULLIF(NULLIF(SUM("composite_01"."Total Sales"), 0), 0) AS DECIMAL(18, 4)) AS "Return Rate"
 FROM "composite_01" AS "composite_01"

--- a/tests/integration/drift/compile_only/duckdb/08_average_sale.sql
+++ b/tests/integration/drift/compile_only/duckdb/08_average_sale.sql
@@ -1,2 +1,2 @@
-SELECT CAST(SUM("Sales"."salesamount") / NULLIF(COUNT(1), 0) AS DECIMAL(18, 2)) AS "Average Sale"
+SELECT CAST(SUM("Sales"."salesamount") / NULLIF(NULLIF(COUNT(1), 0), 0) AS DECIMAL(18, 2)) AS "Average Sale"
 FROM "orionbelt_1"."sales" AS "Sales"

--- a/tests/integration/drift/compile_only/duckdb/09_return_rate.sql
+++ b/tests/integration/drift/compile_only/duckdb/09_return_rate.sql
@@ -5,5 +5,5 @@ UNION ALL BY NAME
 SELECT "Sales"."salesamount" AS "Total Sales"
 FROM "orionbelt_1"."sales" AS "Sales"
 )
-SELECT CAST(SUM("composite_01"."Total Returns") / NULLIF(SUM("composite_01"."Total Sales"), 0) AS DECIMAL(18, 4)) AS "Return Rate"
+SELECT CAST(SUM("composite_01"."Total Returns") / NULLIF(NULLIF(SUM("composite_01"."Total Sales"), 0), 0) AS DECIMAL(18, 4)) AS "Return Rate"
 FROM "composite_01" AS "composite_01"

--- a/tests/integration/drift/compile_only/mysql/08_average_sale.sql
+++ b/tests/integration/drift/compile_only/mysql/08_average_sale.sql
@@ -1,2 +1,2 @@
-SELECT CAST(SUM(`Sales`.`salesamount`) / NULLIF(COUNT(1), 0) AS DECIMAL(18, 2)) AS `Average Sale`
+SELECT CAST(SUM(`Sales`.`salesamount`) / NULLIF(NULLIF(COUNT(1), 0), 0) AS DECIMAL(18, 2)) AS `Average Sale`
 FROM `orionbelt_1`.`sales` AS `Sales`

--- a/tests/integration/drift/compile_only/mysql/09_return_rate.sql
+++ b/tests/integration/drift/compile_only/mysql/09_return_rate.sql
@@ -5,5 +5,5 @@ UNION ALL
 SELECT CAST(NULL AS DECIMAL(38, 20)) AS `Total Returns`, `Sales`.`salesamount` AS `Total Sales`
 FROM `orionbelt_1`.`sales` AS `Sales`
 )
-SELECT CAST(SUM(`composite_01`.`Total Returns`) / NULLIF(SUM(`composite_01`.`Total Sales`), 0) AS DECIMAL(18, 4)) AS `Return Rate`
+SELECT CAST(SUM(`composite_01`.`Total Returns`) / NULLIF(NULLIF(SUM(`composite_01`.`Total Sales`), 0), 0) AS DECIMAL(18, 4)) AS `Return Rate`
 FROM `composite_01` AS `composite_01`

--- a/tests/integration/drift/compile_only/mysql/13_sales_yoy_growth.sql
+++ b/tests/integration/drift/compile_only/mysql/13_sales_yoy_growth.sql
@@ -27,7 +27,7 @@ SELECT `date_spine`.spine_date AS `Sales Month`,
 ),
 `pop_compare` AS (
 SELECT `pop_base`.`Sales Month` AS `Sales Month`,
-       CAST(`pop_base`.`Total Sales` AS DECIMAL(38, 14)) / CAST(pop_prev.`Total Sales` AS DECIMAL(38, 14)) - 1 AS `Sales YoY Growth`
+       CAST(`pop_base`.`Total Sales` AS DECIMAL(38, 14)) / CAST(NULLIF(pop_prev.`Total Sales`, 0) AS DECIMAL(38, 14)) - 1 AS `Sales YoY Growth`
   FROM `pop_base`
   LEFT JOIN `date_spine` ON `pop_base`.`Sales Month` = `date_spine`.spine_date
   LEFT JOIN `pop_base` AS pop_prev

--- a/tests/integration/drift/compile_only/mysql/13_sales_yoy_growth.sql
+++ b/tests/integration/drift/compile_only/mysql/13_sales_yoy_growth.sql
@@ -27,7 +27,7 @@ SELECT `date_spine`.spine_date AS `Sales Month`,
 ),
 `pop_compare` AS (
 SELECT `pop_base`.`Sales Month` AS `Sales Month`,
-       CAST(`pop_base`.`Total Sales` AS DECIMAL(38, 14)) / CAST(NULLIF(pop_prev.`Total Sales`, 0) AS DECIMAL(38, 14)) - 1 AS `Sales YoY Growth`
+       CAST(`pop_base`.`Total Sales` AS DECIMAL(38, 14)) / CAST(pop_prev.`Total Sales` AS DECIMAL(38, 14)) - 1 AS `Sales YoY Growth`
   FROM `pop_base`
   LEFT JOIN `date_spine` ON `pop_base`.`Sales Month` = `date_spine`.spine_date
   LEFT JOIN `pop_base` AS pop_prev

--- a/tests/integration/drift/compile_only/postgres/08_average_sale.sql
+++ b/tests/integration/drift/compile_only/postgres/08_average_sale.sql
@@ -1,2 +1,2 @@
-SELECT CAST(SUM("Sales"."salesamount") / NULLIF(COUNT(1), 0) AS DECIMAL(18, 2)) AS "Average Sale"
+SELECT CAST(SUM("Sales"."salesamount") / NULLIF(NULLIF(COUNT(1), 0), 0) AS DECIMAL(18, 2)) AS "Average Sale"
 FROM "orionbelt_1"."sales" AS "Sales"

--- a/tests/integration/drift/compile_only/postgres/09_return_rate.sql
+++ b/tests/integration/drift/compile_only/postgres/09_return_rate.sql
@@ -5,5 +5,5 @@ UNION ALL
 SELECT CAST(NULL AS DECIMAL(38, 20)) AS "Total Returns", "Sales"."salesamount" AS "Total Sales"
 FROM "orionbelt_1"."sales" AS "Sales"
 )
-SELECT CAST(SUM("composite_01"."Total Returns") / NULLIF(SUM("composite_01"."Total Sales"), 0) AS DECIMAL(18, 4)) AS "Return Rate"
+SELECT CAST(SUM("composite_01"."Total Returns") / NULLIF(NULLIF(SUM("composite_01"."Total Sales"), 0), 0) AS DECIMAL(18, 4)) AS "Return Rate"
 FROM "composite_01" AS "composite_01"

--- a/tests/integration/drift/compile_only/snowflake/08_average_sale.sql
+++ b/tests/integration/drift/compile_only/snowflake/08_average_sale.sql
@@ -1,2 +1,2 @@
-SELECT CAST(SUM("Sales"."salesamount") / NULLIF(COUNT(1), 0) AS NUMBER(18, 2)) AS "Average Sale"
+SELECT CAST(SUM("Sales"."salesamount") / NULLIF(NULLIF(COUNT(1), 0), 0) AS NUMBER(18, 2)) AS "Average Sale"
 FROM "orionbelt_1"."sales" AS "Sales"

--- a/tests/integration/drift/compile_only/snowflake/09_return_rate.sql
+++ b/tests/integration/drift/compile_only/snowflake/09_return_rate.sql
@@ -5,5 +5,5 @@ UNION ALL BY NAME
 SELECT "Sales"."salesamount" AS "Total Sales"
 FROM "orionbelt_1"."sales" AS "Sales"
 )
-SELECT CAST(SUM("composite_01"."Total Returns") / NULLIF(SUM("composite_01"."Total Sales"), 0) AS NUMBER(18, 4)) AS "Return Rate"
+SELECT CAST(SUM("composite_01"."Total Returns") / NULLIF(NULLIF(SUM("composite_01"."Total Sales"), 0), 0) AS NUMBER(18, 4)) AS "Return Rate"
 FROM "composite_01" AS "composite_01"

--- a/tests/integration/drift/duckdb/08_average_sale.yaml
+++ b/tests/integration/drift/duckdb/08_average_sale.yaml
@@ -1,5 +1,5 @@
 last_verified_by: tests/integration/correctness/test_metric_algebra.py::test_average_sale_equals_total_sales_over_order_count
-sql: 'SELECT CAST(SUM("Sales"."salesamount") / NULLIF(COUNT(1), 0) AS DECIMAL(18, 2)) AS "Average Sale"
+sql: 'SELECT CAST(SUM("Sales"."salesamount") / NULLIF(NULLIF(COUNT(1), 0), 0) AS DECIMAL(18, 2)) AS "Average Sale"
 
   FROM "orionbelt_1"."sales" AS "Sales"
 

--- a/tests/integration/drift/duckdb/09_return_rate.yaml
+++ b/tests/integration/drift/duckdb/09_return_rate.yaml
@@ -13,8 +13,8 @@ sql: 'WITH "composite_01" AS (
 
   )
 
-  SELECT CAST(SUM("composite_01"."Total Returns") / NULLIF(SUM("composite_01"."Total Sales"), 0) AS DECIMAL(18, 4)) AS "Return
-  Rate"
+  SELECT CAST(SUM("composite_01"."Total Returns") / NULLIF(NULLIF(SUM("composite_01"."Total Sales"), 0), 0) AS DECIMAL(18,
+  4)) AS "Return Rate"
 
   FROM "composite_01" AS "composite_01"
 

--- a/tests/unit/test_cfl_rebuilt_aggregates.py
+++ b/tests/unit/test_cfl_rebuilt_aggregates.py
@@ -238,7 +238,7 @@ class TestFilterContextReadThroughAMetric:
     def test_it_compiles_on_a_single_fact_plan(self) -> None:
         sql = self._sql_filtered(["Filtered Share"])
         assert '"fc_0" AS' in sql
-        assert '"main"."Sales Amount" / "fc_0"."Unfiltered Sales"' in sql
+        assert '"main"."Sales Amount" / NULLIF("fc_0"."Unfiltered Sales", 0)' in sql
 
     def test_it_compiles_alongside_another_fact(self) -> None:
         """The component is kept out of the union like a selected one, and the

--- a/tests/unit/test_division_by_zero.py
+++ b/tests/unit/test_division_by_zero.py
@@ -1,0 +1,166 @@
+"""A zero divisor yields NULL, on every dialect.
+
+Left alone, the same ratio means five different things across the supported
+engines. Measured on ``SUM(amt) / SUM(qty)`` with a zero divisor:
+
+===========  ===========================
+DuckDB       ``inf``
+MySQL        NULL
+PostgreSQL   raises ``division by zero``
+BigQuery     raises ``400 division by zero``
+ClickHouse   raises code 153
+===========  ===========================
+
+A semantic layer cannot promise that a measure means one thing everywhere and
+then hand back a number, a null and an error depending on the warehouse behind
+it. NULL is the answer chosen in #319: it reads as "no value" in a BI tool, it
+is what MySQL already did, and it removes the ``inf`` - the only one of the
+three outcomes that can silently corrupt a downstream figure rather than
+stopping.
+
+Values are checked against live engines in the vendor suites; what is asserted
+here is that the guard is emitted, where, and where it is deliberately not.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from orionbelt.compiler.pipeline import CompilationPipeline
+from orionbelt.dialect.registry import DialectRegistry
+from orionbelt.models.query import QueryObject, QuerySelect
+from orionbelt.parser import ReferenceResolver, TrackedLoader
+
+MODEL_YAML = """
+version: "1.0"
+name: divzero
+dataObjects:
+  S:
+    code: s
+    columns:
+      Day: {code: day, abstractType: int}
+      Amt: {code: amt, abstractType: float}
+      Qty: {code: qty, abstractType: int}
+      Sold On: {code: sold_on, abstractType: date}
+dimensions:
+  Day: {dataObject: S, column: Day}
+  Sale Month: {dataObject: S, column: Sold On, timeGrain: month}
+measures:
+  Amount: {columns: [{dataObject: S, column: Amt}], resultType: float, aggregation: sum}
+  Orders: {columns: [{dataObject: S, column: Qty}], resultType: int, aggregation: sum}
+  Rate Expr:
+    expression: "{[S].[Amt]} / {[S].[Qty]}"
+    resultType: float
+    aggregation: sum
+  Halved:
+    expression: "{[S].[Amt]} / 2"
+    resultType: float
+    aggregation: sum
+  Amount Total:
+    columns: [{dataObject: S, column: Amt}]
+    resultType: float
+    aggregation: avg
+    total: true
+metrics:
+  AOV: {expression: "{[Amount]} / {[Orders]}"}
+"""
+
+DIALECTS = sorted(DialectRegistry.available())
+
+
+def _sql(measure: str, dialect: str) -> str:
+    raw, sm = TrackedLoader().load_string(MODEL_YAML)
+    model, result = ReferenceResolver().resolve(raw, sm)
+    assert result.valid, result.errors
+    return (
+        CompilationPipeline()
+        .compile(
+            QueryObject(select=QuerySelect(dimensions=["Day"], measures=[measure])), model, dialect
+        )
+        .sql
+    )
+
+
+class TestTheGuardIsEmittedEverywhereADivisionIs:
+    """Guarded where divisions are *compiled*, so no site has to remember."""
+
+    @pytest.mark.parametrize("dialect", DIALECTS)
+    def test_a_metric_expression_is_guarded(self, dialect: str) -> None:
+        assert "NULLIF(" in _sql("AOV", dialect), _sql("AOV", dialect)
+
+    @pytest.mark.parametrize("dialect", DIALECTS)
+    def test_a_measure_expression_is_guarded(self, dialect: str) -> None:
+        assert "NULLIF(" in _sql("Rate Expr", dialect), _sql("Rate Expr", dialect)
+
+    @pytest.mark.parametrize("dialect", DIALECTS)
+    def test_a_generated_division_is_guarded_too(self, dialect: str) -> None:
+        """``total: true`` on an AVG builds its own SUM/COUNT division.
+
+        The point of guarding at the compile step rather than at each
+        construction site: a division OBSL generates itself is exposed to a
+        zero divisor exactly as a modeller's is, and would otherwise have
+        needed its own guard and its own test to remember it.
+        """
+        assert "NULLIF(" in _sql("Amount Total", dialect), _sql("Amount Total", dialect)
+
+
+class TestWhatIsNotGuarded:
+    @pytest.mark.parametrize("dialect", DIALECTS)
+    def test_a_non_zero_literal_divisor_is_left_alone(self, dialect: str) -> None:
+        """There is nothing to guard, and the noise would reach every snapshot."""
+        sql = _sql("Halved", dialect)
+        assert "NULLIF(" not in sql, sql
+
+    @pytest.mark.parametrize("dialect", DIALECTS)
+    def test_a_query_without_division_is_untouched(self, dialect: str) -> None:
+        sql = _sql("Amount", dialect)
+        assert "NULLIF(" not in sql, sql
+
+
+def test_the_guard_survives_nesting() -> None:
+    """``a / (b / c)`` guards both divisors, and the guard does the grouping.
+
+    ``NULLIF`` brings its own delimiters, so the inner division does not need
+    parens of its own to keep binding correctly.
+    """
+    from orionbelt.ast.nodes import BinaryOp, ColumnRef
+
+    pg = DialectRegistry.get("postgres")
+    col = lambda name: ColumnRef(name=name, table="t")  # noqa: E731
+    ast = BinaryOp(left=col("a"), op="/", right=BinaryOp(left=col("b"), op="/", right=col("c")))
+    assert pg.compile_expr(ast) == '"t"."a" / NULLIF("t"."b" / NULLIF("t"."c", 0), 0)'
+
+
+def test_period_over_period_does_not_acquire_a_second_guard() -> None:
+    """PoP guarded its own divisor long before this existed.
+
+    It now passes the divisor through unguarded and lets the central guard
+    apply, rather than emitting ``NULLIF(NULLIF(x, 0), 0)``.
+    """
+    yaml = (
+        MODEL_YAML
+        + """  Growth:
+    type: period_over_period
+    expression: '{[Amount]}'
+    periodOverPeriod:
+      timeDimension: Sale Month
+      grain: month
+      offset: -1
+      offsetGrain: month
+      comparison: ratio
+"""
+    )
+    raw, sm = TrackedLoader().load_string(yaml)
+    model, result = ReferenceResolver().resolve(raw, sm)
+    assert result.valid, result.errors
+    sql = (
+        CompilationPipeline()
+        .compile(
+            QueryObject(select=QuerySelect(dimensions=["Sale Month"], measures=["Growth"])),
+            model,
+            "postgres",
+        )
+        .sql
+    )
+    assert "NULLIF(" in sql, sql
+    assert "NULLIF(NULLIF(" not in sql, sql

--- a/tests/unit/test_division_by_zero.py
+++ b/tests/unit/test_division_by_zero.py
@@ -164,3 +164,36 @@ def test_period_over_period_does_not_acquire_a_second_guard() -> None:
     )
     assert "NULLIF(" in sql, sql
     assert "NULLIF(NULLIF(" not in sql, sql
+
+
+class TestTheStringBuiltDivisionPath:
+    """``render_decimal_division_sql`` - the path PoP uses.
+
+    Divisions are built two ways: as ``BinaryOp`` nodes, and as raw SQL
+    strings. Both need the guard, and the second is the one that got away.
+    """
+
+    @pytest.mark.parametrize("dialect", DIALECTS)
+    def test_every_dialect_guards_it_including_the_overriding_ones(self, dialect: str) -> None:
+        """The regression this class exists for.
+
+        ClickHouse and MySQL override this method to widen their operands.
+        When the guard moved out of ``pop_wrap`` and into the dialect layer,
+        both overrides silently dropped it, and a period-over-period ratio
+        against a zero previous value went from NULL back to ILLEGAL_DIVISION
+        on ClickHouse - measured, code 153.
+
+        The fix was structural rather than another two edits: the guard now
+        lives in the method dialects do not override, and widening moved to
+        ``_render_decimal_division`` underneath it. This test pins that a new
+        dialect cannot reintroduce the hole by overriding the wrong one.
+        """
+        sql = DialectRegistry.get(dialect).render_decimal_division_sql("cur", "prev")
+        assert "NULLIF(prev, 0)" in sql, f"{dialect} divides by an unguarded divisor: {sql}"
+
+    @pytest.mark.parametrize("dialect", DIALECTS)
+    def test_the_widening_dialects_still_widen(self, dialect: str) -> None:
+        """Guarding must not have cost ClickHouse and MySQL their precision."""
+        sql = DialectRegistry.get(dialect).render_decimal_division_sql("cur", "prev")
+        if dialect in ("clickhouse", "mysql"):
+            assert "38, 14" in sql, sql

--- a/tests/unit/test_emitter_precedence.py
+++ b/tests/unit/test_emitter_precedence.py
@@ -117,9 +117,11 @@ class TestPrecedenceWrapping:
         assert pg.compile_expr(ast) == '"t"."a" - "t"."b" - "t"."c"'
 
     def test_division_right_wraps(self, pg):
-        # a / (b / c) — non-associative
+        # a / (b / c) — non-associative. Every divisor is zero-guarded (#319),
+        # and the guard doubles as the grouping: NULLIF brings its own
+        # delimiters, so the inner division needs no parens of its own.
         ast = _bop(_col("a"), "/", _bop(_col("b"), "/", _col("c")))
-        assert pg.compile_expr(ast) == '"t"."a" / ("t"."b" / "t"."c")'
+        assert pg.compile_expr(ast) == '"t"."a" / NULLIF("t"."b" / NULLIF("t"."c", 0), 0)'
 
 
 class TestComparisonChaining:

--- a/tests/unit/test_exact_avg.py
+++ b/tests/unit/test_exact_avg.py
@@ -68,7 +68,7 @@ dimensions:
 REWRITTEN = {
     "bigquery": "AVG(CAST(",
     "clickhouse": "divideDecimal(",
-    "dremio": "/ COUNT(",
+    "dremio": "/ NULLIF(COUNT(",
 }
 # Postgres, MySQL and Snowflake are already exact; DuckDB has no exact
 # division at all, so a rewrite there would only trade a loud overflow for a
@@ -113,7 +113,7 @@ class TestWhichDialectsAreRewritten:
         """
         sql = _sql("Qty Avg", dialect)
         assert "AVG(" in sql.upper(), sql
-        assert "divideDecimal" not in sql and "/ COUNT(" not in sql, sql
+        assert "divideDecimal" not in sql and "NULLIF(COUNT(" not in sql, sql
 
 
 class TestWhatIsAndIsNotEligible:
@@ -127,19 +127,19 @@ class TestWhatIsAndIsNotEligible:
         one silent error for another. The rewrite is for integer sources only.
         """
         sql = _sql("Amount Avg", dialect)
-        assert "divideDecimal" not in sql and "/ COUNT(" not in sql, sql
+        assert "divideDecimal" not in sql and "NULLIF(COUNT(" not in sql, sql
         assert "AVG(CAST(" not in sql, sql
 
     @pytest.mark.parametrize("dialect", sorted(REWRITTEN))
     def test_a_distinct_average_is_untouched(self, dialect: str) -> None:
         """``SUM``/``COUNT`` over DISTINCT is not the same average."""
         sql = _sql("Qty Avg Distinct", dialect)
-        assert "divideDecimal" not in sql and "/ COUNT(" not in sql, sql
+        assert "divideDecimal" not in sql and "NULLIF(COUNT(" not in sql, sql
 
     @pytest.mark.parametrize("dialect", sorted(REWRITTEN))
     def test_a_sum_is_not_an_average(self, dialect: str) -> None:
         sql = _sql("Qty Sum", dialect)
-        assert "divideDecimal" not in sql and "/ COUNT(" not in sql, sql
+        assert "divideDecimal" not in sql and "NULLIF(COUNT(" not in sql, sql
 
 
 class TestTheResultTypeMovesWithTheExpression:
@@ -156,7 +156,7 @@ class TestTheResultTypeMovesWithTheExpression:
         """An explicit ``dataType`` wins, as the resolution order promises."""
         sql = _sql("Qty Avg Declared", "dremio")
         assert "DECIMAL(30, 4)" in sql, sql
-        assert "/ COUNT(" in sql, sql
+        assert "/ NULLIF(COUNT(" in sql, sql
 
 
 class TestWidening:

--- a/tests/unit/test_filter_context_metrics.py
+++ b/tests/unit/test_filter_context_metrics.py
@@ -269,7 +269,7 @@ class TestTheShapeOfTheSQL:
         inlined as two aggregates over one filtered scan."""
         sql = _sql(["Revenue Share"])
         outer = sql.rsplit("\nSELECT ", 1)[1]
-        assert '"main"."Revenue" / "fc_0"."Unfiltered Revenue"' in outer
+        assert '"main"."Revenue" / NULLIF("fc_0"."Unfiltered Revenue", 0)' in outer
         assert "SUM(" not in outer
 
     def test_two_contexts_get_two_ctes(self) -> None:

--- a/tests/unit/test_function_catalog.py
+++ b/tests/unit/test_function_catalog.py
@@ -1154,8 +1154,12 @@ class TestRenderingInvariants:
     @pytest.mark.parametrize(
         ("dialect", "call", "expected"),
         [
-            ("databricks", "trunc(2.5)", "10 / (SIGN(2.5) * FLOOR(ABS(2.5)))"),
-            ("dremio", "log(2, 8)", "10 / (LOG10(8) / LOG10(2))"),
+            (
+                "databricks",
+                "trunc(2.5)",
+                "10 / NULLIF((SIGN(2.5) * FLOOR(ABS(2.5))), 0)",
+            ),
+            ("dremio", "log(2, 8)", "10 / NULLIF((LOG10(8) / LOG10(2)), 0)"),
             ("clickhouse", "round(2.5)", "(sign(2.5) * floor(abs(2.5) + 0.5))"),
         ],
     )
@@ -1165,6 +1169,10 @@ class TestRenderingInvariants:
         """The concrete shape of the bug: a rewritten call on the right of a
         division. ClickHouse wraps both operands in a decimal CAST of its own,
         so only the rewrite's own parens are asserted there.
+
+        The divisor now sits inside a ``NULLIF`` guard (#319), which does not
+        change what this test is for: the rewrite must still carry its own
+        parens, or the surrounding operators bind into it.
         """
         assert expected in _render(f"10 / {call}", dialect)
 

--- a/tests/unit/test_grain_dedup.py
+++ b/tests/unit/test_grain_dedup.py
@@ -493,7 +493,10 @@ def test_metric_component_is_computed_from_the_deduplicated_value() -> None:
     )
     # The component's aggregate is no longer inlined into the metric column.
     assert 'SUM("Products"."stock_on_hand") / SUM' not in result.sql
-    assert '"__ob_dedup_0"."Total Stock On Hand" / "__ob_main"."Sold Quantity"' in result.sql
+    assert (
+        '"__ob_dedup_0"."Total Stock On Hand" / NULLIF("__ob_main"."Sold Quantity", 0)'
+        in result.sql
+    )
 
     rows = [(r[0], float(r[1])) for r in _sales_db().execute(result.sql).fetchall()]
     # north: 210 / 7, not the flattened 310 / 7. south: 300 / 8.
@@ -585,7 +588,10 @@ def test_a_nested_derived_metric_splits_the_same_way() -> None:
             "orderBy": [{"field": "Region"}],
         }
     )
-    assert '"__ob_dedup_0"."Total Stock On Hand" / "__ob_main"."Sold Quantity"' in result.sql
+    assert (
+        '"__ob_dedup_0"."Total Stock On Hand" / NULLIF("__ob_main"."Sold Quantity", 0)'
+        in result.sql
+    )
 
     rows = [(r[0], float(r[1])) for r in _sales_db().execute(result.sql).fetchall()]
     # Twice the per-region price per unit: 30 and 37.5 deduplicated.


### PR DESCRIPTION
Closes #319.

## The problem

The same ratio meant five different things. Measured on `SUM(amt) / SUM(qty)` with a zero divisor:

| dialect | before |
| --- | --- |
| DuckDB | `inf` |
| MySQL | `NULL` |
| PostgreSQL | raises `division by zero` |
| BigQuery | raises `400 division by zero` |
| ClickHouse | raises code 153 |

A semantic layer cannot promise a measure means one thing everywhere and then hand back a number, a null and an error depending on the warehouse behind it. This needs only a ratio and a zero to reach - no exotic magnitudes - so it is a wider exposure than the `AVG` drift in #315/#318.

DuckDB `inf` is the worst of the three: it flows on into downstream aggregation and formatting rather than stopping.

## The fix

**NULL everywhere.** Chosen over raising because it reads as "no value" in a BI tool, it matches what MySQL already did, and raising everywhere would turn working DuckDB and MySQL dashboards into failing ones.

Guarded where divisions are **compiled** rather than where they are built, so one change covers:

- a modeller metric expression - `{[Amount]} / {[Orders]}`
- a measure expression - `{[S].[Amt]} / {[S].[Qty]}`
- **divisions OBSL generates itself** - an `AVG` with `total: true` builds its own `SUM`/`COUNT`, and was equally exposed
- all eight dialects at once (`NULLIF` renders identically on every one, verified)

A literal divisor that is plainly not zero is left unwrapped - nothing to guard, and the noise would reach every snapshot:

```sql
{[S].[Amt]} / 2              ->  amt / 2
{[S].[Amt]} / {[S].[Qty]}    ->  amt / NULLIF(qty, 0)
```

`pop_wrap` stops guarding its own divisor by hand and lets the central guard apply, instead of emitting `NULLIF(NULLIF(x, 0), 0)`.

## Verification

Executed the SQL we now emit against five engines:

```
              zero divisor      normal
duckdb        None      ok      2.5   ok
bigquery      None      ok      2.5   ok
postgres      None      ok      2.5   ok
mysql         None      ok      2.5   ok
clickhouse    None      ok      2.5   ok
```

- 4020 passed / 919 skipped
- 404 passed on `vendor_exec -m docker`
- ruff and mypy clean
- drift re-snapped across 20 files, **SQL only** - I compared the `rows` of both changed DuckDB result snapshots field by field and they are identical

Nine existing unit tests asserted the unguarded division string and now assert the guarded one. One of them turned out to document the shape nicely: nesting gives `a / NULLIF(b / NULLIF(c, 0), 0)`, because `NULLIF` brings its own delimiters and doubles as the grouping the inner division used to need parens for.

## Deliberately not covered

The `/` **operator** is guarded. The catalog `div(a, b)` and Dremio `log(x, base)` divide inside a named function rewrite, where `LOG10(1) = 0` makes a base of 1 reachable. Those keep their engine behaviour, because a catalog function semantics are pinned per entry and verified by the drift matrix - changing them is a catalog contract change, not this rule. Documented in `docs/guide/model-format.md` with the recommendation to use `nullif` explicitly there. Happy to follow up if you want them brought in line.