### PR TITLE
fix(dialect): Databricks needs the exact AVG rewrite too

### DIFF
--- a/docs/guide/model-format.md
+++ b/docs/guide/model-format.md
@@ -1198,12 +1198,22 @@ Pass-through (no CAST emitted): `min`, `max`, `any_value`, `median`, `mode`, `li
     | dialect | `AVG` over a 64-bit value | what OBSL emits |
     | --- | --- | --- |
     | PostgreSQL, MySQL, Snowflake | already exact | plain `AVG` |
-    | BigQuery | FLOAT64, drifts | `AVG(CAST(x AS NUMERIC))` |
-    | Dremio | DOUBLE, drifts | `CAST(SUM(x) AS DECIMAL(38, s)) / COUNT(x)` |
-    | Databricks | drifts | `CAST(SUM(x) AS DECIMAL(38, s)) / COUNT(x)` |
-    | ClickHouse | Float64, drifts | `divideDecimal(SUM(x), COUNT(x), s)` |
+    | BigQuery | FLOAT64, drifts | `AVG(CAST(x AS NUMERIC))`, BIGNUMERIC above scale 9 |
+    | Dremio, Databricks | drift | `CAST(SUM(CAST(x AS DECIMAL(38, 0))) AS DECIMAL(38, s)) / COUNT(x)` |
+    | ClickHouse | Float64, drifts | `divideDecimal(SUM(toDecimal128(x, 0)), toDecimal128(COUNT(x), 0), s)`, guarded against a zero count |
     | DuckDB | DOUBLE, drifts | plain `AVG` - no exact route exists |
-    
+
+    **The inner cast is the load-bearing part** of the Dremio and Databricks
+    form, and of the ClickHouse one. `SUM` over a 64-bit column accumulates in
+    64 bits, so widening afterwards only widens a number that has already
+    overflowed: two rows of 9000000000000000000 summed to
+    -446744073709551616 on Dremio and ClickHouse, silently, and raise
+    `ARITHMETIC_OVERFLOW` on Databricks. Casting the argument first is what
+    makes the running total exact.
+
+    The divisor is also NULLIF-guarded, as every division is - see
+    [Division by Zero](#division-by-zero) above.
+
     The rewritten result also carries a wider type than the `decimal(18, 2)`
     default, since an exact average of 64-bit values needs 19 integer digits.
     An explicit `dataType` is respected as declared.

--- a/docs/guide/model-format.md
+++ b/docs/guide/model-format.md
@@ -1200,10 +1200,10 @@ Pass-through (no CAST emitted): `min`, `max`, `any_value`, `median`, `mode`, `li
     | PostgreSQL, MySQL, Snowflake | already exact | plain `AVG` |
     | BigQuery | FLOAT64, drifts | `AVG(CAST(x AS NUMERIC))` |
     | Dremio | DOUBLE, drifts | `CAST(SUM(x) AS DECIMAL(38, s)) / COUNT(x)` |
+    | Databricks | drifts | `CAST(SUM(x) AS DECIMAL(38, s)) / COUNT(x)` |
     | ClickHouse | Float64, drifts | `divideDecimal(SUM(x), COUNT(x), s)` |
     | DuckDB | DOUBLE, drifts | plain `AVG` - no exact route exists |
-    | Databricks | not yet verified | plain `AVG` |
-
+    
     The rewritten result also carries a wider type than the `decimal(18, 2)`
     default, since an exact average of 64-bit values needs 19 integer digits.
     An explicit `dataType` is respected as declared.

