### PR TITLE
fix(obml): div and log yield NULL outside their domain, on every dialect

### DIFF
--- a/docs/guide/model-format.md
+++ b/docs/guide/model-format.md
@@ -1263,13 +1263,20 @@ Rate:
   expression: "{[S].[Amt]} / {[S].[Qty]}"   # emits  amt / NULLIF(qty, 0)
 ```
 
-!!! note "Named division functions are not covered"
+!!! note "Named division functions follow the same rule"
 
-    This applies to the `/` operator. The catalog's `div(a, b)` function and
-    `log(x, base)` (which divides by `LOG10(base)`, zero when the base is 1)
-    keep whatever their engine does, because a catalog function's semantics are
-    pinned per entry rather than by this rule. Guard those with `nullif`
-    explicitly if a zero or a base of 1 is reachable in your data.
+    The two catalog functions that divide internally are covered too, each by
+    its own entry rather than by this one:
+
+    - `div(a, b)` yields NULL when `b` is zero.
+    - `log(base, x)` yields NULL outside its domain: a base of 0 or 1, or a
+      value of 0 or less. A base of 1 is the subtle case, since `LOG10(1)` is
+      zero and two dialects rewrite the call as `log10(x) / log10(base)`.
+
+    They needed pinning for the same reason the operator did. Measured, `div(7,
+    0)` returned NULL on two engines and raised on four, and `log` outside its
+    domain had four different answers - including `inf`, `-0.0`, `-inf` and
+    `nan` on ClickHouse, which is the silent case NULL exists to remove.
 
 ### Explicit Data Type
 

--- a/src/orionbelt/dialect/base.py
+++ b/src/orionbelt/dialect/base.py
@@ -521,9 +521,9 @@ class Dialect(ABC):
             case "trunc":
                 return self._render_trunc(args)
             case "div":
-                return self._render_div(args)
+                return self._render_div(self._with_guarded_divisor(args))
             case "log":
-                return self._render_log(args)
+                return self._guard_log_domain(args)
             case "greatest" | "least":
                 return self._render_extremum(name, args)
             case "date_trunc":
@@ -682,6 +682,60 @@ class Dialect(ABC):
             return self._render_infix(f"SIGN({value}) * FLOOR(ABS({value}))")
         scale = f"POWER(10, {self.compile_expr(args[1])})"
         return self._render_infix(f"SIGN({value}) * FLOOR(ABS({value}) * {scale}) / {scale}")
+
+    def _with_guarded_divisor(self, args: list[Expr]) -> list[Expr]:
+        """``div(a, b)`` with its divisor wrapped so a zero yields NULL.
+
+        ``div`` is a named function, so it never reaches the guard the ``/``
+        operator gets (#319), and the engines disagree just as widely: measured,
+        ``div(7, 0)`` returns NULL on DuckDB and MySQL and raises on PostgreSQL,
+        BigQuery, Snowflake and ClickHouse.
+
+        Guarded by rewriting the **argument** rather than the rendering, because
+        every dialect spells this function differently - ``a // b``, ``DIV(a,
+        b)``, ``intDiv``, ``a DIV b``, ``TRUNC(a / b)`` - and a guard applied to
+        the argument is carried by all of them. ``nullif`` is itself a catalog
+        entry, so it renders per dialect too.
+
+        Applied at the dispatch site rather than inside ``_render_div``, so a
+        dialect that overrides the rendering cannot drop the guard by doing so.
+        The internal caller in ``_render_days_to_weeks`` divides by a literal 7
+        and goes straight to ``_render_div``, unguarded, which is right.
+        """
+        if len(args) != 2:
+            return args
+        return [args[0], FunctionCall(name="nullif", args=[args[1], Literal.number(0)])]
+
+    def _guard_log_domain(self, args: list[Expr]) -> str:
+        """``log(base, x)`` outside its domain yields NULL rather than nonsense.
+
+        The catalog exists to pin one meaning per function, and this one had
+        four. Measured, for every undefined input - base of 1, base of 0, x of
+        0, negative x - PostgreSQL, DuckDB, BigQuery and Snowflake raise, MySQL
+        answers NULL, and **ClickHouse returns a number**: ``inf``, ``-0.0``,
+        ``-inf`` and ``nan`` respectively. A silent ``inf`` flowing into an
+        aggregate is the worst of the three, and the same reason #319 chose NULL
+        for a zero divisor.
+
+        Guarding only the base of 1 - the case that is literally a zero divisor,
+        since ClickHouse and Dremio rewrite this as ``log10(x) / log10(base)`` -
+        would leave its three neighbours silently wrong on the same engine, so
+        the whole undefined domain is guarded together.
+
+        A ``CASE`` is used rather than NULLIF-ing the arguments because the
+        domain is not just "not zero": a negative ``x`` has no logarithm either.
+        Verified that the guard holds for literal arguments too, on PostgreSQL,
+        DuckDB and ClickHouse - constant folding does not evaluate the ``ELSE``
+        branch and raise before the ``WHEN`` is considered.
+        """
+        rendered = self._render_log(args)
+        if len(args) != 2:
+            return rendered
+        base = self.compile_expr(args[0])
+        value = self.compile_expr(args[1])
+        return self._render_infix(
+            f"CASE WHEN {base} <= 0 OR {base} = 1 OR {value} <= 0 THEN NULL ELSE {rendered} END"
+        )
 
     def _render_div(self, args: list[Expr]) -> str:
         """Default: native ``DIV(a, b)`` (BigQuery, Postgres)."""

--- a/src/orionbelt/models/functions.py
+++ b/src/orionbelt/models/functions.py
@@ -512,8 +512,13 @@ _NUMERIC_FUNCTIONS: tuple[FunctionSpec, ...] = (
         examples=(
             FunctionExample("log(10, 100)", 2),
             FunctionExample("log(2, 8)", 3),
+            # All four undefined cases, not two: the ClickHouse answers differ
+            # per case (inf, -0.0, -inf, nan), so pinning half would leave the
+            # other half free to drift.
             FunctionExample("log(1, 8)", None),
+            FunctionExample("log(0, 8)", None),
             FunctionExample("log(2, 0)", None),
+            FunctionExample("log(2, -8)", None),
         ),
     ),
 )

--- a/src/orionbelt/models/functions.py
+++ b/src/orionbelt/models/functions.py
@@ -475,11 +475,16 @@ _NUMERIC_FUNCTIONS: tuple[FunctionSpec, ...] = (
             "``div(a, b)`` and DuckDB has no such function at all, so the name is "
             "an OBSL one that every dialect renders: ``a // b`` on DuckDB, "
             "``intDiv`` on ClickHouse, the ``DIV`` operator on MySQL and "
-            "Databricks, ``TRUNC(a / b)`` on Snowflake."
+            "Databricks, ``TRUNC(a / b)`` on Snowflake.\n\n"
+            "A divisor of zero yields NULL, matching the ``/`` operator. The "
+            "engines do not agree on their own: measured, div(7, 0) returns "
+            "NULL on DuckDB and MySQL and raises on Postgres, BigQuery, "
+            "Snowflake and ClickHouse, so the divisor is wrapped in nullif."
         ),
         examples=(
             FunctionExample("div(7, 2)", 3),
             FunctionExample("div(-7, 2)", -3),
+            FunctionExample("div(7, 0)", None),
         ),
     ),
     FunctionSpec(
@@ -496,11 +501,19 @@ _NUMERIC_FUNCTIONS: tuple[FunctionSpec, ...] = (
             "single-argument ``log`` is deliberately not in the catalog: it is "
             "base 10 on DuckDB and Postgres and natural on ClickHouse, MySQL and "
             "BigQuery, which is a silent factor of 2.3. Use ``ln(x)`` for the "
-            "natural logarithm."
+            "natural logarithm.\n\n"
+            "Outside its domain the result is NULL: a base of 0 or 1, or a "
+            "value of 0 or less. The engines had four different answers here "
+            "and one of them was silent - measured, Postgres, DuckDB, BigQuery "
+            "and Snowflake raise, MySQL returns NULL, and ClickHouse returns a "
+            "number: inf for a base of 1, -0.0 for a base of 0, -inf for a "
+            "value of 0 and nan for a negative one."
         ),
         examples=(
             FunctionExample("log(10, 100)", 2),
             FunctionExample("log(2, 8)", 3),
+            FunctionExample("log(1, 8)", None),
+            FunctionExample("log(2, 0)", None),
         ),
     ),
 )

--- a/tests/integration/drift/compile_only/bigquery/functions/numeric.sql
+++ b/tests/integration/drift/compile_only/bigquery/functions/numeric.sql
@@ -71,5 +71,9 @@ DIV(7, NULLIF(0, 0));
 (CASE WHEN 2 <= 0 OR 2 = 1 OR 8 <= 0 THEN NULL ELSE LOG(8, 2) END);
 --   log(1, 8) = None
 (CASE WHEN 1 <= 0 OR 1 = 1 OR 8 <= 0 THEN NULL ELSE LOG(8, 1) END);
+--   log(0, 8) = None
+(CASE WHEN 0 <= 0 OR 0 = 1 OR 8 <= 0 THEN NULL ELSE LOG(8, 0) END);
 --   log(2, 0) = None
 (CASE WHEN 2 <= 0 OR 2 = 1 OR 0 <= 0 THEN NULL ELSE LOG(0, 2) END);
+--   log(2, -8) = None
+(CASE WHEN 2 <= 0 OR 2 = 1 OR -8 <= 0 THEN NULL ELSE LOG(-8, 2) END);

--- a/tests/integration/drift/compile_only/bigquery/functions/numeric.sql
+++ b/tests/integration/drift/compile_only/bigquery/functions/numeric.sql
@@ -58,12 +58,18 @@ MOD(-7, 3);
 
 -- div(a, b)
 --   div(7, 2) = 3
-DIV(7, 2);
+DIV(7, NULLIF(2, 0));
 --   div(-7, 2) = -3
-DIV(-7, 2);
+DIV(-7, NULLIF(2, 0));
+--   div(7, 0) = None
+DIV(7, NULLIF(0, 0));
 
 -- log(base, x)
 --   log(10, 100) = 2
-LOG(100, 10);
+(CASE WHEN 10 <= 0 OR 10 = 1 OR 100 <= 0 THEN NULL ELSE LOG(100, 10) END);
 --   log(2, 8) = 3
-LOG(8, 2);
+(CASE WHEN 2 <= 0 OR 2 = 1 OR 8 <= 0 THEN NULL ELSE LOG(8, 2) END);
+--   log(1, 8) = None
+(CASE WHEN 1 <= 0 OR 1 = 1 OR 8 <= 0 THEN NULL ELSE LOG(8, 1) END);
+--   log(2, 0) = None
+(CASE WHEN 2 <= 0 OR 2 = 1 OR 0 <= 0 THEN NULL ELSE LOG(0, 2) END);

--- a/tests/integration/drift/compile_only/clickhouse/functions/numeric.sql
+++ b/tests/integration/drift/compile_only/clickhouse/functions/numeric.sql
@@ -58,12 +58,18 @@ MOD(-7, 3);
 
 -- div(a, b)
 --   div(7, 2) = 3
-intDiv(7, 2);
+intDiv(7, NULLIF(2, 0));
 --   div(-7, 2) = -3
-intDiv(-7, 2);
+intDiv(-7, NULLIF(2, 0));
+--   div(7, 0) = None
+intDiv(7, NULLIF(0, 0));
 
 -- log(base, x)
 --   log(10, 100) = 2
-(log10(100) / log10(10));
+(CASE WHEN 10 <= 0 OR 10 = 1 OR 100 <= 0 THEN NULL ELSE (log10(100) / log10(10)) END);
 --   log(2, 8) = 3
-(log10(8) / log10(2));
+(CASE WHEN 2 <= 0 OR 2 = 1 OR 8 <= 0 THEN NULL ELSE (log10(8) / log10(2)) END);
+--   log(1, 8) = None
+(CASE WHEN 1 <= 0 OR 1 = 1 OR 8 <= 0 THEN NULL ELSE (log10(8) / log10(1)) END);
+--   log(2, 0) = None
+(CASE WHEN 2 <= 0 OR 2 = 1 OR 0 <= 0 THEN NULL ELSE (log10(0) / log10(2)) END);

--- a/tests/integration/drift/compile_only/clickhouse/functions/numeric.sql
+++ b/tests/integration/drift/compile_only/clickhouse/functions/numeric.sql
@@ -71,5 +71,9 @@ intDiv(7, NULLIF(0, 0));
 (CASE WHEN 2 <= 0 OR 2 = 1 OR 8 <= 0 THEN NULL ELSE (log10(8) / log10(2)) END);
 --   log(1, 8) = None
 (CASE WHEN 1 <= 0 OR 1 = 1 OR 8 <= 0 THEN NULL ELSE (log10(8) / log10(1)) END);
+--   log(0, 8) = None
+(CASE WHEN 0 <= 0 OR 0 = 1 OR 8 <= 0 THEN NULL ELSE (log10(8) / log10(0)) END);
 --   log(2, 0) = None
 (CASE WHEN 2 <= 0 OR 2 = 1 OR 0 <= 0 THEN NULL ELSE (log10(0) / log10(2)) END);
+--   log(2, -8) = None
+(CASE WHEN 2 <= 0 OR 2 = 1 OR -8 <= 0 THEN NULL ELSE (log10(-8) / log10(2)) END);

--- a/tests/integration/drift/compile_only/databricks/functions/numeric.sql
+++ b/tests/integration/drift/compile_only/databricks/functions/numeric.sql
@@ -71,5 +71,9 @@ MOD(-7, 3);
 (CASE WHEN 2 <= 0 OR 2 = 1 OR 8 <= 0 THEN NULL ELSE LOG(2, 8) END);
 --   log(1, 8) = None
 (CASE WHEN 1 <= 0 OR 1 = 1 OR 8 <= 0 THEN NULL ELSE LOG(1, 8) END);
+--   log(0, 8) = None
+(CASE WHEN 0 <= 0 OR 0 = 1 OR 8 <= 0 THEN NULL ELSE LOG(0, 8) END);
 --   log(2, 0) = None
 (CASE WHEN 2 <= 0 OR 2 = 1 OR 0 <= 0 THEN NULL ELSE LOG(2, 0) END);
+--   log(2, -8) = None
+(CASE WHEN 2 <= 0 OR 2 = 1 OR -8 <= 0 THEN NULL ELSE LOG(2, -8) END);

--- a/tests/integration/drift/compile_only/databricks/functions/numeric.sql
+++ b/tests/integration/drift/compile_only/databricks/functions/numeric.sql
@@ -58,12 +58,18 @@ MOD(-7, 3);
 
 -- div(a, b)
 --   div(7, 2) = 3
-(7 div 2);
+(7 div NULLIF(2, 0));
 --   div(-7, 2) = -3
-(-7 div 2);
+(-7 div NULLIF(2, 0));
+--   div(7, 0) = None
+(7 div NULLIF(0, 0));
 
 -- log(base, x)
 --   log(10, 100) = 2
-LOG(10, 100);
+(CASE WHEN 10 <= 0 OR 10 = 1 OR 100 <= 0 THEN NULL ELSE LOG(10, 100) END);
 --   log(2, 8) = 3
-LOG(2, 8);
+(CASE WHEN 2 <= 0 OR 2 = 1 OR 8 <= 0 THEN NULL ELSE LOG(2, 8) END);
+--   log(1, 8) = None
+(CASE WHEN 1 <= 0 OR 1 = 1 OR 8 <= 0 THEN NULL ELSE LOG(1, 8) END);
+--   log(2, 0) = None
+(CASE WHEN 2 <= 0 OR 2 = 1 OR 0 <= 0 THEN NULL ELSE LOG(2, 0) END);

--- a/tests/integration/drift/compile_only/dremio/functions/numeric.sql
+++ b/tests/integration/drift/compile_only/dremio/functions/numeric.sql
@@ -58,12 +58,18 @@ MOD(-7, 3);
 
 -- div(a, b)
 --   div(7, 2) = 3
-(SIGN((7 * 1.0 / 2)) * FLOOR(ABS((7 * 1.0 / 2))));
+(SIGN((7 * 1.0 / NULLIF(2, 0))) * FLOOR(ABS((7 * 1.0 / NULLIF(2, 0)))));
 --   div(-7, 2) = -3
-(SIGN((-7 * 1.0 / 2)) * FLOOR(ABS((-7 * 1.0 / 2))));
+(SIGN((-7 * 1.0 / NULLIF(2, 0))) * FLOOR(ABS((-7 * 1.0 / NULLIF(2, 0)))));
+--   div(7, 0) = None
+(SIGN((7 * 1.0 / NULLIF(0, 0))) * FLOOR(ABS((7 * 1.0 / NULLIF(0, 0)))));
 
 -- log(base, x)
 --   log(10, 100) = 2
-(LOG10(100) / LOG10(10));
+(CASE WHEN 10 <= 0 OR 10 = 1 OR 100 <= 0 THEN NULL ELSE (LOG10(100) / LOG10(10)) END);
 --   log(2, 8) = 3
-(LOG10(8) / LOG10(2));
+(CASE WHEN 2 <= 0 OR 2 = 1 OR 8 <= 0 THEN NULL ELSE (LOG10(8) / LOG10(2)) END);
+--   log(1, 8) = None
+(CASE WHEN 1 <= 0 OR 1 = 1 OR 8 <= 0 THEN NULL ELSE (LOG10(8) / LOG10(1)) END);
+--   log(2, 0) = None
+(CASE WHEN 2 <= 0 OR 2 = 1 OR 0 <= 0 THEN NULL ELSE (LOG10(0) / LOG10(2)) END);

--- a/tests/integration/drift/compile_only/dremio/functions/numeric.sql
+++ b/tests/integration/drift/compile_only/dremio/functions/numeric.sql
@@ -71,5 +71,9 @@ MOD(-7, 3);
 (CASE WHEN 2 <= 0 OR 2 = 1 OR 8 <= 0 THEN NULL ELSE (LOG10(8) / LOG10(2)) END);
 --   log(1, 8) = None
 (CASE WHEN 1 <= 0 OR 1 = 1 OR 8 <= 0 THEN NULL ELSE (LOG10(8) / LOG10(1)) END);
+--   log(0, 8) = None
+(CASE WHEN 0 <= 0 OR 0 = 1 OR 8 <= 0 THEN NULL ELSE (LOG10(8) / LOG10(0)) END);
 --   log(2, 0) = None
 (CASE WHEN 2 <= 0 OR 2 = 1 OR 0 <= 0 THEN NULL ELSE (LOG10(0) / LOG10(2)) END);
+--   log(2, -8) = None
+(CASE WHEN 2 <= 0 OR 2 = 1 OR -8 <= 0 THEN NULL ELSE (LOG10(-8) / LOG10(2)) END);

--- a/tests/integration/drift/compile_only/duckdb/functions/numeric.sql
+++ b/tests/integration/drift/compile_only/duckdb/functions/numeric.sql
@@ -71,5 +71,9 @@ MOD(-7, 3);
 (CASE WHEN 2 <= 0 OR 2 = 1 OR 8 <= 0 THEN NULL ELSE LOG(2, 8) END);
 --   log(1, 8) = None
 (CASE WHEN 1 <= 0 OR 1 = 1 OR 8 <= 0 THEN NULL ELSE LOG(1, 8) END);
+--   log(0, 8) = None
+(CASE WHEN 0 <= 0 OR 0 = 1 OR 8 <= 0 THEN NULL ELSE LOG(0, 8) END);
 --   log(2, 0) = None
 (CASE WHEN 2 <= 0 OR 2 = 1 OR 0 <= 0 THEN NULL ELSE LOG(2, 0) END);
+--   log(2, -8) = None
+(CASE WHEN 2 <= 0 OR 2 = 1 OR -8 <= 0 THEN NULL ELSE LOG(2, -8) END);

--- a/tests/integration/drift/compile_only/duckdb/functions/numeric.sql
+++ b/tests/integration/drift/compile_only/duckdb/functions/numeric.sql
@@ -58,12 +58,18 @@ MOD(-7, 3);
 
 -- div(a, b)
 --   div(7, 2) = 3
-(7 // 2);
+(7 // NULLIF(2, 0));
 --   div(-7, 2) = -3
-(-7 // 2);
+(-7 // NULLIF(2, 0));
+--   div(7, 0) = None
+(7 // NULLIF(0, 0));
 
 -- log(base, x)
 --   log(10, 100) = 2
-LOG(10, 100);
+(CASE WHEN 10 <= 0 OR 10 = 1 OR 100 <= 0 THEN NULL ELSE LOG(10, 100) END);
 --   log(2, 8) = 3
-LOG(2, 8);
+(CASE WHEN 2 <= 0 OR 2 = 1 OR 8 <= 0 THEN NULL ELSE LOG(2, 8) END);
+--   log(1, 8) = None
+(CASE WHEN 1 <= 0 OR 1 = 1 OR 8 <= 0 THEN NULL ELSE LOG(1, 8) END);
+--   log(2, 0) = None
+(CASE WHEN 2 <= 0 OR 2 = 1 OR 0 <= 0 THEN NULL ELSE LOG(2, 0) END);

--- a/tests/integration/drift/compile_only/mysql/functions/numeric.sql
+++ b/tests/integration/drift/compile_only/mysql/functions/numeric.sql
@@ -58,12 +58,18 @@ MOD(-7, 3);
 
 -- div(a, b)
 --   div(7, 2) = 3
-(7 DIV 2);
+(7 DIV NULLIF(2, 0));
 --   div(-7, 2) = -3
-(-7 DIV 2);
+(-7 DIV NULLIF(2, 0));
+--   div(7, 0) = None
+(7 DIV NULLIF(0, 0));
 
 -- log(base, x)
 --   log(10, 100) = 2
-LOG(10, 100);
+(CASE WHEN 10 <= 0 OR 10 = 1 OR 100 <= 0 THEN NULL ELSE LOG(10, 100) END);
 --   log(2, 8) = 3
-LOG(2, 8);
+(CASE WHEN 2 <= 0 OR 2 = 1 OR 8 <= 0 THEN NULL ELSE LOG(2, 8) END);
+--   log(1, 8) = None
+(CASE WHEN 1 <= 0 OR 1 = 1 OR 8 <= 0 THEN NULL ELSE LOG(1, 8) END);
+--   log(2, 0) = None
+(CASE WHEN 2 <= 0 OR 2 = 1 OR 0 <= 0 THEN NULL ELSE LOG(2, 0) END);

--- a/tests/integration/drift/compile_only/mysql/functions/numeric.sql
+++ b/tests/integration/drift/compile_only/mysql/functions/numeric.sql
@@ -71,5 +71,9 @@ MOD(-7, 3);
 (CASE WHEN 2 <= 0 OR 2 = 1 OR 8 <= 0 THEN NULL ELSE LOG(2, 8) END);
 --   log(1, 8) = None
 (CASE WHEN 1 <= 0 OR 1 = 1 OR 8 <= 0 THEN NULL ELSE LOG(1, 8) END);
+--   log(0, 8) = None
+(CASE WHEN 0 <= 0 OR 0 = 1 OR 8 <= 0 THEN NULL ELSE LOG(0, 8) END);
 --   log(2, 0) = None
 (CASE WHEN 2 <= 0 OR 2 = 1 OR 0 <= 0 THEN NULL ELSE LOG(2, 0) END);
+--   log(2, -8) = None
+(CASE WHEN 2 <= 0 OR 2 = 1 OR -8 <= 0 THEN NULL ELSE LOG(2, -8) END);

--- a/tests/integration/drift/compile_only/postgres/functions/numeric.sql
+++ b/tests/integration/drift/compile_only/postgres/functions/numeric.sql
@@ -58,12 +58,18 @@ MOD(-7, 3);
 
 -- div(a, b)
 --   div(7, 2) = 3
-DIV(7, 2);
+DIV(7, NULLIF(2, 0));
 --   div(-7, 2) = -3
-DIV(-7, 2);
+DIV(-7, NULLIF(2, 0));
+--   div(7, 0) = None
+DIV(7, NULLIF(0, 0));
 
 -- log(base, x)
 --   log(10, 100) = 2
-LOG(10, 100);
+(CASE WHEN 10 <= 0 OR 10 = 1 OR 100 <= 0 THEN NULL ELSE LOG(10, 100) END);
 --   log(2, 8) = 3
-LOG(2, 8);
+(CASE WHEN 2 <= 0 OR 2 = 1 OR 8 <= 0 THEN NULL ELSE LOG(2, 8) END);
+--   log(1, 8) = None
+(CASE WHEN 1 <= 0 OR 1 = 1 OR 8 <= 0 THEN NULL ELSE LOG(1, 8) END);
+--   log(2, 0) = None
+(CASE WHEN 2 <= 0 OR 2 = 1 OR 0 <= 0 THEN NULL ELSE LOG(2, 0) END);

--- a/tests/integration/drift/compile_only/postgres/functions/numeric.sql
+++ b/tests/integration/drift/compile_only/postgres/functions/numeric.sql
@@ -71,5 +71,9 @@ DIV(7, NULLIF(0, 0));
 (CASE WHEN 2 <= 0 OR 2 = 1 OR 8 <= 0 THEN NULL ELSE LOG(2, 8) END);
 --   log(1, 8) = None
 (CASE WHEN 1 <= 0 OR 1 = 1 OR 8 <= 0 THEN NULL ELSE LOG(1, 8) END);
+--   log(0, 8) = None
+(CASE WHEN 0 <= 0 OR 0 = 1 OR 8 <= 0 THEN NULL ELSE LOG(0, 8) END);
 --   log(2, 0) = None
 (CASE WHEN 2 <= 0 OR 2 = 1 OR 0 <= 0 THEN NULL ELSE LOG(2, 0) END);
+--   log(2, -8) = None
+(CASE WHEN 2 <= 0 OR 2 = 1 OR -8 <= 0 THEN NULL ELSE LOG(2, -8) END);

--- a/tests/integration/drift/compile_only/snowflake/functions/numeric.sql
+++ b/tests/integration/drift/compile_only/snowflake/functions/numeric.sql
@@ -58,12 +58,18 @@ MOD(-7, 3);
 
 -- div(a, b)
 --   div(7, 2) = 3
-TRUNC(7 / 2);
+TRUNC(7 / NULLIF(2, 0));
 --   div(-7, 2) = -3
-TRUNC(-7 / 2);
+TRUNC(-7 / NULLIF(2, 0));
+--   div(7, 0) = None
+TRUNC(7 / NULLIF(0, 0));
 
 -- log(base, x)
 --   log(10, 100) = 2
-LOG(10, 100);
+(CASE WHEN 10 <= 0 OR 10 = 1 OR 100 <= 0 THEN NULL ELSE LOG(10, 100) END);
 --   log(2, 8) = 3
-LOG(2, 8);
+(CASE WHEN 2 <= 0 OR 2 = 1 OR 8 <= 0 THEN NULL ELSE LOG(2, 8) END);
+--   log(1, 8) = None
+(CASE WHEN 1 <= 0 OR 1 = 1 OR 8 <= 0 THEN NULL ELSE LOG(1, 8) END);
+--   log(2, 0) = None
+(CASE WHEN 2 <= 0 OR 2 = 1 OR 0 <= 0 THEN NULL ELSE LOG(2, 0) END);

--- a/tests/integration/drift/compile_only/snowflake/functions/numeric.sql
+++ b/tests/integration/drift/compile_only/snowflake/functions/numeric.sql
@@ -71,5 +71,9 @@ TRUNC(7 / NULLIF(0, 0));
 (CASE WHEN 2 <= 0 OR 2 = 1 OR 8 <= 0 THEN NULL ELSE LOG(2, 8) END);
 --   log(1, 8) = None
 (CASE WHEN 1 <= 0 OR 1 = 1 OR 8 <= 0 THEN NULL ELSE LOG(1, 8) END);
+--   log(0, 8) = None
+(CASE WHEN 0 <= 0 OR 0 = 1 OR 8 <= 0 THEN NULL ELSE LOG(0, 8) END);
 --   log(2, 0) = None
 (CASE WHEN 2 <= 0 OR 2 = 1 OR 0 <= 0 THEN NULL ELSE LOG(2, 0) END);
+--   log(2, -8) = None
+(CASE WHEN 2 <= 0 OR 2 = 1 OR -8 <= 0 THEN NULL ELSE LOG(2, -8) END);

--- a/tests/unit/test_function_catalog.py
+++ b/tests/unit/test_function_catalog.py
@@ -1015,13 +1015,15 @@ class TestArgumentRewrites:
     @pytest.mark.parametrize(
         ("dialect", "expected"),
         [
-            ("duckdb", "(-7 // 2)"),
-            ("postgres", "DIV(-7, 2)"),
-            ("mysql", "(-7 DIV 2)"),
-            ("clickhouse", "intDiv(-7, 2)"),
-            ("snowflake", "TRUNC(-7 / 2)"),
-            ("bigquery", "DIV(-7, 2)"),
-            ("databricks", "(-7 div 2)"),
+            # The divisor is wrapped so a zero yields NULL (#321) - the
+            # spelling of the division itself is what this test is about.
+            ("duckdb", "(-7 // NULLIF(2, 0))"),
+            ("postgres", "DIV(-7, NULLIF(2, 0))"),
+            ("mysql", "(-7 DIV NULLIF(2, 0))"),
+            ("clickhouse", "intDiv(-7, NULLIF(2, 0))"),
+            ("snowflake", "TRUNC(-7 / NULLIF(2, 0))"),
+            ("bigquery", "DIV(-7, NULLIF(2, 0))"),
+            ("databricks", "(-7 div NULLIF(2, 0))"),
         ],
     )
     def test_integer_division_is_spelled_differently_on_every_engine(
@@ -1033,14 +1035,16 @@ class TestArgumentRewrites:
         assert _render("div(-7, 2)", dialect) == expected
 
     def test_log_base_comes_first_and_bigquery_reverses_it(self) -> None:
-        assert _render("log(10, 100)", "duckdb") == "LOG(10, 100)"
-        assert _render("log(10, 100)", "bigquery") == "LOG(100, 10)"
+        # Asserted as a substring: the call now sits inside a domain guard
+        # (#321), and the argument order is what this test is about.
+        assert "LOG(10, 100)" in _render("log(10, 100)", "duckdb")
+        assert "LOG(100, 10)" in _render("log(10, 100)", "bigquery")
 
     def test_clickhouse_log_changes_base_through_log10(self) -> None:
         """ClickHouse has no two-argument log, and its ``ln`` is a fast
         approximation: ``ln(100) / ln(10)`` returns 1.9999999996784485.
         """
-        assert _render("log(10, 100)", "clickhouse") == "(log10(100) / log10(10))"
+        assert "(log10(100) / log10(10))" in _render("log(10, 100)", "clickhouse")
 
     @pytest.mark.parametrize(
         ("dialect", "expected"),
@@ -1159,7 +1163,12 @@ class TestRenderingInvariants:
                 "trunc(2.5)",
                 "10 / NULLIF((SIGN(2.5) * FLOOR(ABS(2.5))), 0)",
             ),
-            ("dremio", "log(2, 8)", "10 / NULLIF((LOG10(8) / LOG10(2)), 0)"),
+            (
+                "dremio",
+                "log(2, 8)",
+                "10 / NULLIF((CASE WHEN 2 <= 0 OR 2 = 1 OR 8 <= 0 "
+                "THEN NULL ELSE (LOG10(8) / LOG10(2)) END), 0)",
+            ),
             ("clickhouse", "round(2.5)", "(sign(2.5) * floor(abs(2.5) + 0.5))"),
         ],
     )


### PR DESCRIPTION
Closes #321. Follow-up to #320, which guarded the `/` **operator** but deliberately left the two catalog functions that divide inside their own rewrite.

## What the engines actually did

The catalog exists to pin one meaning per function. These two had three answers for `div` and **four** for `log`:

| call | DuckDB | Postgres | BigQuery | Snowflake | MySQL | ClickHouse |
| --- | --- | --- | --- | --- | --- | --- |
| `div(7, 0)` | NULL | raises | raises | raises | NULL | raises |
| `log(1, 8)` base 1 | raises | raises | raises | raises | NULL | **`inf`** |
| `log(0, 8)` base 0 | raises | raises | raises | raises | NULL | **`-0.0`** |
| `log(2, 0)` value 0 | raises | raises | - | - | NULL | **`-inf`** |
| `log(2, -8)` negative | raises | raises | - | - | NULL | **`nan`** |

The ClickHouse column is why this matters more than tidiness: a silent `inf` flowing into an aggregate is worse than either a null or an error, and it is the same failure mode #319 was opened for.

`log(x, 1)` is the non-obvious one - `LOG10(1) = 0`, so an ordinary-looking argument is a zero divisor once ClickHouse and Dremio rewrite the call as `log10(x) / log10(base)`.

## The contract

**NULL outside the domain**, following #319: a zero divisor for `div`, and for `log` a base of 0 or 1 or a value of 0 or less. Both catalog entries now say so, and carry executed examples, so the drift matrix checks it from here.

## Two different guards, for a reason

**`div` guards the argument, not the rendering.** Seven dialects spell it seven ways - `a // b`, `DIV(a, b)`, `intDiv`, `a DIV b`, `TRUNC(a / b)`, and Dremio SIGN/FLOOR form - and an argument is carried by all of them. `nullif` is itself a catalog entry, so it renders per dialect too.

