### PR TITLE
test(dremio): default to the model this directory's stack actually serves

### DIFF
--- a/tests/integration/dremio/README.md
+++ b/tests/integration/dremio/README.md
@@ -60,7 +60,7 @@ The fixtures honour the following env vars for CI or non-default ports:
 | `DREMIO_REST_URL` | `http://localhost:19047` |
 | `OBSL_PGWIRE_HOST` | `obsl` (the docker network alias) |
 | `OBSL_PGWIRE_PORT` | `5432` |
-| `OBSL_MODEL_NAME` | `commerce` (the model name served by the `demo/dremio/` stack; `run.sh` overrides it to `orionbelt_1_commerce` for the dedicated test stack) |
+| `OBSL_MODEL_NAME` | `orionbelt_1_commerce` (what the compose stack in this directory serves). Export `commerce` to point the suite at the separate `demo/dremio/` stack instead |
 
 ## What this suite does NOT cover
 

--- a/tests/integration/dremio/conftest.py
+++ b/tests/integration/dremio/conftest.py
@@ -31,11 +31,18 @@ import pytest
 DREMIO_REST_URL = os.environ.get("DREMIO_REST_URL", "http://localhost:19047")
 OBSL_PGWIRE_HOST = os.environ.get("OBSL_PGWIRE_HOST", "obsl")  # docker network alias
 OBSL_PGWIRE_PORT = int(os.environ.get("OBSL_PGWIRE_PORT", "5432"))
-# Defaults to ``commerce`` (the model name served by the demo stack in
-# ``demo/dremio/``, the usual local target). The dedicated test stack in
-# this directory bakes the ``orionbelt_1_commerce`` example, so ``run.sh``
-# exports ``OBSL_MODEL_NAME=orionbelt_1_commerce`` to match it.
-OBSL_MODEL_NAME = os.environ.get("OBSL_MODEL_NAME", "commerce")
+# Defaults to the model **this directory's** stack serves. The compose file
+# beside this conftest sets ``MODEL_FILES: orionbelt_1_commerce.yaml,...``, so
+# that is what these tests find when nobody says otherwise.
+#
+# It used to default to ``commerce``, the name the separate demo stack in
+# ``demo/dremio/`` serves, and ``run.sh`` exported the right one on the way
+# past. That made the suite pass under ``run.sh`` and fail under a plain
+# ``pytest`` - with three errors that read like a compiler regression
+# (``DATA_READ ERROR`` on a semantic query, ``InvalidCatalogName``) rather
+# than like a name mismatch. Point these tests at the demo stack by exporting
+# ``OBSL_MODEL_NAME=commerce``; that is the unusual case, and an explicit one.
+OBSL_MODEL_NAME = os.environ.get("OBSL_MODEL_NAME", "orionbelt_1_commerce")
 # Stage-2: Dremio-backed model. OBSL compiles to Dremio SQL and executes
 # back against the same Dremio container via the ob-dremio Flight driver.
 OBSL_STAGE2_MODEL_NAME = os.environ.get("OBSL_STAGE2_MODEL_NAME", "dremio_info_schema")

--- a/tests/integration/dremio/run.sh
+++ b/tests/integration/dremio/run.sh
@@ -41,6 +41,8 @@ for _ in {1..90}; do
     sleep 2
 done
 
+# These three now match the conftest defaults, so a plain `pytest -m dremio`
+# against this stack works too. Kept explicit: this script pins what it built.
 echo "Running pytest -m dremio..."
 DREMIO_REST_URL="http://localhost:19047" \
 OBSL_PGWIRE_HOST="obsl" \


### PR DESCRIPTION
Closes #324.

## It was a name mismatch, not a missing model

I diagnosed this wrong when I filed it. The OBSL container is fine and the model **is** loaded - under a different name than the tests ask for.

- `tests/integration/dremio/docker-compose.yml` sets `MODEL_FILES: orionbelt_1_commerce.yaml,...`
- `conftest.py` defaulted `OBSL_MODEL_NAME` to `commerce`, which is what the *separate* demo stack in `demo/dremio/` serves
- `run.sh` exported the right name on the way past, so the divergence only appeared when it was not used

Hence three errors that read like a compiler regression - `DATA_READ ERROR: no model is available for database=commerce` on a semantic query, `InvalidCatalogName` on pgwire - for what is really "you asked for a model this stack does not serve".

## Fix

The default now matches the stack in this directory, which is what these tests target. Pointing them at the demo stack stays possible and is now the explicit case: `OBSL_MODEL_NAME=commerce`.

`run.sh` keeps its exports - they pin what it built - with a note that they now agree with the defaults.

## Verified both ways, against the running stack

```
bare  pytest tests/integration/dremio -m dremio                    -> 91 passed
run.sh environment (DREMIO_REST_URL, OBSL_PGWIRE_HOST, MODEL_NAME)  -> 91 passed
```

Previously the bare invocation gave 3 failed / 1 passed for `test_dremio_postgres_source` alone. Full suite 4039 passed / 919 skipped, ruff clean.

## Why it was worth fixing rather than documenting

I closed this as not-planned an hour ago on the grounds that it was a minor papercut. It cost two false attributions in a single session - both times the check was `git stash`, re-run, confirm the same three fail unmodified - and the fix turned out to be a one-line default rather than the fixture-provisioning work I had assumed. The estimate was wrong because the diagnosis was.