### PR TITLE
fix(dialect): a measure's decimal cast carries 38 digits on MySQL

### DIFF
--- a/docs/guide/model-format.md
+++ b/docs/guide/model-format.md
@@ -1186,9 +1186,10 @@ Pass-through (no CAST emitted): `min`, `max`, `any_value`, `median`, `mode`, `li
 
     An **undeclared** column cannot be widened, because nothing in the model
     says how large its values are. A total that outgrows `decimal(18, 2)` then
-    fails on PostgreSQL, DuckDB and ClickHouse - and **saturates silently on
-    MySQL**, returning `9999999999999999.99` for a true
-    `100000000000000001.10` with no warning. Declare the column width, or pin
+    fails on PostgreSQL, DuckDB and ClickHouse. It does not fail on MySQL,
+    whose casts carry 38 digits precisely because it would otherwise saturate
+    rather than refuse (see [Numeric Overflow](#numeric-overflow)) - so a model
+    that only ever runs there will not notice. Declare the column width, or pin
     the measure's `dataType`, if your totals can reach 16 digits.
 
 !!! note "Large integer measures"
@@ -1241,9 +1242,11 @@ Pass-through (no CAST emitted): `min`, `max`, `any_value`, `median`, `mode`, `li
     got there natively or by rewrite, since an exact average the declared type
     cannot hold is no better than an inexact one. `decimal(18, 2)` carries 16
     integer digits and a 64-bit value needs 19. Measured, the default made