--- a/src/orionbelt/dialect/base.py
+++ b/src/orionbelt/dialect/base.py
@@ -310,6 +310,60 @@ class Dialect(ABC):
         """
         return Cast(expr=expr, type_name=self.render_obml_type(obml_type))
 
+    # Widest decimal every supported engine accepts, and the integer digits kept
+    # free for a running total. A sum is as many digits as its rows make it, so
+    # it needs room the average it divides down to does not.
+    _MAX_DECIMAL_PRECISION = 38
+    _SUM_HEADROOM_DIGITS = 24
+
+    def _exact_avg_by_sum_over_count(self, arg: Expr, obml_type: OBMLType) -> Expr | None:
+        """``SUM(x) / COUNT(x)`` in decimal, for engines that divide exactly.
+
+        The textbook rewrite, shared by Dremio and Databricks. It is *not*
+        available on DuckDB, where every division returns DOUBLE whatever the
+        operands, which is why that engine has no exact route at all (#316).
+
+        **The cast goes inside the SUM.** ``SUM`` over a 64-bit column
+        accumulates in 64 bits, and casting afterwards only widens a number
+        that has already wrapped: two rows of 9000000000000000000 summed to
+        -446744073709551616 on Dremio, silently, and raise ARITHMETIC_OVERFLOW
+        on Databricks. Both are fixed by widening the argument first.
+
+        The running total then needs integer room the average will not, so the
+        scale is capped to leave ``_SUM_HEADROOM_DIGITS`` for the integer part:
+        38 digits cannot hold both a large total and a long fraction. A result
+        asking for more scale gets the extra places as zeros, which is the
+        honest trade against overflowing on a total the source holds legally.
+
+        An empty group divides to NULL on both engines, measured, so no
+        zero-count guard is needed here - unlike ClickHouse, whose
+        ``divideDecimal`` raises.
+        """
+        if not isinstance(obml_type, DecimalType):
+            return None
+        scale = min(obml_type.scale, self._MAX_DECIMAL_PRECISION - self._SUM_HEADROOM_DIGITS)
+        accumulated = FunctionCall(
+            name="SUM",
+            args=[
+                Cast(
+                    expr=arg,
+                    type_name=self.render_obml_type(
+                        DecimalType(precision=self._MAX_DECIMAL_PRECISION, scale=0)
+                    ),
+                )
+            ],
+        )
+        return BinaryOp(
+            left=Cast(
+                expr=accumulated,
+                type_name=self.render_obml_type(
+                    DecimalType(precision=self._MAX_DECIMAL_PRECISION, scale=scale)
+                ),
+            ),
+            op="/",
+            right=FunctionCall(name="COUNT", args=[arg]),
+        )
+
     def exact_integer_avg(self, arg: Expr, obml_type: OBMLType) -> Expr | None:
         """An exact ``AVG(arg)`` over an integer column, or ``None`` for none.
 

--- a/src/orionbelt/dialect/databricks.py
+++ b/src/orionbelt/dialect/databricks.py
@@ -11,6 +11,7 @@ from orionbelt.dialect.base import (
 )
 from orionbelt.dialect.registry import DialectRegistry
 from orionbelt.models.semantic import TimeGrain
+from orionbelt.models.types import OBMLType
 
 
 @DialectRegistry.register
@@ -55,6 +56,27 @@ class DatabricksDialect(Dialect):
             supports_ilike=False,
             supports_group_by_all=True,
         )
+
+    def exact_integer_avg(self, arg: Expr, obml_type: OBMLType) -> Expr | None:
+        """Databricks drifts like the others, and was classified without being run.
+
+        #318 left it with the plain ``AVG`` because its warehouse would not
+        start, so the classification was an assumption. Measured once the
+        workspace was reachable: ``AVG`` over BIGINT returns 1.0E18 where the
+        true average is 1000000000000000003, so it belongs with BigQuery,
+        ClickHouse and Dremio rather than with the engines that are exact.
+
+        It is the only engine so far where **both** routes work - casting the
+        input and rewriting as SUM/COUNT are each sufficient. SUM/COUNT is used
+        because it carries more scale (decimal(38, 6) against the input cast's
+        decimal(38, 4)) and shares Dremio's implementation.
+
+        Both hazards checked: an empty group divides to NULL, and a sum past 64
+        bits is exact once the cast is inside the SUM. Worth noting that a raw
+        ``SUM`` over BIGINT raises ARITHMETIC_OVERFLOW here rather than wrapping
+        silently as it does on Dremio and ClickHouse.
+        """
+        return self._exact_avg_by_sum_over_count(arg, obml_type)
 
     def quote_identifier(self, name: str) -> str:
         escaped = name.replace("`", "``")

--- a/src/orionbelt/dialect/dremio.py
+++ b/src/orionbelt/dialect/dremio.py
@@ -13,13 +13,7 @@ from orionbelt.dialect.base import (
 )
 from orionbelt.dialect.registry import DialectRegistry
 from orionbelt.models.semantic import TimeGrain
-from orionbelt.models.types import DecimalType, OBMLType
-
-# Widest decimal every supported engine accepts, and the integer digits kept
-# free for a running total. A sum is as many digits as its rows make it, so it
-# needs room the average it divides down to does not.
-_MAX_DECIMAL_PRECISION = 38
-_SUM_HEADROOM_DIGITS = 24
+from orionbelt.models.types import OBMLType
 
 
 @DialectRegistry.register
@@ -46,52 +40,11 @@ class DremioDialect(Dialect):
         """Dremio divides decimals exactly, so SUM/COUNT is all it takes.
 
         Measured: ``CAST(SUM(x) AS DECIMAL(38, 2)) / COUNT(x)`` returns
-        1000000000000000003.000000 where ``AVG(x)`` returns 1e+18. This is the
-        textbook rewrite, and worth noting that it is *not* available on
-        DuckDB, where every division returns DOUBLE whatever the operands. An
-        empty group divides to NULL here rather than raising, measured, so it
-        needs no guard of its own.
-
-        **The cast goes inside the SUM**, which is the whole reason for the
-        inner ``DECIMAL(38, 0)``. ``SUM`` over BIGINT accumulates in BIGINT and
-        wraps: two rows of 9000000000000000000 summed to
-        -446744073709551616, and casting afterwards only widens a number that
-        had already overflowed. Note this is a case where Dremio's own ``AVG``
-        is wrong too - it answered -2.23e17 - so the rewrite fixes more than
+        1000000000000000003.000000 where ``AVG(x)`` returns 1e+18 - a case
+        where Dremio's own ``AVG`` is wrong too, so the rewrite fixes more than
         the floating-point drift it was written for.
-
-        The running total then needs integer room the average will not: a sum
-        is as many digits as its rows make it. Scale is therefore capped so
-        ``_SUM_HEADROOM_DIGITS`` remain for the integer part, since 38 digits
-        cannot hold both a large total and a long fraction. A result asking for
-        more scale than that gets the extra places as zeros, which is the
-        honest trade - the alternative is overflowing on a total the source
-        holds quite legally.
         """
