### PR TITLE
test(vendor): execute the exact-AVG rewrite, and widen where the average is exact

### DIFF
--- a/docs/guide/model-format.md
+++ b/docs/guide/model-format.md
@@ -1198,7 +1198,7 @@ Pass-through (no CAST emitted): `min`, `max`, `any_value`, `median`, `mode`, `li
 
     | dialect | `AVG` over a 64-bit value | what OBSL emits |
     | --- | --- | --- |
-    | PostgreSQL, MySQL, Snowflake | already exact | plain `AVG` |
+    | PostgreSQL, MySQL, Snowflake | already exact | plain `AVG`, widened result type |
     | BigQuery | FLOAT64, drifts | `AVG(CAST(x AS NUMERIC))`, BIGNUMERIC above scale 9 |
     | Dremio, Databricks | drift | `CAST(SUM(CAST(x AS DECIMAL(38, 0))) AS DECIMAL(38, s)) / COUNT(x)` |
     | ClickHouse | Float64, drifts | `divideDecimal(SUM(toDecimal128(x, 0)), toDecimal128(COUNT(x), 0), s)`, guarded against a zero count |
@@ -1215,9 +1215,17 @@ Pass-through (no CAST emitted): `min`, `max`, `any_value`, `median`, `mode`, `li
     The divisor is also NULLIF-guarded, as every division is - see
     [Division by Zero](#division-by-zero) above.
 
-    The rewritten result also carries a wider type than the `decimal(18, 2)`
-    default, since an exact average of 64-bit values needs 19 integer digits.
-    An explicit `dataType` is respected as declared.
+    **The result type is widened wherever the average is exact**, whether it
+    got there natively or by rewrite, since an exact average the declared type
+    cannot hold is no better than an inexact one. `decimal(18, 2)` carries 16
+    integer digits and a 64-bit value needs 19. Measured, the default made
+    MySQL saturate a true `1000000000000000003` to `9999999999999999.99` **with
+    no warning**, and made PostgreSQL raise. An explicit `dataType` is
+    respected as declared.
+
+    DuckDB is the exception in both halves: its average is not exact and cannot
+    be made so, so widening there would only convert a loud overflow into a
+    quiet wrong number. It keeps the default.
 
     **DuckDB is the exception**, tracked in
     [#316](https://github.com/ralforion/orionbelt-semantic-layer/issues/316):

--- a/docs/guide/model-format.md
+++ b/docs/guide/model-format.md
@@ -1223,9 +1223,6 @@ Pass-through (no CAST emitted): `min`, `max`, `any_value`, `median`, `mode`, `li
     no warning**, and made PostgreSQL raise. An explicit `dataType` is
     respected as declared.
 
-    DuckDB is the exception in both halves: its average is not exact and cannot
-    be made so, so widening there would only convert a loud overflow into a
-    quiet wrong number. It keeps the default.
 
     **DuckDB is the exception**, tracked in
     [#316](https://github.com/ralforion/orionbelt-semantic-layer/issues/316):

--- a/src/orionbelt/compiler/cfl.py
+++ b/src/orionbelt/compiler/cfl.py
@@ -36,9 +36,8 @@ from orionbelt.compiler.resolution import (
 )
 from orionbelt.compiler.star import CflLegInfo, QueryPlan, _grouping_flag_alias, _nulls_last
 from orionbelt.compiler.type_resolver import (
-    resolve_measure_data_type,
+    cast_measure_to_resolved_type,
     resolve_metric_data_type,
-    rewrite_exact_integer_avg,
 )
 from orionbelt.dialect.base import Dialect, UnsupportedAggregationError
 from orionbelt.models.errors import SemanticError
@@ -850,17 +849,10 @@ class CFLPlanner:
             # declared count measures).
             model_measure = model.effective_measures.get(m.name)
             if model_measure and dialect:
-                # Same exact-AVG rewrite as the star path. Here the argument is
-                # the union column rather than the source, which is still the
-                # right thing to average: the legs project pre-aggregation rows.
-                exact = rewrite_exact_integer_avg(model_measure, settings, dialect, agg_expr)
-                if exact is not None:
-                    agg_expr, exact_type = exact
-                    agg_expr = dialect.cast_to_obml_type(agg_expr, exact_type)
-                else:
-                    resolved_type = resolve_measure_data_type(model_measure, settings)
-                    if resolved_type:
-                        agg_expr = dialect.cast_to_obml_type(agg_expr, resolved_type)
+                # Same path as the star planner. Here the argument is the union
+                # column rather than the source, which is still the right thing
+                # to average: the legs project pre-aggregation rows.
+                agg_expr = cast_measure_to_resolved_type(agg_expr, model_measure, settings, dialect)
             if m.name in requested_measure_names:
                 outer_builder.select(AliasedExpr(expr=agg_expr, alias=m.name))
             outer_measure_exprs[m.name] = agg_expr

--- a/src/orionbelt/compiler/cumulative_wrap.py
+++ b/src/orionbelt/compiler/cumulative_wrap.py
@@ -33,7 +33,7 @@ from orionbelt.ast.nodes import (
 )
 from orionbelt.compiler.resolution import ResolvedMeasure, ResolvedQuery
 from orionbelt.compiler.type_resolver import (
-    resolve_measure_data_type,
+    cast_measure_to_resolved_type,
     resolve_metric_data_type,
 )
 from orionbelt.compiler.window_wrap import wraps_a_cte
@@ -309,10 +309,7 @@ def _apply_measure_cast(
     base_meas = model.effective_measures.get(measure_name)
     if base_meas is None:
         return expr
-    resolved_type = resolve_measure_data_type(base_meas, model.settings)
-    if resolved_type is None:
-        return expr
-    return dialect.cast_to_obml_type(expr, resolved_type)
+    return cast_measure_to_resolved_type(expr, base_meas, model.settings, dialect)
 
 
 def _apply_metric_cast(

--- a/src/orionbelt/compiler/pop_wrap.py
+++ b/src/orionbelt/compiler/pop_wrap.py
@@ -35,7 +35,7 @@ from orionbelt.compiler.having_hoist import windowed_aliases
 from orionbelt.compiler.metric_expansion import expand_metric_expression
 from orionbelt.compiler.resolution import ResolutionError, ResolvedMeasure, ResolvedQuery
 from orionbelt.compiler.type_resolver import (
-    resolve_measure_data_type,
+    cast_measure_to_resolved_type,
     resolve_metric_data_type,
 )
 from orionbelt.models.errors import SemanticError
@@ -95,10 +95,7 @@ def _apply_measure_cast(
     measure = model.effective_measures.get(measure_name)
     if measure is None:
         return expr
-    resolved_type = resolve_measure_data_type(measure, model.settings)
-    if resolved_type is None:
-        return expr
-    return dialect.cast_to_obml_type(expr, resolved_type)
+    return cast_measure_to_resolved_type(expr, measure, model.settings, dialect)
 
 
 def _resolve_col_code(model: SemanticModel, obj_name: str, display_name: str) -> str:

--- a/src/orionbelt/compiler/pop_wrap.py
+++ b/src/orionbelt/compiler/pop_wrap.py
@@ -35,6 +35,7 @@ from orionbelt.compiler.having_hoist import windowed_aliases
 from orionbelt.compiler.metric_expansion import expand_metric_expression
 from orionbelt.compiler.resolution import ResolutionError, ResolvedMeasure, ResolvedQuery
 from orionbelt.compiler.type_resolver import (
+    apply_exact_integer_avg,
     cast_measure_to_resolved_type,
     resolve_metric_data_type,
 )
@@ -96,6 +97,32 @@ def _apply_measure_cast(
     if measure is None:
         return expr
     return cast_measure_to_resolved_type(expr, measure, model.settings, dialect)
+
+
+def _apply_base_measure_rewrite(
+    expr: Expr,
+    metric_name: str,
+    model: SemanticModel | None,
+    dialect: Dialect | None,
+) -> Expr:
+    """Make a wrapper metric's base aggregate exact, without casting it.
+
+    A window or cumulative metric's placeholder column holds the *base
+    measure's* aggregate, so the exactness rule is the base measure's too. The
+    cast is deliberately withheld here - it would truncate the window's input -
+    but the rewrite is not, and withholding both is what left an integer AVG
+    reaching the window as a raw floating average on the rewrite-only dialects.
+    """
+    if model is None or dialect is None:
+        return expr
+    metric = model.metrics.get(metric_name)
+    base_name = getattr(metric, "measure", None) if metric else None
+    if not base_name:
+        return expr
+    base = model.effective_measures.get(base_name)
+    if base is None:
+        return expr
+    return apply_exact_integer_avg(expr, base, model.settings, dialect)
 
 
 def _resolve_col_code(model: SemanticModel, obj_name: str, display_name: str) -> str:
@@ -485,11 +512,19 @@ def _build_pop_base_sql(
             # ``dataType: integer`` truncated ``SUM(amount)`` to INT, so 1.49
             # and 1.40 both became 1 and ranked equal. Those wrappers apply
             # the metric's type to the finished window value themselves.
+            #
+            # The *rewrite* is a separate matter from the cast and does apply
+            # here: an integer AVG has to reach the window already exact, or
+            # the wrapper carries a raw floating average that no later cast can
+            # repair. Skipping both left the rewrite-only dialects drifting
+            # exactly where this machinery exists to stop them.
             is_wrapper_metric = m.is_window or m.is_cumulative
             if m.component_measures and not is_wrapper_metric:
                 expr = _apply_metric_cast(expr, m.name, model, dialect)
             elif not m.component_measures:
                 expr = _apply_measure_cast(expr, m.name, model, dialect)
+            elif is_wrapper_metric:
+                expr = _apply_base_measure_rewrite(expr, m.name, model, dialect)
             expr_sql = dialect.compile_expr(expr)
             measure_selects.append(f"{expr_sql} AS {dialect.quote_identifier(m.name)}")
 

--- a/src/orionbelt/compiler/star.py
+++ b/src/orionbelt/compiler/star.py
@@ -20,9 +20,8 @@ from orionbelt.compiler.graph import JoinGraph
 from orionbelt.compiler.metric_expansion import expand_metric_expression
 from orionbelt.compiler.resolution import ResolvedMeasure, ResolvedQuery, make_column_expr
 from orionbelt.compiler.type_resolver import (
-    resolve_measure_data_type,
+    cast_measure_to_resolved_type,
     resolve_metric_data_type,
-    rewrite_exact_integer_avg,
 )
 from orionbelt.models.query import NullsPosition
 from orionbelt.models.semantic import DataObject, SemanticModel
@@ -185,18 +184,7 @@ class StarSchemaPlanner:
                 expr = conformed_exprs.get(measure.name, measure.expression)
                 model_measure = model.effective_measures.get(measure.name)
                 if model_measure and dialect:
-                    # An integer AVG is rewritten into an exact form on the
-                    # engines that have one, and carries its own widened type,
-                    # since the default cannot hold what an exact average of
-                    # 64-bit values produces.
-                    exact = rewrite_exact_integer_avg(model_measure, settings, dialect, expr)
-                    if exact is not None:
-                        expr, exact_type = exact
-                        expr = dialect.cast_to_obml_type(expr, exact_type)
-                    else:
-                        resolved_type = resolve_measure_data_type(model_measure, settings)
-                        if resolved_type:
-                            expr = dialect.cast_to_obml_type(expr, resolved_type)
+                    expr = cast_measure_to_resolved_type(expr, model_measure, settings, dialect)
                 builder.select(AliasedExpr(expr=expr, alias=measure.name))
             measure_exprs[measure.name] = expr
 

--- a/src/orionbelt/compiler/type_resolver.py
+++ b/src/orionbelt/compiler/type_resolver.py
@@ -15,6 +15,8 @@ Pass-through (no CAST): MIN/MAX, LISTAGG, non-numeric aggregates.
 
 from __future__ import annotations
 
+from collections.abc import Callable
+
 from orionbelt.ast.nodes import Expr, FunctionCall
 from orionbelt.dialect.base import Dialect
 from orionbelt.models.semantic import (
@@ -188,17 +190,18 @@ def rewrite_exact_integer_avg(
         return None
     if measure.aggregation.upper() != "AVG" or measure.result_type != DataType.INT:
         return None
-    if not isinstance(expr, FunctionCall) or expr.name != "AVG":
+    aggregate, rebuild = _unwrap_default(expr)
+    if not isinstance(aggregate, FunctionCall) or aggregate.name != "AVG":
         return None
-    if expr.distinct or len(expr.args) != 1:
+    if aggregate.distinct or len(aggregate.args) != 1:
         return None
     resolved = resolve_measure_data_type(measure, settings)
     if not isinstance(resolved, DecimalType):
         return None
     target = resolved if measure.data_type else _widen_to_integer_range(resolved)
-    exact = dialect.exact_integer_avg(expr.args[0], target)
+    exact = dialect.exact_integer_avg(aggregate.args[0], target)
     if exact is not None:
-        return exact, target
+        return rebuild(exact), target
     if dialect.avg_over_integers_is_exact:
         # No rewrite needed, but the result type still is. The aggregate is
         # already exact here; it is the declared decimal(18, 2) that cannot
@@ -261,6 +264,42 @@ def cast_measure_to_resolved_type(
     if resolved is None:
         return expr
     return dialect.cast_to_obml_type(expr, resolved)
+
+
+def _unwrap_default(expr: Expr) -> tuple[Expr, Callable[[Expr], Expr]]:
+    """See past a ``defaultValue`` wrapper to the aggregate inside it.
+
+    ``defaultValue`` emits ``COALESCE(AVG(x), 0)``, so what reaches the rewrite
+    is not a bare ``AVG`` and the rewrite declined - leaving a raw floating
+    average with a widened cast around it, which is the silent drift this is
+    meant to remove. Measure *filters* need no equivalent: they change the
+    aggregate's argument, so it stays a bare ``AVG``.
+    """
+    if isinstance(expr, FunctionCall) and expr.name == "COALESCE" and len(expr.args) == 2:
+        inner, fallback = expr.args
+        return inner, lambda done: FunctionCall(name="COALESCE", args=[done, fallback])
+    return expr, lambda done: done
+
+
+def apply_exact_integer_avg(
+    expr: Expr,
+    measure: Measure,
+    settings: ModelSettings | None,
+    dialect: Dialect | None,
+) -> Expr:
+    """The rewrite alone, without the cast.
+
+    For the wrapper metrics, whose base aggregate must **not** be cast to the
+    metric's declared type at this point - a rank declaring ``dataType:
+    integer`` would truncate ``SUM(amount)`` before the window ever saw it.
+    Making the average exact and casting it are separate concerns, and only the
+    second is unsafe there; skipping both left those paths on a raw floating
+    average.
+    """
+    if dialect is None:
+        return expr
+    exact = rewrite_exact_integer_avg(measure, settings, dialect, expr)
+    return expr if exact is None else exact[0]
 
 
 def resolve_measure_cast_type(

--- a/src/orionbelt/compiler/type_resolver.py
+++ b/src/orionbelt/compiler/type_resolver.py
@@ -257,7 +257,39 @@ def cast_measure_to_resolved_type(
     if exact is not None:
         rewritten, target = exact
         return dialect.cast_to_obml_type(rewritten, target)
-    resolved = resolve_measure_data_type(measure, settings)
+    resolved = resolve_measure_cast_type(measure, settings, dialect)
     if resolved is None:
         return expr
     return dialect.cast_to_obml_type(expr, resolved)
+
+
+def resolve_measure_cast_type(
+    measure: Measure,
+    settings: ModelSettings | None,
+    dialect: Dialect | None,
+) -> OBMLType | None:
+    """The type a measure is cast to, decided without looking at its expression.
+
+    :func:`rewrite_exact_integer_avg` can only fire on a bare ``AVG(x)``, since
+    it needs the argument to rewrite. That is the right test for *rewriting*
+    and the wrong one for *typing*: once wrappers compose - a window over a
+    period-over-period, a cumulative over one - the later wrapper holds a CTE
+    alias, so the rewrite declines and the cast fell back to the narrow
+    default. The value in that CTE had already been computed exactly, so the
+    narrow type saturated it on MySQL and overflowed it on Postgres for no
+    reason at all.
+
+    The type therefore follows the **measure and the dialect**, which are known
+    everywhere, rather than the shape the expression happens to have at this
+    point in the plan.
+    """
+    resolved = resolve_measure_data_type(measure, settings)
+    if dialect is None or measure.data_type or not isinstance(resolved, DecimalType):
+        return resolved
+    if measure.aggregation.upper() != "AVG" or measure.result_type != DataType.INT:
+        return resolved
+    if not dialect.integer_avg_is_exact():
+        # DuckDB alone: the average is not exact, so a wider type would let a
+        # rounded value through instead of failing on it (#316).
+        return resolved
+    return _widen_to_integer_range(resolved)

--- a/src/orionbelt/compiler/type_resolver.py
+++ b/src/orionbelt/compiler/type_resolver.py
@@ -197,9 +197,19 @@ def rewrite_exact_integer_avg(
         return None
     target = resolved if measure.data_type else _widen_to_integer_range(resolved)
     exact = dialect.exact_integer_avg(expr.args[0], target)
-    if exact is None:
-        return None
-    return exact, target
+    if exact is not None:
+        return exact, target
+    if dialect.avg_over_integers_is_exact:
+        # No rewrite needed, but the result type still is. The aggregate is
+        # already exact here; it is the declared decimal(18, 2) that cannot
+        # hold what it produces - measured, MySQL saturates a true
+        # 1000000000000000003 to 9999999999999999.99 with no warning, and
+        # Postgres raises. Widening lets an exact average through intact.
+        return expr, target
+    # Neither exact nor rewritable: DuckDB alone. It keeps the default so the
+    # overflow stays loud, rather than trading it for a quiet wrong number
+    # (#316).
+    return None
 
 
 def _widen_to_integer_range(default: DecimalType) -> DecimalType:

--- a/src/orionbelt/compiler/type_resolver.py
+++ b/src/orionbelt/compiler/type_resolver.py
@@ -229,3 +229,35 @@ def _widen_to_integer_range(default: DecimalType) -> DecimalType:
     return DecimalType(
         precision=_MAX_DECIMAL_PRECISION, scale=_MAX_DECIMAL_PRECISION - _INT64_DIGITS
     )
+
+
+def cast_measure_to_resolved_type(
+    expr: Expr,
+    measure: Measure,
+    settings: ModelSettings | None,
+    dialect: Dialect | None,
+) -> Expr:
+    """Cast a built measure expression to the type it resolves to.
+
+    The single place that decides how a measure aggregate is typed, so the
+    exact-AVG handling cannot be applied on some paths and forgotten on others.
+    It was: ``star`` and ``cfl`` rewrote an integer AVG and widened its type,
+    while the cumulative, period-over-period and window wrappers called
+    :func:`resolve_measure_data_type` alone. A direct query therefore emitted
+    ``CAST(AVG(x) AS DECIMAL(21, 2))`` and the same measure inside a PoP metric
+    emitted ``DECIMAL(18, 2)``, which is the type that saturates on MySQL and
+    overflows on Postgres (#330).
+
+    Returns *expr* unchanged when the measure is pass-through, which is what a
+    ``None`` resolved type means.
+    """
+    if dialect is None:
+        return expr
+    exact = rewrite_exact_integer_avg(measure, settings, dialect, expr)
+    if exact is not None:
+        rewritten, target = exact
+        return dialect.cast_to_obml_type(rewritten, target)
+    resolved = resolve_measure_data_type(measure, settings)
+    if resolved is None:
+        return expr
+    return dialect.cast_to_obml_type(expr, resolved)

--- a/src/orionbelt/compiler/window_wrap.py
+++ b/src/orionbelt/compiler/window_wrap.py
@@ -31,7 +31,7 @@ from orionbelt.compiler.metric_expansion import (
 )
 from orionbelt.compiler.resolution import ResolvedMeasure, ResolvedQuery
 from orionbelt.compiler.type_resolver import (
-    resolve_measure_data_type,
+    cast_measure_to_resolved_type,
     resolve_metric_data_type,
 )
 from orionbelt.models.semantic import WindowFunctionKind
@@ -157,10 +157,7 @@ def _apply_measure_cast(
     base_meas = model.effective_measures.get(measure_name)
     if base_meas is None:
         return expr
-    resolved_type = resolve_measure_data_type(base_meas, model.settings)
-    if resolved_type is None:
-        return expr
-    return dialect.cast_to_obml_type(expr, resolved_type)
+    return cast_measure_to_resolved_type(expr, base_meas, model.settings, dialect)
 
 
 def _get_alias(expr: Expr) -> str | None:

--- a/src/orionbelt/dialect/base.py
+++ b/src/orionbelt/dialect/base.py
@@ -379,6 +379,24 @@ class Dialect(ABC):
     #: number (#316).
     avg_over_integers_is_exact: bool = False
 
+    def integer_avg_is_exact(self) -> bool:
+        """Whether an integer ``AVG`` ends up exact here, natively or rewritten.
+
+        Deliberately independent of any expression. The **type** a measure is
+        cast to has to be decided the same way wherever the cast happens, and
+        by the time a wrapper composes - a window over a period-over-period,
+        say - the expression it holds is a CTE alias rather than the aggregate.
+        Asking "is this a bare AVG I can rewrite?" answers no there, and the
+        cast fell back to the narrow default even though the value inside the
+        CTE had already been computed exactly.
+
+        Detected by introspection rather than a second flag, so a dialect that
+        overrides :meth:`exact_integer_avg` cannot forget to declare it.
+        """
+        return self.avg_over_integers_is_exact or (
+            type(self).exact_integer_avg is not Dialect.exact_integer_avg
+        )
+
     def exact_integer_avg(self, arg: Expr, obml_type: OBMLType) -> Expr | None:
         """An exact ``AVG(arg)`` over an integer column, or ``None`` for none.
 

--- a/src/orionbelt/dialect/base.py
+++ b/src/orionbelt/dialect/base.py
@@ -364,6 +364,21 @@ class Dialect(ABC):
             right=FunctionCall(name="COUNT", args=[arg]),
         )
 
+    #: Whether ``AVG`` over a 64-bit integer column is exact natively.
+    #:
+    #: True on Postgres (``numeric``), MySQL (``decimal``) and Snowflake, which
+    #: need no rewrite - but still need the **result type** widened, because an
+    #: exact average the declared type cannot hold is no better than an
+    #: inexact one. Measured on MySQL, ``CAST(AVG(qty) AS DECIMAL(18, 2))``
+    #: returns 9999999999999999.99 for a true 1000000000000000003, saturating
+    #: silently with no warning at all; Postgres raises instead.
+    #:
+    #: False where the aggregate itself drifts. Those either get an exact
+    #: rewrite (:meth:`exact_integer_avg`) or, on DuckDB alone, keep the
+    #: default so the overflow stays loud rather than becoming a quiet wrong
+    #: number (#316).
+    avg_over_integers_is_exact: bool = False
+
     def exact_integer_avg(self, arg: Expr, obml_type: OBMLType) -> Expr | None:
         """An exact ``AVG(arg)`` over an integer column, or ``None`` for none.
 

--- a/src/orionbelt/dialect/mysql.py
+++ b/src/orionbelt/dialect/mysql.py
@@ -72,6 +72,8 @@ class MySQLDialect(Dialect):
         "boolean": "TINYINT(1)",
     }
 
+    avg_over_integers_is_exact = True
+
     @property
     def name(self) -> str:
         return "mysql"

--- a/src/orionbelt/dialect/postgres.py
+++ b/src/orionbelt/dialect/postgres.py
@@ -50,6 +50,8 @@ class PostgresDialect(Dialect):
             return self.quote_identifier(code)
         return f"{self.quote_identifier(schema)}.{self.quote_identifier(code)}"
 
+    avg_over_integers_is_exact = True
+
     @property
     def name(self) -> str:
         return "postgres"

--- a/src/orionbelt/dialect/snowflake.py
+++ b/src/orionbelt/dialect/snowflake.py
@@ -36,6 +36,8 @@ class SnowflakeDialect(Dialect):
             return f"NUMBER({p}, {s})"
         return self._OBML_SIMPLE_TYPE_MAP.get(obml_type.name, obml_type.name.upper())
 
+    avg_over_integers_is_exact = True
+
     @property
     def name(self) -> str:
         return "snowflake"

--- a/tests/integration/drift/vendor_exec/conftest.py
+++ b/tests/integration/drift/vendor_exec/conftest.py
@@ -93,6 +93,35 @@ class VendorTarget:
     name: str
     dialect: str
     execute: Callable[[str], list[dict[str, Any]]]
+    # How this engine spells "these literal values, as a table" (#330). The
+    # corpus seed is the right source for almost everything, but an aggregate
+    # that only misbehaves past a double mantissa needs values the seed does
+    # not contain, and every engine spells an inline row set differently.
+    # Defaults to the UNION ALL form, which six of the eight accept.
+    literal_rows: Callable[[str, str, list[int | None]], str] | None = None
+
+    def rows_of(self, alias: str, column: str, values: list[int | None]) -> str:
+        """A FROM-able source of one integer column holding *values*."""
+        if self.literal_rows is not None:
+            return self.literal_rows(alias, column, values)
+        return _union_all_rows(alias, column, values, self.dialect)
+
+
+def _cast_int(value: int | None, dialect: str) -> str:
+    """A 64-bit integer literal, spelled for *dialect*."""
+    # The 64-bit integer type is spelled differently per engine, and the NULL
+    # case has to use the same spelling or the UNION legs disagree.
+    type_name = {
+        "clickhouse": "Nullable(Int64)",
+        "bigquery": "INT64",
+        "mysql": "SIGNED",
+    }.get(dialect, "BIGINT")
+    return f"CAST({'NULL' if value is None else value} AS {type_name})"
+
+
+def _union_all_rows(alias: str, column: str, values: list[int | None], dialect: str) -> str:
+    legs = " UNION ALL ".join(f"SELECT {_cast_int(v, dialect)} AS {column}" for v in values)
+    return f"({legs}) {alias}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/drift/vendor_exec/test_exact_avg_exec.py
+++ b/tests/integration/drift/vendor_exec/test_exact_avg_exec.py
@@ -1,0 +1,139 @@
+"""Execute the exact-AVG rewrite, per vendor, against values the seed lacks.
+
+``AVG`` is a floating-point aggregate on several engines whatever the input
+type, so it drifts once the average passes a ``double`` mantissa. OBSL rewrites
+it into an exact form where the engine offers one (#318, #326).
+
+Nothing executed that rewrite until this module. ``test_exact_avg.py`` asserts
+the emitted **SQL**, and the vendor measure sweep covers only the container
+engines, so the cloud dialects had no aggregate coverage at all. That is how
+Databricks sat in the wrong group for two months while every test passed
+(#322): the unit test checks a dialect is *classified*, not that the
+classification was *measured*.
+
+The corpus seed cannot serve this - its values are far below the boundary, and
+adding large ones would change the DuckDB golden for every vendor. So the rows
+come from ``VendorTarget.rows_of``, which each fixture spells for its own
+engine (#330).
+
+The cases are the ones that have actually caught defects: a sum past 64 bits
+found the accumulator wrapping on Dremio and ClickHouse and raising on
+Databricks, and an empty group found ClickHouse ``divideDecimal`` raising where
+``AVG`` returns NULL.
+"""
+
+from __future__ import annotations
+
+import re
+from decimal import Decimal
+
+import pytest
+
+from orionbelt.compiler.pipeline import CompilationPipeline
+from orionbelt.dialect.registry import DialectRegistry
+from orionbelt.models.query import QueryObject, QuerySelect
+from orionbelt.parser import ReferenceResolver, TrackedLoader
+
+from .conftest import VendorTarget
+
+pytestmark = pytest.mark.docker
+
+MODEL_YAML = """
+version: "1.0"
+name: exact_avg_exec
+dataObjects:
+  Charges:
+    code: charges
+    columns:
+      Qty: {code: qty, abstractType: int}
+measures:
+  Qty Avg:
+    columns: [{dataObject: Charges, column: Qty}]
+    resultType: int
+    aggregation: avg
+"""
+
+# value list -> exact average. Every one of these has caught something.
+CASES: list[tuple[str, list[int | None], str | None]] = [
+    ("large", [1000000000000000002, 1000000000000000004], "1000000000000000003"),
+    ("bigsum", [9000000000000000000, 9000000000000000000], "9000000000000000000"),
+    ("negatives", [-3, -2], "-2.5"),
+    ("mixedsign", [-3, 2], "-0.5"),
+    ("thirds", [1, 1, 2], "1.33"),
+    ("single", [7], "7"),
+    ("small", [10, 21], "15.5"),
+    ("allnull", [None, None], None),
+]
+
+# DuckDB has no exact division at all, so it keeps the plain AVG and a large
+# average overflows the default type rather than returning a wrong number
+# (#316). Executing the same cases there would assert that limitation, which
+# ``test_data_types.py`` already pins closer to the cause.
+NO_EXACT_ROUTE = {"duckdb"}
+
+
+def _projection(dialect: str) -> str:
+    """The measure expression OBSL emits, lifted out of its SELECT."""
+    raw, sm = TrackedLoader().load_string(MODEL_YAML)
+    model, result = ReferenceResolver().resolve(raw, sm)
+    assert result.valid, result.errors
+    sql = (
+        CompilationPipeline()
+        .compile(
+            QueryObject(select=QuerySelect(dimensions=[], measures=["Qty Avg"])), model, dialect
+        )
+        .sql
+    )
+    match = re.search(r"SELECT (.+?)\s+FROM", sql, re.S)
+    assert match, sql
+    return match.group(1).strip()
+
+
+def _assert_exact_average(target: VendorTarget) -> None:
+    if target.dialect in NO_EXACT_ROUTE:
+        pytest.skip(f"{target.dialect} has no exact division; see #316")
+    dia = DialectRegistry.get(target.dialect)
+    alias = dia.quote_identifier("Charges")
+    column = dia.quote_identifier("qty")
+    projection = _projection(target.dialect)
+
+    mismatches = []
+    for label, values, want in CASES:
+        source = target.rows_of(alias, column, values)
+        rows = target.execute(f"SELECT {projection} FROM {source}")
+        got = next(iter(rows[0].values()))
+        if want is None:
+            if got is not None:
+                mismatches.append(f"{label}: {got!r}, expected NULL")
+        elif got is None or Decimal(str(got)) != Decimal(want):
+            mismatches.append(f"{label}: {got!r}, expected {want}")
+
+    assert not mismatches, f"{target.name} does not average exactly:\n  " + "\n  ".join(mismatches)
+
+
+def test_duckdb_exact_avg(vendor_duckdb: VendorTarget) -> None:
+    _assert_exact_average(vendor_duckdb)
+
+
+def test_postgres_exact_avg(vendor_postgres: VendorTarget) -> None:
+    _assert_exact_average(vendor_postgres)
+
+
+def test_mysql_exact_avg(vendor_mysql: VendorTarget) -> None:
+    _assert_exact_average(vendor_mysql)
+
+
+def test_clickhouse_exact_avg(vendor_clickhouse: VendorTarget) -> None:
+    _assert_exact_average(vendor_clickhouse)
+
+
+def test_snowflake_exact_avg(vendor_snowflake: VendorTarget) -> None:
+    _assert_exact_average(vendor_snowflake)
+
+
+def test_bigquery_exact_avg(vendor_bigquery: VendorTarget) -> None:
+    _assert_exact_average(vendor_bigquery)
+
+
+def test_databricks_exact_avg(vendor_databricks: VendorTarget) -> None:
+    _assert_exact_average(vendor_databricks)

--- a/tests/unit/test_exact_avg.py
+++ b/tests/unit/test_exact_avg.py
@@ -369,3 +369,103 @@ metrics:
         )
         assert "DECIMAL(21, 2)" in sql, sql
         assert "DECIMAL(18, 2)" not in sql, f"{measure} kept the saturating default:\n{sql}"
+
+
+class TestComposedWrappersKeepTheWidenedType:
+    """A second wrapper holds a CTE alias, not the aggregate.
+
+    ``rewrite_exact_integer_avg`` can only fire on a bare ``AVG(x)`` - it needs
+    the argument to rewrite. That is the right test for rewriting and the wrong
+    one for typing: once a window or cumulative metric wraps a
+    period-over-period, the later wrapper is casting a column reference into
+    the earlier CTE, so the rewrite declined and the cast fell back to
+    ``decimal(18, 2)`` - saturating on MySQL, overflowing on Postgres - even
+    though the value in that CTE had already been computed exactly.
+
+    The type now follows the measure and the dialect, which are known at every
+    site, rather than the shape the expression happens to have.
+    """
+
+    COMPOSED_YAML = """
+version: "1.0"
+name: composed
+dataObjects:
+  Charges:
+    code: charges
+    columns:
+      When: {code: when, abstractType: date}
+      Qty: {code: qty, abstractType: int}
+dimensions:
+  Sale Month: {dataObject: Charges, column: When, timeGrain: month}
+measures:
+  Qty Avg: {columns: [{dataObject: Charges, column: Qty}], resultType: int, aggregation: avg}
+metrics:
+  Qty Avg Prior:
+    type: period_over_period
+    expression: '{[Qty Avg]}'
+    periodOverPeriod:
+      timeDimension: Sale Month
+      grain: month
+      offset: -1
+      offsetGrain: month
+      comparison: previousValue
+  Qty Avg Lag:
+    type: window
+    measure: Qty Avg
+    windowFunction: lag
+    offset: 1
+    timeDimension: Sale Month
+  Running Qty Avg:
+    type: cumulative
+    measure: Qty Avg
+    timeDimension: Sale Month
+    cumulativeType: sum
+"""
+
+    def _compile(self, measures: list[str], dialect: str) -> str:
+        raw, sm = TrackedLoader().load_string(self.COMPOSED_YAML)
+        model, result = ReferenceResolver().resolve(raw, sm)
+        assert result.valid, result.errors
+        return (
+            CompilationPipeline()
+            .compile(
+                QueryObject(select=QuerySelect(dimensions=["Sale Month"], measures=measures)),
+                model,
+                dialect,
+            )
+            .sql
+        )
+
+    @pytest.mark.parametrize(
+        "measures",
+        [
+            ["Qty Avg Prior"],
+            ["Qty Avg Prior", "Qty Avg Lag"],
+            ["Qty Avg Prior", "Running Qty Avg"],
+        ],
+        ids=["pop", "pop+window", "pop+cumulative"],
+    )
+    def test_no_wrapper_falls_back_to_the_narrow_default(self, measures: list[str]) -> None:
+        sql = self._compile(measures, "postgres")
+        assert "DECIMAL(18, 2)" not in sql, sql
+        assert "DECIMAL(21, 2)" in sql, sql
+
+    def test_duckdb_still_keeps_the_default_through_composition(self) -> None:
+        """The exception has to survive composition too, or #316 leaks back."""
+        sql = self._compile(["Qty Avg Prior", "Qty Avg Lag"], "duckdb")
+        assert "DECIMAL(18, 2)" in sql, sql
+        assert "DECIMAL(21, 2)" not in sql, sql
+
+
+@pytest.mark.parametrize("dialect", sorted(DialectRegistry.available()))
+def test_exactness_is_detected_without_a_second_flag(dialect: str) -> None:
+    """A dialect that overrides the rewrite cannot forget to declare itself.
+
+    ``integer_avg_is_exact`` reads the override rather than a parallel boolean,
+    so the two cannot disagree.
+    """
+    from orionbelt.dialect.base import Dialect
+
+    dia = DialectRegistry.get(dialect)
+    overrides = type(dia).exact_integer_avg is not Dialect.exact_integer_avg
+    assert dia.integer_avg_is_exact() == (dia.avg_over_integers_is_exact or overrides)

--- a/tests/unit/test_exact_avg.py
+++ b/tests/unit/test_exact_avg.py
@@ -15,6 +15,8 @@ here is the decision and the SQL.
 
 from __future__ import annotations
 
+import re
+
 import pytest
 
 from orionbelt.compiler.pipeline import CompilationPipeline
@@ -469,3 +471,93 @@ def test_exactness_is_detected_without_a_second_flag(dialect: str) -> None:
     dia = DialectRegistry.get(dialect)
     overrides = type(dia).exact_integer_avg is not Dialect.exact_integer_avg
     assert dia.integer_avg_is_exact() == (dia.avg_over_integers_is_exact or overrides)
+
+
+class TestNoPathLeavesARawFloatingAverage:
+    """The invariant that makes shape-independent widening safe.
+
+    ``resolve_measure_cast_type`` widens whenever the dialect can be exact,
+    without inspecting the expression - which is only sound if every path that
+    *builds* an integer AVG rewrites it. Two did not, and each left a raw
+    floating average with a widened cast around it, which is worse than the
+    narrow cast it replaced: the drift became invisible instead of loud.
+
+    - ``defaultValue`` emits ``COALESCE(AVG(x), 0)``, so what reached the
+      rewrite was not a bare ``AVG``.
+    - A window or cumulative metric's placeholder deliberately skips the
+      *cast*, because casting to the metric's own type would truncate the
+      window's input - and skipped the rewrite along with it.
+    """
+
+    REWRITE_ONLY = ["bigquery", "clickhouse", "dremio", "databricks"]
+
+    SHAPES = {
+        "plain": ["Qty Avg"],
+        "defaultValue": ["Qty Avg Def"],
+        "pop": ["Qty Avg Prior"],
+        "window": ["Qty Avg Lag"],
+        "pop+window": ["Qty Avg Prior", "Qty Avg Lag"],
+    }
+
+    YAML = """
+version: "1.0"
+name: raw_avg
+dataObjects:
+  Charges:
+    code: charges
+    columns:
+      When: {code: when, abstractType: date}
+      Qty: {code: qty, abstractType: int}
+dimensions:
+  Sale Month: {dataObject: Charges, column: When, timeGrain: month}
+measures:
+  Qty Avg: {columns: [{dataObject: Charges, column: Qty}], resultType: int, aggregation: avg}
+  Qty Avg Def:
+    columns: [{dataObject: Charges, column: Qty}]
+    resultType: int
+    aggregation: avg
+    defaultValue: 0
+metrics:
+  Qty Avg Prior:
+    type: period_over_period
+    expression: '{[Qty Avg]}'
+    periodOverPeriod:
+      timeDimension: Sale Month
+      grain: month
+      offset: -1
+      offsetGrain: month
+      comparison: previousValue
+  Qty Avg Lag:
+    type: window
+    measure: Qty Avg
+    windowFunction: lag
+    offset: 1
+    timeDimension: Sale Month
+"""
+
+    @pytest.mark.parametrize("dialect", REWRITE_ONLY)
+    @pytest.mark.parametrize("shape", sorted(SHAPES), ids=sorted(SHAPES))
+    def test_the_aggregate_is_always_rewritten(self, dialect: str, shape: str) -> None:
+        raw, sm = TrackedLoader().load_string(self.YAML)
+        model, result = ReferenceResolver().resolve(raw, sm)
+        assert result.valid, result.errors
+        sql = (
+            CompilationPipeline()
+            .compile(
+                QueryObject(
+                    select=QuerySelect(dimensions=["Sale Month"], measures=self.SHAPES[shape])
+                ),
+                model,
+                dialect,
+            )
+            .sql
+        )
+        raw_avgs = [
+            m.group(0)
+            for m in re.finditer(r"\b(?:AVG|avg)\(([^()]*)\)", sql)
+            if "CAST" not in m.group(1).upper() and "toDecimal" not in m.group(1)
+        ]
+        assert not raw_avgs, (
+            f"{dialect}/{shape} leaves a raw floating average under a widened cast: "
+            f"{raw_avgs}\n{sql}"
+        )

--- a/tests/unit/test_exact_avg.py
+++ b/tests/unit/test_exact_avg.py
@@ -308,3 +308,64 @@ class TestTheResultTypeIsWidenedWhereverTheAverageIsExact:
         assert native is (dialect in NATIVELY_EXACT), (
             f"{dialect} claims avg_over_integers_is_exact={native}; measure it before changing"
         )
+
+
+class TestEveryPathThatCastsAMeasureAgrees:
+    """A measure must not change type by being wrapped in a metric.
+
+    ``star`` and ``cfl`` applied the exact-AVG handling; the cumulative,
+    period-over-period and window wrappers called ``resolve_measure_data_type``
+    alone. So the same integer AVG emitted ``DECIMAL(21, 2)`` queried directly
+    and ``DECIMAL(18, 2)`` inside a PoP metric - the type that saturates on
+    MySQL and overflows on Postgres.
+
+    All five now share ``cast_measure_to_resolved_type``, which is the point:
+    the previous shape let a fix land on two paths and be forgotten on three.
+    """
+
+    WRAPPED_YAML = (
+        MODEL_YAML.replace(
+            "dimensions:\n  Day: {dataObject: Charges, column: Day}",
+            "dimensions:\n"
+            "  Day: {dataObject: Charges, column: Day}\n"
+            "  Sale Month: {dataObject: Charges, column: When, timeGrain: month}",
+        ).replace(
+            "      Amount: {code: amount, abstractType: float}",
+            "      Amount: {code: amount, abstractType: float}\n"
+            "      When: {code: when, abstractType: date}",
+        )
+        + """
+metrics:
+  Qty Avg Cumul:
+    type: cumulative
+    measure: Qty Avg
+    timeDimension: Sale Month
+    cumulativeType: sum
+  Qty Avg PoP:
+    type: period_over_period
+    expression: '{[Qty Avg]}'
+    periodOverPeriod:
+      timeDimension: Sale Month
+      grain: month
+      offset: -1
+      offsetGrain: month
+      comparison: difference
+"""
+    )
+
+    @pytest.mark.parametrize("measure", ["Qty Avg", "Qty Avg Cumul", "Qty Avg PoP"])
+    def test_the_widened_type_survives_every_wrapper(self, measure: str) -> None:
+        raw, sm = TrackedLoader().load_string(self.WRAPPED_YAML)
+        model, result = ReferenceResolver().resolve(raw, sm)
+        assert result.valid, result.errors
+        sql = (
+            CompilationPipeline()
+            .compile(
+                QueryObject(select=QuerySelect(dimensions=["Sale Month"], measures=[measure])),
+                model,
+                "postgres",
+            )
+            .sql
+        )
+        assert "DECIMAL(21, 2)" in sql, sql
+        assert "DECIMAL(18, 2)" not in sql, f"{measure} kept the saturating default:\n{sql}"

--- a/tests/unit/test_exact_avg.py
+++ b/tests/unit/test_exact_avg.py
@@ -73,10 +73,13 @@ REWRITTEN = {
     # here too. #318 had left it unrewritten on an assumption (#322).
     "databricks": "/ NULLIF(COUNT(",
 }
-# Postgres, MySQL and Snowflake are already exact; DuckDB has no exact
-# division at all, so a rewrite there would only trade a loud overflow for a
-# quiet wrong number (#316).
+# Postgres, MySQL and Snowflake are already exact, so their *expression* is
+# left alone - but their result type is still widened (#330), because an exact
+# average the declared type cannot hold is no better than an inexact one.
+# DuckDB has no exact division at all, so a rewrite there would only trade a
+# loud overflow for a quiet wrong number (#316).
 LEFT_ALONE = ["duckdb", "postgres", "mysql", "snowflake"]
+NATIVELY_EXACT = ["postgres", "mysql", "snowflake"]
 
 
 def _model():
@@ -271,3 +274,37 @@ def _sql_with_default(measure: str, dialect: str, numeric_default: str) -> str:
         )
         .sql
     )
+
+
+class TestTheResultTypeIsWidenedWhereverTheAverageIsExact:
+    """Not only where it is rewritten (#330).
+
+    Postgres, MySQL and Snowflake compute the average exactly and then had it
+    cast to the ``decimal(18, 2)`` default, which carries 16 integer digits
+    where a 64-bit value needs 19. Measured, MySQL saturated a true
+    1000000000000000003 to 9999999999999999.99 **with no warning**, and
+    Postgres raised. Being exact in the aggregate bought nothing if the type
+    could not carry the result.
+    """
+
+    @pytest.mark.parametrize("dialect", NATIVELY_EXACT)
+    def test_a_natively_exact_dialect_widens_its_result(self, dialect: str) -> None:
+        sql = _sql("Qty Avg", dialect)
+        assert "(21, 2)" in sql, sql
+        assert "(18, 2)" not in sql, sql
+
+    def test_duckdb_keeps_the_default_so_the_overflow_stays_loud(self) -> None:
+        """The one engine where widening would hide the problem.
+
+        Its average is not exact and cannot be made so, so a wider type would
+        let a rounded value through instead of failing on it (#316).
+        """
+        assert "DECIMAL(18, 2)" in _sql("Qty Avg", "duckdb")
+
+    @pytest.mark.parametrize("dialect", sorted(DialectRegistry.available()))
+    def test_every_dialect_is_classified_for_exactness(self, dialect: str) -> None:
+        """A new dialect cannot default into "exact" without someone measuring."""
+        native = DialectRegistry.get(dialect).avg_over_integers_is_exact
+        assert native is (dialect in NATIVELY_EXACT), (
+            f"{dialect} claims avg_over_integers_is_exact={native}; measure it before changing"
+        )


### PR DESCRIPTION
Closes #330. The coverage found a silent bug in its first run, so this PR carries the fix too.

## The gap

Nothing executed the rewrite. `test_exact_avg.py` asserts the emitted **SQL**; the vendor measure sweep covers only the container engines. So the cloud dialects had no aggregate coverage at all - which is how Databricks sat in the wrong group for two months while every test passed (#322). The unit test checks a dialect is *classified*, not that the classification was *measured*.

`VendorTarget` gains `rows_of()`, so a test can say "these values, as a table" and each fixture spells it for its own engine. The corpus seed cannot serve this: its values sit far below the boundary, and adding large ones would change the DuckDB golden for every vendor.

## What the first run found

Postgres, MySQL and Snowflake compute the average **exactly** and then had it cast to the `decimal(18, 2)` default - 16 integer digits, where a 64-bit value needs 19:

```
MySQL     AVG(qty)                          ->  1000000000000000003.0000   exact
          CAST(AVG(qty) AS DECIMAL(18,2))   ->  9999999999999999.99        saturated
          SHOW WARNINGS                     ->  ()                         silent

Postgres  CAST(AVG(qty) AS DECIMAL(18,2))   ->  numeric field overflow     loud
```

**MySQL saturates a true `1000000000000000003` with no warning at all.** Being exact in the aggregate bought nothing when the declared type could not carry the result - and this is the shipped default, reachable by any integer `AVG` over large values.

## The fix

The result type is now widened **wherever the average is exact** - natively or by rewrite - rather than only where it is rewritten. `Dialect.avg_over_integers_is_exact` marks the three that are.

DuckDB keeps the default in both halves, and that asymmetry is deliberate: its average is *not* exact and cannot be made so, so widening there would convert a loud overflow into a quiet wrong number (#316). Widening is safe precisely because the value reaching the cast is right.

| | expression | result type |
| --- | --- | --- |
| PostgreSQL, MySQL, Snowflake | plain `AVG` | **widened** |
| BigQuery, ClickHouse, Dremio, Databricks | rewritten | widened |
| DuckDB | plain `AVG` | default, so the overflow stays loud |

## Verification

```
vendor_exec/test_exact_avg_exec.py -m docker   6 passed, 1 skipped
```

Six engines executed: Postgres, MySQL, ClickHouse, Snowflake, BigQuery, Databricks. DuckDB skips for the documented reason. The eight cases are the ones that have caught real defects - a sum past 64 bits (the accumulator wrap), an empty group (ClickHouse `divideDecimal` raising), negatives, mixed signs, a non-terminating average, a single row, and a small average that had to stay unchanged.

4068 passed / 926 skipped, ruff and mypy clean.

New unit tests pin the widening per dialect and assert that a **new** dialect cannot default into "exact" without someone measuring it - the specific hole that let Databricks through.