-    MySQL saturate a true `1000000000000000003` to `9999999999999999.99` **with
-    no warning**, and made PostgreSQL raise. An explicit `dataType` is
-    respected as declared.
+    PostgreSQL raise and MySQL return `9999999999999999.99` for a true
+    `1000000000000000003` - a saturated cast, which its widened cast now holds
+    (see [Numeric Overflow](#numeric-overflow)), but the widened *result type*
+    is what keeps the exact average on the other engines. An explicit
+    `dataType` is respected as declared.
 
 
     **DuckDB is the exception**, tracked in
@@ -1315,6 +1318,58 @@ Rate:
     0)` returned NULL on two engines and raised on four, and `log` outside its
     domain had four different answers - including `inf`, `-0.0`, `-inf` and
     `nan` on ClickHouse, which is the silent case NULL exists to remove.
+
+### Numeric Overflow
+
+**A value that outgrows its type is an error on every engine but MySQL, which
+returns a wrong number instead.** Measured on the same measure over the same
+data, a true total of `100000000000000000` under `dataType: "decimal(18, 2)"`:
+
+| dialect | result |
+| --- | --- |
+| DuckDB | raises `Conversion Error` |
+| PostgreSQL | raises `numeric field overflow` |
+| ClickHouse | raises code 407 |
+| Snowflake | raises |
+| Databricks | raises |
+| BigQuery | `100000000000000000` - its `NUMERIC` is (38, 9), so the value fits |
+| MySQL | `9999999999999999.99` - saturated |
+
+MySQL attaches warning 1264 to that row, but a warning is not an error and no
+driver on this stack surfaces one, so what reaches a dashboard is a plausible
+wrong number. No session setting changes it: `STRICT_ALL_TABLES`,
+`STRICT_TRANS_TABLES` and `TRADITIONAL` all saturate exactly as the default
+does, because those modes govern writes rather than a `SELECT`-time `CAST`.
+
+So on MySQL a measure's decimal cast is widened to at least 38 digits, and the
+overflow stops being reachable rather than being caught:
+
+```sql
+CAST(SUM(`s`.`amt`) AS DECIMAL(38, 2))   -- MySQL; DECIMAL(18, 2) elsewhere
+```
+
+Only the **precision** moves. The scale is what shapes the value and is carried
+through exactly as declared, so `decimal(18, 2)` still rounds to two places and
+only stops refusing totals the source holds legally. A model that declares more
+than 38 keeps what it declared.
+
+38 and no further, though MySQL itself allows 65: it is what every other
+supported engine accepts, so a value MySQL now returns is one a portable model
+could have carried anyway. Widening to 65 would let this one engine answer
+where the other seven cannot, which reverses the divergence rather than
+removing it.
+
+!!! warning "One case is still saturated: a 64-bit integer cast"
+
+    A measure that resolves to `bigint` casts to `SIGNED`, which is MySQL's
+    only 64-bit integer cast target - its `CAST` vocabulary has no wider one.
+    A `SUM` over a bigint column past `9223372036854775807` therefore still
+    returns `9223372036854775807` on MySQL where the other engines raise.
+
+    Widening it would mean casting every count to `DECIMAL`, changing the type
+    family of the most common measure in a model to reach a value no real count
+    has. If your integer totals can pass 9.2 quintillion, declare a
+    `dataType: "decimal(38, 0)"` on the measure, which is not affected.
 
 ### Explicit Data Type
 

--- a/src/orionbelt/dialect/mysql.py
+++ b/src/orionbelt/dialect/mysql.py
@@ -13,9 +13,15 @@ from orionbelt.dialect.base import (
 )
 from orionbelt.dialect.registry import DialectRegistry
 from orionbelt.models.semantic import TimeGrain
+from orionbelt.models.types import DecimalType, OBMLType
 
 _VARCHAR_RE = re.compile(r"^\s*VARCHAR\s*(?:\(\s*(\d+)\s*\))?\s*$", re.IGNORECASE)
 _MYSQL_CAST_CHAR_MAX = 255
+
+# The widest decimal precision every supported engine accepts. A measure cast
+# is widened to at least this on MySQL, and deliberately no further - see
+# ``cast_to_obml_type`` (#336).
+_PORTABLE_DECIMAL_PRECISION = 38
 
 
 @DialectRegistry.register
@@ -211,6 +217,59 @@ class MySQLDialect(Dialect):
 
     def render_cast(self, expr: Expr, target_type: str) -> Expr:
         return Cast(expr=expr, type_name=target_type)
+
+    def cast_to_obml_type(self, expr: Expr, obml_type: OBMLType) -> Expr:
+        """MySQL: a measure's decimal cast carries at least 38 digits.
+
+        Every other supported engine refuses a value the target type cannot
+        hold - "Conversion Error" on DuckDB, "numeric field overflow" on
+        Postgres, code 407 on ClickHouse. MySQL saturates instead and returns
+        the largest value the type can express as an ordinary row: measured,
+        ``CAST(SUM(amt) AS DECIMAL(18, 2))`` over a true 100000000000000001.10
+        gives 9999999999999999.99. It attaches warning 1264, but a warning is
+        not an error and no driver on this stack surfaces one, so what reaches
+        a dashboard is a plausible wrong number (#336).
+
+        Nothing here can make MySQL raise. There is no SELECT-time strictness
+        to switch on - ``STRICT_ALL_TABLES``, ``STRICT_TRANS_TABLES`` and
+        ``TRADITIONAL`` were each measured saturating exactly as the default
+        does - and a range check around every measure cast buys the NULL at the
+        cost of a ``CASE`` on one dialect and no other.
+
+        So the cast is widened rather than guarded, and the overflow stops
+        being reachable instead of being caught. Only the **precision** moves;
+        the scale is what shapes the value and is left exactly as declared, so
+        ``decimal(18, 2)`` still rounds to two places and only stops refusing
+        totals the source holds legally.
+
+        Widened to 38 and no further on purpose, though MySQL itself allows 65:
+        38 is what every other supported engine accepts, so a value MySQL now
+        returns is one a portable model could have carried anyway. Going to 65
+        would let this one engine answer where the other seven cannot, which is
+        the divergence this is meant to remove rather than reverse. A model
+        that declares more than 38 keeps what it declared.
+
+        This puts MySQL where BigQuery already sits, which returns the true
+        value for the same query because its ``NUMERIC`` is (38, 9).
+        """
+        return Cast(expr=expr, type_name=self.render_obml_type(self._widened(obml_type)))
+
+    @staticmethod
+    def _widened(obml_type: OBMLType) -> OBMLType:
+        """The declared type with room for a total the source holds legally.
+
+        The scale is carried through untouched, so a large declared scale still
+        limits the integer digits available inside the precision - a
+        ``decimal(38, 20)`` leaves 18 either way. That is the same trade
+        ``_widen_to_integer_range`` makes in the type resolver, and widening
+        the precision cannot fix it without changing the rounding the model
+        asked for.
+        """
+        if not isinstance(obml_type, DecimalType):
+            return obml_type
+        if obml_type.precision >= _PORTABLE_DECIMAL_PRECISION:
+            return obml_type
+        return DecimalType(precision=_PORTABLE_DECIMAL_PRECISION, scale=obml_type.scale)
 
     def _render_decimal_division(self, left_sql: str, right_sql: str) -> str:
         """MySQL's ``div_precision_increment`` defaults to 4, capping

--- a/tests/integration/drift/compile_only/mysql/01_total_sales.sql
+++ b/tests/integration/drift/compile_only/mysql/01_total_sales.sql
@@ -1,2 +1,2 @@
-SELECT CAST(SUM(`Sales`.`salesamount`) AS DECIMAL(18, 2)) AS `Total Sales`
+SELECT CAST(SUM(`Sales`.`salesamount`) AS DECIMAL(38, 2)) AS `Total Sales`
 FROM `orionbelt_1`.`sales` AS `Sales`

--- a/tests/integration/drift/compile_only/mysql/02_total_sales_by_country.sql
+++ b/tests/integration/drift/compile_only/mysql/02_total_sales_by_country.sql
@@ -1,4 +1,4 @@
-SELECT `Countries`.`countryname` AS `Sales Country Name`, CAST(SUM(`Sales`.`salesamount`) AS DECIMAL(18, 2)) AS `Total Sales`
+SELECT `Countries`.`countryname` AS `Sales Country Name`, CAST(SUM(`Sales`.`salesamount`) AS DECIMAL(38, 2)) AS `Total Sales`
 FROM `orionbelt_1`.`sales` AS `Sales`
 LEFT JOIN `orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`
 LEFT JOIN `orionbelt_1`.`countries` AS `Countries` ON `Clients`.`clientcountryid` = `Countries`.`countryid`

--- a/tests/integration/drift/compile_only/mysql/03_total_sales_by_year_month.sql
+++ b/tests/integration/drift/compile_only/mysql/03_total_sales_by_year_month.sql
@@ -1,3 +1,3 @@
-SELECT DATE_FORMAT(`Sales`.`salesdate`, '%Y-01-01') AS `Sales Year`, DATE_FORMAT(`Sales`.`salesdate`, '%Y-%m-01') AS `Sales Month`, CAST(SUM(`Sales`.`salesamount`) AS DECIMAL(18, 2)) AS `Total Sales`
+SELECT DATE_FORMAT(`Sales`.`salesdate`, '%Y-01-01') AS `Sales Year`, DATE_FORMAT(`Sales`.`salesdate`, '%Y-%m-01') AS `Sales Month`, CAST(SUM(`Sales`.`salesamount`) AS DECIMAL(38, 2)) AS `Total Sales`
 FROM `orionbelt_1`.`sales` AS `Sales`
 GROUP BY DATE_FORMAT(`Sales`.`salesdate`, '%Y-01-01'), DATE_FORMAT(`Sales`.`salesdate`, '%Y-%m-01')

--- a/tests/integration/drift/compile_only/mysql/04_sales_returns_cfl_by_country.sql
+++ b/tests/integration/drift/compile_only/mysql/04_sales_returns_cfl_by_country.sql
@@ -10,6 +10,6 @@ LEFT JOIN `orionbelt_1`.`sales` AS `Sales` ON `Returns`.`returnsalesid` = `Sales
 LEFT JOIN `orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`
 LEFT JOIN `orionbelt_1`.`countries` AS `Countries` ON `Clients`.`clientcountryid` = `Countries`.`countryid`
 )
-SELECT `Sales Country Name` AS `Sales Country Name`, CAST(SUM(`composite_01`.`Total Sales`) AS DECIMAL(18, 2)) AS `Total Sales`, CAST(SUM(`composite_01`.`Total Returns`) AS DECIMAL(18, 2)) AS `Total Returns`
+SELECT `Sales Country Name` AS `Sales Country Name`, CAST(SUM(`composite_01`.`Total Sales`) AS DECIMAL(38, 2)) AS `Total Sales`, CAST(SUM(`composite_01`.`Total Returns`) AS DECIMAL(38, 2)) AS `Total Returns`
 FROM `composite_01` AS `composite_01`
 GROUP BY `Sales Country Name`

