### PR TITLE
feat(obml): nestedIn, a data object whose rows are a parent's array column

### DIFF
--- a/ontology/obsl.shacl.ttl
+++ b/ontology/obsl.shacl.ttl
@@ -151,6 +151,27 @@ obsl:ColumnShape a sh:NodeShape ;
 # Join --- a join path between two data objects
 # -----------------------------------------------------------------------------
 
+obsl:NestedSourceShape a sh:NodeShape ;
+    sh:targetClass obsl:NestedSource ;
+    rdfs:label "OBSL Nested Source Shape" ;
+    rdfs:comment "Validates that a nested source names exactly one parent data object and exactly one array column on it." ;
+    sh:property [
+        sh:path obsl:nestedInObject ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:class obsl:DataObject ;
+        sh:name "nested in object" ;
+        sh:message "A nested source must reference exactly one parent obsl:DataObject via obsl:nestedInObject."
+    ] ;
+    sh:property [
+        sh:path obsl:nestedInColumn ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
+        sh:name "nested in column" ;
+        sh:message "A nested source must name exactly one array column on its parent via obsl:nestedInColumn."
+    ] .
+
 obsl:JoinShape a sh:NodeShape ;
     sh:targetClass obsl:Join ;
     rdfs:label "OBSL Join Shape" ;

--- a/ontology/obsl.ttl
+++ b/ontology/obsl.ttl
@@ -49,6 +49,10 @@ obsl:Join a owl:Class ;
     rdfs:label "Join" ;
     rdfs:comment "A join path between two data objects, defined by source/target columns and cardinality." .
 
+obsl:NestedSource a owl:Class ;
+    rdfs:label "Nested Source" ;
+    rdfs:comment "Where a nested data object's rows come from: an array column on a parent data object, unnested. The correlation is containment rather than a key, so no join columns are declared." .
+
 obsl:Dimension a owl:Class ;
     rdfs:label "Dimension" ;
     rdfs:comment "A grouping or filtering attribute exposed to analysts.  References a column in a data object." .
@@ -142,6 +146,24 @@ obsl:joinTo a owl:ObjectProperty ;
     rdfs:comment "Target data object of a join path." ;
     rdfs:domain obsl:Join ;
     rdfs:range obsl:DataObject .
+
+obsl:nestedIn a owl:ObjectProperty ;
+    rdfs:label "nested in" ;
+    rdfs:comment "The nested source a data object takes its rows from instead of, or in addition to, a table." ;
+    rdfs:domain obsl:DataObject ;
+    rdfs:range obsl:NestedSource .
+
+obsl:nestedInObject a owl:ObjectProperty ;
+    rdfs:label "nested in object" ;
+    rdfs:comment "The parent data object whose array column supplies a nested object's rows." ;
+    rdfs:domain obsl:NestedSource ;
+    rdfs:range obsl:DataObject .
+
+obsl:nestedInColumn a owl:DatatypeProperty ;
+    rdfs:label "nested in column" ;
+    rdfs:comment "The parent's array column. A dotted path addresses an array nested inside a struct." ;
+    rdfs:domain obsl:NestedSource ;
+    rdfs:range xsd:string .
 
 obsl:columnFrom a owl:ObjectProperty ;
     rdfs:label "column from" ;

--- a/packages/osi-orionbelt/src/osi_orionbelt/obml_to_osi.py
+++ b/packages/osi-orionbelt/src/osi_orionbelt/obml_to_osi.py
@@ -260,6 +260,12 @@ class OBMLtoOSI:
             do_extras["obml_countable"] = do_obj["countable"]
         if do_obj.get("countLabel") is not None:
             do_extras["obml_count_label"] = do_obj["countLabel"]
+        # A nested source has no OSI equivalent: OSI datasets are tables, and
+        # this one's rows are an array column on another dataset. Carried in the
+        # OBML vendor extension so a round trip does not silently turn a nested
+        # object into a table with an empty name.
+        if do_obj.get("nestedIn"):
+            do_extras["obml_nested_in"] = do_obj["nestedIn"]
         if do_extras:
             ds_exts = dataset.setdefault("custom_extensions", [])
             ds_exts.append(

--- a/packages/osi-orionbelt/src/osi_orionbelt/osi_to_obml.py
+++ b/packages/osi-orionbelt/src/osi_orionbelt/osi_to_obml.py
@@ -363,6 +363,8 @@ class OSItoOBML:
                         do["countable"] = ext_data["obml_countable"]
                     if ext_data.get("obml_count_label") is not None:
                         do["countLabel"] = ext_data["obml_count_label"]
+                    if ext_data.get("obml_nested_in"):
+                        do["nestedIn"] = ext_data["obml_nested_in"]
                 except (json.JSONDecodeError, TypeError):
                     pass
                 break

--- a/packages/osi-orionbelt/src/osi_orionbelt/schemas/obml-schema.json
+++ b/packages/osi-orionbelt/src/osi_orionbelt/schemas/obml-schema.json
@@ -126,13 +126,27 @@
             "mode"
           ],
           "additionalProperties": false
