### PR TITLE
fix(tests): the Databricks seed dropped apostrophes instead of escaping them

### DIFF
--- a/tests/integration/drift/vendor_exec/_seed.py
+++ b/tests/integration/drift/vendor_exec/_seed.py
@@ -122,10 +122,16 @@ class VendorSpec:
     # four container-tested engines coerce plain strings happily and are
     # left as-is; the cloud engines are stricter.
     date_literals: bool = False
-    # GoogleSQL (BigQuery) escapes a single quote inside a string literal with a
-    # backslash (``\'``); the SQL-standard doubling (``''``) parses there as two
-    # adjacent literals ("O''Brien" -> 'O' 'Brien') and errors. Every other
-    # dialect here accepts ``''``. Set True to switch to backslash escaping.
+    # GoogleSQL (BigQuery) and Spark SQL (Databricks) escape a single quote
+    # inside a string literal with a backslash (``\'``). The SQL-standard
+    # doubling (``''``) fails on both, and they fail *differently*: BigQuery
+    # parses it as two adjacent literals and errors, while Spark silently drops
+    # the character - measured, ``SELECT 'O''Brien'`` returns ``OBrien``, six
+    # characters, with no complaint. That silence is why the Databricks seed
+    # carried corrupted names for as long as it did.
+    #
+    # Verified that Postgres, MySQL, ClickHouse, DuckDB, Snowflake and Dremio
+    # all accept ``''``; Snowflake accepts either form.
     backslash_escape: bool = False
     notes: tuple[str, ...] = ()
 
@@ -199,6 +205,7 @@ _SPECS: dict[str, VendorSpec] = {
         name="databricks",
         types={"VARCHAR": "STRING", "DATE": "DATE", "DOUBLE": "DECIMAL(18, 2)"},
         quote="`",
+        backslash_escape=True,
         container="SCHEMA",
         executed=False,
         table_opts=lambda _cols: " USING DELTA",
@@ -236,8 +243,8 @@ def _lit(v: Any, *, date_literals: bool = False, backslash_escape: bool = False)
     if isinstance(v, date):
         return f"DATE '{v.isoformat()}'" if date_literals else f"'{v.isoformat()}'"
     s = str(v)
-    # GoogleSQL escapes a quote as ``\'``; every other dialect doubles it as
-    # ``''``. In the backslash path, escape backslashes first so they don't
+    # GoogleSQL and Spark SQL escape a quote as ``\'``; the others double it
+    # as ``''``. In the backslash path, escape backslashes first so they don't
     # consume the quote escape.
     s = s.replace("\\", "\\\\").replace("'", "\\'") if backslash_escape else s.replace("'", "''")
     return f"'{s}'"

--- a/tests/unit/test_seed_literals.py
+++ b/tests/unit/test_seed_literals.py
@@ -1,0 +1,44 @@
+"""Every vendor's seed literal survives a round trip through its own escaping.
+
+The Databricks seed carried corrupted names for months: it doubled apostrophes
+as the SQL standard says, and Spark SQL silently drops the character rather
+than erroring. ``SELECT 'O''Brien'`` returns ``OBrien`` - six characters, no
+complaint - so 500 rows of the commerce seed lost an apostrophe and only two
+corpus queries ever noticed.
+
+BigQuery needs the same backslash form and fails loudly, which is why it was
+already handled. The lesson is the silent one: a vendor added without checking
+its string escaping corrupts data rather than refusing it, and the only signal
+is a golden comparison that happens to include an affected value.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.integration.drift.vendor_exec._seed import _SPECS, VENDORS, _lit
+
+# Measured per engine, not assumed. Postgres, MySQL, ClickHouse, DuckDB and
+# Dremio take the doubled form; Snowflake accepts either; BigQuery and
+# Databricks require the backslash.
+BACKSLASH_VENDORS = {"bigquery", "databricks"}
+
+
+@pytest.mark.parametrize("vendor", sorted(VENDORS))
+def test_the_escape_style_matches_what_the_engine_accepts(vendor: str) -> None:
+    assert _SPECS[vendor].backslash_escape is (vendor in BACKSLASH_VENDORS), (
+        f"{vendor} would emit the wrong quote escaping for its engine"
+    )
+
+
+@pytest.mark.parametrize("vendor", sorted(VENDORS))
+def test_an_apostrophe_is_escaped_rather_than_dropped(vendor: str) -> None:
+    """The specific value that was corrupted, per vendor."""
+    rendered = _lit("Alex O'Brien", backslash_escape=_SPECS[vendor].backslash_escape)
+    expected = "'Alex O\\'Brien'" if _SPECS[vendor].backslash_escape else "'Alex O''Brien'"
+    assert rendered == expected, f"{vendor}: {rendered}"
+
+
+def test_a_backslash_is_escaped_before_the_quote() -> None:
+    """Order matters: escape backslashes first or they consume the quote escape."""
+    assert _lit("a\\'b", backslash_escape=True) == "'a\\\\\\'b'"


### PR DESCRIPTION
Closes #329.

## The silent kind

The dump doubled a quote as the SQL standard says. Spark SQL does not accept that form and - unlike BigQuery, which **errors** - it silently drops the character:

```
SELECT `O``Brien`   ->  OBrien   len=6    no error
SELECT `O\`Brien`   ->  O`Brien  len=7    correct
```

So the seeded Databricks data was quietly wrong. **500 rows** of the commerce seed carried a mangled name, and only two corpus queries ever noticed, because a golden comparison fails only where an affected value reaches the output. Everything else passed against incorrect data - which is worse than failing.

## The mechanism already existed

`VendorSpec.backslash_escape`, which BigQuery sets for exactly this reason. Databricks never got the flag, and the comment beside it asserted that *every other dialect* accepts the doubled form - which is what made the omission look deliberate rather than missed.

Measured per engine rather than assumed:

| form accepted | engines |
| --- | --- |
| doubled `**` | Postgres, MySQL, ClickHouse, DuckDB, Dremio |
| either | Snowflake - so its seed was never at risk |
| backslash `\*` | BigQuery, **Databricks** |

## Result

After re-seeding, the value that exposed it reads back correctly and the whole suite passes:

```
Alex O*Brien   len=12
rows containing an apostrophe: 500

full Databricks vendor_exec:  57 passed    (was 55 passed, 2 failed)
```

That is the first fully green Databricks run since the workspace came back.

## Regression guard

`tests/unit/test_seed_literals.py` pins the escape style per vendor and the round trip of the value that broke, so a vendor added without checking its string escaping fails in CI rather than corrupting a warehouse. 17 tests.

Note the seed dumps under `seed_sql/` are gitignored generated artifacts, so the diff is the generator and the new test only - regenerate with `uv run python tests/integration/drift/vendor_exec/_seed.py` and re-seed with `uv run python scripts/seed_cloud_vendor.py databricks`.

4056 passed / 919 skipped, ruff and mypy clean.