--- a/tests/integration/drift/compile_only/mysql/05_sales_purchases_cfl_ungrouped.sql
+++ b/tests/integration/drift/compile_only/mysql/05_sales_purchases_cfl_ungrouped.sql
@@ -5,5 +5,5 @@ UNION ALL
 SELECT CAST(NULL AS DECIMAL(38, 20)) AS `Total Sales`, `Purchases`.`purchaseamount` AS `Total Purchases`
 FROM `orionbelt_1`.`purchases` AS `Purchases`
 )
-SELECT CAST(SUM(`composite_01`.`Total Sales`) AS DECIMAL(18, 2)) AS `Total Sales`, CAST(SUM(`composite_01`.`Total Purchases`) AS DECIMAL(18, 2)) AS `Total Purchases`
+SELECT CAST(SUM(`composite_01`.`Total Sales`) AS DECIMAL(38, 2)) AS `Total Sales`, CAST(SUM(`composite_01`.`Total Purchases`) AS DECIMAL(38, 2)) AS `Total Purchases`
 FROM `composite_01` AS `composite_01`

--- a/tests/integration/drift/compile_only/mysql/06_total_sales_by_sales_client.sql
+++ b/tests/integration/drift/compile_only/mysql/06_total_sales_by_sales_client.sql
@@ -1,4 +1,4 @@
-SELECT `Clients`.`clientname` AS `Sales Client Name`, CAST(SUM(`Sales`.`salesamount`) AS DECIMAL(18, 2)) AS `Total Sales`
+SELECT `Clients`.`clientname` AS `Sales Client Name`, CAST(SUM(`Sales`.`salesamount`) AS DECIMAL(38, 2)) AS `Total Sales`
 FROM `orionbelt_1`.`sales` AS `Sales`
 LEFT JOIN `orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`
 GROUP BY `Clients`.`clientname`

--- a/tests/integration/drift/compile_only/mysql/07_total_sales_by_client_with_complaints.sql
+++ b/tests/integration/drift/compile_only/mysql/07_total_sales_by_client_with_complaints.sql
@@ -7,7 +7,7 @@ SELECT CAST(NULL AS CHAR(255)) AS `Sales Client Name`, `Clients`.`clientname` AS
 FROM `orionbelt_1`.`clientcomplaints` AS `Client Complaints`
 LEFT JOIN `orionbelt_1`.`clients` AS `Clients` ON `Client Complaints`.`complclientid` = `Clients`.`clientid`
 )
-SELECT COALESCE(`Sales Client Name`, `Complaint Client Name`) AS `Client`, CAST(SUM(`composite_01`.`Total Sales`) AS DECIMAL(18, 2)) AS `Total Sales`, CAST(COUNT(`composite_01`.`Client Complaints Count`) AS SIGNED) AS `Client Complaints Count`
+SELECT COALESCE(`Sales Client Name`, `Complaint Client Name`) AS `Client`, CAST(SUM(`composite_01`.`Total Sales`) AS DECIMAL(38, 2)) AS `Total Sales`, CAST(COUNT(`composite_01`.`Client Complaints Count`) AS SIGNED) AS `Client Complaints Count`
 FROM `composite_01` AS `composite_01`
 GROUP BY COALESCE(`Sales Client Name`, `Complaint Client Name`)
 HAVING CAST(COUNT(`composite_01`.`Client Complaints Count`) AS SIGNED) > 0

--- a/tests/integration/drift/compile_only/mysql/08_average_sale.sql
+++ b/tests/integration/drift/compile_only/mysql/08_average_sale.sql
@@ -1,2 +1,2 @@
-SELECT CAST(SUM(`Sales`.`salesamount`) / NULLIF(NULLIF(COUNT(1), 0), 0) AS DECIMAL(18, 2)) AS `Average Sale`
+SELECT CAST(SUM(`Sales`.`salesamount`) / NULLIF(NULLIF(COUNT(1), 0), 0) AS DECIMAL(38, 2)) AS `Average Sale`
 FROM `orionbelt_1`.`sales` AS `Sales`

--- a/tests/integration/drift/compile_only/mysql/09_return_rate.sql
+++ b/tests/integration/drift/compile_only/mysql/09_return_rate.sql
@@ -5,5 +5,5 @@ UNION ALL
 SELECT CAST(NULL AS DECIMAL(38, 20)) AS `Total Returns`, `Sales`.`salesamount` AS `Total Sales`
 FROM `orionbelt_1`.`sales` AS `Sales`
 )
-SELECT CAST(SUM(`composite_01`.`Total Returns`) / NULLIF(NULLIF(SUM(`composite_01`.`Total Sales`), 0), 0) AS DECIMAL(18, 4)) AS `Return Rate`
+SELECT CAST(SUM(`composite_01`.`Total Returns`) / NULLIF(NULLIF(SUM(`composite_01`.`Total Sales`), 0), 0) AS DECIMAL(38, 4)) AS `Return Rate`
 FROM `composite_01` AS `composite_01`

--- a/tests/integration/drift/compile_only/mysql/10_cumulative_sales_by_month.sql
+++ b/tests/integration/drift/compile_only/mysql/10_cumulative_sales_by_month.sql
@@ -1,7 +1,7 @@
 WITH `cumulative_base` AS (
-SELECT DATE_FORMAT(`Sales`.`salesdate`, '%Y-%m-01') AS `Sales Month`, CAST(SUM(`Sales`.`salesamount`) AS DECIMAL(18, 2)) AS `Total Sales`
+SELECT DATE_FORMAT(`Sales`.`salesdate`, '%Y-%m-01') AS `Sales Month`, CAST(SUM(`Sales`.`salesamount`) AS DECIMAL(38, 2)) AS `Total Sales`
 FROM `orionbelt_1`.`sales` AS `Sales`
 GROUP BY DATE_FORMAT(`Sales`.`salesdate`, '%Y-%m-01')
 )
