### PR TITLE
fix(compiler): an integer SUM is exact on the two engines whose accumulator wraps

### DIFF
--- a/docs/guide/model-format.md
+++ b/docs/guide/model-format.md
@@ -1198,7 +1198,28 @@ Pass-through (no CAST emitted): `min`, `max`, `any_value`, `median`, `mode`, `li
     needs 19. Left to default, `SUM` over a `BIGINT` produced a value the
     engine computed correctly and then failed to cast, so the query errored on
     a perfectly legal figure. A measure declaring `resultType: int` therefore
-    infers `bigint` for `SUM`, which is exact on every dialect.
+    infers `bigint` for `SUM`.
+
+    **On two engines the sum itself is rewritten**, because their accumulator
+    is 64-bit and *wraps* rather than overflowing. Measured on two rows of
+    `9000000000000000000`, ClickHouse and Dremio both returned
+    `-446744073709551616`, a negative total from two positive rows, where
+    DuckDB, PostgreSQL, BigQuery and Databricks raise and Snowflake answers
+    exactly. No output type repairs that: `sumWithOverflow` gives the same
+    value on ClickHouse, and so does casting the result to `DECIMAL(38, 0)`,
+    because the accumulator has already wrapped. So the **argument** is widened
+    instead, and the result carries `decimal(38, 0)`:
+
+    | dialect | `SUM` over a 64-bit measure |
+    | --- | --- |
+    | ClickHouse | `SUM(toDecimal128(x, 0))` |
+    | Dremio | `SUM(CAST(x AS DECIMAL(38, 0)))` |
+    | everyone else | plain `SUM`, cast to `bigint` |
+
+    Only `resultType: int` is rewritten, and only a plain `SUM`. A windowed sum
+    inside a cumulative or period-over-period metric keeps the engine's own
+    behaviour; the measure it aggregates is already rewritten inside the CTE,
+    which is where the accumulation over rows happens.
 
     **`AVG` over an integer measure is rewritten** on the engines that need
     it, rather than widened. See the note below for which, and why the
@@ -1233,7 +1254,8 @@ Pass-through (no CAST emitted): `min`, `max`, `any_value`, `median`, `mode`, `li
     overflowed: two rows of 9000000000000000000 summed to
     -446744073709551616 on Dremio and ClickHouse, silently, and raise
     `ARITHMETIC_OVERFLOW` on Databricks. Casting the argument first is what