+        },
+        "nestedIn": {
+          "$ref": "#/definitions/nestedSource"
         }
       },
       "required": [
-        "code",
         "columns"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "anyOf": [
+        {
+          "required": [
+            "code"
+          ]
+        },
+        {
+          "required": [
+            "nestedIn"
+          ]
+        }
+      ]
     },
     "dataType": {
       "description": "OrionBelt internal Data Type",
@@ -716,7 +730,11 @@
           "description": "will use the total value of the measure"
         },
         "defaultValue": {
-          "type": ["string", "number", "boolean"],
+          "type": [
+            "string",
+            "number",
+            "boolean"
+          ],
           "description": "Value to report when the aggregate has nothing to add up. An aggregate over no rows is NULL in standard SQL, which a filtered measure reaches routinely, and engines disagree: ClickHouse returns 0 over an empty row set where Postgres, DuckDB and the rest return NULL. Setting this pins the value on every dialect (emitted as COALESCE around the aggregate); leaving it unset keeps the SQL-standard NULL. Same slot as a metric's defaultValue."
         },
         "anchor": {
@@ -1054,6 +1072,25 @@
         }
       ],
       "additionalProperties": false
+    },
+    "nestedSource": {
+      "type": "object",
+      "description": "Take this object's rows by unnesting an array column on a parent object rather than from a table of its own. The correlation is containment, not a key: an unnest pairs each parent row with the elements of its own array.",
+      "properties": {
+        "dataObject": {
+          "type": "string",
+          "description": "The parent data object whose array column supplies these rows"
+        },
+        "column": {
+          "type": "string",
+          "description": "The parent's array column. A dotted path addresses an array nested inside a struct, such as x_Project.Ancestors"
+        }
+      },
+      "required": [
+        "dataObject",
+        "column"
+      ],
+      "additionalProperties": false
     }
   },
   "type": "object",
@@ -1263,7 +1300,10 @@
         },
         "expressionMode": {
           "type": "string",
-          "enum": ["permissive", "portable"],
+          "enum": [
+            "permissive",
+            "portable"
+          ],
           "description": "How function calls in expressions are held to the portable function catalog (GET /v1/reference/functions). 'permissive' (default) emits a call the catalog does not carry as written and warns with NON_PORTABLE_FUNCTION, keeping vendor SQL available; 'portable' rejects it, so a model that has to run on any dialect cannot acquire a dependency on one engine's SQL by accident.",
           "default": "permissive"
         },
@@ -1273,7 +1313,10 @@
         },
         "weekStart": {
           "type": "string",
-          "enum": ["monday", "sunday"],
+          "enum": [
+            "monday",
+            "sunday"
+          ],
           "description": "Which day a week begins on, for date_trunc('week', ...) and the week boundaries date_diff('week', ...) counts. ISO 8601 (monday) by default; 'sunday' for a US retail calendar. Week numbering from extract('week', ...) stays ISO either way, because a Sunday-start week number has no definition the engines agree on.",
           "default": "monday"
         },

--- a/schema/obml-contract.yml
+++ b/schema/obml-contract.yml
@@ -185,6 +185,29 @@ classes:
         json_schema: true
         ontology_property: null
         osi_roundtrip: true
+      nested_in:
+        alias: nestedIn
+        type: "NestedSource | None"
+        json_schema: true
+        ontology_property: nestedIn
+        osi_roundtrip: true
+  NestedSource:
+    python: orionbelt.models.semantic.NestedSource
+    json_schema_def: nestedSource
+    ontology_class: NestedSource
+    fields:
+      data_object:
+        alias: dataObject
+        type: "str"
+        json_schema: true
+        ontology_property: nestedInObject
+        osi_roundtrip: true
+      column:
+        alias: column
+        type: "str"
+        json_schema: true
+        ontology_property: nestedInColumn
+        osi_roundtrip: true
   DataObjectColumn:
     python: orionbelt.models.semantic.DataObjectColumn
     json_schema_def: column

--- a/schema/obml-schema.json
+++ b/schema/obml-schema.json
@@ -126,13 +126,27 @@
             "mode"
           ],
           "additionalProperties": false
+        },
+        "nestedIn": {
+          "$ref": "#/definitions/nestedSource"
         }
       },
       "required": [
-        "code",
         "columns"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "anyOf": [
+        {
+          "required": [
+            "code"
+          ]
+        },
+        {
+          "required": [
+            "nestedIn"
+          ]
+        }
+      ]
     },
     "dataType": {
       "description": "OrionBelt internal Data Type",
@@ -716,7 +730,11 @@
           "description": "will use the total value of the measure"
         },
         "defaultValue": {
-          "type": ["string", "number", "boolean"],
+          "type": [
+            "string",
+            "number",
+            "boolean"
+          ],
           "description": "Value to report when the aggregate has nothing to add up. An aggregate over no rows is NULL in standard SQL, which a filtered measure reaches routinely, and engines disagree: ClickHouse returns 0 over an empty row set where Postgres, DuckDB and the rest return NULL. Setting this pins the value on every dialect (emitted as COALESCE around the aggregate); leaving it unset keeps the SQL-standard NULL. Same slot as a metric's defaultValue."
         },
         "anchor": {
@@ -1054,6 +1072,25 @@
         }
       ],
       "additionalProperties": false
+    },
+    "nestedSource": {
+      "type": "object",
+      "description": "Take this object's rows by unnesting an array column on a parent object rather than from a table of its own. The correlation is containment, not a key: an unnest pairs each parent row with the elements of its own array.",
+      "properties": {
+        "dataObject": {
+          "type": "string",
+          "description": "The parent data object whose array column supplies these rows"
+        },
+        "column": {
+          "type": "string",
+          "description": "The parent's array column. A dotted path addresses an array nested inside a struct, such as x_Project.Ancestors"
+        }
+      },
+      "required": [
+        "dataObject",
+        "column"
+      ],
+      "additionalProperties": false
     }
   },
   "type": "object",