-        if not isinstance(obml_type, DecimalType):
-            return None
-        scale = min(obml_type.scale, _MAX_DECIMAL_PRECISION - _SUM_HEADROOM_DIGITS)
-        accumulated = FunctionCall(
-            name="SUM",
-            args=[
-                Cast(
-                    expr=arg,
-                    type_name=self.render_obml_type(
-                        DecimalType(precision=_MAX_DECIMAL_PRECISION, scale=0)
-                    ),
-                )
-            ],
-        )
-        return BinaryOp(
-            left=Cast(
-                expr=accumulated,
-                type_name=self.render_obml_type(
-                    DecimalType(precision=_MAX_DECIMAL_PRECISION, scale=scale)
-                ),
-            ),
-            op="/",
-            right=FunctionCall(name="COUNT", args=[arg]),
-        )
+        return self._exact_avg_by_sum_over_count(arg, obml_type)
 
     def format_table_ref(self, database: str, schema: str, code: str) -> str:
         """Dremio: supports multi-level paths via the ``code`` field.
@@ -125,7 +78,6 @@ class DremioDialect(Dialect):
         return Cast(expr=expr, type_name=target_type)
 
     def render_string_contains(self, column: Expr, pattern: Expr) -> Expr:
-        from orionbelt.ast.nodes import BinaryOp
 
         return BinaryOp(
             left=FunctionCall(name="LOWER", args=[column]),

--- a/tests/unit/test_exact_avg.py
+++ b/tests/unit/test_exact_avg.py
@@ -69,11 +69,14 @@ REWRITTEN = {
     "bigquery": "AVG(CAST(",
     "clickhouse": "divideDecimal(",
     "dremio": "/ NULLIF(COUNT(",
+    # Measured once its workspace was reachable: AVG over BIGINT returns 1.0E18
+    # here too. #318 had left it unrewritten on an assumption (#322).
+    "databricks": "/ NULLIF(COUNT(",
 }
 # Postgres, MySQL and Snowflake are already exact; DuckDB has no exact
 # division at all, so a rewrite there would only trade a loud overflow for a
 # quiet wrong number (#316).
-LEFT_ALONE = ["duckdb", "postgres", "mysql", "snowflake", "databricks"]
+LEFT_ALONE = ["duckdb", "postgres", "mysql", "snowflake"]
 
 
 def _model():


### PR DESCRIPTION
Found by actually running Databricks for the first time since June. Relates to #322.

## The classification was an assumption

#318 put Databricks in the "not rewritten" group because its warehouse would not start, so nothing was measured. With the workspace reachable it drifts like the others:

```
plain AVG(BIGINT)                -> 1.0E18                     truth 1000000000000000003
AVG(CAST(qty AS DECIMAL(38,0)))  -> 1000000000000000003.0000    exact  [decimal(38,4)]
SUM(CAST(...))/COUNT(qty)        -> 1000000000000000003.000000  exact  [decimal(38,6)]
```

It is the only engine so far where **both** routes are exact. SUM/COUNT is adopted because it carries more scale and because Dremio already needed the same shape - which now lives once, in `Dialect._exact_avg_by_sum_over_count`, instead of twice.

## Hazards

Both checked, since they broke the first cut of #318:

| hazard | Dremio | Databricks |
| --- | --- | --- |
| raw `SUM` past 64 bits | wraps **silently** to -446744073709551616 | raises `ARITHMETIC_OVERFLOW` |
| cast inside the SUM | exact | exact |
| empty group | NULL | NULL |

So neither needs ClickHouse zero-count guard, and both need the cast inside the SUM - Databricks for a loud reason, Dremio for a silent one.

## Verification

Against the live warehouse, 8 cases:

```
large      1000000000000000003   ok      bigsum     9000000000000000000   ok
negatives  -2.5                  ok      mixedsign  -0.5                  ok
thirds     1.33                  ok      single     7                     ok
small      15.5                  ok      allnull    None                  ok
```

- 4039 passed / 919 skipped, ruff and mypy clean, no drift snapshot changed
- `test_every_dialect_is_accounted_for` still passes; Databricks simply moves from `LEFT_ALONE` to the rewritten group

## Worth noting

That test asserts every dialect sits in one group or the other, which it did - it cannot tell a **measured** classification from an **assumed** one. Databricks sat in the safe-looking list for two months on documentation alone. Seeding its workspace turned up two more contract violations of the same kind, which I am filing separately rather than folding in here.