**`log` needs a `CASE`.** Its domain is not merely "not zero" - a negative value has no logarithm either, so NULLIF cannot express it. I checked the obvious objection: does constant folding evaluate the `ELSE` branch and raise before the `WHEN` is considered? Measured on Postgres, DuckDB and ClickHouse with literal arguments - it does not.

Guarding only the base of 1, the case that is literally a zero divisor, would have left its **three neighbours silently wrong on the same engine**. That is the half-fix pattern from #318, so the whole domain is guarded together.

Both applied at the **dispatch site**, so a dialect overriding the rendering cannot drop the guard - the same structural approach that fixed `render_decimal_division_sql` in #320. The internal caller in `_render_days_to_weeks` divides by a literal 7 and goes straight to `_render_div` unguarded, which is right.

## Verification

10 cases across both functions, executed on **seven engines** - DuckDB, BigQuery, Snowflake, Postgres, MySQL, ClickHouse, Dremio - all pass. That includes the four valid cases (`div(7, 2)`, `div(-7, 2)`, `log(2, 8)`, `log(10, 100)`) which had to stay unchanged.

- 4036 passed / 919 skipped
- 404 on `vendor_exec -m docker`; the per-function exec tests now cover the new examples on the four container engines (Snowflake, BigQuery and Databricks skip locally and were verified by hand)
- ruff and mypy clean
- 8 numeric function drift snapshots re-snapped

Databricks remains documentation-derived, as in #322.