@@ -1263,7 +1300,10 @@
         },
         "expressionMode": {
           "type": "string",
-          "enum": ["permissive", "portable"],
+          "enum": [
+            "permissive",
+            "portable"
+          ],
           "description": "How function calls in expressions are held to the portable function catalog (GET /v1/reference/functions). 'permissive' (default) emits a call the catalog does not carry as written and warns with NON_PORTABLE_FUNCTION, keeping vendor SQL available; 'portable' rejects it, so a model that has to run on any dialect cannot acquire a dependency on one engine's SQL by accident.",
           "default": "permissive"
         },
@@ -1273,7 +1313,10 @@
         },
         "weekStart": {
           "type": "string",
-          "enum": ["monday", "sunday"],
+          "enum": [
+            "monday",
+            "sunday"
+          ],
           "description": "Which day a week begins on, for date_trunc('week', ...) and the week boundaries date_diff('week', ...) counts. ISO 8601 (monday) by default; 'sunday' for a US retail calendar. Week numbering from extract('week', ...) stays ISO either way, because a Sunday-start week number has no definition the engines agree on.",
           "default": "monday"
         },

--- a/src/orionbelt/compiler/pipeline.py
+++ b/src/orionbelt/compiler/pipeline.py
@@ -16,7 +16,7 @@ from orionbelt.compiler.validator import validate_sql
 from orionbelt.dialect.registry import DialectRegistry
 from orionbelt.models.errors import SemanticError
 from orionbelt.models.query import QueryFilter, QueryFilterGroup, QueryFilterItem, QueryObject
-from orionbelt.models.semantic import SemanticModel
+from orionbelt.models.semantic import DataObject, SemanticModel
 from orionbelt.models.warnings import WarningCode, warning
 
 
@@ -208,9 +208,13 @@ class CompilationPipeline:
         # calendar can be set on it without leaking into another query.
         if model.settings is not None:
             dialect.week_start = model.settings.week_start
-        qualify_table = lambda obj: dialect.format_table_ref(  # noqa: E731
-            obj.database, obj.schema_name, obj.code
-        )
+
+        def qualify_table(obj: DataObject) -> str:
+            # Guarded rather than trusting ``code`` to be non-empty: a nested
+            # object without the fallback has no table, and an unguarded empty
+            # code renders as FROM "" (#342 review).
+            obj.require_table_source()
+            return dialect.format_table_ref(obj.database, obj.schema_name, obj.code)
 
         # Phase 1: Resolution
         resolved = self._resolver.resolve(query, model, qualify_table=qualify_table)

--- a/src/orionbelt/models/semantic.py
+++ b/src/orionbelt/models/semantic.py
@@ -381,6 +381,14 @@ class RefreshPolicy(BaseModel):
     model_config = {"populate_by_name": True, "extra": "forbid"}
 
 
