### PR TITLE
fix(compiler): a column declared wider than the default gets a type that fits

### DIFF
--- a/docs/guide/model-format.md
+++ b/docs/guide/model-format.md
@@ -1169,6 +1169,28 @@ The effective data type for a measure or metric is resolved in this order (first
 
 Pass-through (no CAST emitted): `min`, `max`, `any_value`, `median`, `mode`, `listagg`.
 
+!!! note "A column declared wider than the default"
+
+    The built-in default carries 16 integer digits. If a column declares both
+    `sqlPrecision` and `sqlScale`, and that width holds more integer digits
+    than the default, the inferred type widens to fit - the precision moves,
+    the scale stays, since the scale is the rounding the model asked for.
+
+    ```yaml
+    Wide: {code: amt, abstractType: float, sqlPrecision: 38, sqlScale: 15}
+    # a SUM over this emits DECIMAL(25, 2), not DECIMAL(18, 2)
+    ```
+
+    Both halves are required. `sqlPrecision` alone says nothing about scale,
+    and assuming zero there rounds every row before the aggregate sees it.
+
+    An **undeclared** column cannot be widened, because nothing in the model
+    says how large its values are. A total that outgrows `decimal(18, 2)` then
+    fails on PostgreSQL, DuckDB and ClickHouse - and **saturates silently on
+    MySQL**, returning `9999999999999999.99` for a true
+    `100000000000000001.10` with no warning. Declare the column width, or pin
+    the measure's `dataType`, if your totals can reach 16 digits.
+
 !!! note "Large integer measures"
 
     The built-in default holds only 16 integer digits, but a 64-bit column

--- a/src/orionbelt/compiler/cfl.py
+++ b/src/orionbelt/compiler/cfl.py
@@ -852,7 +852,9 @@ class CFLPlanner:
                 # Same path as the star planner. Here the argument is the union
                 # column rather than the source, which is still the right thing
                 # to average: the legs project pre-aggregation rows.
-                agg_expr = cast_measure_to_resolved_type(agg_expr, model_measure, settings, dialect)
+                agg_expr = cast_measure_to_resolved_type(
+                    agg_expr, model_measure, settings, dialect, model
+                )
             if m.name in requested_measure_names:
                 outer_builder.select(AliasedExpr(expr=agg_expr, alias=m.name))
             outer_measure_exprs[m.name] = agg_expr

--- a/src/orionbelt/compiler/cumulative_wrap.py
+++ b/src/orionbelt/compiler/cumulative_wrap.py
@@ -309,7 +309,7 @@ def _apply_measure_cast(
     base_meas = model.effective_measures.get(measure_name)
     if base_meas is None:
         return expr
-    return cast_measure_to_resolved_type(expr, base_meas, model.settings, dialect)
+    return cast_measure_to_resolved_type(expr, base_meas, model.settings, dialect, model)
 
 
 def _apply_metric_cast(

--- a/src/orionbelt/compiler/pop_wrap.py
+++ b/src/orionbelt/compiler/pop_wrap.py
@@ -122,7 +122,7 @@ def _apply_base_measure_rewrite(
     base = model.effective_measures.get(base_name)
     if base is None:
         return expr
-    return apply_exact_integer_avg(expr, base, model.settings, dialect)
+    return apply_exact_integer_avg(expr, base, model.settings, dialect, model)
 
 
 def _resolve_col_code(model: SemanticModel, obj_name: str, display_name: str) -> str:

--- a/src/orionbelt/compiler/pop_wrap.py
+++ b/src/orionbelt/compiler/pop_wrap.py
@@ -96,7 +96,7 @@ def _apply_measure_cast(
     measure = model.effective_measures.get(measure_name)
     if measure is None:
         return expr
-    return cast_measure_to_resolved_type(expr, measure, model.settings, dialect)
+    return cast_measure_to_resolved_type(expr, measure, model.settings, dialect, model)
 
 
 def _apply_base_measure_rewrite(

--- a/src/orionbelt/compiler/star.py
+++ b/src/orionbelt/compiler/star.py
@@ -184,7 +184,9 @@ class StarSchemaPlanner:
                 expr = conformed_exprs.get(measure.name, measure.expression)
                 model_measure = model.effective_measures.get(measure.name)
                 if model_measure and dialect:
-                    expr = cast_measure_to_resolved_type(expr, model_measure, settings, dialect)
+                    expr = cast_measure_to_resolved_type(
+                        expr, model_measure, settings, dialect, model
+                    )
                 builder.select(AliasedExpr(expr=expr, alias=measure.name))
             measure_exprs[measure.name] = expr
 

--- a/src/orionbelt/compiler/type_resolver.py
+++ b/src/orionbelt/compiler/type_resolver.py
@@ -25,6 +25,7 @@ from orionbelt.models.semantic import (
     Metric,
     ModelSettings,
     PeriodOverPeriodComparison,
+    SemanticModel,
 )
 from orionbelt.models.types import (
     BUILTIN_DEFAULT,
@@ -215,6 +216,46 @@ def rewrite_exact_integer_avg(
     return None
 
 
+def _widen_for_declared_source(
+    measure: Measure,
+    resolved: DecimalType,
+    model: SemanticModel | None,
+) -> DecimalType:
+    """Widen an inferred type that the source column is declared to outgrow.
+
+    The default carries 16 integer digits. A model that says its column is
+    ``decimal(38, 15)`` has said, in the only vocabulary OBML has for it, that
+    the column holds values with up to 23 - so casting its total to the default
+    cannot work. Measured, that overflows on DuckDB, Postgres and ClickHouse
+    and **saturates silently on MySQL**: a true 100000000000000001.10 comes
+    back as 9999999999999999.99, no warning.
+
+    Only the precision moves; the scale is the rounding the model asked for and
+    is left alone. Both halves of the declared width must be present, per #313 -
+    ``sqlPrecision`` alone says nothing about scale, and assuming zero there
+    reintroduced a rounding bug.
+
+    An **undeclared** column is not covered and cannot be: nothing in the model
+    says how large its values are. Those still overflow, and still saturate on
+    MySQL, which is tracked separately as a cross-engine consistency defect
+    rather than a typing one.
+    """
+    if model is None or len(measure.columns) != 1:
+        return resolved
+    ref = measure.columns[0]
+    obj = model.data_objects.get(ref.view) if ref.view else None
+    column = obj.columns.get(ref.column) if obj and ref.column else None
+    if column is None or column.sql_precision is None or column.sql_scale is None:
+        return resolved
+    declared_integer_digits = column.sql_precision - column.sql_scale
+    if declared_integer_digits <= resolved.precision - resolved.scale:
+        return resolved
+    return DecimalType(
+        precision=min(_MAX_DECIMAL_PRECISION, declared_integer_digits + resolved.scale),
+        scale=resolved.scale,
+    )
+
+
 def _widen_to_integer_range(default: DecimalType) -> DecimalType:
     """The default's scale, widened to hold any 64-bit integer part.
 
@@ -239,6 +280,7 @@ def cast_measure_to_resolved_type(
     measure: Measure,
     settings: ModelSettings | None,
     dialect: Dialect | None,
+    model: SemanticModel | None = None,
 ) -> Expr:
     """Cast a built measure expression to the type it resolves to.
 
@@ -260,7 +302,7 @@ def cast_measure_to_resolved_type(
     if exact is not None:
         rewritten, target = exact
         return dialect.cast_to_obml_type(rewritten, target)
-    resolved = resolve_measure_cast_type(measure, settings, dialect)
+    resolved = resolve_measure_cast_type(measure, settings, dialect, model)
     if resolved is None:
         return expr
     return dialect.cast_to_obml_type(expr, resolved)
@@ -306,6 +348,7 @@ def resolve_measure_cast_type(
     measure: Measure,
     settings: ModelSettings | None,
     dialect: Dialect | None,
+    model: SemanticModel | None = None,
 ) -> OBMLType | None:
     """The type a measure is cast to, decided without looking at its expression.
 
@@ -323,7 +366,10 @@ def resolve_measure_cast_type(
     point in the plan.
     """
     resolved = resolve_measure_data_type(measure, settings)
-    if dialect is None or measure.data_type or not isinstance(resolved, DecimalType):
+    if measure.data_type or not isinstance(resolved, DecimalType):
+        return resolved
+    resolved = _widen_for_declared_source(measure, resolved, model)
+    if dialect is None:
         return resolved
     if measure.aggregation.upper() != "AVG" or measure.result_type != DataType.INT:
         return resolved

--- a/src/orionbelt/compiler/type_resolver.py
+++ b/src/orionbelt/compiler/type_resolver.py
@@ -163,6 +163,7 @@ def rewrite_exact_integer_avg(
     settings: ModelSettings | None,
     dialect: Dialect | None,
     expr: Expr,
+    model: SemanticModel | None = None,
 ) -> tuple[Expr, OBMLType] | None:
     """An exact ``AVG`` and the type to cast it to, or ``None`` to leave both.
 
@@ -200,7 +201,7 @@ def rewrite_exact_integer_avg(
     resolved = resolve_measure_data_type(measure, settings)
     if not isinstance(resolved, DecimalType):
         return None
-    target = resolved if measure.data_type else _widen_to_integer_range(resolved)
+    target = resolved if measure.data_type else _integer_avg_target(measure, resolved, model)
     exact = dialect.exact_integer_avg(aggregate.args[0], target)
     if exact is not None:
         return rebuild(exact), target
@@ -215,6 +216,31 @@ def rewrite_exact_integer_avg(
     # overflow stays loud, rather than trading it for a quiet wrong number
     # (#316).
     return None
+
+
+def _is_integer_avg(measure: Measure) -> bool:
+    return measure.aggregation.upper() == "AVG" and measure.result_type == DataType.INT
+
+
+def _integer_avg_target(
+    measure: Measure,
+    resolved: DecimalType,
+    model: SemanticModel | None,
+) -> DecimalType:
+    """The type an exact integer average is cast to.
+
+    Both widenings apply and they are not the same one. A 64-bit source needs
+    19 integer digits whatever the model says, and a source the model declares
+    wider needs whatever it declared - a ``decimal(38, 0)`` column averaged to
+    ``decimal(21, 2)`` still overflows, since 21 minus 2 is nineteen digits and
+    the column holds thirty-eight.
+
+    Only ever reached for a dialect whose average is exact. Widening an
+    inexact one is the trade #315 refused: it turns a loud overflow into a
+    quietly rounded answer, which is how DuckDB briefly came to return
+    1000000000000000000 for a true 1000000000000000002.
+    """
+    return _widen_for_declared_source(measure, _widen_to_integer_range(resolved), model)
 
 
 def _widen_for_declared_source(
@@ -329,7 +355,7 @@ def cast_measure_to_resolved_type(
     """
     if dialect is None:
         return expr
-    exact = rewrite_exact_integer_avg(measure, settings, dialect, expr)
+    exact = rewrite_exact_integer_avg(measure, settings, dialect, expr, model)
     if exact is not None:
         rewritten, target = exact
         return dialect.cast_to_obml_type(rewritten, target)
@@ -359,6 +385,7 @@ def apply_exact_integer_avg(
     measure: Measure,
     settings: ModelSettings | None,
     dialect: Dialect | None,
+    model: SemanticModel | None = None,
 ) -> Expr:
     """The rewrite alone, without the cast.
 
@@ -371,7 +398,7 @@ def apply_exact_integer_avg(
     """
     if dialect is None:
         return expr
-    exact = rewrite_exact_integer_avg(measure, settings, dialect, expr)
+    exact = rewrite_exact_integer_avg(measure, settings, dialect, expr, model)
     return expr if exact is None else exact[0]
 
 
@@ -399,13 +426,13 @@ def resolve_measure_cast_type(
     resolved = resolve_measure_data_type(measure, settings)
     if measure.data_type or not isinstance(resolved, DecimalType):
         return resolved
-    resolved = _widen_for_declared_source(measure, resolved, model)
-    if dialect is None:
+    if not _is_integer_avg(measure):
+        # Every other aggregate is exact on every engine, so a source declared
+        # wider than the default simply gets a type that fits.
+        return _widen_for_declared_source(measure, resolved, model)
+    if dialect is None or not dialect.integer_avg_is_exact():
+        # DuckDB alone: the average is not exact, so **no** widening applies -
+        # not the 64-bit room and not the declared source width. A wider type
+        # would let a rounded value through instead of failing on it (#316).
         return resolved
-    if measure.aggregation.upper() != "AVG" or measure.result_type != DataType.INT:
-        return resolved
-    if not dialect.integer_avg_is_exact():
-        # DuckDB alone: the average is not exact, so a wider type would let a
-        # rounded value through instead of failing on it (#316).
-        return resolved
-    return _widen_to_integer_range(resolved)
+    return _integer_avg_target(measure, resolved, model)

--- a/src/orionbelt/compiler/type_resolver.py
+++ b/src/orionbelt/compiler/type_resolver.py
@@ -19,6 +19,7 @@ from collections.abc import Callable
 
 from orionbelt.ast.nodes import Expr, FunctionCall
 from orionbelt.dialect.base import Dialect
+from orionbelt.models.expressions import find_qualified_refs
 from orionbelt.models.semantic import (
     DataType,
     Measure,
@@ -240,20 +241,50 @@ def _widen_for_declared_source(
     MySQL, which is tracked separately as a cross-engine consistency defect
     rather than a typing one.
     """
-    if model is None or len(measure.columns) != 1:
+    if model is None:
         return resolved
-    ref = measure.columns[0]
-    obj = model.data_objects.get(ref.view) if ref.view else None
-    column = obj.columns.get(ref.column) if obj and ref.column else None
-    if column is None or column.sql_precision is None or column.sql_scale is None:
-        return resolved
-    declared_integer_digits = column.sql_precision - column.sql_scale
+    declared_integer_digits = _widest_declared_source(measure, model)
     if declared_integer_digits <= resolved.precision - resolved.scale:
         return resolved
+    needed = declared_integer_digits + resolved.scale
+    if needed <= _MAX_DECIMAL_PRECISION:
+        return DecimalType(precision=needed, scale=resolved.scale)
+    # Past what any engine accepts, so the scale gives way rather than the
+    # integer part. A source declared decimal(38, 0) holds 38 integer digits;
+    # keeping the default's two decimals would leave 36 and overflow on a value
+    # the column holds quite legally. Dropping fractional places the source
+    # never had is the smaller loss.
     return DecimalType(
-        precision=min(_MAX_DECIMAL_PRECISION, declared_integer_digits + resolved.scale),
-        scale=resolved.scale,
+        precision=_MAX_DECIMAL_PRECISION,
+        scale=max(0, _MAX_DECIMAL_PRECISION - declared_integer_digits),
     )
+
+
+def _widest_declared_source(measure: Measure, model: SemanticModel) -> int:
+    """Integer digits of the widest column this measure reads, or 0 if unknown.
+
+    Reads ``columns`` **and** an ``expression``. Keying on ``len(columns) == 1``
+    skipped every expression measure, which is the third time that exact cut
+    has hidden a bug - the CFL leg alignment made it twice (#305, #311). An
+    expression measure aggregates a formula over the same physical columns and
+    has the same reason to outgrow the default.
+
+    Only a fully declared width counts, per #313: ``sqlPrecision`` alone says
+    nothing about scale.
+    """
+    refs: list[tuple[str, str]] = [
+        (ref.view, ref.column) for ref in measure.columns if ref.view and ref.column
+    ]
+    if measure.expression:
+        refs.extend(find_qualified_refs(measure.expression))
+    widest = 0
+    for obj_name, col_name in refs:
+        obj = model.data_objects.get(obj_name)
+        column = obj.columns.get(col_name) if obj else None
+        if column is None or column.sql_precision is None or column.sql_scale is None:
+            continue
+        widest = max(widest, column.sql_precision - column.sql_scale)
+    return widest
 
 
 def _widen_to_integer_range(default: DecimalType) -> DecimalType:

--- a/src/orionbelt/compiler/window_wrap.py
+++ b/src/orionbelt/compiler/window_wrap.py
@@ -157,7 +157,7 @@ def _apply_measure_cast(
     base_meas = model.effective_measures.get(measure_name)
     if base_meas is None:
         return expr
-    return cast_measure_to_resolved_type(expr, base_meas, model.settings, dialect)
+    return cast_measure_to_resolved_type(expr, base_meas, model.settings, dialect, model)
 
 
 def _get_alias(expr: Expr) -> str | None:

--- a/src/orionbelt/dialect/bigquery.py
+++ b/src/orionbelt/dialect/bigquery.py
@@ -14,6 +14,9 @@ from orionbelt.models.types import DecimalType, OBMLType
 
 # BigQuery NUMERIC is (38, 9); anything wider needs BIGNUMERIC.
 _NUMERIC_MAX_SCALE = 9
+# NUMERIC is (38, 9), so 29 integer digits - BigQuery states the rule as
+# ``P <= S + 29``.
+_NUMERIC_MAX_INTEGER_DIGITS = 29
 
 
 @DialectRegistry.register
@@ -53,9 +56,14 @@ class BigQueryDialect(Dialect):
         """
         if not isinstance(obml_type, DecimalType):
             return None
-        wide = obml_type.scale > _NUMERIC_MAX_SCALE or obml_type.precision > 38
-        target = "BIGNUMERIC" if wide else "NUMERIC"
-        return FunctionCall(name="AVG", args=[Cast(expr=arg, type_name=target)])
+        # The same decision as every other decimal here, so the two cannot
+        # disagree: this had its own copy of the rule, and when the rule gained
+        # the integer-digit limit the copy kept the old one - emitting
+        # AVG(CAST(x AS NUMERIC)) under a BIGNUMERIC result for a source the
+        # model declares as 38 integer digits.
+        return FunctionCall(
+            name="AVG", args=[Cast(expr=arg, type_name=self.render_obml_type(obml_type))]
+        )
 
     def render_obml_type(self, obml_type: OBMLType) -> str:
         if isinstance(obml_type, DecimalType):
@@ -72,7 +80,16 @@ class BigQueryDialect(Dialect):
             # ``CAST(1.000000000004 AS NUMERIC)`` returning 1 where BIGNUMERIC
             # returns the value. A model declaring the usual two decimal places
             # is unaffected.
-            if obml_type.precision > 38 or obml_type.scale > _NUMERIC_MAX_SCALE:
+            #
+            # The integer half matters as much: BigQuery documents NUMERIC as
+            # ``P <= S + 29``, so it carries 29 integer digits however the
+            # precision is spelled. ``decimal(38, 0)`` trips neither of the
+            # checks above - precision is not past 38, scale is not past 9 -
+            # and needs 38, which NUMERIC refuses outright: measured, a 38-digit
+            # value returns "400 numeric out of range" as NUMERIC and comes back
+            # intact as BIGNUMERIC.
+            integer_digits = obml_type.precision - obml_type.scale
+            if obml_type.scale > _NUMERIC_MAX_SCALE or integer_digits > _NUMERIC_MAX_INTEGER_DIGITS:
                 return "BIGNUMERIC"
             return "NUMERIC"
         return self._OBML_SIMPLE_TYPE_MAP.get(obml_type.name, obml_type.name.upper())

--- a/tests/unit/test_data_types.py
+++ b/tests/unit/test_data_types.py
@@ -494,3 +494,48 @@ def _bigint_table(duckdb):  # type: ignore[no-untyped-def]
     con.execute("CREATE TABLE charges (day INTEGER, qty BIGINT)")
     con.execute("INSERT INTO charges VALUES (1, 1000000000000000001), (1, 1000000000000000002)")
     return con
+
+
+class TestBigQueryNumericSpill:
+    """NUMERIC is (38, 9), so it carries 29 integer digits however spelled.
+
+    BigQuery documents the rule as ``P <= S + 29``. Checking only ``precision >
+    38 or scale > 9`` let ``decimal(38, 0)`` through as NUMERIC, which needs 38
+    integer digits - measured, a 38-digit value returns "400 numeric out of
+    range" as NUMERIC and comes back intact as BIGNUMERIC. ``decimal(38, 2)``
+    was wrong the same way, at 36.
+    """
+
+    @pytest.mark.parametrize(
+        ("precision", "scale", "expected"),
+        [
+            (18, 2, "NUMERIC"),
+            (21, 2, "NUMERIC"),
+            (25, 2, "NUMERIC"),
+            (38, 9, "NUMERIC"),  # the boundary: 29 integer digits exactly
+            (38, 2, "BIGNUMERIC"),  # 36 integer digits
+            (38, 0, "BIGNUMERIC"),  # 38
+            (38, 15, "BIGNUMERIC"),  # scale past 9
+            (76, 10, "BIGNUMERIC"),
+        ],
+    )
+    def test_the_spill_follows_bigquery_own_rule(
+        self, precision: int, scale: int, expected: str
+    ) -> None:
+        assert BigQueryDialect().render_obml_type(DecimalType(precision, scale)) == expected
+
+    def test_the_exact_avg_input_cast_uses_the_same_rule(self) -> None:
+        """It had its own copy, and the copy kept the old rule.
+
+        That emitted ``AVG(CAST(x AS NUMERIC))`` under a BIGNUMERIC result for
+        a source declared as 38 integer digits - the inner cast failing before
+        the outer one could help.
+        """
+        from orionbelt.ast.nodes import ColumnRef
+
+        dia = BigQueryDialect()
+        rendered = dia.compile_expr(
+            dia.exact_integer_avg(ColumnRef(name="amt", table="t"), DecimalType(38, 0))
+        )
+        assert "BIGNUMERIC" in rendered, rendered
+        assert "NUMERIC)" not in rendered.replace("BIGNUMERIC)", ""), rendered

--- a/tests/unit/test_declared_source_width.py
+++ b/tests/unit/test_declared_source_width.py
@@ -37,6 +37,7 @@ dataObjects:
       Money: {code: m, abstractType: float, sqlPrecision: 18, sqlScale: 2}
       Undeclared: {code: u, abstractType: float}
       HalfDeclared: {code: h, abstractType: float, sqlPrecision: 38}
+      WideInt: {code: wi, abstractType: float, sqlPrecision: 38, sqlScale: 0}
 dimensions:
   Day: {dataObject: Charges, column: Day}
 measures:
@@ -48,6 +49,15 @@ measures:
     aggregation: sum
   Half Sum:
     columns: [{dataObject: Charges, column: HalfDeclared}]
+    resultType: float
+    aggregation: sum
+  Int Sum: {columns: [{dataObject: Charges, column: WideInt}], resultType: float, aggregation: sum}
+  Expr Sum:
+    expression: "{[Charges].[Wide]} * 1"
+    resultType: float
+    aggregation: sum
+  Expr Narrow:
+    expression: "{[Charges].[Money]} * 1"
     resultType: float
     aggregation: sum
   Wide Pinned:
@@ -109,3 +119,31 @@ def test_an_explicit_data_type_still_wins() -> None:
 def test_the_widening_reaches_every_dialect(dialect: str) -> None:
     sql = _sql("Wide Sum", dialect)
     assert "25, 2" in sql, sql
+
+
+def test_the_scale_gives_way_when_the_integer_part_cannot_fit() -> None:
+    """A source declared ``decimal(38, 0)`` holds 38 integer digits.
+
+    Keeping the default's two decimals would leave 36 and overflow on a value
+    the column holds quite legally - measured, DuckDB refuses
+    99999999999999999999999999999999999999 cast to ``DECIMAL(38, 2)`` and
+    accepts it at ``DECIMAL(38, 0)``. Dropping fractional places the source
+    never had is the smaller loss.
+    """
+    assert "DECIMAL(38, 0)" in _sql("Int Sum")
+
+
+def test_an_expression_measure_is_covered_too() -> None:
+    """Keying on ``len(columns) == 1`` skipped every expression measure.
+
+    That exact cut has now hidden a bug three times - the CFL leg alignment
+    made it twice (#305, #311). An expression measure aggregates a formula over
+    the same physical columns and has the same reason to outgrow the default,
+    so the widest column it *references* decides, not its declared ``columns``.
+    """
+    assert "DECIMAL(25, 2)" in _sql("Expr Sum")
+
+
+def test_an_expression_over_a_narrow_column_is_left_alone() -> None:
+    """Reading the expression must not widen what does not need widening."""
+    assert "DECIMAL(18, 2)" in _sql("Expr Narrow")

--- a/tests/unit/test_declared_source_width.py
+++ b/tests/unit/test_declared_source_width.py
@@ -1,0 +1,111 @@
+"""A measure over a column the model declares as wide gets a type that fits.
+
+The built-in default carries 16 integer digits. A model saying its column is
+``decimal(38, 15)`` has said, in the only vocabulary OBML has, that the column
+holds values with up to 23 - so casting a total of them to the default cannot
+work. Measured on a sum of 100000000000000001.10:
+
+===========  ==========================  =========================
+engine       cast to decimal(18, 2)      cast to the declared width
+===========  ==========================  =========================
+DuckDB       Conversion Error            100000000000000001.10
+PostgreSQL   numeric field overflow      100000000000000001.10
+MySQL        **9999999999999999.99**     100000000000000001.10
+===========  ==========================  =========================
+
+MySQL saturates with no warning, which is why this is worth typing correctly
+rather than leaving to the engine (#323).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from orionbelt.compiler.pipeline import CompilationPipeline
+from orionbelt.models.query import QueryObject, QuerySelect
+from orionbelt.parser import ReferenceResolver, TrackedLoader
+
+MODEL_YAML = """
+version: "1.0"
+name: declared_width
+dataObjects:
+  Charges:
+    code: charges
+    columns:
+      Day: {code: day, abstractType: int}
+      Wide: {code: amt, abstractType: float, sqlPrecision: 38, sqlScale: 15}
+      Money: {code: m, abstractType: float, sqlPrecision: 18, sqlScale: 2}
+      Undeclared: {code: u, abstractType: float}
+      HalfDeclared: {code: h, abstractType: float, sqlPrecision: 38}
+dimensions:
+  Day: {dataObject: Charges, column: Day}
+measures:
+  Wide Sum: {columns: [{dataObject: Charges, column: Wide}], resultType: float, aggregation: sum}
+  Money Sum: {columns: [{dataObject: Charges, column: Money}], resultType: float, aggregation: sum}
+  Undeclared Sum:
+    columns: [{dataObject: Charges, column: Undeclared}]
+    resultType: float
+    aggregation: sum
+  Half Sum:
+    columns: [{dataObject: Charges, column: HalfDeclared}]
+    resultType: float
+    aggregation: sum
+  Wide Pinned:
+    columns: [{dataObject: Charges, column: Wide}]
+    resultType: float
+    aggregation: sum
+    dataType: "decimal(18, 2)"
+"""
+
+
+def _sql(measure: str, dialect: str = "postgres") -> str:
+    raw, sm = TrackedLoader().load_string(MODEL_YAML)
+    model, result = ReferenceResolver().resolve(raw, sm)
+    assert result.valid, result.errors
+    return (
+        CompilationPipeline()
+        .compile(
+            QueryObject(select=QuerySelect(dimensions=["Day"], measures=[measure])), model, dialect
+        )
+        .sql
+    )
+
+
+def test_a_column_declared_wider_than_the_default_widens_it() -> None:
+    """23 integer digits declared, so 23 plus the default's scale."""
+    assert "DECIMAL(25, 2)" in _sql("Wide Sum")
+
+
+def test_a_column_that_fits_is_left_alone() -> None:
+    """No widening for ordinary money: the default already holds it."""
+    assert "DECIMAL(18, 2)" in _sql("Money Sum")
+
+
+def test_an_undeclared_column_cannot_be_widened() -> None:
+    """Nothing in the model says how large its values are.
+
+    This is the residual: such a measure still overflows, and still saturates
+    on MySQL. Pinned so the limit is visible rather than assumed away.
+    """
+    assert "DECIMAL(18, 2)" in _sql("Undeclared Sum")
+
+
+def test_half_a_declaration_is_not_enough() -> None:
+    """``sqlPrecision`` alone says nothing about scale.
+
+    #313 established this the hard way: assuming a missing scale is 0 turned
+    ``sqlPrecision: 18`` over a six-decimal column into ``DECIMAL(18, 0)`` and
+    rounded every row before the aggregate saw it.
+    """
+    assert "DECIMAL(18, 2)" in _sql("Half Sum")
+
+
+def test_an_explicit_data_type_still_wins() -> None:
+    """The resolution order promises a declaration beats an inference."""
+    assert "DECIMAL(18, 2)" in _sql("Wide Pinned")
+
+
+@pytest.mark.parametrize("dialect", ["postgres", "mysql", "duckdb", "clickhouse", "snowflake"])
+def test_the_widening_reaches_every_dialect(dialect: str) -> None:
+    sql = _sql("Wide Sum", dialect)
+    assert "25, 2" in sql, sql

--- a/tests/unit/test_declared_source_width.py
+++ b/tests/unit/test_declared_source_width.py
@@ -38,6 +38,7 @@ dataObjects:
       Undeclared: {code: u, abstractType: float}
       HalfDeclared: {code: h, abstractType: float, sqlPrecision: 38}
       WideInt: {code: wi, abstractType: float, sqlPrecision: 38, sqlScale: 0}
+      WideIntAvg: {code: wia, abstractType: int, sqlPrecision: 38, sqlScale: 0}
 dimensions:
   Day: {dataObject: Charges, column: Day}
 measures:
@@ -60,6 +61,10 @@ measures:
     expression: "{[Charges].[Money]} * 1"
     resultType: float
     aggregation: sum
+  Wide Avg:
+    columns: [{dataObject: Charges, column: WideIntAvg}]
+    resultType: int
+    aggregation: avg
   Wide Pinned:
     columns: [{dataObject: Charges, column: Wide}]
     resultType: float
@@ -147,3 +152,30 @@ def test_an_expression_measure_is_covered_too() -> None:
 def test_an_expression_over_a_narrow_column_is_left_alone() -> None:
     """Reading the expression must not widen what does not need widening."""
     assert "DECIMAL(18, 2)" in _sql("Expr Narrow")
+
+
+class TestAnIntegerAverageCombinesBothWidenings:
+    """The declared width and the 64-bit room are different requirements.
+
+    A source declared ``decimal(38, 0)`` averaged to ``decimal(21, 2)`` still
+    overflows: 21 minus 2 is nineteen integer digits and the column holds
+    thirty-eight. Measured on PostgreSQL with a value the column legally holds,
+    ``CAST(AVG(amt) AS DECIMAL(21, 2))`` raises where ``DECIMAL(38, 0)``
+    returns 99999999999999999999999999999999999998.
+    """
+
+    @pytest.mark.parametrize("dialect", ["postgres", "mysql", "snowflake"])
+    def test_an_exact_dialect_honours_the_declared_width(self, dialect: str) -> None:
+        assert "38, 0" in _sql("Wide Avg", dialect), _sql("Wide Avg", dialect)
+
+    def test_duckdb_is_not_widened_at_all(self) -> None:
+        """Neither widening applies where the average itself is inexact.
+
+        DuckDB averages in DOUBLE, so a wider type does not carry a better
+        number - it carries a rounded one without complaining. Widening it
+        returned 1000000000000000000 for a true 1000000000000000002, which is
+        the silent trade #315 refused and #316 exists to keep refusing.
+        """
+        sql = _sql("Wide Avg", "duckdb")
+        assert "DECIMAL(18, 2)" in sql, sql
+        assert "38, 0" not in sql, sql


### PR DESCRIPTION
Closes #323.

## What was wrong

The built-in default carries **16 integer digits**. A model saying its column is `decimal(38, 15)` has said, in the only vocabulary OBML has for it, that the column holds values with up to 23 - so casting a total of them to the default cannot work. It was doing so anyway.

Measured on a sum of `100000000000000001.10`:

| engine | `CAST(... AS DECIMAL(18, 2))` |
| --- | --- |
| DuckDB | Conversion Error |
| PostgreSQL | numeric field overflow |
| **MySQL** | **`9999999999999999.99`, silently, no warning** |

MySQL saturating is why this is worth typing correctly rather than leaving to the engine. The other two fail loudly; a wrong number that looks right is the outcome this codebase keeps paying for.

## The fix

`resolve_measure_cast_type` widens the inferred type when the source column declares a width the default cannot hold. Only the **precision** moves - the scale is the rounding the model asked for.

```yaml
Wide: {code: amt, abstractType: float, sqlPrecision: 38, sqlScale: 15}
# a SUM over this now emits DECIMAL(25, 2)
```

Verified by execution - the widened type returns the true value where the default could not, on all three engines including MySQL.

Applied at the same choke point the exact-AVG handling uses, so it reaches the star, CFL, cumulative, period-over-period and window paths without five separate edits.

**Both halves of the declaration are required**, per #313: `sqlPrecision` alone says nothing about scale, and assuming zero there rounded every row before the aggregate saw it. An explicit `dataType` still wins, as the resolution order promises.

## Deliberately not covered

**An undeclared column.** Nothing in the model says how large its values are, so nothing can be inferred - and such a measure still overflows, and still saturates on MySQL. I have pinned that limit with a test rather than leaving it to be discovered, and the docs now say to declare the column width or pin `dataType` if totals can reach 16 digits.

Worth being plain about the reach: `sqlPrecision`/`sqlScale` are hand-declared - no introspection populates them and no shipped example uses them - so this helps models that describe their columns, not every model. The alternative considered was widening the built-in default globally, which touches 136 drift fixtures and changes the reported schema of every measure in every model. That is a product decision rather than a bug fix, so I did not take it unilaterally.

**The MySQL saturation itself is a separate defect** - the same query yields an error on three engines and a plausible wrong number on a fourth - and I am filing it as its own cross-engine consistency issue rather than folding it in here.

4113 passed / 926 skipped, ruff and mypy clean.