### PR TITLE
fix(compiler): a CFL leg carries its measure typed where the engine needs it

### DIFF
--- a/src/orionbelt/compiler/cfl.py
+++ b/src/orionbelt/compiler/cfl.py
@@ -588,38 +588,19 @@ class CFLPlanner:
                             )
                             leg_builder.select(AliasedExpr(expr=null_expr, alias=alias))
                 elif m.name in this_measure_names:
-                    # Whether this leg casts the measure it owns is
-                    # ``resolve_owning_leg_cast_type``'s decision, and it turns
-                    # on whether the engine resolves a union's legs to a common
-                    # type. This comment used to assert the cast unconditional;
-                    # #313 made it conditional and left the claim standing,
-                    # which is how ClickHouse spent a month unable to run a CFL
-                    # query while every snapshot stayed green (#339).
                     own_expr: Expr = self._unwrap_aggregation(
                         replace(m, expression=conformed_exprs[m.name])
                         if m.name in conformed_exprs
                         else m
                     )
-                    # The leg that owns the measure projects it **uncast**, in
-                    # the source's own type, exactly as the star path does.
-                    #
-                    # Only the NULL pads below carry a declared type, and that
-                    # is enough to settle the union: measured on DuckDB,
-                    # Postgres and ClickHouse, a typed pad beside an uncast
-                    # column resolves to the *column's* type, in any leg order.
-                    # Casting this side as well is what rounded pre-aggregation
-                    # rows to the declared output type (#305), and then, once
-                    # the alignment was widened to carry the scale, overflowed
-                    # a value the source column held quite legally: a
-                    # DECIMAL(38, 20) leaves only 18 integer digits, so a
-                    # DECIMAL(38, 15) source failed on Postgres and DuckDB
-                    # under CFL while succeeding alone (#311). Not casting
-                    # cannot do either, because there is no second type.
-                    #
-                    # The exception is an alignment that *converts* rather than
-                    # widens - LISTAGG over an integer column pads with text -
-                    # where an uncast leg would meet a pad of another type and
-                    # Postgres would refuse the union.
+                    # Whether this leg casts the measure it owns belongs to
+                    # ``resolve_owning_leg_cast_type``, which states the rule
+                    # and the measurements behind it. Deliberately not restated
+                    # here: this spot carried a second copy, it went stale when
+                    # #313 changed the rule, and the copy still read as
+                    # authoritative while ClickHouse could not run a CFL query
+                    # at all (#339). One statement, in the function that
+                    # decides.
                     own_type_name = self._resolve_owning_leg_cast_type(m, model, dialect)
                     if own_type_name:
                         own_expr = Cast(expr=own_expr, type_name=own_type_name)

--- a/src/orionbelt/compiler/cfl.py
+++ b/src/orionbelt/compiler/cfl.py
@@ -588,12 +588,13 @@ class CFLPlanner:
                             )
                             leg_builder.select(AliasedExpr(expr=null_expr, alias=alias))
                 elif m.name in this_measure_names:
-                    # Cast the own-measure column to the same type used for
-                    # NULL padding in sibling legs, so every leg's column
-                    # agrees on a single type. Without this, strict-typed
-                    # engines (ClickHouse with UNION ALL) produce a Variant
-                    # type that SUM can't aggregate ("ILLEGAL_TYPE_OF_ARGUMENT
-                    # Variant(Decimal, Float64)").
+                    # Whether this leg casts the measure it owns is
+                    # ``resolve_owning_leg_cast_type``'s decision, and it turns
+                    # on whether the engine resolves a union's legs to a common
+                    # type. This comment used to assert the cast unconditional;
+                    # #313 made it conditional and left the claim standing,
+                    # which is how ClickHouse spent a month unable to run a CFL
+                    # query while every snapshot stayed green (#339).
                     own_expr: Expr = self._unwrap_aggregation(
                         replace(m, expression=conformed_exprs[m.name])
                         if m.name in conformed_exprs

--- a/src/orionbelt/compiler/cfl_projection.py
+++ b/src/orionbelt/compiler/cfl_projection.py
@@ -296,8 +296,32 @@ def resolve_union_alignment_type(
     if column is not None and column.sql_precision is not None and column.sql_scale is not None:
         precision, scale = column.sql_precision, column.sql_scale
     else:
-        precision, scale = _ALIGNMENT_PRECISION, _ALIGNMENT_SCALE
+        precision, scale = _fallback_alignment(dialect)
     return dialect.render_obml_type(DecimalType(precision=precision, scale=scale))
+
+
+def _fallback_alignment(dialect: Dialect) -> tuple[int, int]:
+    """The guessed width, widened to whatever the engine can express.
+
+    38 leaves 18 integer digits at scale 20, which is enough for an engine that
+    unifies the union itself: nothing is cast there, so nothing can overflow,
+    and the pad's width does not constrain the column beside it - measured, a
+    ``numeric(38, 20)`` pad on Postgres resolves the column to plain
+    ``numeric`` and carries a 21-integer-digit value through.
+
+    An engine that cannot unify has its owning leg cast to this type, and there
+    the same width is a hazard: measured on ClickHouse, casting a
+    21-integer-digit value to ``Decimal(38, 20)`` returns 955136920807833575.50
+    rather than raising. Its own maximum is 76, which leaves 56 integer digits
+    and puts the overflow out of reach of any source a model does not declare.
+
+    Widened only for those engines, not as a general rule. Postgres reports a
+    maximum of 131072 and would take the pad with it, which it will not accept
+    in a type declaration at all.
+    """
+    if dialect.unions_resolve_leg_types:
+        return _ALIGNMENT_PRECISION, _ALIGNMENT_SCALE
+    return max(_ALIGNMENT_PRECISION, dialect.max_decimal_precision), _ALIGNMENT_SCALE
 
 
 def resolve_owning_leg_cast_type(
@@ -307,25 +331,34 @@ def resolve_owning_leg_cast_type(
 ) -> str | None:
     """The cast for the leg that *owns* a measure, or ``None`` to leave it be.
 
-    The NULL pads always carry a type; this side usually should not. A typed
-    pad beside an uncast column resolves to the **column's** type on DuckDB,
-    Postgres and ClickHouse, in any leg order, so the union is already settled
-    and casting here can only lose: to the declared output type it rounded
-    pre-aggregation rows (#305), and to a fixed wide decimal it overflowed
-    values the source held legally, since ``DECIMAL(38, 20)`` keeps just 18
-    integer digits (#311).
+    The NULL pads always carry a type; this side usually should not. Where the
+    engine resolves a union's legs to a common type, a typed pad beside an
+    uncast column settles it already, and casting here can only lose: to the
+    declared output type it rounded pre-aggregation rows (#305), and to a fixed
+    wide decimal it overflowed values the source held legally, since
+    ``DECIMAL(38, 20)`` keeps just 18 integer digits (#311).
 
-    It is kept where the alignment is a **conversion** rather than a widening.
-    ``LISTAGG`` over an integer column aligns the pads on text, and an uncast
-    integer leg meeting a text pad is a union Postgres refuses outright. Those
-    measures are exactly the ones :func:`resolve_union_alignment_type` answers
-    from the column's own type, so the rule is: cast when the alignment is not
-    the numeric widening.
+    ``unions_resolve_leg_types`` is the measured limit of that. It holds on
+    Postgres, which widens the column to plain ``numeric``, and on DuckDB. It
+    does not hold on ClickHouse, which builds ``Variant(Decimal, Float64)`` and
+    refuses to ``SUM`` it - so #313 left four CFL queries unrunnable there for
+    a month, and the compile-only snapshots could not see it because the SQL is
+    well formed (#339). That engine gets the cast, and its alignment carries
+    the headroom to make it safe; see :func:`_fallback_alignment`.
+
+    The cast is kept everywhere when the alignment is a **conversion** rather
+    than a widening. ``LISTAGG`` over an integer column aligns the pads on
+    text, and an uncast integer leg meeting a text pad is a union Postgres
+    refuses outright. Those measures are exactly the ones
+    :func:`resolve_union_alignment_type` answers from the column's own type, so
+    the rule is: cast when the alignment is not the numeric widening, or when
+    the engine will not settle the union on its own.
     """
     model_measure = model.effective_measures.get(measure.name)
     if (
         model_measure is not None
         and dialect is not None
+        and dialect.unions_resolve_leg_types
         and (model_measure.aggregation or "").lower() not in _RAW_COLUMN_AGGREGATIONS
         and _alignment_source(model_measure, model)[0] is not None
     ):

--- a/src/orionbelt/dialect/base.py
+++ b/src/orionbelt/dialect/base.py
@@ -295,6 +295,15 @@ class Dialect(ABC):
         "boolean": "BOOLEAN",
     }
 
+    @property
+    def max_decimal_precision(self) -> int:
+        """The widest decimal precision this engine accepts.
+
+        Public because the CFL union alignment has to reason about it from
+        outside the dialect layer (#339).
+        """
+        return self._MAX_DECIMAL_PRECISION
+
     def render_obml_type(self, obml_type: OBMLType) -> str:
         """Render an OBMLType to a dialect-specific SQL type string.
 
@@ -370,6 +379,23 @@ class Dialect(ABC):
             op="/",
             right=FunctionCall(name="COUNT", args=[arg]),
         )
+
+    #: Whether a UNION column whose legs carry different numeric types
+    #: resolves to a common type here.
+    #:
+    #: True everywhere but ClickHouse, and measured rather than assumed: a
+    #: ``numeric(38, 20)`` NULL pad beside an uncast ``numeric`` column
+    #: resolves to plain ``numeric`` on Postgres and carries a 21-integer-digit
+    #: value through intact, and DuckDB widens to accommodate the leg the same
+    #: way. ClickHouse instead builds ``Variant(Decimal(38, 20), Float64)`` and
+    #: refuses to ``SUM`` it with ILLEGAL_TYPE_OF_ARGUMENT.
+    #:
+    #: That difference decides whether a CFL leg has to cast the measure it
+    #: owns. Where the engine unifies, casting can only lose - it rounded
+    #: pre-aggregation rows (#305) and then overflowed a value the source held
+    #: legally (#311) - so the leg is left alone. Where it does not, one type
+    #: per union column has to be spelled out (#339).
+    unions_resolve_leg_types: bool = True
 
     #: Whether ``AVG`` over a 64-bit integer column is exact natively.
     #:

--- a/src/orionbelt/dialect/clickhouse.py
+++ b/src/orionbelt/dialect/clickhouse.py
@@ -42,6 +42,8 @@ class ClickHouseDialect(Dialect):
         "boolean": "Bool",
     }
 
+    unions_resolve_leg_types = False
+
     def exact_integer_sum(self, arg: Expr) -> Expr | None:
         """``SUM`` over Int64 accumulates in Int64 here, and wraps.
 
@@ -253,9 +255,16 @@ class ClickHouseDialect(Dialect):
         if not nullable.startswith("Nullable("):
             nullable = f"Nullable({resolved_type})"
         inner_sql = self.compile_expr(inner)
-        # Detect Decimal(P, S) targets and round to scale S first.
+        # Detect Decimal(P, S) targets and round to scale S first. A NULL
+        # literal is exempt: rounding it is a no-op - measured, ``round(NULL,
+        # 20)`` is NULL typed ``Nullable(Nothing)`` and casts cleanly - and
+        # every CFL NULL pad carries a decimal type, so the rule as written put
+        # ``round(NULL, 20)`` in every union leg for nothing.
         upper = resolved_type.upper()
-        if upper.startswith("DECIMAL") or upper.startswith("NULLABLE(DECIMAL"):
+        is_null_literal = isinstance(inner, Literal) and inner.value is None
+        if not is_null_literal and (
+            upper.startswith("DECIMAL") or upper.startswith("NULLABLE(DECIMAL")
+        ):
             scale_token = resolved_type.split(",")[-1].rstrip(") ")
             scale = int(scale_token.strip())
             inner_sql = f"round({inner_sql}, {scale})"

--- a/tests/integration/drift/compile_only/clickhouse/04_sales_returns_cfl_by_country.sql
+++ b/tests/integration/drift/compile_only/clickhouse/04_sales_returns_cfl_by_country.sql
@@ -1,10 +1,10 @@
 WITH "composite_01" AS (
-SELECT "Countries"."countryname" AS "Sales Country Name", "Sales"."salesamount" AS "Total Sales", CAST(round(NULL, 20) AS Nullable(Decimal(38, 20))) AS "Total Returns"
+SELECT "Countries"."countryname" AS "Sales Country Name", CAST(round("Sales"."salesamount", 20) AS Nullable(Decimal(76, 20))) AS "Total Sales", CAST(NULL AS Nullable(Decimal(76, 20))) AS "Total Returns"
 FROM "orionbelt_1"."sales" AS "Sales"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"
 LEFT JOIN "orionbelt_1"."countries" AS "Countries" ON "Clients"."clientcountryid" = "Countries"."countryid"
 UNION ALL
-SELECT "Countries"."countryname" AS "Sales Country Name", CAST(round(NULL, 20) AS Nullable(Decimal(38, 20))) AS "Total Sales", "Returns"."returnamount" AS "Total Returns"
+SELECT "Countries"."countryname" AS "Sales Country Name", CAST(NULL AS Nullable(Decimal(76, 20))) AS "Total Sales", CAST(round("Returns"."returnamount", 20) AS Nullable(Decimal(76, 20))) AS "Total Returns"
 FROM "orionbelt_1"."returns" AS "Returns"
 LEFT JOIN "orionbelt_1"."sales" AS "Sales" ON "Returns"."returnsalesid" = "Sales"."salesid"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"

--- a/tests/integration/drift/compile_only/clickhouse/05_sales_purchases_cfl_ungrouped.sql
+++ b/tests/integration/drift/compile_only/clickhouse/05_sales_purchases_cfl_ungrouped.sql
@@ -1,8 +1,8 @@
 WITH "composite_01" AS (
-SELECT "Sales"."salesamount" AS "Total Sales", CAST(round(NULL, 20) AS Nullable(Decimal(38, 20))) AS "Total Purchases"
+SELECT CAST(round("Sales"."salesamount", 20) AS Nullable(Decimal(76, 20))) AS "Total Sales", CAST(NULL AS Nullable(Decimal(76, 20))) AS "Total Purchases"
 FROM "orionbelt_1"."sales" AS "Sales"
 UNION ALL
-SELECT CAST(round(NULL, 20) AS Nullable(Decimal(38, 20))) AS "Total Sales", "Purchases"."purchaseamount" AS "Total Purchases"
+SELECT CAST(NULL AS Nullable(Decimal(76, 20))) AS "Total Sales", CAST(round("Purchases"."purchaseamount", 20) AS Nullable(Decimal(76, 20))) AS "Total Purchases"
 FROM "orionbelt_1"."purchases" AS "Purchases"
 )
 SELECT CAST(round(SUM("composite_01"."Total Sales"), 2) AS Nullable(Decimal(18, 2))) AS "Total Sales", CAST(round(SUM("composite_01"."Total Purchases"), 2) AS Nullable(Decimal(18, 2))) AS "Total Purchases"

--- a/tests/integration/drift/compile_only/clickhouse/07_total_sales_by_client_with_complaints.sql
+++ b/tests/integration/drift/compile_only/clickhouse/07_total_sales_by_client_with_complaints.sql
@@ -1,9 +1,9 @@
 WITH "composite_01" AS (
-SELECT "Clients"."clientname" AS "Sales Client Name", CAST(NULL AS Nullable(String)) AS "Complaint Client Name", "Sales"."salesamount" AS "Total Sales", CAST(NULL AS Nullable(Int32)) AS "Client Complaints Count"
+SELECT "Clients"."clientname" AS "Sales Client Name", CAST(NULL AS Nullable(String)) AS "Complaint Client Name", CAST(round("Sales"."salesamount", 20) AS Nullable(Decimal(76, 20))) AS "Total Sales", CAST(NULL AS Nullable(Int32)) AS "Client Complaints Count"
 FROM "orionbelt_1"."sales" AS "Sales"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Sales"."salesclient" = "Clients"."clientid"
 UNION ALL
-SELECT CAST(NULL AS Nullable(String)) AS "Sales Client Name", "Clients"."clientname" AS "Complaint Client Name", CAST(round(NULL, 20) AS Nullable(Decimal(38, 20))) AS "Total Sales", CAST(1 AS Nullable(Int32)) AS "Client Complaints Count"
+SELECT CAST(NULL AS Nullable(String)) AS "Sales Client Name", "Clients"."clientname" AS "Complaint Client Name", CAST(NULL AS Nullable(Decimal(76, 20))) AS "Total Sales", CAST(1 AS Nullable(Int32)) AS "Client Complaints Count"
 FROM "orionbelt_1"."clientcomplaints" AS "Client Complaints"
 LEFT JOIN "orionbelt_1"."clients" AS "Clients" ON "Client Complaints"."complclientid" = "Clients"."clientid"
 )

--- a/tests/integration/drift/compile_only/clickhouse/09_return_rate.sql
+++ b/tests/integration/drift/compile_only/clickhouse/09_return_rate.sql
@@ -1,8 +1,8 @@
 WITH "composite_01" AS (
-SELECT "Returns"."returnamount" AS "Total Returns", CAST(round(NULL, 20) AS Nullable(Decimal(38, 20))) AS "Total Sales"
+SELECT CAST(round("Returns"."returnamount", 20) AS Nullable(Decimal(76, 20))) AS "Total Returns", CAST(NULL AS Nullable(Decimal(76, 20))) AS "Total Sales"
 FROM "orionbelt_1"."returns" AS "Returns"
 UNION ALL
-SELECT CAST(round(NULL, 20) AS Nullable(Decimal(38, 20))) AS "Total Returns", "Sales"."salesamount" AS "Total Sales"
+SELECT CAST(NULL AS Nullable(Decimal(76, 20))) AS "Total Returns", CAST(round("Sales"."salesamount", 20) AS Nullable(Decimal(76, 20))) AS "Total Sales"
 FROM "orionbelt_1"."sales" AS "Sales"
 )
 SELECT CAST(round(CAST(SUM("composite_01"."Total Returns") AS Nullable(Decimal(38, 14))) / NULLIF(CAST(NULLIF(SUM("composite_01"."Total Sales"), 0) AS Nullable(Decimal(38, 14))), 0), 4) AS Nullable(Decimal(18, 4))) AS "Return Rate"

--- a/tests/unit/test_cfl_union_alignment.py
+++ b/tests/unit/test_cfl_union_alignment.py
@@ -213,12 +213,18 @@ class TestUnionAlignmentPreservesInput:
         )
 
     def test_every_leg_agrees_on_one_type(self) -> None:
-        """The reason the cast exists at all.
+        """The reason the cast exists at all, on the one engine that needs it.
 
         ClickHouse will not union columns whose types disagree: it builds a
-        ``Variant(Decimal, Float64)`` and refuses to ``SUM`` it. Widening the
-        own-measure cast without widening the NULL padding to match would trade
-        this bug for that one.
+        ``Variant(Decimal, Float64)`` and refuses to ``SUM`` it.
+
+        **Counts the casts, not just their distinct types.** As written before,
+        this collected ``AS Nullable(Decimal(p, s))`` and asserted one distinct
+        value - which an uncast owning leg satisfies trivially, because the
+        only occurrences left are the pads. #313 stopped casting the owning leg
+        and this test went on passing while four ClickHouse queries could not
+        run at all (#339). Every measure column of every leg has to carry the
+        type, so the count is what makes the assertion bite.
         """
         sql = PIPELINE.compile(
             QueryObject(select=QuerySelect(dimensions=["Day"], measures=["Charged", "Invoiced"])),
@@ -229,11 +235,37 @@ class TestUnionAlignmentPreservesInput:
         # those two carry different types, so searching the statement as a
         # whole would find the difference the fix introduces on purpose.
         legs = sql[sql.index("WITH ") : sql.rindex(")\nSELECT")]
-        types = set(re.findall(r"AS (Nullable\(Decimal\(\d+, \d+\)\))", legs))
-        assert len(types) == 1, f"legs disagree on the union type: {types}\n{legs}"
+        typed = re.findall(r"AS (Nullable\(Decimal\(\d+, \d+\)\))", legs)
+        assert len(set(typed)) == 1, f"legs disagree on the union type: {set(typed)}\n{legs}"
+        assert len(typed) == 4, (
+            "two legs times two measures should each carry the union type; "
+            f"found {len(typed)}, so a leg is projecting uncast:\n{legs}"
+        )
         assert re.search(r"CAST\(round\(SUM\(.*?\), 2\) AS Nullable\(Decimal\(18, 2\)\)\)", sql), (
             f"the outer aggregate should still narrow to the declared type:\n{sql}"
         )
+
+    def test_the_engines_that_unify_still_leave_the_leg_alone(self) -> None:
+        """The cast is not a general rule; it is one engine's requirement.
+
+        Measured: a ``numeric(38, 20)`` pad beside an uncast ``numeric`` column
+        resolves to plain ``numeric`` on Postgres and carries a
+        21-integer-digit value through intact, and DuckDB widens to the leg the
+        same way. Casting there is what rounded pre-aggregation rows (#305) and
+        then overflowed a legal value (#311), so those two keep projecting the
+        column as it stands.
+        """
+        for dialect in ("duckdb", "postgres", "snowflake"):
+            sql = PIPELINE.compile(
+                QueryObject(
+                    select=QuerySelect(dimensions=["Day"], measures=["Charged", "Invoiced"])
+                ),
+                _model(),
+                dialect,
+            ).sql
+            assert not re.search(r'CAST\("(?:Charges|Invoices)"\."amount" AS', sql), (
+                f"{dialect} unifies its own unions and should not cast the leg:\n{sql}"
+            )
 
 
 class TestWhatIsAndIsNotWidened:


### PR DESCRIPTION
Closes #339.

## What was wrong

Four ClickHouse execution cases had been failing since #313, which made the leg that owns a measure project it uncast. They are docker-marked, so CI stayed green, and a compile-only snapshot could not have caught it: the SQL is well formed and only the engine refuses it.

```
DB::Exception: Illegal type Variant(Decimal(38, 20), Float64) of argument
for aggregate function SUM. (ILLEGAL_TYPE_OF_ARGUMENT)
```

Bisected to `75873b7`: 15 passed before it, 4 failed at it.

## Why the premise was wrong, not the reasoning

#313 justified dropping the cast on the grounds that a typed pad beside an uncast column resolves to the column's type "on DuckDB, Postgres and ClickHouse". I measured all three:

| engine | `numeric(38, 20)` pad beside an uncast column |
| --- | --- |
| PostgreSQL | resolves to plain `numeric`; a 21-integer-digit value survives intact |
| DuckDB | widens to accommodate the leg the same way |
| ClickHouse | builds `Variant(Decimal(38, 20), Float64)` and refuses to `SUM` it |

So the premise held for two engines out of three, and the conclusion was drawn for all of them.

## The fix follows the measurement

`unions_resolve_leg_types` is the per-engine fact, false on ClickHouse alone. **Only that engine casts.** Postgres, DuckDB and the rest emit exactly what they emit today, so #305 (casting rounded pre-aggregation rows) and #311 (a fixed wide decimal overflowed a legal value) stay fixed where they were found. The drift churn is four ClickHouse files and nothing else.

That also resolves the three-way bind in the issue without picking a loser: the two constraints that conflict with casting only ever bit on engines that do not need it.

**Casting needs headroom the shared width does not have.** Measured on ClickHouse, casting a 21-integer-digit value to `Decimal(38, 20)` returns `955136920807833575.50` rather than raising - a silent wrong number, not an error. So the fallback alignment takes that engine's own maximum of 76, leaving 56 integer digits and putting overflow out of reach of any source a model does not declare. Widened only for engines that cast: Postgres reports a maximum of 131072 and would otherwise take the pad with it, which it will not accept in a type declaration at all.

## The test that should have caught this

`test_every_leg_agrees_on_one_type` was written for exactly this failure and **had gone vacuous**. It collected `AS Nullable(Decimal(p, s))` from the legs and asserted one distinct value - which an uncast leg satisfies trivially, because the only occurrences left are the pads. It now counts them (two legs times two measures) and fails when a leg projects uncast. Verified by removing the trait: `found 2, so a leg is projecting uncast`.

A companion test pins the other half, that the engines which unify are still left alone, so this cannot quietly become a general rule.

## Also in here

- **The `round(NULL, 20)` in every CFL pad is gone.** ClickHouse pre-rounds decimal casts because its `CAST` truncates where other engines round, and the rule looked only at the target type. Measured: `round(NULL, 20)` is NULL typed `Nullable(Nothing)` either way, so it was pure noise on every union leg.
- **The comment in `cfl.py`** that still described the cast as unconditional, sitting directly above the code that had stopped doing it. That is how the claim outlived the code that backed it.

## Verification

Full docker suite: **653 passed, 0 failed**. The four cases in `test_clickhouse_execution.py` pass, and nothing else moved.

## Still worth doing separately

The container suites do not run in CI. That is the whole reason this survived a month behind green checks, and no compile-only test can substitute: the SQL is valid, the engine just will not run it.