+class UnrenderableDataObjectError(Exception):
+    """A data object cannot be rendered as a FROM target.
+
+    Raised at compile time rather than load time: the model is well formed, and
+    which objects a *query* touches is what decides whether the gap is reached.
+    """
+
+
 class NestedSource(BaseModel):
     """Where a nested data object's rows come from: an array column on a parent.
 
@@ -469,7 +477,34 @@ class DataObject(BaseModel):
     @property
     def qualified_code(self) -> str:
         """Full qualified table reference: database.schema.code."""
+        self.require_table_source()
         return f"{self.database}.{self.schema_name}.{self.code}"
+
+    def require_table_source(self) -> None:
+        """Raise unless this object has a table a FROM clause can name.
+
+        A ``nestedIn`` object without ``code`` has no table: its rows are an
+        array column on its parent, and reaching them needs an unnest that no
+        dialect renders yet. Without this guard the planners fall through to an
+        empty ``code`` and emit ``FROM "" AS "Charge Labels"`` - and a
+        synthesized count makes that reachable on any model that adopts the
+        field, with no measure declared at all.
+
+        Removed when the per-dialect rendering lands; until then a model may
+        *declare* a nested object and cannot *query* one unless it also carries
+        the ``code`` fallback, which is exactly what the fallback is for.
+        """
+        if self.code:
+            return
+        source = self.nested_in
+        raise UnrenderableDataObjectError(
+            f"Data object '{self.name}' takes its rows by unnesting "
+            f"'{source.data_object}.{source.column}', and no dialect compiles a "
+            f"nested data object yet. Declare 'code' alongside 'nestedIn' to read a "
+            f"flattening view in the meantime, or leave this object out of the query."
+            if source is not None
+            else f"Data object '{self.name}' has no 'code' to select from."
+        )
 
     @model_validator(mode="after")
     def _validate_has_a_source(self) -> DataObject:

--- a/src/orionbelt/models/semantic.py
+++ b/src/orionbelt/models/semantic.py
@@ -381,6 +381,35 @@ class RefreshPolicy(BaseModel):
     model_config = {"populate_by_name": True, "extra": "forbid"}
 
 
+class NestedSource(BaseModel):
+    """Where a nested data object's rows come from: an array column on a parent.
+
+    A repeated column is a table - one nested table per parent row - so it is
+    modelled as a data object rather than reached through an accessor. That is
+    what lets its fields be ordinary columns, its keys stay data rather than
+    model-time constants, and a measure live on it at its own grain.
+
+    There is no ``columnsFrom``/``columnsTo`` because there is no key to join
+    on. The correlation is *containment*: an unnest pairs each parent row with
+    the elements of its own array, so the association exists before any SQL
+    runs. A flattening view has to manufacture a key precisely because it
+    destroys that containment; inline, there is nothing to recover.
+    """
+
+    data_object: str = Field(
+        alias="dataObject",
+        description="The parent data object whose array column supplies these rows.",
+    )
+    column: str = Field(
+        description=(
+            "The parent's array column. A dotted path addresses an array nested "
+            "inside a struct, such as ``x_Project.Ancestors``."
+        ),
+    )
+
+    model_config = {"populate_by_name": True, "extra": "forbid"}
+
+
 class DataObject(BaseModel):
     """A database table or view with its columns and joins."""
 
@@ -420,11 +449,44 @@ class DataObject(BaseModel):
             "Drives result-cache TTL composition. PLAN_freshness_driven_cache.md §5."
         ),
     )
+    nested_in: NestedSource | None = Field(
+        default=None,
+        alias="nestedIn",
+        description=(
+            "Take this object's rows by unnesting an array column on another object "
+            "rather than from a table of its own. Declared alongside ``code`` rather "
+            "than instead of it: where both are present the unnest is used and the "
+            "table is the fallback, which is what makes moving a model off a "
+            "hand-written flattening view incremental."
+        ),
+    )
+
+    @property
+    def is_nested(self) -> bool:
+        """Whether this object's rows come from unnesting a parent's column."""
+        return self.nested_in is not None
 
     @property
     def qualified_code(self) -> str:
         """Full qualified table reference: database.schema.code."""
         return f"{self.database}.{self.schema_name}.{self.code}"
+
+    @model_validator(mode="after")
+    def _validate_has_a_source(self) -> DataObject:
+        """An object needs somewhere for its rows to come from.
+
+        ``code`` or ``nestedIn``, and both together is the supported case rather
+        than an error: an object that can be unnested *and* has a flattening
+        view behind it stays queryable on an engine that cannot unnest, and
+        lets a model migrate one object at a time instead of all at once.
+        """
+        if not self.code and self.nested_in is None:
+            raise ValueError(
+                f"Data object '{self.name}' declares neither 'code' nor 'nestedIn', "
+                "so it has no rows. Give it a table name, or nest it in a parent "
+                "object's array column."
+            )
+        return self
 
     @model_validator(mode="after")
     def _validate_count_label(self) -> DataObject:

--- a/src/orionbelt/models/synthesis.py
+++ b/src/orionbelt/models/synthesis.py
@@ -121,6 +121,13 @@ def synthesize_count_measures(model: SemanticModel) -> dict[str, Measure]:
     for object_key, obj in model.data_objects.items():
         if not obj.countable:
             continue
+        if not obj.code:
+            # A nested object with no table fallback cannot be selected from
+            # yet, so synthesizing its count would advertise a measure that
+            # fails on use - and would do so on every model that adopts
+            # ``nestedIn``, with nothing declared. Returns when the per-dialect
+            # unnest lands.
+            continue
         name = count_label(object_key, obj, pattern)
         if name in model.measures or name in out:
             continue

--- a/src/orionbelt/obsl/exporter.py
+++ b/src/orionbelt/obsl/exporter.py
@@ -47,6 +47,10 @@ def _column_uri(model_id: str, obj_name: str, col_name: str) -> URIRef:
     return URIRef(f"{BASE}{model_id}/data-object/{_slug(obj_name)}/column/{_slug(col_name)}")
 
 
+def _nested_source_uri(model_id: str, obj_name: str) -> URIRef:
+    return URIRef(f"{BASE}{model_id}/data-object/{_slug(obj_name)}/nested-source")
+
+
 def _join_uri(
     model_id: str,
     obj_name: str,
@@ -197,6 +201,7 @@ def export_obsl(model: SemanticModel, model_id: str) -> Graph:
         OBSL.DataObject,
         OBSL.Column,
         OBSL.Join,
+        OBSL.NestedSource,
         OBSL.Dimension,
         OBSL.Measure,
         OBSL.Metric,
@@ -206,6 +211,7 @@ def export_obsl(model: SemanticModel, model_id: str) -> Graph:
         (OBSL.DataObject, "Data Object"),
         (OBSL.Column, "Column"),
         (OBSL.Join, "Join"),
+        (OBSL.NestedSource, "Nested Source"),
         (OBSL.Dimension, "Dimension"),
         (OBSL.Measure, "Measure"),
         (OBSL.Metric, "Metric"),
@@ -272,6 +278,8 @@ def export_obsl(model: SemanticModel, model_id: str) -> Graph:
         (OBSL.hasColumn, OBSL.DataObject, OBSL.Column),
         (OBSL.hasJoin, OBSL.DataObject, OBSL.Join),
         (OBSL.joinTo, OBSL.Join, OBSL.DataObject),
+        (OBSL.nestedIn, OBSL.DataObject, OBSL.NestedSource),
+        (OBSL.nestedInObject, OBSL.NestedSource, OBSL.DataObject),
         (OBSL.columnFrom, OBSL.Join, OBSL.Column),
         (OBSL.columnTo, OBSL.Join, OBSL.Column),
         (OBSL.dataObject, OBSL.Dimension, OBSL.DataObject),
@@ -427,6 +435,26 @@ def export_obsl(model: SemanticModel, model_id: str) -> Graph:
             _emit_custom_extensions(g, col_uri, getattr(col, "custom_extensions", []))
 
         # Joins — path_name disambiguates multiple joins to the same target
+        if obj.nested_in is not None:
+            # A nested object's rows are an array column on a parent, so the
+            # source is its own node: the parent is a reference and the column
+            # is a literal, which a SPARQL query needs to tell apart.
+            ns_uri = _nested_source_uri(model_id, obj_name)
+            g.add((obj_uri, OBSL.nestedIn, ns_uri))
+            g.add((ns_uri, RDF.type, OBSL.NestedSource))
+            g.add((ns_uri, RDF.type, OWL.NamedIndividual))
+            g.add(
+                (
+                    ns_uri,
+                    RDFS.label,
+                    Literal(f"{obj.nested_in.data_object}.{obj.nested_in.column}"),
+                )
+            )
+            g.add(
+                (ns_uri, OBSL.nestedInObject, _data_object_uri(model_id, obj.nested_in.data_object))
+            )
+            g.add((ns_uri, OBSL.nestedInColumn, Literal(obj.nested_in.column)))
+
         for join in obj.joins:
             join_uri = _join_uri(model_id, obj_name, join.join_to, join.path_name)
             g.add((obj_uri, OBSL.hasJoin, join_uri))

--- a/src/orionbelt/parser/resolver.py
+++ b/src/orionbelt/parser/resolver.py
@@ -31,6 +31,7 @@ from orionbelt.models.semantic import (
     ModelExample,
     ModelFilter,
     ModelSettings,
+    NestedSource,
     PeriodOverPeriod,
     RefreshPolicy,
     SemanticModel,
@@ -133,6 +134,20 @@ _CUSTOM_EXTENSION_KEYS = _allowed_keys(CustomExtension)
 # field set, but the inner periodOverPeriod block has its own shape.
 _PERIOD_OVER_PERIOD_KEYS = _allowed_keys(PeriodOverPeriod)
 _METRIC_KEYS = _allowed_keys(Metric, exclude=("name",))
+
+
+def _parse_nested_in(raw: object) -> NestedSource | None:
+    """Build a :class:`NestedSource` from the raw ``nestedIn`` mapping.
+
+    Shape errors are left to Pydantic: the caller already wraps object
+    construction and reports a failure against the object's source span, so
+    raising here would report it twice and less precisely.
+    """
+    if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        raise TypeError("'nestedIn' must be a mapping with 'dataObject' and 'column'")
+    return NestedSource(**raw)
 
 
 def _parse_extensions(
@@ -473,6 +488,7 @@ class ReferenceResolver:
                     synonyms=raw_obj.get("synonyms", []),
                     custom_extensions=_parse_extensions(raw_obj),
                     refresh=_parse_refresh(raw_obj.get("refresh"), name, errors),
+                    nested_in=_parse_nested_in(raw_obj.get("nestedIn")),
                 )
             except Exception as e:
                 span = source_map.get(f"dataObjects.{name}") if source_map else None

--- a/src/orionbelt/parser/validator.py
+++ b/src/orionbelt/parser/validator.py
@@ -56,6 +56,94 @@ class SemanticValidator:
         errors.extend(self._check_via_reachability(model))
         errors.extend(self._check_missing_via(model))
         errors.extend(self._check_measure_anchors(model))
+        errors.extend(self._check_nested_objects(model))
+        return errors
+
+    def _check_nested_objects(self, model: SemanticModel) -> list[SemanticError]:
+        """Rules a ``nestedIn`` object has to satisfy.
+
+        A nested object's rows exist only inside its parent's, which constrains
+        it in ways an ordinary object is not:
+
+        * its parent has to exist, and cannot be itself;
+        * the chain of parents has to terminate, or a leg would never reach a
+          table to select from;
+        * nothing may join **to** it. There is no key to join on - the parent
+          correlation is containment rather than an equality - and its rows
+          cannot be addressed from outside the parent. Emitting SQL for such a
+          join is not possible, so it is refused here rather than later.
+
+        Joining *from* a nested object to a third one is fine and deliberately
+        not checked: the nested object is already in FROM through its parent,
+        and the join it declares is an ordinary keyed one.
+        """
+        errors: list[SemanticError] = []
+        nested = {name: obj for name, obj in model.data_objects.items() if obj.is_nested}
+
+        for name, obj in nested.items():
+            assert obj.nested_in is not None
+            parent = obj.nested_in.data_object
+            path = f"dataObjects.{name}.nestedIn"
+            if parent == name:
+                errors.append(
+                    SemanticError(
+                        code="INVALID_NESTED_SOURCE",
+                        message=f"Data object '{name}' is nested in itself.",
+                        path=path,
+                    )
+                )
+                continue
+            if parent not in model.data_objects:
+                errors.append(
+                    SemanticError(
+                        code="UNKNOWN_DATA_OBJECT",
+                        message=(
+                            f"Data object '{name}' is nested in '{parent}', which is not "
+                            f"a data object in this model."
+                        ),
+                        path=path,
+                    )
+                )
+                continue
+            # Walk to a non-nested ancestor. An array inside an array is
+            # supported, so depth is fine; a cycle is not.
+            seen = {name}
+            cursor = parent
+            while cursor in nested:
+                if cursor in seen:
+                    errors.append(
+                        SemanticError(
+                            code="INVALID_NESTED_SOURCE",
+                            message=(
+                                f"Data object '{name}' has a cyclic nestedIn chain through "
+                                f"'{cursor}', so it never reaches a table."
+                            ),
+                            path=path,
+                        )
+                    )
+                    break
+                seen.add(cursor)
+                next_parent = nested[cursor].nested_in
+                assert next_parent is not None
+                cursor = next_parent.data_object
+
+        for name, obj in model.data_objects.items():
+            for idx, join in enumerate(obj.joins):
+                target = nested.get(join.join_to)
+                if target is not None and target.nested_in is not None:
+                    errors.append(
+                        SemanticError(
+                            code="INVALID_NESTED_SOURCE",
+                            message=(
+                                f"Data object '{name}' joins to '{join.join_to}', which is "
+                                f"nested in '{target.nested_in.data_object}'. "
+                                f"A nested object has no key to join on - its rows exist "
+                                f"only inside its parent's - so it can only be reached "
+                                f"through that parent."
+                            ),
+                            path=f"dataObjects.{name}.joins[{idx}].joinTo",
+                        )
+                    )
         return errors
 
     def _check_unique_identifiers(self, model: SemanticModel) -> list[SemanticError]:

--- a/tests/unit/test_nested_data_objects.py
+++ b/tests/unit/test_nested_data_objects.py
@@ -1,0 +1,182 @@
+"""A data object whose rows come from unnesting a parent's array column.
+
+A repeated column is a table - one nested table per parent row - so it is
+modelled as a data object rather than reached through a scalar accessor. That is
+what keeps its keys *data* rather than model-time constants, lets a four-field
+shape like Google's ``x_Tags`` keep the two fields beyond key/value, and lets a
+measure live on it at its own grain.
+
+This module covers the **OBML surface only**: the field, its validation, and its
+propagation. Nothing compiles a ``nestedIn`` object to SQL yet; the rendering
+matrix and the codegen land separately.
+
+The design and the per-dialect measurements are in
+``design/PLAN_nested_data_objects.md``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from orionbelt.models.semantic import DataObject, NestedSource
+from orionbelt.parser import ReferenceResolver, TrackedLoader
+from orionbelt.parser.validator import SemanticValidator
+
+HEAD = """
+version: "1.0"
+name: nested
+dataObjects:
+  Charges:
+    code: charges
+    columns:
+      Cost: {code: cost, abstractType: float}
+"""
+TAIL = """
+measures:
+  Total Cost:
+    columns: [{dataObject: Charges, column: Cost}]
+    resultType: float
+    aggregation: sum
+"""
+
+
+def _resolve(objects: str) -> tuple[object, list]:
+    """Resolve, then run the semantic validator the way ``ModelStore`` does."""
+    raw, source_map = TrackedLoader().load_string(HEAD + objects + TAIL)
+    model, result = ReferenceResolver().resolve(raw, source_map)
+    errors = list(result.errors)
+    if result.valid:
+        errors.extend(SemanticValidator().validate(model))
+    return model, errors
+
+
+LABELS = """  Charge Labels:
+    nestedIn: {dataObject: Charges, column: Labels}
+    columns:
+      Label Key: {code: Key, abstractType: string}
+      Label Value: {code: Value, abstractType: string}
+"""
+
+
+class TestTheSurface:
+    def test_a_nested_object_resolves(self) -> None:
+        model, errors = _resolve(LABELS)
+        assert not errors, errors
+        obj = model.data_objects["Charge Labels"]
+        assert obj.is_nested
+        assert obj.nested_in == NestedSource(data_object="Charges", column="Labels")
+
+    def test_a_dotted_column_addresses_an_array_inside_a_struct(self) -> None:
+        """``x_Project.Ancestors`` in the Google export is a repeated record
+        inside a nullable record, so the column is a path rather than a name.
+        """
+        model, errors = _resolve(
+            "  Ancestors:\n"
+            "    nestedIn: {dataObject: Charges, column: x_Project.Ancestors}\n"
+            "    columns: {Display Name: {code: DisplayName, abstractType: string}}\n"
+        )
+        assert not errors, errors
+        assert model.data_objects["Ancestors"].nested_in.column == "x_Project.Ancestors"
+
+    def test_an_ordinary_object_is_not_nested(self) -> None:
+        model, _ = _resolve(LABELS)
+        assert not model.data_objects["Charges"].is_nested
+
+    def test_code_and_nested_in_together_are_the_supported_case(self) -> None:
+        """Not an either/or. An object that can be unnested *and* has a
+        flattening view behind it stays queryable on an engine that cannot
+        unnest, which is what makes moving a model off hand-written views
+        incremental rather than all-at-once.
+        """
+        model, errors = _resolve(
+            "  Charge Credits:\n"
+            "    nestedIn: {dataObject: Charges, column: Credits}\n"
+            "    code: v_charge_credits\n"
+            "    columns: {Credit Type: {code: Type, abstractType: string}}\n"
+        )
+        assert not errors, errors
+        obj = model.data_objects["Charge Credits"]
+        assert obj.is_nested and obj.code == "v_charge_credits"
+
+    def test_an_object_with_neither_source_is_refused(self) -> None:
+        _, errors = _resolve("  Nowhere:\n    columns: {K: {code: k, abstractType: string}}\n")
+        assert errors and "neither" in errors[0].message
+
+
+class TestWhatTheValidatorRefuses:
+    def test_a_parent_that_does_not_exist(self) -> None:
+        _, errors = _resolve(
+            "  L:\n    nestedIn: {dataObject: Nope, column: Labels}\n"
+            "    columns: {K: {code: Key, abstractType: string}}\n"
+        )
+        assert [e.code for e in errors] == ["UNKNOWN_DATA_OBJECT"]
+
+    def test_an_object_nested_in_itself(self) -> None:
+        _, errors = _resolve(
+            "  L:\n    nestedIn: {dataObject: L, column: Labels}\n"
+            "    columns: {K: {code: Key, abstractType: string}}\n"
+        )
+        assert [e.code for e in errors] == ["INVALID_NESTED_SOURCE"]
+
+    def test_a_cyclic_chain_never_reaches_a_table(self) -> None:
+        _, errors = _resolve(
+            "  A:\n    nestedIn: {dataObject: B, column: x}\n"
+            "    columns: {K: {code: Key, abstractType: string}}\n"
+            "  B:\n    nestedIn: {dataObject: A, column: y}\n"
+            "    columns: {K2: {code: Key, abstractType: string}}\n"
+        )
+        assert {e.code for e in errors} == {"INVALID_NESTED_SOURCE"}
+        assert len(errors) == 2
+
+    def test_joining_to_a_nested_object_from_elsewhere(self) -> None:
+        """There is no key to join on. A nested object's rows exist only inside
+        its parent's, so it can only be reached through that parent - emitting
+        SQL for such a join is not possible, so it is refused at load.
+        """
+        _, errors = _resolve(
+            LABELS + "  Other:\n    code: other\n"
+            "    columns: {K2: {code: k2, abstractType: string}}\n"
+            "    joins: [{joinType: many-to-one, joinTo: Charge Labels,"
+            " columnsFrom: [K2], columnsTo: [Label Key]}]\n"
+        )
+        assert [e.code for e in errors] == ["INVALID_NESTED_SOURCE"]
+        assert "no key to join on" in errors[0].message
+
+
+class TestWhatIsAllowed:
+    def test_an_array_inside_an_array(self) -> None:
+        """Depth is fine - only a cycle is not. A nested object whose parent is
+        itself nested reaches a table by walking up the chain.
+        """
+        _, errors = _resolve(
+            LABELS + "  Label Parts:\n"
+            "    nestedIn: {dataObject: Charge Labels, column: Parts}\n"
+            "    columns: {Part: {code: Part, abstractType: string}}\n"
+        )
+        assert not errors, errors
+
+    def test_a_nested_object_joining_onward_to_a_third(self) -> None:
+        """The nested object is already in FROM through its parent, so a join it
+        declares is an ordinary keyed one and is left alone.
+        """
+        _, errors = _resolve(
+            "  Currencies:\n    code: currencies\n"
+            "    columns: {Code: {code: code, abstractType: string}}\n"
+            "  Charge Credits:\n"
+            "    nestedIn: {dataObject: Charges, column: Credits}\n"
+            "    columns: {Currency Code: {code: Currency, abstractType: string}}\n"
+            "    joins: [{joinType: many-to-one, joinTo: Currencies,"
+            " columnsFrom: [Currency Code], columnsTo: [Code]}]\n"
+        )
+        assert not errors, errors
+
+
+def test_nested_source_rejects_unknown_keys() -> None:
+    """``extra: forbid``, so a typo is an error rather than a silent no-op."""
+    with pytest.raises(ValueError):
+        NestedSource(dataObject="Charges", colunm="Labels")  # type: ignore[call-arg]
+
+
+def test_a_plain_object_still_needs_no_nested_in() -> None:
+    obj = DataObject(name="X", code="x", database="", schema="")
+    assert obj.nested_in is None and not obj.is_nested