-    makes the running total exact.
+    makes the running total exact. A plain `SUM` measure meets the same
+    accumulator and is rewritten the same way - see the note above.
 
     The divisor is also NULLIF-guarded, as every division is - see
     [Division by Zero](#division-by-zero) above.

--- a/src/orionbelt/compiler/pop_wrap.py
+++ b/src/orionbelt/compiler/pop_wrap.py
@@ -36,6 +36,7 @@ from orionbelt.compiler.metric_expansion import expand_metric_expression
 from orionbelt.compiler.resolution import ResolutionError, ResolvedMeasure, ResolvedQuery
 from orionbelt.compiler.type_resolver import (
     apply_exact_integer_avg,
+    apply_exact_integer_sum,
     cast_measure_to_resolved_type,
     resolve_metric_data_type,
 )
@@ -112,6 +113,12 @@ def _apply_base_measure_rewrite(
     cast is deliberately withheld here - it would truncate the window's input -
     but the rewrite is not, and withholding both is what left an integer AVG
     reaching the window as a raw floating average on the rewrite-only dialects.
+
+    Both rewrites apply. Only the average was applied at first, so a query
+    selecting a period-over-period metric *and* a cumulative one over the same
+    integer ``SUM`` put a raw ``SUM(qty)`` in ``pop_base`` for the cumulative
+    placeholder - the 64-bit accumulator this exists to avoid, reached by
+    composing two wrappers rather than by using either alone.
     """
     if model is None or dialect is None:
         return expr
@@ -122,7 +129,8 @@ def _apply_base_measure_rewrite(
     base = model.effective_measures.get(base_name)
     if base is None:
         return expr
-    return apply_exact_integer_avg(expr, base, model.settings, dialect, model)
+    expr = apply_exact_integer_avg(expr, base, model.settings, dialect, model)
+    return apply_exact_integer_sum(expr, base, dialect)
 
 
 def _resolve_col_code(model: SemanticModel, obj_name: str, display_name: str) -> str:

--- a/src/orionbelt/compiler/type_resolver.py
+++ b/src/orionbelt/compiler/type_resolver.py
@@ -218,6 +218,60 @@ def rewrite_exact_integer_avg(
     return None
 
 
+def rewrite_exact_integer_sum(
+    measure: Measure,
+    settings: ModelSettings | None,
+    dialect: Dialect | None,
+    expr: Expr,
+) -> tuple[Expr, OBMLType] | None:
+    """An exact ``SUM`` and the type to cast it to, or ``None`` to leave both.
+
+    The ``AVG`` counterpart above exists because that aggregate *drifts*; this
+    one exists because on one engine it *wraps*. Measured on two rows of
+    9000000000000000000, ClickHouse returns -446744073709551616 - a negative
+    total from two positive rows - where DuckDB, Postgres, BigQuery and
+    Databricks raise and Snowflake answers exactly. The accumulator is Int64
+    and has already overflowed by the time anything casts it, so an output type
+    cannot repair it; :meth:`Dialect.exact_integer_sum` says how to cast the
+    **argument** instead, and answers ``None`` on the seven engines that need
+    nothing.
+
+    An integer ``SUM`` infers ``bigint`` (#315) on the strength of being "exact
+    everywhere", which is what this disproves for one engine. The rewrite
+    therefore carries its own result type, or the exact 128-bit total would be
+    cast straight back into the 64 bits it was rewritten to escape.
+
+    A **declared** ``dataType`` still wins, as the resolution order promises,
+    and the expression is still rewritten under it - the same split the ``AVG``
+    rewrite makes. A declaration too narrow for its own data is a modelling
+    error, and one that stays as visible here as anywhere else.
+
+    Deliberately conservative in the same way: only a bare ``SUM(x)``
+    qualifies. A windowed sum arrives as a ``WindowFunction`` rather than a call
+    and keeps today's behaviour, which is the cumulative and period-over-period
+    wrappers. A DISTINCT one is declined rather than rewritten - OBML has no
+    aggregation that produces it today, so the branch would be untestable, and
+    dropping the keyword silently is the one way this rewrite could change an
+    answer rather than repair it.
+    """
+    if dialect is None:
+        return None
+    if measure.aggregation.upper() != "SUM" or measure.result_type != DataType.INT:
+        return None
+    aggregate, rebuild = _unwrap_default(expr)
+    if not isinstance(aggregate, FunctionCall) or aggregate.name != "SUM":
+        return None
+    if aggregate.distinct or len(aggregate.args) != 1:
+        return None
+    exact = dialect.exact_integer_sum(aggregate.args[0])
+    if exact is None:
+        return None
+    rewritten, target = exact
+    if measure.data_type:
+        target = parse_data_type(measure.data_type)
+    return rebuild(rewritten), target
+
+
 def _is_integer_avg(measure: Measure) -> bool:
     return measure.aggregation.upper() == "AVG" and measure.result_type == DataType.INT
 
@@ -356,6 +410,8 @@ def cast_measure_to_resolved_type(
     if dialect is None:
         return expr
     exact = rewrite_exact_integer_avg(measure, settings, dialect, expr, model)
+    if exact is None:
+        exact = rewrite_exact_integer_sum(measure, settings, dialect, expr)
     if exact is not None:
         rewritten, target = exact
         return dialect.cast_to_obml_type(rewritten, target)

--- a/src/orionbelt/compiler/type_resolver.py
+++ b/src/orionbelt/compiler/type_resolver.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 from collections.abc import Callable
 
 from orionbelt.ast.nodes import Expr, FunctionCall
-from orionbelt.dialect.base import Dialect
+from orionbelt.dialect.base import PORTABLE_DECIMAL_PRECISION, Dialect
 from orionbelt.models.expressions import find_qualified_refs
 from orionbelt.models.semantic import (
     DataType,
@@ -218,58 +218,50 @@ def rewrite_exact_integer_avg(
     return None
 
 
-def rewrite_exact_integer_sum(
-    measure: Measure,
-    settings: ModelSettings | None,
-    dialect: Dialect | None,
+def apply_exact_integer_sum(
     expr: Expr,
-) -> tuple[Expr, OBMLType] | None:
-    """An exact ``SUM`` and the type to cast it to, or ``None`` to leave both.
+    measure: Measure,
+    dialect: Dialect | None,
+) -> Expr:
+    """The integer-``SUM`` rewrite alone, without the cast.
 
-    The ``AVG`` counterpart above exists because that aggregate *drifts*; this
-    one exists because on one engine it *wraps*. Measured on two rows of
-    9000000000000000000, ClickHouse returns -446744073709551616 - a negative
-    total from two positive rows - where DuckDB, Postgres, BigQuery and
-    Databricks raise and Snowflake answers exactly. The accumulator is Int64
-    and has already overflowed by the time anything casts it, so an output type
-    cannot repair it; :meth:`Dialect.exact_integer_sum` says how to cast the
-    **argument** instead, and answers ``None`` on the seven engines that need
-    nothing.
+    The ``AVG`` counterpart exists because that aggregate *drifts*; this one
+    exists because on two engines it *wraps*. Measured on two rows of
+    9000000000000000000, ClickHouse and Dremio both return -446744073709551616
+    - a negative total from two positive rows - where DuckDB, Postgres,
+    BigQuery and Databricks raise and Snowflake answers exactly. The
+    accumulator is 64-bit and has already overflowed by the time anything casts
+    it, so :meth:`Dialect.exact_integer_sum` widens the **argument** instead,
+    and answers ``None`` on the six engines that need nothing.
 
-    An integer ``SUM`` infers ``bigint`` (#315) on the strength of being "exact
-    everywhere", which is what this disproves for one engine. The rewrite
-    therefore carries its own result type, or the exact 128-bit total would be
-    cast straight back into the 64 bits it was rewritten to escape.
+    Rewrite-only, and used on every path rather than only the wrapper ones. The
+    cast cannot be applied here - a wrapper metric's placeholder holds the base
+    measure's aggregate and casting it would truncate the window's input - and
+    the type is not this function's business anyway: it comes from
+    :func:`resolve_measure_cast_type`, which decides without looking at an
+    expression and therefore still decides correctly once wrappers compose.
 
-    A **declared** ``dataType`` still wins, as the resolution order promises,
-    and the expression is still rewritten under it - the same split the ``AVG``
-    rewrite makes. A declaration too narrow for its own data is a modelling
-    error, and one that stays as visible here as anywhere else.
-
-    Deliberately conservative in the same way: only a bare ``SUM(x)``
-    qualifies. A windowed sum arrives as a ``WindowFunction`` rather than a call
-    and keeps today's behaviour, which is the cumulative and period-over-period
-    wrappers. A DISTINCT one is declined rather than rewritten - OBML has no
-    aggregation that produces it today, so the branch would be untestable, and
-    dropping the keyword silently is the one way this rewrite could change an
-    answer rather than repair it.
+    Deliberately conservative: only a bare ``SUM(x)`` qualifies. A windowed sum
+    arrives as a ``WindowFunction`` rather than a call, and the measure it
+    aggregates is already rewritten in the CTE beneath it, which is where the
+    accumulation over rows happens. A DISTINCT one is declined rather than
+    rewritten - OBML has no aggregation that produces one today, so the branch
+    would be untestable, and dropping the keyword silently is the one way this
+    could change an answer rather than repair it.
     """
-    if dialect is None:
-        return None
-    if measure.aggregation.upper() != "SUM" or measure.result_type != DataType.INT:
-        return None
+    if dialect is None or not _is_integer_sum(measure):
+        return expr
     aggregate, rebuild = _unwrap_default(expr)
     if not isinstance(aggregate, FunctionCall) or aggregate.name != "SUM":
-        return None
+        return expr
     if aggregate.distinct or len(aggregate.args) != 1:
-        return None
-    exact = dialect.exact_integer_sum(aggregate.args[0])
-    if exact is None:
-        return None
-    rewritten, target = exact
-    if measure.data_type:
-        target = parse_data_type(measure.data_type)
-    return rebuild(rewritten), target
+        return expr
+    rewritten = dialect.exact_integer_sum(aggregate.args[0])
+    return expr if rewritten is None else rebuild(rewritten)
+
+
+def _is_integer_sum(measure: Measure) -> bool:
+    return measure.aggregation.upper() == "SUM" and measure.result_type == DataType.INT
 
 
 def _is_integer_avg(measure: Measure) -> bool:
@@ -410,11 +402,10 @@ def cast_measure_to_resolved_type(
     if dialect is None:
         return expr
     exact = rewrite_exact_integer_avg(measure, settings, dialect, expr, model)
-    if exact is None:
-        exact = rewrite_exact_integer_sum(measure, settings, dialect, expr)
     if exact is not None:
         rewritten, target = exact
         return dialect.cast_to_obml_type(rewritten, target)
+    expr = apply_exact_integer_sum(expr, measure, dialect)
     resolved = resolve_measure_cast_type(measure, settings, dialect, model)
     if resolved is None:
         return expr
@@ -480,7 +471,18 @@ def resolve_measure_cast_type(
     point in the plan.
     """
     resolved = resolve_measure_data_type(measure, settings)
-    if measure.data_type or not isinstance(resolved, DecimalType):
+    if measure.data_type:
+        return resolved
+    if _is_integer_sum(measure) and dialect is not None and dialect.integer_sum_is_widened():
+        # ClickHouse and Dremio widen the accumulator, so ``bigint`` - which an
+        # integer SUM otherwise infers (#315) - would cast the exact 128-bit
+        # total straight back into the 64 bits the rewrite escaped. Decided
+        # here rather than alongside the rewrite because the two see different
+        # things: once a cumulative composes over a period-over-period, the
+        # expression is a CTE alias and no rewrite fires, but the value inside
+        # that CTE is already 128-bit and still needs a type that holds it.
+        return DecimalType(precision=PORTABLE_DECIMAL_PRECISION, scale=0)
+    if not isinstance(resolved, DecimalType):
         return resolved
     if not _is_integer_avg(measure):
         # Every other aggregate is exact on every engine, so a source declared

--- a/src/orionbelt/dialect/base.py
+++ b/src/orionbelt/dialect/base.py
@@ -256,6 +256,13 @@ class DialectCapabilities:
     unsupported_functions: list[str] = field(default_factory=list)
 
 
+#: The widest decimal precision every supported engine accepts. Where a dialect
+#: has to choose a width of its own - widening a wrapping accumulator (#338), or
+#: a cast that would otherwise saturate (#336) - this is the ceiling, so that
+#: a value one engine now returns is one a portable model could have carried.
+PORTABLE_DECIMAL_PRECISION = 38
+
+
 class Dialect(ABC):
     """Abstract base for all SQL dialects.
 
@@ -419,6 +426,50 @@ class Dialect(ABC):
         ``obml_type`` is the type the result will be cast to, already widened
         to hold a 64-bit integer part, and carries the scale an engine needs
         when it wants one explicitly.
+        """
+        return None
+
+    def _sum_over_widened_argument(self, arg: Expr) -> tuple[Expr, OBMLType]:
+        """``SUM(CAST(arg AS DECIMAL(38, 0)))`` and the type it produces.
+
+        The plain form of the same move :meth:`_exact_avg_by_sum_over_count`
+        makes, for the engines whose only problem is the accumulator. Dremio
+        uses it; ClickHouse spells the widening ``toDecimal128`` and overrides.
+
+        ``PORTABLE_DECIMAL_PRECISION`` rather than this dialect's own maximum,
+        which is 76 on ClickHouse: a total the rewrite lets through should be
+        one every supported engine could carry, so that widening an aggregate
+        does not quietly make a model unportable.
+        """
+        target = DecimalType(precision=PORTABLE_DECIMAL_PRECISION, scale=0)
+        widened = Cast(expr=arg, type_name=self.render_obml_type(target))
+        return FunctionCall(name="SUM", args=[widened]), target
+
+    def exact_integer_sum(self, arg: Expr) -> tuple[Expr, OBMLType] | None:
+        """An exact ``SUM(arg)`` over an integer column, and its type.
+
+        ``None`` - the default - keeps the plain ``SUM``, which is right for
+        every engine that either computes the total exactly or refuses it. Most
+        do one or the other: measured on two rows of 9000000000000000000,
+        DuckDB, Postgres, BigQuery and Databricks raise, and Snowflake returns
+        18000000000000000000 intact.
+
+        A dialect overrides this where its accumulator **wraps** instead. That
+        is the one outcome no output type can repair, for the same reason
+        :meth:`exact_integer_avg` exists: the loss is inside the aggregate, and
+        a cast only widens a number that has already gone wrong. Measured on
+        ClickHouse, ``SUM`` over Int64 returns -446744073709551616 for that
+        pair, and casting the result to ``Decimal(38, 0)`` returns it
+        unchanged, while casting the **argument** returns the true total.
+
+        Returns the type as well as the expression, because they cannot be
+        chosen separately. An integer ``SUM`` infers ``bigint`` (#315), and
+        leaving that in place would cast the exact 128-bit total straight back
+        into the 64-bit type it was rewritten to escape.
+
+        Takes no ``obml_type``, unlike its ``AVG`` counterpart: an average
+        needs a scale to divide to, and a sum of integers has no fractional
+        part to declare one for.
         """
         return None
 

--- a/src/orionbelt/dialect/base.py
+++ b/src/orionbelt/dialect/base.py
@@ -429,23 +429,39 @@ class Dialect(ABC):
         """
         return None
 
-    def _sum_over_widened_argument(self, arg: Expr) -> tuple[Expr, OBMLType]:
-        """``SUM(CAST(arg AS DECIMAL(38, 0)))`` and the type it produces.
+    def _sum_over_widened_argument(self, arg: Expr) -> Expr:
+        """``SUM(CAST(arg AS DECIMAL(38, 0)))``.
 
         The plain form of the same move :meth:`_exact_avg_by_sum_over_count`
         makes, for the engines whose only problem is the accumulator. Dremio
         uses it; ClickHouse spells the widening ``toDecimal128`` and overrides.
-
-        ``PORTABLE_DECIMAL_PRECISION`` rather than this dialect's own maximum,
-        which is 76 on ClickHouse: a total the rewrite lets through should be
-        one every supported engine could carry, so that widening an aggregate
-        does not quietly make a model unportable.
         """
-        target = DecimalType(precision=PORTABLE_DECIMAL_PRECISION, scale=0)
-        widened = Cast(expr=arg, type_name=self.render_obml_type(target))
-        return FunctionCall(name="SUM", args=[widened]), target
+        widened = Cast(
+            expr=arg,
+            type_name=self.render_obml_type(
+                DecimalType(precision=PORTABLE_DECIMAL_PRECISION, scale=0)
+            ),
+        )
+        return FunctionCall(name="SUM", args=[widened])
 
-    def exact_integer_sum(self, arg: Expr) -> tuple[Expr, OBMLType] | None:
+    def integer_sum_is_widened(self) -> bool:
+        """Whether an integer ``SUM`` is rewritten to a wider accumulator here.
+
+        Deliberately independent of any expression, for the same reason
+        :meth:`integer_avg_is_exact` is. The **type** such a measure is cast to
+        has to be decided the same way wherever the cast happens, and by the
+        time a wrapper composes - a cumulative over a period-over-period, say -
+        what it holds is a CTE alias rather than the aggregate. Asking "is this
+        a bare SUM I can rewrite?" answers no there, and the cast fell back to
+        the inferred ``bigint``, narrowing an exact 128-bit total straight back
+        into the 64 bits the rewrite existed to escape.
+
+        Detected by introspection rather than a second flag, so a dialect that
+        overrides :meth:`exact_integer_sum` cannot forget to declare it.
+        """
+        return type(self).exact_integer_sum is not Dialect.exact_integer_sum
+
+    def exact_integer_sum(self, arg: Expr) -> Expr | None:
         """An exact ``SUM(arg)`` over an integer column, and its type.
 
         ``None`` - the default - keeps the plain ``SUM``, which is right for
@@ -462,10 +478,11 @@ class Dialect(ABC):
         pair, and casting the result to ``Decimal(38, 0)`` returns it
         unchanged, while casting the **argument** returns the true total.
 
-        Returns the type as well as the expression, because they cannot be
-        chosen separately. An integer ``SUM`` infers ``bigint`` (#315), and
-        leaving that in place would cast the exact 128-bit total straight back
-        into the 64-bit type it was rewritten to escape.
+        Returns the expression only. An integer ``SUM`` infers ``bigint``
+        (#315), which would cast the exact 128-bit total straight back into the
+        64 bits the rewrite escaped, so the result type has to move too - but
+        it moves through :meth:`integer_sum_is_widened`, which answers without
+        looking at an expression and so still answers inside a wrapper.
 
         Takes no ``obml_type``, unlike its ``AVG`` counterpart: an average
         needs a scale to divide to, and a sum of integers has no fractional

--- a/src/orionbelt/dialect/clickhouse.py
+++ b/src/orionbelt/dialect/clickhouse.py
@@ -42,7 +42,7 @@ class ClickHouseDialect(Dialect):
         "boolean": "Bool",
     }
 
-    def exact_integer_sum(self, arg: Expr) -> tuple[Expr, OBMLType] | None:
+    def exact_integer_sum(self, arg: Expr) -> Expr | None:
         """``SUM`` over Int64 accumulates in Int64 here, and wraps.
 
         The same overflow ``exact_integer_avg`` below already dodges inside its
@@ -57,16 +57,14 @@ class ClickHouseDialect(Dialect):
         one that hands back a plausible wrong number, which is why it is the
         only override (#338).
 
-        ``Decimal(38, 0)`` rather than Decimal128's full 38-digit-plus range:
-        it is what every supported engine can express, so a total ClickHouse
-        now returns is one a portable model could have carried. A sum of
-        integers has no fractional part, so the scale is zero.
+        The result type moves with it, to ``PORTABLE_DECIMAL_PRECISION`` rather
+        than this engine's own 76: a total the rewrite lets through should be
+        one every supported engine could carry. That is decided by
+        ``integer_sum_is_widened`` rather than returned here, so it holds
+        inside a wrapper too, where no aggregate is visible to key on.
         """
-        return (
-            FunctionCall(
-                name="SUM", args=[FunctionCall(name="toDecimal128", args=[arg, Literal.number(0)])]
-            ),
-            DecimalType(precision=38, scale=0),
+        return FunctionCall(
+            name="SUM", args=[FunctionCall(name="toDecimal128", args=[arg, Literal.number(0)])]
         )
 
     def exact_integer_avg(self, arg: Expr, obml_type: OBMLType) -> Expr | None:

--- a/src/orionbelt/dialect/clickhouse.py
+++ b/src/orionbelt/dialect/clickhouse.py
@@ -42,6 +42,33 @@ class ClickHouseDialect(Dialect):
         "boolean": "Bool",
     }
 
+    def exact_integer_sum(self, arg: Expr) -> tuple[Expr, OBMLType] | None:
+        """``SUM`` over Int64 accumulates in Int64 here, and wraps.
+
+        The same overflow ``exact_integer_avg`` below already dodges inside its
+        own rewrite, reached by the plainer road: measured, two rows of
+        9000000000000000000 summed to -446744073709551616, a negative total
+        from two positive rows, and ``sumWithOverflow`` returns the same. So
+        does an outer ``CAST(SUM(x) AS Decimal(38, 0))``, because by then the
+        accumulator has already wrapped. Casting the **argument** returns
+        18000000000000000000.
+
+        Every other engine either answers exactly or refuses; this is the only
+        one that hands back a plausible wrong number, which is why it is the
+        only override (#338).
+
+        ``Decimal(38, 0)`` rather than Decimal128's full 38-digit-plus range:
+        it is what every supported engine can express, so a total ClickHouse
+        now returns is one a portable model could have carried. A sum of
+        integers has no fractional part, so the scale is zero.
+        """
+        return (
+            FunctionCall(
+                name="SUM", args=[FunctionCall(name="toDecimal128", args=[arg, Literal.number(0)])]
+            ),
+            DecimalType(precision=38, scale=0),
+        )
+
     def exact_integer_avg(self, arg: Expr, obml_type: OBMLType) -> Expr | None:
         """ClickHouse needs its own function, and two guards around it.
 

--- a/src/orionbelt/dialect/dremio.py
+++ b/src/orionbelt/dialect/dremio.py
@@ -36,7 +36,7 @@ class DremioDialect(Dialect):
             unsupported_aggregations=["mode", "measure"],
         )
 
-    def exact_integer_sum(self, arg: Expr) -> tuple[Expr, OBMLType] | None:
+    def exact_integer_sum(self, arg: Expr) -> Expr | None:
         """``SUM`` over BIGINT accumulates in 64 bits here, and wraps.
 
         Measured against Dremio OSS: two rows of 9000000000000000000 sum to

--- a/src/orionbelt/dialect/dremio.py
+++ b/src/orionbelt/dialect/dremio.py
@@ -36,6 +36,21 @@ class DremioDialect(Dialect):
             unsupported_aggregations=["mode", "measure"],
         )
 
+    def exact_integer_sum(self, arg: Expr) -> tuple[Expr, OBMLType] | None:
+        """``SUM`` over BIGINT accumulates in 64 bits here, and wraps.
+
+        Measured against Dremio OSS: two rows of 9000000000000000000 sum to
+        -446744073709551616, a negative total from two positive rows, and
+        ``CAST(SUM(qty) AS BIGINT)`` - what OBSL emitted - returns the same,
+        because the accumulator has already wrapped by the time the cast runs.
+        Casting the argument first returns 18000000000000000000.
+
+        The same overflow ``exact_integer_avg`` below already dodges inside its
+        own rewrite, which is where it was first found (#318). It reaches a
+        plain ``SUM`` by the same road (#338).
+        """
+        return self._sum_over_widened_argument(arg)
+
     def exact_integer_avg(self, arg: Expr, obml_type: OBMLType) -> Expr | None:
         """Dremio divides decimals exactly, so SUM/COUNT is all it takes.
 

--- a/src/orionbelt/dialect/mysql.py
+++ b/src/orionbelt/dialect/mysql.py
@@ -6,6 +6,7 @@ import re
 
 from orionbelt.ast.nodes import Cast, Expr, FunctionCall, Literal, OrderByItem
 from orionbelt.dialect.base import (
+    PORTABLE_DECIMAL_PRECISION,
     Dialect,
     DialectCapabilities,
     UnsupportedAggregationError,
@@ -17,11 +18,6 @@ from orionbelt.models.types import DecimalType, OBMLType
 
 _VARCHAR_RE = re.compile(r"^\s*VARCHAR\s*(?:\(\s*(\d+)\s*\))?\s*$", re.IGNORECASE)
 _MYSQL_CAST_CHAR_MAX = 255
-
-# The widest decimal precision every supported engine accepts. A measure cast
-# is widened to at least this on MySQL, and deliberately no further - see
-# ``cast_to_obml_type`` (#336).
-_PORTABLE_DECIMAL_PRECISION = 38
 
 
 @DialectRegistry.register
@@ -267,9 +263,9 @@ class MySQLDialect(Dialect):
         """
         if not isinstance(obml_type, DecimalType):
             return obml_type
-        if obml_type.precision >= _PORTABLE_DECIMAL_PRECISION:
+        if obml_type.precision >= PORTABLE_DECIMAL_PRECISION:
             return obml_type
-        return DecimalType(precision=_PORTABLE_DECIMAL_PRECISION, scale=obml_type.scale)
+        return DecimalType(precision=PORTABLE_DECIMAL_PRECISION, scale=obml_type.scale)
 
     def _render_decimal_division(self, left_sql: str, right_sql: str) -> str:
         """MySQL's ``div_precision_increment`` defaults to 4, capping

--- a/tests/integration/drift/vendor_exec/test_overflow_cast_exec.py
+++ b/tests/integration/drift/vendor_exec/test_overflow_cast_exec.py
@@ -187,3 +187,86 @@ def test_mysql_still_saturates_a_64_bit_integer_cast(vendor_mysql: VendorTarget)
     """
     got = _outcome(vendor_mysql, "Qty Sum", OVERFLOWING[1][1])
     assert got not in (None, "raised") and Decimal(got) == Decimal(2**63 - 1), got
+
+
+# A period-over-period metric and a cumulative one over the same integer SUM.
+# PoP plans first and hosts the cumulative metric's placeholder inside
+# ``pop_base``, so the composition reaches a site neither wrapper touches
+# alone - which is how a raw 64-bit ``SUM`` survived the fix for #338 and had
+# to be found in review instead.
+COMPOSED_MODEL_YAML = """
+version: "1.0"
+name: composed_wrappers
+dataObjects:
+  Charges:
+    code: charges_overflow
+    columns:
+      Qty: {code: qty, abstractType: int}
+      Day: {code: day, abstractType: date}
+dimensions:
+  Charge Month: {dataObject: Charges, column: Day, timeGrain: month}
+measures:
+  Qty Sum: {columns: [{dataObject: Charges, column: Qty}], resultType: int, aggregation: sum}
+metrics:
+  Qty Running:
+    type: cumulative
+    measure: Qty Sum
+    timeDimension: Charge Month
+  Qty MoM:
+    type: period_over_period
+    expression: "{[Qty Sum]}"
+    periodOverPeriod:
+      timeDimension: Charge Month
+      grain: month
+      offsetGrain: month
+      comparison: difference
+"""
+
+
+def test_clickhouse_composed_wrappers_do_not_wrap(vendor_clickhouse: VendorTarget) -> None:
+    """Both halves of the composition, each with data that reaches it.
+
+    The first month holds **two** rows of 9000000000000000000, so the
+    per-group ``SUM`` inside ``pop_base`` overflows 64 bits on its own - that
+    is the placeholder that was projected raw. The second month adds one, so
+    the running total the window accumulates overflows as well - that is the
+    alias ``cumulative_base`` re-cast to ``Nullable(Int64)``.
+
+    Spread over two months rather than one because a single month exercises
+    only the second half: measured, with one row per month this test passed
+    with the placeholder rewrite removed.
+    """
+    raw, sm = TrackedLoader().load_string(COMPOSED_MODEL_YAML)
+    model, result = ReferenceResolver().resolve(raw, sm)
+    assert result.valid, result.errors
+    sql = (
+        CompilationPipeline()
+        .compile(
+            QueryObject(
+                select=QuerySelect(
+                    dimensions=["Charge Month"], measures=["Qty MoM", "Qty Running"]
+                ),
+                order_by=[{"field": "Charge Month", "direction": "asc"}],
+            ),
+            model,
+            "clickhouse",
+        )
+        .sql
+    )
+    vendor_clickhouse.execute("DROP TABLE IF EXISTS charges_overflow")
+    vendor_clickhouse.execute("CREATE TABLE charges_overflow (qty Int64, day Date) ENGINE = Memory")
+    try:
+        vendor_clickhouse.execute(
+            "INSERT INTO charges_overflow VALUES "
+            "(9000000000000000000, '2026-01-15'), (9000000000000000000, '2026-01-20'), "
+            "(1, '2026-02-15')"
+        )
+        rows = vendor_clickhouse.execute(sql)
+        running = [Decimal(str(r["Qty Running"])) for r in rows]
+    finally:
+        vendor_clickhouse.execute("DROP TABLE IF EXISTS charges_overflow")
+
+    assert running == [
+        Decimal("18000000000000000000"),
+        Decimal("18000000000000000001"),
+    ], running

--- a/tests/integration/drift/vendor_exec/test_overflow_cast_exec.py
+++ b/tests/integration/drift/vendor_exec/test_overflow_cast_exec.py
@@ -71,19 +71,17 @@ OVERFLOWING = [
 # have cost the ordinary answer.
 IN_RANGE = [1000, 2000]
 
-# Engines that still answer with a number on the 64-bit case, each for its own
-# reason, and each asserted by a test of its own rather than through the shared
-# contract:
+# MySQL still answers with a number on the 64-bit case: it saturates its
+# ``SIGNED`` cast, and its CAST vocabulary has no wider integer target. That
+# residue is asserted by a test of its own rather than through the shared
+# contract; see ``test_mysql_still_saturates_a_64_bit_integer_cast``.
 #
-# * ClickHouse wraps ``SUM`` over Int64 before any cast is reached, returning
-#   -446744073709551616. The loss is inside the aggregate, where no output type
-#   reaches it - the reason the exact-AVG rewrite casts inside the SUM (#318) -
-#   so it is a different defect from this one.
-# * MySQL saturates its ``SIGNED`` cast, the residue this fix leaves; see
-#   ``test_mysql_still_saturates_a_64_bit_integer_cast``.
+# ClickHouse was here too, wrapping its Int64 accumulator to
+# -446744073709551616 before any cast was reached. #338 casts the argument
+# instead, so it now holds the value and the contract covers it.
 #
 # The decimal case, whose total stays well inside Int64, runs everywhere.
-SATURATES_AT_64_BITS = {"clickhouse", "mysql"}
+SATURATES_AT_64_BITS = {"mysql"}
 
 
 def _projection(measure: str, dialect: str) -> str:

--- a/tests/unit/test_exact_integer_sum.py
+++ b/tests/unit/test_exact_integer_sum.py
@@ -1,0 +1,154 @@
+"""An integer ``SUM`` is exact on every dialect, including the two that wrap.
+
+``SUM`` over a 64-bit column accumulates in 64 bits on ClickHouse and Dremio,
+so it wraps rather than overflowing. Measured on two rows of
+9000000000000000000, against ClickHouse 25 and Dremio OSS:
+
+===========  ==============================
+DuckDB       raises
+PostgreSQL   raises
+BigQuery     raises
+Databricks   raises
+Snowflake    ``18000000000000000000``
+MySQL        ``9223372036854775807`` (#336)
+ClickHouse   ``-446744073709551616``
+Dremio       ``-446744073709551616``
+===========  ==============================
+
+A negative total from two positive rows is the one outcome no output type can
+repair: ``sumWithOverflow`` returns the same value on ClickHouse, and so does
+``CAST(SUM(x) AS Decimal(38, 0))``, because the accumulator has already wrapped
+by the time anything casts it. Casting the **argument** returns
+18000000000000000000 on both engines.
+
+This is the same overflow ``exact_integer_avg`` already dodges *inside* its own
+rewrite - ``dialect/base.py`` calls the inner cast "the load-bearing part" and
+cites this exact value - reached by the plainer road. It was fixed for the
+aggregate that drifts and not for the one that wraps (#338).
+
+Values are checked against live engines in
+``tests/integration/drift/vendor_exec/test_overflow_cast_exec.py``; what is
+asserted here is which dialects rewrite, what type the rewrite carries, and
+what it declines to touch.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from orionbelt.compiler.pipeline import CompilationPipeline
+from orionbelt.dialect.registry import DialectRegistry
+from orionbelt.models.query import QueryObject, QuerySelect
+from orionbelt.parser import ReferenceResolver, TrackedLoader
+
+MODEL_YAML = """
+version: "1.0"
+name: exact_integer_sum
+dataObjects:
+  Charges:
+    code: charges
+    columns:
+      Qty: {code: qty, abstractType: int}
+      Amt: {code: amt, abstractType: float}
+      Day: {code: day, abstractType: date}
+dimensions:
+  Charge Month: {dataObject: Charges, column: Day, timeGrain: month}
+measures:
+  Qty Sum: {columns: [{dataObject: Charges, column: Qty}], resultType: int, aggregation: sum}
+  Qty Count: {columns: [{dataObject: Charges, column: Qty}], resultType: int, aggregation: count}
+  Amt Sum: {columns: [{dataObject: Charges, column: Amt}], resultType: float, aggregation: sum}
+  Qty Sum Pinned:
+    columns: [{dataObject: Charges, column: Qty}]
+    resultType: int
+    aggregation: sum
+    dataType: "decimal(30, 0)"
+metrics:
+  Qty Running:
+    type: cumulative
+    measure: Qty Sum
+    timeDimension: Charge Month
+    dataType: "decimal(38, 0)"
+"""
+
+# The two whose accumulator wraps. Every other engine either answers exactly or
+# refuses, so a rewrite there would be noise on eight dialects to fix two.
+WRAPS = ["clickhouse", "dremio"]
+DIALECTS = sorted(DialectRegistry.available())
+UNAFFECTED = [d for d in DIALECTS if d not in WRAPS]
+
+
+def _sql(measure: str, dialect: str, dimensions: list[str] | None = None) -> str:
+    raw, sm = TrackedLoader().load_string(MODEL_YAML)
+    model, result = ReferenceResolver().resolve(raw, sm)
+    assert result.valid, result.errors
+    return (
+        CompilationPipeline()
+        .compile(
+            QueryObject(select=QuerySelect(dimensions=dimensions or [], measures=[measure])),
+            model,
+            dialect,
+        )
+        .sql
+    )
+
+
+class TestTheRewrite:
+    def test_clickhouse_widens_the_argument(self) -> None:
+        """``toDecimal128``, the spelling its own AVG rewrite already uses."""
+        assert "SUM(toDecimal128(" in _sql("Qty Sum", "clickhouse")
+
+    def test_dremio_widens_the_argument(self) -> None:
+        assert 'SUM(CAST("Charges"."qty" AS DECIMAL(38, 0)))' in _sql("Qty Sum", "dremio")
+
+    @pytest.mark.parametrize("dialect", WRAPS)
+    def test_the_result_type_moves_with_it(self, dialect: str) -> None:
+        """Otherwise the exact 128-bit total is cast straight back into the 64
+        bits it was rewritten to escape. An integer SUM infers ``bigint``
+        (#315), which is why the rewrite has to carry its own type.
+        """
+        sql = _sql("Qty Sum", dialect)
+        assert "38, 0" in sql, sql
+        assert "Int64" not in sql and "BIGINT" not in sql, sql
+
+    @pytest.mark.parametrize("dialect", WRAPS)
+    def test_a_declared_type_still_wins(self, dialect: str) -> None:
+        """The resolution order promises a declaration beats an inference, and
+        the expression is rewritten under it either way - the same split the
+        AVG rewrite makes. The accumulator wraps whatever the output type is.
+        """
+        sql = _sql("Qty Sum Pinned", dialect)
+        assert "30, 0" in sql, sql
+        assert "SUM(toDecimal128(" in sql or "SUM(CAST(" in sql, sql
+
+
+class TestWhatIsNotRewritten:
+    @pytest.mark.parametrize("dialect", UNAFFECTED)
+    def test_an_engine_that_answers_or_refuses_is_left_alone(self, dialect: str) -> None:
+        sql = _sql("Qty Sum", dialect)
+        assert "SUM(toDecimal128(" not in sql, sql
+        assert "SUM(CAST(" not in sql, sql
+
+    @pytest.mark.parametrize("dialect", WRAPS)
+    def test_a_float_sum_is_untouched(self, dialect: str) -> None:
+        """Only ``resultType: int`` reaches the 64-bit accumulator. A
+        fractional sum accumulates in a wider type already, and rewriting it
+        would change the scale the model asked for.
+        """
+        assert "toDecimal128" not in _sql("Amt Sum", dialect)
+        assert "SUM(CAST(" not in _sql("Amt Sum", dialect)
+
+    @pytest.mark.parametrize("dialect", WRAPS)
+    def test_a_count_is_untouched(self, dialect: str) -> None:
+        sql = _sql("Qty Count", dialect)
+        assert "toDecimal128" not in sql and "COUNT(" in sql, sql
+
+    @pytest.mark.parametrize("dialect", WRAPS)
+    def test_a_windowed_sum_keeps_todays_behaviour(self, dialect: str) -> None:
+        """A cumulative wrapper builds a ``WindowFunction``, not a call, so the
+        rewrite declines rather than guessing at a shape it cannot verify. The
+        inner measure inside the CTE is still rewritten, which is where the
+        accumulation over rows actually happens.
+        """
+        sql = _sql("Qty Running", dialect, ["Charge Month"])
+        assert "OVER (" in sql, sql
+        assert sql.count("SUM(toDecimal128(") + sql.count("SUM(CAST(") == 1, sql

--- a/tests/unit/test_exact_integer_sum.py
+++ b/tests/unit/test_exact_integer_sum.py
@@ -37,8 +37,10 @@ from __future__ import annotations
 import pytest
 
 from orionbelt.compiler.pipeline import CompilationPipeline
+from orionbelt.compiler.type_resolver import resolve_measure_cast_type
 from orionbelt.dialect.registry import DialectRegistry
 from orionbelt.models.query import QueryObject, QuerySelect
+from orionbelt.models.types import DecimalType, SimpleType
 from orionbelt.parser import ReferenceResolver, TrackedLoader
 
 MODEL_YAML = """
@@ -68,6 +70,18 @@ metrics:
     measure: Qty Sum
     timeDimension: Charge Month
     dataType: "decimal(38, 0)"
+  Qty Running Untyped:
+    type: cumulative
+    measure: Qty Sum
+    timeDimension: Charge Month
+  Qty MoM:
+    type: period_over_period
+    expression: "{[Qty Sum]}"
+    periodOverPeriod:
+      timeDimension: Charge Month
+      grain: month
+      offsetGrain: month
+      comparison: difference
 """
 
 # The two whose accumulator wraps. Every other engine either answers exactly or
@@ -77,14 +91,21 @@ DIALECTS = sorted(DialectRegistry.available())
 UNAFFECTED = [d for d in DIALECTS if d not in WRAPS]
 
 
-def _sql(measure: str, dialect: str, dimensions: list[str] | None = None) -> str:
+def _sql(
+    measure: str,
+    dialect: str,
+    dimensions: list[str] | None = None,
+    extra: list[str] | None = None,
+) -> str:
     raw, sm = TrackedLoader().load_string(MODEL_YAML)
     model, result = ReferenceResolver().resolve(raw, sm)
     assert result.valid, result.errors
     return (
         CompilationPipeline()
         .compile(
-            QueryObject(select=QuerySelect(dimensions=dimensions or [], measures=[measure])),
+            QueryObject(
+                select=QuerySelect(dimensions=dimensions or [], measures=[*(extra or []), measure])
+            ),
             model,
             dialect,
         )
@@ -152,3 +173,74 @@ class TestWhatIsNotRewritten:
         sql = _sql("Qty Running", dialect, ["Charge Month"])
         assert "OVER (" in sql, sql
         assert sql.count("SUM(toDecimal128(") + sql.count("SUM(CAST(") == 1, sql
+
+
+class TestTheTypeIsDecidedWithoutLookingAtTheExpression:
+    """The half of this that a rewrite alone cannot reach.
+
+    ``resolve_measure_cast_type`` answers from the measure and the dialect,
+    never from the shape the expression happens to have. Keying on "is this a
+    bare SUM" would be right for *rewriting* and wrong for *typing*: once a
+    wrapper composes, what it holds is a CTE alias, no rewrite fires, and the
+    cast fell back to the inferred ``bigint`` - narrowing an exact 128-bit
+    total straight back into the 64 bits the rewrite escaped.
+
+    The AVG path learned this in #330 and its own resolver says so; the SUM
+    path had to learn it again from a review of #340.
+    """
+
+    @pytest.mark.parametrize("dialect", WRAPS)
+    def test_a_wrapper_alias_is_typed_wide_not_bigint(self, dialect: str) -> None:
+        sql = _sql("Qty Running", dialect, ["Charge Month"])
+        assert "Int64" not in sql and "BIGINT" not in sql, sql
+
+    @pytest.mark.parametrize("dialect", DIALECTS)
+    def test_the_widened_type_follows_the_rewrite_and_nothing_else(self, dialect: str) -> None:
+        """Asserted on the resolved type rather than the rendered SQL, because
+        the spellings collide: Snowflake renders plain ``bigint`` as
+        ``NUMBER(38, 0)``, which looks exactly like the widened type and is not
+        one.
+        """
+        raw, sm = TrackedLoader().load_string(MODEL_YAML)
+        model, result = ReferenceResolver().resolve(raw, sm)
+        assert result.valid, result.errors
+        resolved = resolve_measure_cast_type(
+            model.effective_measures["Qty Sum"],
+            model.settings,
+            DialectRegistry.get(dialect),
+            model,
+        )
+        expected = DecimalType(precision=38, scale=0) if dialect in WRAPS else SimpleType("bigint")
+        assert resolved == expected, f"{dialect}: {resolved}"
+
+
+class TestTwoWrappersComposed:
+    """A period-over-period metric and a cumulative one over the same measure.
+
+    PoP runs first and hosts the cumulative metric's placeholder inside
+    ``pop_base``. That placeholder holds the base measure's aggregate, so it
+    needs the rewrite as much as any other site - and got only the ``AVG`` one,
+    so a raw ``SUM(qty)`` reached the 64-bit accumulator by composing two
+    wrappers where neither alone would have. Found in review of #340.
+    """
+
+    @pytest.mark.parametrize("dialect", WRAPS)
+    def test_the_placeholder_inside_pop_base_is_rewritten(self, dialect: str) -> None:
+        sql = _sql("Qty Running", dialect, ["Charge Month"], extra=["Qty MoM"])
+        raw = [
+            line
+            for line in sql.splitlines()
+            if "SUM(" in line and "toDecimal128" not in line and "SUM(CAST(" not in line
+        ]
+        # The one legitimate bare SUM is the window over the CTE column, which
+        # is already 128-bit by then.
+        assert len(raw) == 1 and "OVER (" in raw[0], sql
+
+    @pytest.mark.parametrize("dialect", WRAPS)
+    def test_the_alias_recast_between_them_stays_wide(self, dialect: str) -> None:
+        """``cumulative_base`` re-casts the alias ``pop_compare`` carries. It
+        was ``Nullable(Int64)``, which re-wrapped the value the rewrite had
+        just made exact.
+        """
+        sql = _sql("Qty Running Untyped", dialect, ["Charge Month"], extra=["Qty MoM"])
+        assert "Int64" not in sql and "BIGINT" not in sql, sql


### PR DESCRIPTION
Closes #338.

## What was wrong

ClickHouse and Dremio accumulate `SUM` over a 64-bit column in 64 bits, so it wraps rather than overflowing. Measured on two rows of `9000000000000000000`, against ClickHouse 25 and Dremio OSS:

| dialect | `SUM` over a 64-bit integer measure |
| --- | --- |
| DuckDB | raises |
| PostgreSQL | raises |
| BigQuery | raises |
| Databricks | raises |
| Snowflake | `18000000000000000000` |
| MySQL | `9223372036854775807`, saturated (known, #336) |
| ClickHouse | `-446744073709551616` |
| Dremio | `-446744073709551616` |

A negative total from two positive rows is the one outcome no output type can repair. `sumWithOverflow` returns the same value on ClickHouse, and so does `CAST(SUM(x) AS Decimal(38, 0))`, because the accumulator has already wrapped by the time anything casts it. Casting the **argument** returns `18000000000000000000` on both.

**This is not a new technique.** `base.py` already documents this exact value and calls the inner cast "the load-bearing part" of the exact-AVG rewrite (#318). It was applied to the aggregate that drifts and not to the one that wraps, and a plain `SUM` meets the same accumulator by the plainer road.

## What this does

`exact_integer_sum` is a dialect hook alongside `exact_integer_avg`, dispatched from `cast_measure_to_resolved_type` - the single place a measure's result type is applied, so the star and CFL projections and the cumulative, period-over-period and window wrappers all inherit it.

```sql
-- ClickHouse
CAST(round(SUM(toDecimal128("Charges"."qty", 0)), 0) AS Nullable(Decimal(38, 0)))
-- Dremio
CAST(SUM(CAST("Charges"."qty" AS DECIMAL(38, 0))) AS DECIMAL(38, 0))
-- the other six: unchanged
CAST(SUM("Charges"."qty") AS BIGINT)
```

The hook returns the result type as well as the expression, because the two cannot be chosen separately: an integer `SUM` infers `bigint` (#315), and leaving that in place would cast the exact 128-bit total straight back into the 64 bits it was rewritten to escape.

Both target `decimal(38, 0)` rather than either engine's own maximum, which is 76 on ClickHouse: a total the rewrite lets through should be one every supported engine could carry. That number is now one `PORTABLE_DECIMAL_PRECISION` constant in `base.py` rather than a copy here and a copy in the MySQL cast width from #336.

## Declined, each for a stated reason

- **A float `SUM`.** Its accumulator is already wider, and rewriting it would change the scale the model asked for.
- **A windowed sum.** It arrives as a `WindowFunction` rather than a call. The measure it aggregates is rewritten inside the CTE, which is where the accumulation over rows happens.
- **A DISTINCT sum.** No OBML aggregation produces one today (there is no `sum_distinct`), so the branch would be untestable, and silently dropping the keyword is the one way this rewrite could change an answer rather than repair it. It declines rather than rewriting.

## Verification

ClickHouse now passes the 64-bit case of the cross-vendor overflow contract in `test_overflow_cast_exec.py`, which had to exclude it when that suite landed.

**NULL handling was measured rather than assumed**, because CFL runs the outer `SUM` over a column of NULL pads and this rewrite wraps that column in `toDecimal128`:

| case | rewritten | plain |
| --- | --- | --- |
| one value, one NULL | `5` | `5` |
| all NULL | NULL | NULL |
| empty group | `0` | `0` |

Identical, so CFL is unaffected.

Full docker suite: only the four pre-existing #339 ClickHouse CFL failures, the same set as before this change.

**Dremio's value was measured by hand** against the OSS container in `tests/integration/dremio/`, since `vendor_exec` has no Dremio fixture. Its rewrite is asserted in CI at the SQL level only. Adding a Dremio `VendorTarget` would close that, and is worth its own change.

## An observation

No drift snapshot moves, because **every `SUM` in the commerce corpus is `resultType: float`**. The corpus has no integer sum at all, which is part of why this went unnoticed. Adding one would give the drift matrix and the vendor sweeps real coverage, the way #300 added computed columns for the function catalog. I have not done it here, since it touches a shared fixture and re-snaps all eight dialects.