-SELECT `Sales Month` AS `Sales Month`, CAST(SUM(`Total Sales`) OVER (ORDER BY `Sales Month` ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS DECIMAL(18, 2)) AS `Cumulative Sales`
+SELECT `Sales Month` AS `Sales Month`, CAST(SUM(`Total Sales`) OVER (ORDER BY `Sales Month` ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS DECIMAL(38, 2)) AS `Cumulative Sales`
 FROM `cumulative_base` AS `cumulative_base`

--- a/tests/integration/drift/compile_only/mysql/11_rolling_30_day_sales.sql
+++ b/tests/integration/drift/compile_only/mysql/11_rolling_30_day_sales.sql
@@ -1,7 +1,7 @@
 WITH `cumulative_base` AS (
-SELECT DATE_FORMAT(`Sales`.`salesdate`, '%Y-%m-%d') AS `Sales Date`, CAST(SUM(`Sales`.`salesamount`) AS DECIMAL(18, 2)) AS `Total Sales`
+SELECT DATE_FORMAT(`Sales`.`salesdate`, '%Y-%m-%d') AS `Sales Date`, CAST(SUM(`Sales`.`salesamount`) AS DECIMAL(38, 2)) AS `Total Sales`
 FROM `orionbelt_1`.`sales` AS `Sales`
 GROUP BY DATE_FORMAT(`Sales`.`salesdate`, '%Y-%m-%d')
 )
-SELECT `Sales Date` AS `Sales Date`, CAST(AVG(`Total Sales`) OVER (ORDER BY `Sales Date` ASC ROWS BETWEEN 29 PRECEDING AND CURRENT ROW) AS DECIMAL(18, 0)) AS `Rolling 30 Day Sales`
+SELECT `Sales Date` AS `Sales Date`, CAST(AVG(`Total Sales`) OVER (ORDER BY `Sales Date` ASC ROWS BETWEEN 29 PRECEDING AND CURRENT ROW) AS DECIMAL(38, 0)) AS `Rolling 30 Day Sales`
 FROM `cumulative_base` AS `cumulative_base`

--- a/tests/integration/drift/compile_only/mysql/12_total_sales_country_in_filter.sql
+++ b/tests/integration/drift/compile_only/mysql/12_total_sales_country_in_filter.sql
@@ -1,4 +1,4 @@
-SELECT CAST(SUM(`Sales`.`salesamount`) AS DECIMAL(18, 2)) AS `Total Sales`
+SELECT CAST(SUM(`Sales`.`salesamount`) AS DECIMAL(38, 2)) AS `Total Sales`
 FROM `orionbelt_1`.`sales` AS `Sales`
 LEFT JOIN `orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`
 LEFT JOIN `orionbelt_1`.`countries` AS `Countries` ON `Clients`.`clientcountryid` = `Countries`.`countryid`

--- a/tests/integration/drift/compile_only/mysql/13_sales_yoy_growth.sql
+++ b/tests/integration/drift/compile_only/mysql/13_sales_yoy_growth.sql
@@ -19,7 +19,7 @@ FROM (
 ),
 `pop_base` AS (
 SELECT `date_spine`.spine_date AS `Sales Month`,
-       CAST(SUM(`Sales`.`salesamount`) AS DECIMAL(18, 2)) AS `Total Sales`
+       CAST(SUM(`Sales`.`salesamount`) AS DECIMAL(38, 2)) AS `Total Sales`
   FROM `date_spine`
   LEFT JOIN `orionbelt_1`.`sales` AS `Sales`
     ON DATE_FORMAT(`Sales`.`salesdate`, '%Y-%m-01') = `date_spine`.spine_date
@@ -33,5 +33,5 @@ SELECT `pop_base`.`Sales Month` AS `Sales Month`,
   LEFT JOIN `pop_base` AS pop_prev
     ON `date_spine`.spine_date_prev = pop_prev.`Sales Month`
 )
-SELECT `Sales Month` AS `Sales Month`, CAST(`Sales YoY Growth` AS DECIMAL(18, 4)) AS `Sales YoY Growth`
+SELECT `Sales Month` AS `Sales Month`, CAST(`Sales YoY Growth` AS DECIMAL(38, 4)) AS `Sales YoY Growth`
 FROM `pop_compare` AS `pop_compare`

--- a/tests/integration/drift/compile_only/mysql/14_total_sales_year_filter.sql
+++ b/tests/integration/drift/compile_only/mysql/14_total_sales_year_filter.sql
@@ -1,3 +1,3 @@
-SELECT CAST(SUM(`Sales`.`salesamount`) AS DECIMAL(18, 2)) AS `Total Sales`
+SELECT CAST(SUM(`Sales`.`salesamount`) AS DECIMAL(38, 2)) AS `Total Sales`
 FROM `orionbelt_1`.`sales` AS `Sales`
 WHERE `Sales`.`salesdate` = '2025-01-01'

--- a/tests/integration/drift/compile_only/mysql/15_total_account_balance.sql
+++ b/tests/integration/drift/compile_only/mysql/15_total_account_balance.sql
@@ -1,2 +1,2 @@
-SELECT CAST(SUM(`Account Balances`.`balanceamt`) AS DECIMAL(18, 2)) AS `Total Account Balance`
+SELECT CAST(SUM(`Account Balances`.`balanceamt`) AS DECIMAL(38, 2)) AS `Total Account Balance`
 FROM `orionbelt_1`.`acctbal` AS `Account Balances`

--- a/tests/integration/drift/compile_only/mysql/16_total_sales_by_email_domain.sql
+++ b/tests/integration/drift/compile_only/mysql/16_total_sales_by_email_domain.sql
@@ -1,4 +1,4 @@
-SELECT CASE WHEN 2 > (CHAR_LENGTH(`Clients`.`clientemail`) - CHAR_LENGTH(REPLACE(`Clients`.`clientemail`, '@', ''))) / CHAR_LENGTH('@') + 1 THEN '' ELSE SUBSTRING_INDEX(SUBSTRING_INDEX(`Clients`.`clientemail`, '@', 2), '@', -1) END AS `Sales Client Email Domain`, CAST(SUM(`Sales`.`salesamount`) AS DECIMAL(18, 2)) AS `Total Sales`
+SELECT CASE WHEN 2 > (CHAR_LENGTH(`Clients`.`clientemail`) - CHAR_LENGTH(REPLACE(`Clients`.`clientemail`, '@', ''))) / CHAR_LENGTH('@') + 1 THEN '' ELSE SUBSTRING_INDEX(SUBSTRING_INDEX(`Clients`.`clientemail`, '@', 2), '@', -1) END AS `Sales Client Email Domain`, CAST(SUM(`Sales`.`salesamount`) AS DECIMAL(38, 2)) AS `Total Sales`
 FROM `orionbelt_1`.`sales` AS `Sales`
 LEFT JOIN `orionbelt_1`.`clients` AS `Clients` ON `Sales`.`salesclient` = `Clients`.`clientid`
 GROUP BY CASE WHEN 2 > (CHAR_LENGTH(`Clients`.`clientemail`) - CHAR_LENGTH(REPLACE(`Clients`.`clientemail`, '@', ''))) / CHAR_LENGTH('@') + 1 THEN '' ELSE SUBSTRING_INDEX(SUBSTRING_INDEX(`Clients`.`clientemail`, '@', 2), '@', -1) END

--- a/tests/integration/drift/vendor_exec/test_overflow_cast_exec.py
+++ b/tests/integration/drift/vendor_exec/test_overflow_cast_exec.py
@@ -1,0 +1,191 @@
+"""Execute a measure whose value outgrows its type, per vendor.
+
+The contract this pins is not "the same answer everywhere" - it cannot be,
+because the engines legitimately hold different ranges. It is the weaker and
+more important one: **no engine returns a plausible wrong number**. Every
+outcome has to be the true value, NULL, or a raised error.
+
+Seven of the eight satisfied it already, by raising or by holding the value.
+MySQL did not: it saturates a cast that overflows and returns the largest value
+the target type can express as an ordinary row, so a measure declared
+``decimal(18, 2)`` over a true 100000000000000000 came back as
+9999999999999999.99 (#336). Its measure casts are now widened to 38 digits, so
+it returns the value.
+
+Both target shapes are executed, because they saturate at different limits and
+only one of them moved: a measure with a declared ``decimal(18, 2)`` is widened,
+while a ``bigint`` measure still casts to ``SIGNED``, MySQL's only 64-bit
+integer cast target. The second is the residue this fix leaves and the reason
+it is executed here rather than argued about - a change either way shows up as
+a diff in this file.
+
+The rows come from ``VendorTarget.rows_of`` rather than the corpus seed, whose
+values are far below any type's limit - the same reason ``test_exact_avg_exec``
+spells its own (#330).
+"""
+
+from __future__ import annotations
+
+import re
+from decimal import Decimal
+
+import pytest
+
+from orionbelt.compiler.pipeline import CompilationPipeline
+from orionbelt.dialect.registry import DialectRegistry
+from orionbelt.models.query import QueryObject, QuerySelect
+from orionbelt.parser import ReferenceResolver, TrackedLoader
+
+from .conftest import VendorTarget
+
+pytestmark = pytest.mark.docker
+
+MODEL_YAML = """
+version: "1.0"
+name: overflow_cast_exec
+dataObjects:
+  Charges:
+    code: charges
+    columns:
+      Qty: {code: qty, abstractType: int}
+measures:
+  Qty Sum:
+    columns: [{dataObject: Charges, column: Qty}]
+    resultType: int
+    aggregation: sum
+  Qty Sum Narrow:
+    columns: [{dataObject: Charges, column: Qty}]
+    resultType: int
+    aggregation: sum
+    dataType: "decimal(18, 2)"
+"""
+
+# (measure, rows, the true total). Two cases, because the two targets saturate
+# at different limits: ``decimal(18, 2)`` runs out after 16 integer digits and
+# ``SIGNED`` after 19.
+OVERFLOWING = [
+    ("Qty Sum Narrow", [50000000000000000, 50000000000000000], "100000000000000000"),
+    ("Qty Sum", [9000000000000000000, 9000000000000000000], "18000000000000000000"),
+]
+# The same measures over values every type holds, so the guard is shown not to
+# have cost the ordinary answer.
+IN_RANGE = [1000, 2000]
+
+# Engines that still answer with a number on the 64-bit case, each for its own
+# reason, and each asserted by a test of its own rather than through the shared
+# contract:
+#
+# * ClickHouse wraps ``SUM`` over Int64 before any cast is reached, returning
+#   -446744073709551616. The loss is inside the aggregate, where no output type
+#   reaches it - the reason the exact-AVG rewrite casts inside the SUM (#318) -
+#   so it is a different defect from this one.
+# * MySQL saturates its ``SIGNED`` cast, the residue this fix leaves; see
+#   ``test_mysql_still_saturates_a_64_bit_integer_cast``.
+#
+# The decimal case, whose total stays well inside Int64, runs everywhere.
+SATURATES_AT_64_BITS = {"clickhouse", "mysql"}
+
+
+def _projection(measure: str, dialect: str) -> str:
+    """The measure expression OBSL emits, lifted out of its SELECT."""
+    raw, sm = TrackedLoader().load_string(MODEL_YAML)
+    model, result = ReferenceResolver().resolve(raw, sm)
+    assert result.valid, result.errors
+    sql = (
+        CompilationPipeline()
+        .compile(QueryObject(select=QuerySelect(dimensions=[], measures=[measure])), model, dialect)
+        .sql
+    )
+    match = re.search(r"SELECT (.+?)\s+FROM", sql, re.S)
+    assert match, sql
+    return match.group(1).strip()
+
+
+def _outcome(target: VendorTarget, measure: str, values: list[int | None]) -> str | None:
+    """``"raised"``, or the returned value as a string (``None`` for NULL)."""
+    dia = DialectRegistry.get(target.dialect)
+    source = target.rows_of(dia.quote_identifier("Charges"), dia.quote_identifier("qty"), values)
+    try:
+        rows = target.execute(f"SELECT {_projection(measure, target.dialect)} FROM {source}")
+    except Exception:  # noqa: BLE001 - any refusal is a passing outcome here
+        return "raised"
+    got = next(iter(rows[0].values()))
+    return None if got is None else str(got)
+
+
+def _assert_no_wrong_number(target: VendorTarget) -> None:
+    mismatches = []
+    for measure, values, total in OVERFLOWING:
+        if measure == "Qty Sum" and target.dialect in SATURATES_AT_64_BITS:
+            continue
+        got = _outcome(target, measure, values)
+        if got not in ("raised", None) and Decimal(got) != Decimal(total):
+            mismatches.append(
+                f"{measure} over a true {total} returned {got}, "
+                "which is neither the value, NULL, nor a refusal"
+            )
+    for measure, _, _ in OVERFLOWING:
+        got = _outcome(target, measure, IN_RANGE)
+        if got is None or got == "raised" or Decimal(got) != Decimal(3000):
+            mismatches.append(f"{measure} over values that fit returned {got}, expected 3000")
+    assert not mismatches, f"{target.name}:\n  " + "\n  ".join(mismatches)
+
+
+def test_duckdb_no_wrong_number(vendor_duckdb: VendorTarget) -> None:
+    _assert_no_wrong_number(vendor_duckdb)
+
+
+def test_postgres_no_wrong_number(vendor_postgres: VendorTarget) -> None:
+    _assert_no_wrong_number(vendor_postgres)
+
+
+def test_mysql_no_wrong_number(vendor_mysql: VendorTarget) -> None:
+    _assert_no_wrong_number(vendor_mysql)
+
+
+def test_clickhouse_no_wrong_number(vendor_clickhouse: VendorTarget) -> None:
+    _assert_no_wrong_number(vendor_clickhouse)
+
+
+def test_snowflake_no_wrong_number(vendor_snowflake: VendorTarget) -> None:
+    _assert_no_wrong_number(vendor_snowflake)
+
+
+def test_bigquery_no_wrong_number(vendor_bigquery: VendorTarget) -> None:
+    _assert_no_wrong_number(vendor_bigquery)
+
+
+def test_databricks_no_wrong_number(vendor_databricks: VendorTarget) -> None:
+    _assert_no_wrong_number(vendor_databricks)
+
+
+def test_mysql_holds_the_value_rather_than_saturating(vendor_mysql: VendorTarget) -> None:
+    """The engine this issue is about, pinned to the specific answer.
+
+    ``_assert_no_wrong_number`` accepts a refusal, which is what most of the
+    others do. MySQL cannot refuse - no ``sql_mode`` makes a SELECT-time cast
+    raise, measured across ``STRICT_ALL_TABLES``, ``STRICT_TRANS_TABLES`` and
+    ``TRADITIONAL`` - so holding the value is the whole of its contract on the
+    decimal path, and a regression would show up as the saturated number rather
+    than as an error.
+    """
+    measure, values, total = OVERFLOWING[0]
+    got = _outcome(vendor_mysql, measure, values)
+    assert got not in (None, "raised") and Decimal(got) == Decimal(total), f"{measure}: {got}"
+
+
+def test_mysql_still_saturates_a_64_bit_integer_cast(vendor_mysql: VendorTarget) -> None:
+    """The residue, recorded rather than left to be rediscovered.
+
+    ``SIGNED`` is MySQL's only 64-bit integer cast target and its CAST
+    vocabulary has no wider one, so a ``SUM`` over a bigint column past
+    9223372036854775807 still comes back saturated. Widening it would mean
+    casting every count to DECIMAL, changing the type family of the most common
+    measure in the model to reach a value no real count has.
+
+    Asserted so that the day it changes - deliberately or not - this file says
+    so. It is the one place a wrong number is still possible, on the one engine
+    that produces them.
+    """
+    got = _outcome(vendor_mysql, "Qty Sum", OVERFLOWING[1][1])
+    assert got not in (None, "raised") and Decimal(got) == Decimal(2**63 - 1), got

--- a/tests/unit/test_declared_source_width.py
+++ b/tests/unit/test_declared_source_width.py
@@ -13,8 +13,10 @@ PostgreSQL   numeric field overflow      100000000000000001.10
 MySQL        **9999999999999999.99**     100000000000000001.10
 ===========  ==========================  =========================
 
-MySQL saturates with no warning, which is why this is worth typing correctly
-rather than leaving to the engine (#323).
+MySQL saturated rather than refusing, which is why this is worth typing
+correctly rather than leaving to the engine (#323). Its own casts now carry 38
+digits so that column can no longer be reached (#336), but the other engines
+still refuse, and a declared width is what makes the measure portable.
 """
 
 from __future__ import annotations
@@ -99,8 +101,10 @@ def test_a_column_that_fits_is_left_alone() -> None:
 def test_an_undeclared_column_cannot_be_widened() -> None:
     """Nothing in the model says how large its values are.
 
-    This is the residual: such a measure still overflows, and still saturates
-    on MySQL. Pinned so the limit is visible rather than assumed away.
+    This is the residual: such a measure still overflows on the engines that
+    refuse one. It no longer saturates on MySQL, whose casts carry 38 digits
+    for that reason (#336), so the failure is at least loud everywhere it
+    happens. Pinned so the limit is visible rather than assumed away.
     """
     assert "DECIMAL(18, 2)" in _sql("Undeclared Sum")
 
@@ -120,10 +124,20 @@ def test_an_explicit_data_type_still_wins() -> None:
     assert "DECIMAL(18, 2)" in _sql("Wide Pinned")
 
 
-@pytest.mark.parametrize("dialect", ["postgres", "mysql", "duckdb", "clickhouse", "snowflake"])
+# MySQL floors a measure's decimal cast at 38 digits of its own, because it
+# saturates an overflow where the others raise (#336). The widening still has
+# to reach it - a narrower resolved type would show up as a narrower cast -
+# it just cannot land on the same number. Substrings rather than whole type
+# names, since the engines spell a decimal differently and the point is width.
+WIDENED_TO = dict.fromkeys(["postgres", "duckdb", "clickhouse", "snowflake"], "25, 2") | {
+    "mysql": "38, 2"
+}
+
+
+@pytest.mark.parametrize("dialect", sorted(WIDENED_TO))
 def test_the_widening_reaches_every_dialect(dialect: str) -> None:
     sql = _sql("Wide Sum", dialect)
-    assert "25, 2" in sql, sql
+    assert WIDENED_TO[dialect] in sql, sql
 
 
 def test_the_scale_gives_way_when_the_integer_part_cannot_fit() -> None:

--- a/tests/unit/test_exact_avg.py
+++ b/tests/unit/test_exact_avg.py
@@ -284,15 +284,22 @@ class TestTheResultTypeIsWidenedWhereverTheAverageIsExact:
     Postgres, MySQL and Snowflake compute the average exactly and then had it
     cast to the ``decimal(18, 2)`` default, which carries 16 integer digits
     where a 64-bit value needs 19. Measured, MySQL saturated a true
-    1000000000000000003 to 9999999999999999.99 **with no warning**, and
-    Postgres raised. Being exact in the aggregate bought nothing if the type
-    could not carry the result.
+    1000000000000000003 to 9999999999999999.99, and Postgres raised. Being
+    exact in the aggregate bought nothing if the type could not carry the
+    result.
     """
+
+    #: MySQL floors a measure's decimal cast at 38 digits of its own, because
+    #: it saturates an overflow where the others raise (#336). The resolver
+    #: still has to widen 18 to 21 - a resolved type that stayed at the default
+    #: would show up as a narrower cast on the other two - so what is asserted
+    #: per dialect is the width that reaches the SQL.
+    WIDENED = {"postgres": "(21, 2)", "snowflake": "(21, 2)", "mysql": "(38, 2)"}
 
     @pytest.mark.parametrize("dialect", NATIVELY_EXACT)
     def test_a_natively_exact_dialect_widens_its_result(self, dialect: str) -> None:
         sql = _sql("Qty Avg", dialect)
-        assert "(21, 2)" in sql, sql
+        assert self.WIDENED[dialect] in sql, sql
         assert "(18, 2)" not in sql, sql
 
     def test_duckdb_keeps_the_default_so_the_overflow_stays_loud(self) -> None:

--- a/tests/unit/test_mysql_cast_width.py
+++ b/tests/unit/test_mysql_cast_width.py
@@ -1,0 +1,165 @@
+"""A measure's decimal cast carries at least 38 digits on MySQL.
+
+Every other supported engine refuses a value the target type cannot hold.
+MySQL saturates instead and returns the largest value the type can express as
+an ordinary row. Measured on the same model and the same data, a true
+``100000000000000000`` under ``dataType: "decimal(18, 2)"``:
+
+==========  ===============================================
+DuckDB      raises ``Conversion Error``
+PostgreSQL  raises ``numeric field overflow``
+ClickHouse  raises code 407
+Snowflake   raises
+Databricks  raises
+BigQuery    ``100000000000000000`` - its NUMERIC is (38, 9)
+MySQL       ``9999999999999999.99``
+==========  ===============================================
+
+MySQL attaches warning 1264 to that row, but a warning is not an error and no
+driver on this stack surfaces one, so what reaches a dashboard is a plausible
+wrong number - the same class of defect as the zero divisor of #319, and the
+worse half of it, because a number flows onward where an error stops.
+
+Nothing at this layer can make MySQL raise: ``STRICT_ALL_TABLES``,
+``STRICT_TRANS_TABLES`` and ``TRADITIONAL`` were each measured saturating
+exactly as the default does. So the cast is widened rather than guarded, and
+the overflow stops being reachable rather than being caught. A range check
+around every measure cast would have bought a NULL at the cost of a ``CASE`` on
+one dialect and no other.
+
+Values are checked against live engines in
+``tests/integration/drift/vendor_exec/test_overflow_cast_exec.py``; what is
+asserted here is which types move, which do not, and that no other dialect is
+touched. See #336.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from orionbelt.ast.nodes import ColumnRef
+from orionbelt.compiler.pipeline import CompilationPipeline
+from orionbelt.dialect.registry import DialectRegistry
+from orionbelt.models.query import QueryObject, QuerySelect
+from orionbelt.models.types import DecimalType, SimpleType
+from orionbelt.parser import ReferenceResolver, TrackedLoader
+
+MODEL_YAML = """
+version: "1.0"
+name: cast_width
+dataObjects:
+  S:
+    code: s
+    columns:
+      Amt: {code: amt, abstractType: float}
+      Qty: {code: qty, abstractType: int}
+      Sold On: {code: sold_on, abstractType: date}
+dimensions:
+  Sale Month: {dataObject: S, column: Sold On, timeGrain: month}
+measures:
+  Amount: {columns: [{dataObject: S, column: Amt}], resultType: float, aggregation: sum}
+  Orders: {columns: [{dataObject: S, column: Qty}], resultType: int, aggregation: sum}
+  Sale Count: {columns: [{dataObject: S, column: Qty}], resultType: int, aggregation: count}
+  Biggest: {columns: [{dataObject: S, column: Amt}], resultType: float, aggregation: max}
+  Wide Amount:
+    columns: [{dataObject: S, column: Amt}]
+    resultType: float
+    aggregation: sum
+    dataType: "decimal(50, 2)"
+metrics:
+  Amount Running:
+    type: cumulative
+    measure: Amount
+    timeDimension: Sale Month
+    dataType: "decimal(18, 2)"
+"""
+
+DIALECTS = sorted(DialectRegistry.available())
+OTHER_DIALECTS = [d for d in DIALECTS if d != "mysql"]
+
+
+def _sql(measure: str, dialect: str) -> str:
+    raw, sm = TrackedLoader().load_string(MODEL_YAML)
+    model, result = ReferenceResolver().resolve(raw, sm)
+    assert result.valid, result.errors
+    return (
+        CompilationPipeline()
+        .compile(
+            QueryObject(select=QuerySelect(dimensions=["Sale Month"], measures=[measure])),
+            model,
+            dialect,
+        )
+        .sql
+    )
+
+
+def _cast(obml_type: DecimalType | SimpleType, dialect: str = "mysql") -> str:
+    dia = DialectRegistry.get(dialect)
+    return dia.compile_expr(dia.cast_to_obml_type(ColumnRef(name="x", table="t"), obml_type))
+
+
+class TestWhatMoves:
+    def test_the_default_decimal_is_widened(self) -> None:
+        """``decimal(18, 2)`` carries 16 integer digits, which a total reaches."""
+        assert "CAST(SUM(`S`.`amt`) AS DECIMAL(38, 2))" in _sql("Amount", "mysql")
+
+    def test_a_wrapper_is_widened_too(self) -> None:
+        """The cumulative wrapper types its result through the same call, so it
+        cannot be widened on the direct path and left narrow inside a CTE.
+        """
+        sql = _sql("Amount Running", "mysql")
+        assert "DECIMAL(18, 2)" not in sql, sql
+        assert sql.count("DECIMAL(38, 2)") == 2, sql
+
+
+class TestWhatDoesNotMove:
+    def test_no_other_dialect_is_touched(self) -> None:
+        for dialect in OTHER_DIALECTS:
+            sql = _sql("Amount", dialect)
+            assert "DECIMAL(38, 2)" not in sql, f"{dialect}: {sql}"
+
+    def test_the_scale_is_carried_through_untouched(self) -> None:
+        """The scale is what shapes the value. Only the range bound moves, so a
+        model still rounds to the places it asked for.
+        """
+        for scale in (0, 2, 6, 20):
+            assert f", {scale})" in _cast(DecimalType(precision=18, scale=scale))
+
+    def test_a_declared_precision_above_the_floor_is_kept(self) -> None:
+        """Widening is a floor, not a rewrite: a model that asked for more than
+        38 already said its values are wider than a portable one.
+        """
+        assert "DECIMAL(50, 2)" in _sql("Wide Amount", "mysql")
+
+    def test_a_precision_beyond_the_engine_is_still_clamped(self) -> None:
+        assert "DECIMAL(65, 2)" in _cast(DecimalType(precision=100, scale=2))
+
+    def test_an_integer_target_is_unchanged(self) -> None:
+        """``SIGNED`` is MySQL's only 64-bit integer cast target and there is no
+        wider one in its CAST vocabulary. A ``SUM`` over a bigint column past
+        9223372036854775807 therefore still saturates, and widening it would
+        mean casting every count to DECIMAL - changing the type family of the
+        most common measure in the model to reach a value no real count has.
+        Recorded rather than fixed; see #336.
+        """
+        assert _cast(SimpleType(name="bigint")) == "CAST(`t`.`x` AS SIGNED)"
+        assert "CAST(COUNT(`S`.`qty`) AS SIGNED)" in _sql("Sale Count", "mysql")
+
+    def test_a_pass_through_measure_still_has_no_cast(self) -> None:
+        assert "CAST(" not in _sql("Biggest", "mysql")
+
+
+@pytest.mark.parametrize(
+    ("precision", "scale", "expected"),
+    [
+        (18, 2, "DECIMAL(38, 2)"),
+        (18, 6, "DECIMAL(38, 6)"),
+        (18, 0, "DECIMAL(38, 0)"),
+        (37, 2, "DECIMAL(38, 2)"),
+        (38, 2, "DECIMAL(38, 2)"),
+        (38, 20, "DECIMAL(38, 20)"),
+        (50, 2, "DECIMAL(50, 2)"),
+    ],
+)
+def test_the_widening_table(precision: int, scale: int, expected: str) -> None:
+    assert expected in _cast(DecimalType(precision=precision, scale=scale))


### PR DESCRIPTION
Closes #336.

## What was wrong

Every other supported engine refuses a value the target type cannot hold. MySQL saturates and returns the largest value the type can express as an ordinary row, so a measure whose total outgrew its declared or inferred type came back as a plausible wrong number.

Measured on the same model and the same data, a true `100000000000000000` under `dataType: "decimal(18, 2)"`:

| dialect | result |
| --- | --- |
| DuckDB | raises `Conversion Error` |
| PostgreSQL | raises `numeric field overflow` |
| ClickHouse | raises code 407 |
| Snowflake | raises |
| Databricks | raises |
| BigQuery | `100000000000000000`, exact: its `NUMERIC` is (38, 9) |
| MySQL | `9999999999999999.99` |

One correction to the issue's own measurement: MySQL does attach warning 1264 to that row. It changes nothing, because a warning is not an error and no driver on this stack surfaces one, but the fix is not justified by "no warning at all".

## What this does

**Widens the cast instead of guarding it**, so the overflow stops being reachable rather than being caught:

```sql
CAST(SUM(`s`.`amt`) AS DECIMAL(38, 2))   -- MySQL; DECIMAL(18, 2) elsewhere
```

The issue proposed Option 1, a range check. I wrote that first and it was wrong for the cost: it puts a `CASE` around every numeric measure cast on one dialect and no other, counts included, where no other dialect in the codebase carries any overflow handling at all. `bigquery.py` is the only other override of `cast_to_obml_type` and it is there to re-apply scale via `ROUND`, not to guard range.

Option 2 is closed by measurement rather than assumption: `STRICT_ALL_TABLES`, `STRICT_TRANS_TABLES` and `TRADITIONAL` were each run against a live MySQL 8.0 and all saturate exactly as the default does. Those modes govern writes, not a SELECT-time `CAST`.

Three things worth naming:

- **Only the precision moves.** The scale is what shapes the value and is carried through exactly as declared, so `decimal(18, 2)` still rounds to two places and only stops refusing totals the source holds legally. Verified: `SUM(amt)/3` still comes back `...33.70`.
- **38 and no further**, though MySQL allows 65. 38 is what every other supported engine accepts, so a value MySQL now returns is one a portable model could have carried anyway. Going to 65 would let this one engine answer where the other seven cannot, reversing the divergence instead of removing it. A model that declares more than 38 keeps what it declared.
- **This puts MySQL where BigQuery already sits.** BigQuery returns the true value for the same query, and the cross-vendor contract already accepts that.

## What stays broken, on purpose

A `bigint` measure casts to `SIGNED`, MySQL's only 64-bit integer cast target - its `CAST` vocabulary has no wider one. A `SUM` past `9223372036854775807` still returns that value where the other engines raise.

Widening it means casting every count to `DECIMAL`, changing the type family of the most common measure in a model to reach a value no real count has. It is asserted in `test_mysql_still_saturates_a_64_bit_integer_cast` rather than left to be rediscovered, and documented with the workaround (`dataType: "decimal(38, 0)"`, which is not affected).

## Verification

Executed on all seven vendor fixtures: DuckDB, PostgreSQL, MySQL, ClickHouse, Snowflake, BigQuery and Databricks, the last three live.

`tests/integration/drift/vendor_exec/test_overflow_cast_exec.py` pins the portable contract, which is not "the same answer everywhere" (it cannot be, the engines hold different ranges) but the weaker and more important one: **no engine returns a plausible wrong number**. Every outcome has to be the true value, NULL, or a raised error.

`tests/unit/test_mysql_cast_width.py` covers which types move and which do not, including that the scale is untouched, a declared precision above 38 is kept, MySQL's own 65 clamp still applies, and no other dialect is affected.

Drift re-snapped for MySQL only: one number per line, 19 lines across 16 files. No other dialect's SQL moves, and no `CASE` appears anywhere.

Two existing tests (`test_declared_source_width.py`, `test_exact_avg.py`) asserted a resolved width by its literal spelling and now assert it per dialect, since MySQL's floor lands above it. The widening they cover is unchanged: a resolved type that stayed at the default would still show up as a narrower cast on the other engines.

Docs: a new "Numeric Overflow" section in the model-format guide, and two existing passages that stated the saturation as the current outcome and had gone stale.

## Left out

ClickHouse wraps `SUM` over Int64 before any cast is reached, returning `-446744073709551616` for a true `18000000000000000000`. Separate defect: the loss is inside the aggregate, where no output type reaches it, and it needs the inner-cast treatment #318 gave `AVG`. Excluded from the new suite by name, with the reason. Happy to open an issue.

Also unrelated and pre-existing, verified on a clean `main`: four `tests/integration/test_clickhouse_execution.py` CFL cases fail with `Illegal type Variant(Decimal(38, 20), Float64) of argument for aggregate function SUM`.