--- a/tests/unit/test_nested_data_objects.py
+++ b/tests/unit/test_nested_data_objects.py
@@ -18,7 +18,10 @@ from __future__ import annotations
 
 import pytest
 
-from orionbelt.models.semantic import DataObject, NestedSource
+from orionbelt.compiler.pipeline import CompilationPipeline
+from orionbelt.models.query import QueryObject, QuerySelect
+from orionbelt.models.semantic import DataObject, NestedSource, UnrenderableDataObjectError
+from orionbelt.obsl.exporter import export_obsl
 from orionbelt.parser import ReferenceResolver, TrackedLoader
 from orionbelt.parser.validator import SemanticValidator
 
@@ -180,3 +183,88 @@ def test_nested_source_rejects_unknown_keys() -> None:
 def test_a_plain_object_still_needs_no_nested_in() -> None:
     obj = DataObject(name="X", code="x", database="", schema="")
     assert obj.nested_in is None and not obj.is_nested
+
+
+class TestANestedObjectIsNotQueryableYet:
+    """No dialect compiles an unnest, so a nested-only object has no table.
+
+    Found in review of #342: without these guards the planners fell through to
+    an empty ``code`` and emitted ``FROM "" AS "Charge Labels"`` - reachable on
+    any model that adopts the field, because a synthesized count covers every
+    countable object and needs no measure declared at all.
+
+    Both guards go when the per-dialect rendering lands.
+    """
+
+    def test_no_count_is_synthesized_for_a_nested_only_object(self) -> None:
+        model, errors = _resolve(LABELS)
+        assert not errors, errors
+        assert "Charges Count" in model.effective_measures
+        assert "Charge Labels Count" not in model.effective_measures
+
+    def test_selecting_from_one_raises_rather_than_emitting_an_empty_table(self) -> None:
+        model, _ = _resolve(LABELS)
+        obj = model.data_objects["Charge Labels"]
+        with pytest.raises(UnrenderableDataObjectError, match="no dialect compiles"):
+            obj.require_table_source()
+        with pytest.raises(UnrenderableDataObjectError):
+            _ = obj.qualified_code
+
+    def test_the_code_fallback_makes_it_queryable_today(self) -> None:
+        """The fallback is not only future-proofing. An object that carries both
+        reads its flattening view now, which is the whole point of allowing
+        both to be declared.
+        """
+        model, errors = _resolve(
+            "  Charge Labels:\n"
+            "    nestedIn: {dataObject: Charges, column: Labels}\n"
+            "    code: v_charge_labels\n"
+            "    columns: {Label Value: {code: Value, abstractType: string}}\n"
+        )
+        assert not errors, errors
+        assert "Charge Labels Count" in model.effective_measures
+        sql = (
+            CompilationPipeline()
+            .compile(
+                QueryObject(select=QuerySelect(dimensions=[], measures=["Charge Labels Count"])),
+                model,
+                "duckdb",
+            )
+            .sql
+        )
+        assert '"v_charge_labels"' in sql and 'FROM ""' not in sql, sql
+
+    def test_a_query_that_never_touches_it_is_unaffected(self) -> None:
+        model, _ = _resolve(LABELS)
+        sql = (
+            CompilationPipeline()
+            .compile(
+                QueryObject(select=QuerySelect(dimensions=[], measures=["Total Cost"])),
+                model,
+                "duckdb",
+            )
+            .sql
+        )
+        assert '"charges"' in sql
+
+
+def test_the_rdf_export_carries_the_nested_source() -> None:
+    """``/graph`` and SPARQL are a surface of their own: the ontology declaring
+    the class is not enough if the exporter never emits an instance of it.
+    Found in review of #342.
+    """
+    model, errors = _resolve(LABELS)
+    assert not errors, errors
+    graph = export_obsl(model, "demo")
+    rows = list(
+        graph.query(
+            "PREFIX obsl: <https://ralforion.com/ns/obsl#> "
+            "SELECT ?o ?parent ?col WHERE { ?o obsl:nestedIn ?ns . "
+            "?ns obsl:nestedInObject ?parent ; obsl:nestedInColumn ?col }"
+        )
+    )
+    assert len(rows) == 1, rows
+    obj, parent, column = rows[0]
+    assert str(obj).endswith("charge-labels")
+    assert str(parent).endswith("charges")
+    assert str(column) == "Labels"

--- a/tests/unit/test_obsl.py
+++ b/tests/unit/test_obsl.py
@@ -530,6 +530,7 @@ class TestExporterAxioms:
             OBSL.DataObject,
             OBSL.Column,
             OBSL.Join,
+            OBSL.NestedSource,
             OBSL.Dimension,
             OBSL.Measure,
             OBSL.Metric,


### PR DESCRIPTION
The OBML surface for nested data objects. **Nothing compiles this to SQL yet** - the per-dialect rendering lands separately, and the field is inert until it does.

Design and the measurements behind it: `design/PLAN_nested_data_objects.md`.

## What it is

A repeated column is a table - one nested table per parent row, with whatever columns it has:

```yaml
Charge Labels:
  nestedIn: {dataObject: Charges, column: x_Labels}
  columns:
    Label Key:   {code: Key,   abstractType: string}
    Label Value: {code: Value, abstractType: string}
```

Modelling it as a data object rather than reaching into it with a scalar accessor is what keeps its **keys as data** rather than model-time constants, keeps the two fields beyond key/value that Google's `x_Tags` carries (`Inherited`, `Namespace` - the difference between "this team spent it" and "this team's parent spent it"), and lets a measure live on it at its own grain. An accessor can do none of those, which is why the `keyValueArray` tier this supersedes was dropped.

## There is no join key, and that is the point

No `columnsFrom`/`columnsTo`, because there is nothing to match on. The correlation is **containment**: an unnest pairs each parent row with the elements of its own array, so the association exists before any SQL runs.

The flattening views this replaces have to *manufacture* a key - the FinOps model behind this uses `FARM_FINGERPRINT(TO_JSON_STRING(t))` - precisely because splitting the elements into a separate table destroys that containment. Verified against a live 79,358-row export:

| | `goog-resource-type` | `mcp-sha` | `ui-sha` |
| --- | --- | --- | --- |
| via views, joined on the fingerprint | 13083 / 0 | 1122 / 0.017102 | 14038 / 3.013036 |
| inline `UNNEST`, no join and no key | 13083 / 0 | 1122 / 0.017102 | 14038 / 3.013036 |

## `code` and `nestedIn` together

Declared together rather than exclusively. Where both are present the unnest wins and the table is the fallback, which lets a model move off a hand-written view **one object at a time** instead of in one commit. The column names line up already, since a flattening view names its columns after the element fields.

## What the validator refuses

It refuses what cannot be rendered, rather than emitting SQL that cannot work:

| refused | why |
| --- | --- |
| a parent that does not exist | nothing to unnest |
| an object nested in itself | no table at the end of the chain |
| a cyclic `nestedIn` chain | same |
| any join **to** a nested object | its rows exist only inside its parent's, so there is no key to match on |

Allowed and deliberately unchecked: joining **onward** from a nested object to a third (the nested object is already in FROM through its parent, so that is an ordinary keyed join), and an array inside an array.

## Propagation

Per AGENTS.md: models, both JSON schemas, the contract manifest, `obsl.ttl` plus its SHACL shape, and the OSI converter in both directions.

OSI has no native equivalent - its datasets are tables - so the source rides in the OBML vendor extension, verified to round-trip with the `code` fallback intact. The `dataObject` schema's `required` list drops `code` in favour of an `anyOf` over `code`/`nestedIn`.

`schema/obml-contract.yml` drove the whole checklist: it failed on the new class, then the JSON schema, then the ontology class, then the ontology properties, in that order.

## Deliberately not here

- **User-facing docs.** The model-format guide should not tell anyone to write a field that produces no SQL. They land with the codegen.
- **The MCP server**, which is a separate repo and not edited from this workspace.

## Verification

`ruff`, `mypy`, and the full non-docker suite: **4,190 passed**. 13 new tests cover the surface, each validator refusal, and both things that stay allowed.
