### PR TITLE
feat(dialect): render an unnest, per dialect, executed on all seven that have one

### DIFF
--- a/src/orionbelt/ast/builder.py
+++ b/src/orionbelt/ast/builder.py
@@ -20,6 +20,7 @@ from orionbelt.ast.nodes import (
     RawSQL,
     Select,
     UnionAll,
+    Unnest,
 )
 
 
@@ -29,7 +30,7 @@ class QueryBuilder:
     def __init__(self) -> None:
         self._columns: list[Expr] = []
         self._from: From | None = None
-        self._joins: list[Join] = []
+        self._joins: list[Join | Unnest] = []
         self._where: Expr | None = None
         self._group_by: list[Expr] = []
         self._having: Expr | None = None
@@ -64,6 +65,15 @@ class QueryBuilder:
         alias: str | None = None,
     ) -> Self:
         self._joins.append(Join(join_type=join_type, source=table, alias=alias, on=on))
+        return self
+
+    def unnest(self, node: Unnest) -> Self:
+        """Append an unnest in path order, alongside the joins.
+
+        Its parent has to already be in scope - the base object, or an earlier
+        join - because the fragment names it.
+        """
+        self._joins.append(node)
         return self
 
     def where(self, condition: Expr) -> Self:

--- a/src/orionbelt/ast/nodes.py
+++ b/src/orionbelt/ast/nodes.py
@@ -328,7 +328,14 @@ class Select:
 
     columns: list[Expr] = field(default_factory=list)
     from_: From | None = None
-    joins: list[Join] = field(default_factory=list)
+    joins: list[Join | Unnest] = field(default_factory=list)
+    """Join clauses and unnests, in the order the planner walked the path.
+
+    One list rather than two, because the order between them matters: an unnest
+    names its parent, so it has to follow whatever put that parent in scope.
+    Keeping them apart would make the planner interleave them again at render
+    time, from information it no longer has.
+    """
     where: Expr | None = None
     group_by: list[Expr] = field(default_factory=list)
     having: Expr | None = None

--- a/src/orionbelt/ast/nodes.py
+++ b/src/orionbelt/ast/nodes.py
@@ -166,6 +166,38 @@ class Between:
 
 
 @dataclass(frozen=True)
+class Unnest:
+    """A parent's array column, unnested into rows beside it.
+
+    Not a :class:`Join`, because the engines do not agree that it is one. It is
+    a comma-lateral on BigQuery, DuckDB, Postgres and Snowflake, a ``LATERAL
+    VIEW`` on Databricks, an ``ARRAY JOIN`` on ClickHouse, and a ``JSON_TABLE``
+    on MySQL - four different clause shapes, only some of which take an ``ON``.
+    ``compile_join`` renders ``<type> JOIN <source> ON <expr>`` and cannot spell
+    the rest, so this is its own node with its own per-dialect renderer.
+
+    There is no join predicate for the same reason there is no join key: the
+    correlation is containment. Each output row pairs one parent row with one
+    element of that parent's own array.
+    """
+
+    parent_alias: str
+    column: str
+    """The parent's array column. Dotted for an array inside a struct."""
+    alias: str
+    """Alias the unnested element is addressed by."""
+    columns: tuple[tuple[str, str], ...] = ()
+    """``(code, sql_type)`` per child column. Only MySQL needs them: its
+    ``JSON_TABLE`` declares the shape it is extracting rather than inferring it.
+    """
+    outer: bool = True
+    """Keep a parent row whose array is empty. The default, because a charge
+    with no labels still contributes its cost to an unfiltered total - measured,
+    61% of the rows in a real billing export carry none.
+    """
+
+
+@dataclass(frozen=True)
 class RegexMatch:
     """Regex match predicate. Each dialect renders its native syntax.
 

--- a/src/orionbelt/compiler/filter_wrap.py
+++ b/src/orionbelt/compiler/filter_wrap.py
@@ -33,6 +33,7 @@ from orionbelt.ast.nodes import (
     JoinType,
     OrderByItem,
     Select,
+    Unnest,
 )
 from orionbelt.compiler.expr_rewrite import map_column_refs, map_nodes
 from orionbelt.compiler.filters import build_filter_expr
@@ -548,7 +549,7 @@ def wrap_with_filter_context(
     # Without ``main`` the first isolated CTE anchors the FROM and the rest
     # cross-join onto it, which is what they would have done anyway.
     anchor = "main" if keep_main else isolated_cte_info[0][0]
-    outer_joins: list[Join] = []
+    outer_joins: list[Join | Unnest] = []
     for cte_name, _, grain in isolated_cte_info:
         if cte_name == anchor:
             continue

--- a/src/orionbelt/compiler/filters.py
+++ b/src/orionbelt/compiler/filters.py
@@ -21,6 +21,7 @@ from orionbelt.ast.nodes import (
     RelativeDateRange,
     Select,
     UnaryOp,
+    Unnest,
 )
 from orionbelt.models.errors import SemanticError
 from orionbelt.models.query import FilterOperator, QueryFilter, UsePathName
@@ -567,7 +568,7 @@ def _join_filter_object_into_subquery(
     subject_object: str,
     target_object: str,
     scope: set[str],
-    joins: list[Join],
+    joins: list[Join | Unnest],
     qualify_table: Callable[[DataObject], str],
     errors: list[SemanticError],
     read_through_expression: bool = False,
@@ -799,7 +800,7 @@ def build_exists_filter_expr(
         alias=first_step.to_object,
     )
 
-    joins: list[Join] = []
+    joins: list[Join | Unnest] = []
     for step in path[1:]:
         step_target_obj = model.data_objects.get(step.to_object)
         if step_target_obj is None:

--- a/src/orionbelt/compiler/grain_dedup.py
+++ b/src/orionbelt/compiler/grain_dedup.py
@@ -70,6 +70,7 @@ from orionbelt.ast.nodes import (
     Literal,
     OrderByItem,
     Select,
+    Unnest,
 )
 from orionbelt.compiler.expr_rewrite import (
     collect_column_refs,
@@ -715,7 +716,7 @@ def wrap_with_grain_dedup(
     outer_from = _MAIN_CTE if keep_main else ordered_ctes[0]
     joined_ctes = ordered_ctes if keep_main else ordered_ctes[1:]
 
-    outer_joins: list[Join] = []
+    outer_joins: list[Join | Unnest] = []
     for cte_name in joined_ctes:
         # A grand-total CTE is a single row with no grain to match on.
         if not dim_names or cte_name in grand_total_ctes:

--- a/src/orionbelt/dialect/base.py
+++ b/src/orionbelt/dialect/base.py
@@ -612,6 +612,20 @@ class Dialect(ABC):
             return f"LEFT JOIN {source} AS {alias} ON TRUE"
         return f", {source} AS {alias}"
 
+    def nested_field(self, alias: str, field: str, sql_type: str | None = None) -> Expr:
+        """How a column of an unnested element is addressed.
+
+        Ordinary column access almost everywhere: measured, ``L."Key"`` reads
+        the field on BigQuery, DuckDB, Postgres, MySQL, ClickHouse and
+        Databricks, because the alias *is* the element. Snowflake overrides,
+        because there the alias is a row whose ``value`` holds the element as a
+        VARIANT.
+
+        ``sql_type`` is what the field should be read as. Only the VARIANT
+        dialect needs it; the rest carry their own types.
+        """
+        return ColumnRef(name=field, table=alias)
+
     def unnest_path(self, node: Unnest) -> str:
         """The parent's array column, quoted segment by segment.
 

--- a/src/orionbelt/dialect/base.py
+++ b/src/orionbelt/dialect/base.py
@@ -33,6 +33,7 @@ from orionbelt.ast.nodes import (
     SubqueryExpr,
     UnaryOp,
     UnionAll,
+    Unnest,
     WindowFunction,
 )
 from orionbelt.models.functions import JSON_PATH_RE, TIME_UNITS, lookup_function
@@ -167,6 +168,20 @@ class CrossColumnOrderNotSupportedError(UnsupportedAggregationError):
             f"Order the measure by its own column, or query it on a dialect "
             f"that supports WITHIN GROUP ordering.",
         )
+
+
+class UnsupportedNestedAccessError(Exception):
+    """A dialect cannot unnest an array column in its FROM clause."""
+
+    def __init__(self, dialect: str, alias: str) -> None:
+        super().__init__(
+            f"Dialect '{dialect}' has no FROM-clause unnest, so data object "
+            f"'{alias}' cannot take its rows from a parent's array column here. "
+            f"Declare 'code' alongside 'nestedIn' to read a flattening view on "
+            f"this dialect."
+        )
+        self.dialect = dialect
+        self.alias = alias
 
 
 class UnsupportedFunctionError(Exception):
@@ -575,6 +590,38 @@ class Dialect(ABC):
     @abstractmethod
     def _render_time_grain(self, column: Expr, grain: TimeGrain) -> Expr:
         """Wrap a column expression for a grain other than a week."""
+
+    def render_unnest(self, node: Unnest) -> str:
+        """A FROM-clause fragment that unnests a parent's array column.
+
+        The default is the comma-lateral every engine but four accepts::
+
+            , UNNEST(`c`.`labels`) AS `l`
+
+        with the outer form spelled as a ``LEFT JOIN ... ON TRUE``, which keeps
+        a parent row whose array is empty. Measured on BigQuery, DuckDB and
+        Postgres; ClickHouse, Databricks, MySQL and Snowflake override.
+
+        Dremio has no FROM-clause form at all - ``FLATTEN`` is a projection
+        function, so the unnest goes in the SELECT list of a derived table -
+        and refuses here rather than emitting something that will not parse.
+        """
+        source = f"UNNEST({self.unnest_path(node)})"
+        alias = self.quote_identifier(node.alias)
+        if node.outer:
+            return f"LEFT JOIN {source} AS {alias} ON TRUE"
+        return f", {source} AS {alias}"
+
+    def unnest_path(self, node: Unnest) -> str:
+        """The parent's array column, quoted segment by segment.
+
+        A dotted ``column`` addresses an array inside a struct, and each segment
+        is an identifier in its own right: ``x_Project.Ancestors`` becomes two
+        quoted identifiers joined by a dot, rather than one quoted string
+        containing a dot, which would name a column that does not exist.
+        """
+        parts = [node.parent_alias, *node.column.split(".")]
+        return ".".join(self.quote_identifier(p) for p in parts)
 
     @abstractmethod
     def render_cast(self, expr: Expr, target_type: str) -> Expr:

--- a/src/orionbelt/dialect/base.py
+++ b/src/orionbelt/dialect/base.py
@@ -633,6 +633,12 @@ class Dialect(ABC):
         is an identifier in its own right: ``x_Project.Ancestors`` becomes two
         quoted identifiers joined by a dot, rather than one quoted string
         containing a dot, which would name a column that does not exist.
+
+        The dotted chain is the majority form, measured on DuckDB, BigQuery,
+        Databricks and ClickHouse. Three engines cannot read it and override:
+        Postgres needs the composite parenthesised, Snowflake needs a VARIANT
+        ``:`` path, and MySQL has to move the member into the JSON path
+        entirely - see :meth:`MySQLDialect.render_unnest`.
         """
         parts = [node.parent_alias, *node.column.split(".")]
         return ".".join(self.quote_identifier(p) for p in parts)

--- a/src/orionbelt/dialect/base.py
+++ b/src/orionbelt/dialect/base.py
@@ -1362,9 +1362,12 @@ class Dialect(ABC):
         if node.from_:
             parts.append(f"FROM {self.compile_from(node.from_)}")
 
-        # JOINs
+        # JOINs, and the unnests that ride between them
         for join in node.joins:
-            parts.append(self.compile_join(join))
+            if isinstance(join, Unnest):
+                parts.append(self.render_unnest(join))
+            else:
+                parts.append(self.compile_join(join))
 
         # WHERE
         if node.where:

--- a/src/orionbelt/dialect/clickhouse.py
+++ b/src/orionbelt/dialect/clickhouse.py
@@ -2,7 +2,15 @@
 
 from __future__ import annotations
 
-from orionbelt.ast.nodes import BinaryOp, Cast, Expr, FunctionCall, Literal, OrderByItem
+from orionbelt.ast.nodes import (
+    BinaryOp,
+    Cast,
+    Expr,
+    FunctionCall,
+    Literal,
+    OrderByItem,
+    Unnest,
+)
 from orionbelt.dialect.base import (
     CrossColumnOrderNotSupportedError,
     Dialect,
@@ -43,6 +51,18 @@ class ClickHouseDialect(Dialect):
     }
 
     unions_resolve_leg_types = False
+
+    def render_unnest(self, node: Unnest) -> str:
+        """``ARRAY JOIN``, which is its own clause rather than a join.
+
+        No ``ON``, and the keyword order is ``LEFT ARRAY JOIN`` rather than
+        ``ARRAY LEFT JOIN``. Measured: the outer form keeps a parent whose array
+        is empty but fills the child with the type's **default** rather than
+        NULL - `''` for a String - which is the same behaviour
+        ``DataObjectJoin.required`` already documents for an unmatched row here.
+        """
+        prefix = "LEFT ARRAY JOIN" if node.outer else "ARRAY JOIN"
+        return f"{prefix} {self.unnest_path(node)} AS {self.quote_identifier(node.alias)}"
 
     def exact_integer_sum(self, arg: Expr) -> Expr | None:
         """``SUM`` over Int64 accumulates in Int64 here, and wraps.

--- a/src/orionbelt/dialect/databricks.py
+++ b/src/orionbelt/dialect/databricks.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from orionbelt.ast.nodes import Cast, Expr, FunctionCall, Literal, OrderByItem
+from orionbelt.ast.nodes import Cast, Expr, FunctionCall, Literal, OrderByItem, Unnest
 from orionbelt.dialect.base import (
     CrossColumnOrderNotSupportedError,
     Dialect,
@@ -84,6 +84,17 @@ class DatabricksDialect(Dialect):
 
     def _render_time_grain(self, column: Expr, grain: TimeGrain) -> Expr:
         return FunctionCall(name="date_trunc", args=[Literal.string(grain.value), column])
+
+    def render_unnest(self, node: Unnest) -> str:
+        """``LATERAL VIEW explode``, which takes no ``ON`` and names its own
+        generated table as well as the column.
+
+        ``OUTER`` goes between ``VIEW`` and the function, not on the join.
+        """
+        keyword = "LATERAL VIEW OUTER" if node.outer else "LATERAL VIEW"
+        alias = self.quote_identifier(node.alias)
+        table_alias = self.quote_identifier(f"{node.alias}__t")
+        return f"{keyword} explode({self.unnest_path(node)}) {table_alias} AS {alias}"
 
     def render_cast(self, expr: Expr, target_type: str) -> Expr:
         return Cast(expr=expr, type_name=target_type)

--- a/src/orionbelt/dialect/dremio.py
+++ b/src/orionbelt/dialect/dremio.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-from orionbelt.ast.nodes import BinaryOp, Cast, Expr, FunctionCall, Literal
+from orionbelt.ast.nodes import BinaryOp, Cast, Expr, FunctionCall, Literal, Unnest
 from orionbelt.dialect.base import (
     Dialect,
     DialectCapabilities,
     UnsupportedAggregationError,
+    UnsupportedNestedAccessError,
     _dremio_access,
     _dremio_row_type,
     _json_path_of,
@@ -35,6 +36,24 @@ class DremioDialect(Dialect):
             # ``measure`` is Databricks Metric View specific.
             unsupported_aggregations=["mode", "measure"],
         )
+
+    def render_unnest(self, node: Unnest) -> str:
+        """Dremio has no FROM-clause unnest, so this refuses.
+
+        ``FLATTEN`` is a **projection** function: the unnest goes in the SELECT
+        list of a derived table, and the fields are read from outside it::
+
+            FROM (SELECT c.id, c.cost, FLATTEN(c.labels) AS l FROM charges c) f
+
+        That restructures the query rather than extending its FROM clause, so it
+        belongs with the planner rather than here. Measured to work, including
+        the outer form emulated by a UNION ALL of the non-empty flatten and the
+        rows whose array is empty - see design/PLAN_nested_data_objects.md.
+
+        Until then a model reaches its data on Dremio through the ``code``
+        fallback, which is what the fallback is for.
+        """
+        raise UnsupportedNestedAccessError(self.name, node.alias)
 
     def exact_integer_sum(self, arg: Expr) -> Expr | None:
         """``SUM`` over BIGINT accumulates in 64 bits here, and wraps.

--- a/src/orionbelt/dialect/duckdb.py
+++ b/src/orionbelt/dialect/duckdb.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from orionbelt.ast.nodes import Cast, Expr, FunctionCall, Literal, OrderByItem, UnionAll
+from orionbelt.ast.nodes import Cast, Expr, FunctionCall, Literal, OrderByItem, UnionAll, Unnest
 from orionbelt.dialect.base import (
     Dialect,
     DialectCapabilities,
@@ -65,6 +65,19 @@ class DuckDBDialect(Dialect):
 
     def _render_time_grain(self, column: Expr, grain: TimeGrain) -> Expr:
         return FunctionCall(name="date_trunc", args=[Literal.string(grain.value), column])
+
+    def render_unnest(self, node: Unnest) -> str:
+        """``UNNEST`` here aliases the *table*, not the element.
+
+        ``AS "L"`` alone makes ``L.Key`` a binder error - measured, "Table L
+        does not have a column named Key" - because the element sits in an
+        unnamed column of a table called L. The two-part ``AS t(col)`` form
+        names both, so the element is addressed the same way it is on the
+        engines whose alias *is* the element.
+        """
+        source = f"UNNEST({self.unnest_path(node)})"
+        alias = f"{self.quote_identifier(node.alias + '__t')}({self.quote_identifier(node.alias)})"
+        return f"LEFT JOIN {source} AS {alias} ON TRUE" if node.outer else f", {source} AS {alias}"
 
     def render_cast(self, expr: Expr, target_type: str) -> Expr:
         return Cast(expr=expr, type_name=target_type)

--- a/src/orionbelt/dialect/mysql.py
+++ b/src/orionbelt/dialect/mysql.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 
-from orionbelt.ast.nodes import Cast, Expr, FunctionCall, Literal, OrderByItem
+from orionbelt.ast.nodes import Cast, Expr, FunctionCall, Literal, OrderByItem, Unnest
 from orionbelt.dialect.base import (
     PORTABLE_DECIMAL_PRECISION,
     Dialect,
@@ -213,6 +213,28 @@ class MySQLDialect(Dialect):
 
     def render_cast(self, expr: Expr, target_type: str) -> Expr:
         return Cast(expr=expr, type_name=target_type)
+
+    def render_unnest(self, node: Unnest) -> str:
+        """``JSON_TABLE``, which extracts a declared shape rather than
+        inferring one.
+
+        The only dialect whose unnest needs the child object's **columns**: the
+        others hand back the element and let a field reference read it, while
+        this one has to be told which paths to pull out and at what type. That
+        is why :class:`Unnest` carries them.
+        """
+        cols = (
+            ", ".join(
+                f"{self.quote_identifier(code)} {sql_type} PATH '$.{code}'"
+                for code, sql_type in node.columns
+            )
+            or "value VARCHAR(1024) PATH '$'"
+        )
+        table = (
+            f"JSON_TABLE({self.unnest_path(node)}, '$[*]' COLUMNS ({cols})) "
+            f"AS {self.quote_identifier(node.alias)}"
+        )
+        return f"LEFT JOIN {table} ON TRUE" if node.outer else f", {table}"
 
     def cast_to_obml_type(self, expr: Expr, obml_type: OBMLType) -> Expr:
         """MySQL: a measure's decimal cast carries at least 38 digits.

--- a/src/orionbelt/dialect/mysql.py
+++ b/src/orionbelt/dialect/mysql.py
@@ -16,6 +16,22 @@ from orionbelt.dialect.registry import DialectRegistry
 from orionbelt.models.semantic import TimeGrain
 from orionbelt.models.types import DecimalType, OBMLType
 
+
+def _json_member(name: str) -> str:
+    """A JSON path member, always quoted.
+
+    Quoting is not optional, and the unquoted form fails two different ways -
+    measured: ``$.Label Key`` raises "Invalid JSON path expression", and
+    ``$.a.b`` **silently returns NULL**, reading a nested key that is not there
+    rather than the literal one. The second is why this quotes unconditionally
+    rather than only when the name looks unsafe: a wrong answer is worse than
+    an error, and an OBML column code is a physical field name that may contain
+    anything.
+    """
+    escaped = name.replace('"', '\\"')
+    return f'"{escaped}"'
+
+
 _VARCHAR_RE = re.compile(r"^\s*VARCHAR\s*(?:\(\s*(\d+)\s*\))?\s*$", re.IGNORECASE)
 _MYSQL_CAST_CHAR_MAX = 255
 
@@ -225,7 +241,7 @@ class MySQLDialect(Dialect):
         """
         cols = (
             ", ".join(
-                f"{self.quote_identifier(code)} {sql_type} PATH '$.{code}'"
+                f"{self.quote_identifier(code)} {sql_type} PATH '$.{_json_member(code)}'"
                 for code, sql_type in node.columns
             )
             or "value VARCHAR(1024) PATH '$'"

--- a/src/orionbelt/dialect/mysql.py
+++ b/src/orionbelt/dialect/mysql.py
@@ -17,6 +17,35 @@ from orionbelt.models.semantic import TimeGrain
 from orionbelt.models.types import DecimalType, OBMLType
 
 
+def _json_source_and_row_path(dialect: MySQLDialect, node: Unnest) -> tuple[str, str]:
+    """Split a dotted column into the JSON document and the path within it.
+
+    ``x_Labels`` reads the whole column as the array: ``JSON_TABLE(col, '$[*]'
+    ...)``. ``x_Project.Ancestors`` reads the array *inside* the document:
+    ``JSON_TABLE(col, '$."Ancestors"[*]' ...)``. Every engine but this one and
+    Snowflake takes the deeper segments as identifiers; MySQL is the only one
+    where they change which argument they belong to.
+    """
+    first, *rest = node.column.split(".")
+    source = f"{dialect.quote_identifier(node.parent_alias)}.{dialect.quote_identifier(first)}"
+    inner = "".join(f".{_json_member(segment)}" for segment in rest)
+    return source, _sql_literal(f"${inner}[*]")
+
+
+def _json_member(name: str) -> str:
+    """One JSON-path member, quoted and escaped for the JSON layer."""
+    return '"' + name.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+def _sql_literal(text: str) -> str:
+    """*text* as a MySQL single-quoted literal.
+
+    MySQL treats a backslash as an escape inside string literals unless
+    ``NO_BACKSLASH_ESCAPES`` is set, so both it and the quote are doubled.
+    """
+    return "'" + text.replace("\\", "\\\\").replace("'", "''") + "'"
+
+
 def _json_path_literal(code: str) -> str:
     """A ``JSON_TABLE`` PATH argument for *code*, escaped for **both** layers.
 
@@ -38,9 +67,7 @@ def _json_path_literal(code: str) -> str:
     MySQL treats a backslash as an escape inside string literals unless
     ``NO_BACKSLASH_ESCAPES`` is set, which is why the SQL layer doubles it.
     """
-    member = '"' + code.replace("\\", "\\\\").replace('"', '\\"') + '"'
-    path = f"$.{member}"
-    return "'" + path.replace("\\", "\\\\").replace("'", "''") + "'"
+    return _sql_literal(f"$.{_json_member(code)}")
 
 
 _VARCHAR_RE = re.compile(r"^\s*VARCHAR\s*(?:\(\s*(\d+)\s*\))?\s*$", re.IGNORECASE)
@@ -257,8 +284,14 @@ class MySQLDialect(Dialect):
             )
             or "value VARCHAR(1024) PATH '$'"
         )
+        # A dotted column is an array inside an object, and here that is not a
+        # deeper *identifier* - it is a deeper JSON path. `C`.`x_Project`.
+        # `Ancestors` is "Unknown column"; the member has to move out of the
+        # source expression and into the row path, leaving the column itself as
+        # the document being read.
+        source, row_path = _json_source_and_row_path(self, node)
         table = (
-            f"JSON_TABLE({self.unnest_path(node)}, '$[*]' COLUMNS ({cols})) "
+            f"JSON_TABLE({source}, {row_path} COLUMNS ({cols})) "
             f"AS {self.quote_identifier(node.alias)}"
         )
         return f"LEFT JOIN {table} ON TRUE" if node.outer else f", {table}"

--- a/src/orionbelt/dialect/mysql.py
+++ b/src/orionbelt/dialect/mysql.py
@@ -17,19 +17,30 @@ from orionbelt.models.semantic import TimeGrain
 from orionbelt.models.types import DecimalType, OBMLType
 
 
-def _json_member(name: str) -> str:
-    """A JSON path member, always quoted.
+def _json_path_literal(code: str) -> str:
+    """A ``JSON_TABLE`` PATH argument for *code*, escaped for **both** layers.
 
-    Quoting is not optional, and the unquoted form fails two different ways -
-    measured: ``$.Label Key`` raises "Invalid JSON path expression", and
-    ``$.a.b`` **silently returns NULL**, reading a nested key that is not there
-    rather than the literal one. The second is why this quotes unconditionally
-    rather than only when the name looks unsafe: a wrong answer is worse than
-    an error, and an OBML column code is a physical field name that may contain
-    anything.
+    The path is a JSON-path expression *inside* a SQL string literal, so it
+    passes through two escaping regimes and needs both. Escaping only the JSON
+    layer looked right and failed three ways against MySQL 8, measured:
+
+    ==========  ===============================================================
+    ``q"t``     ``\\"`` is consumed by the SQL layer, leaving an unbalanced
+                quote and an invalid JSON path
+    ``q't``     the apostrophe closes the SQL literal: syntax error
+    ``a\\b``     the backslash is a SQL escape, and the path silently reads
+                NULL
+    ==========  ===============================================================
+
+    Order matters in both layers: backslashes first, then the quote character,
+    or the escape introduced by the first pass is escaped again by the second.
+
+    MySQL treats a backslash as an escape inside string literals unless
+    ``NO_BACKSLASH_ESCAPES`` is set, which is why the SQL layer doubles it.
     """
-    escaped = name.replace('"', '\\"')
-    return f'"{escaped}"'
+    member = '"' + code.replace("\\", "\\\\").replace('"', '\\"') + '"'
+    path = f"$.{member}"
+    return "'" + path.replace("\\", "\\\\").replace("'", "''") + "'"
 
 
 _VARCHAR_RE = re.compile(r"^\s*VARCHAR\s*(?:\(\s*(\d+)\s*\))?\s*$", re.IGNORECASE)
@@ -241,7 +252,7 @@ class MySQLDialect(Dialect):
         """
         cols = (
             ", ".join(
-                f"{self.quote_identifier(code)} {sql_type} PATH '$.{_json_member(code)}'"
+                f"{self.quote_identifier(code)} {sql_type} PATH {_json_path_literal(code)}"
                 for code, sql_type in node.columns
             )
             or "value VARCHAR(1024) PATH '$'"

--- a/src/orionbelt/dialect/postgres.py
+++ b/src/orionbelt/dialect/postgres.py
@@ -92,6 +92,20 @@ class PostgresDialect(Dialect):
     def _render_time_grain(self, column: Expr, grain: TimeGrain) -> Expr:
         return FunctionCall(name="date_trunc", args=[Literal.string(grain.value), column])
 
+    def unnest_path(self, node: Unnest) -> str:
+        """A field of a composite has to be reached through parentheses.
+
+        ``"C"."x_Project"."Ancestors"`` parses as a three-part *table* name, so
+        Postgres reports "missing FROM-clause entry for table x_Project".
+        ``("C"."x_Project")."Ancestors"`` is composite field access and reads
+        the array. A single-segment column needs no parentheses and gets none.
+        """
+        parts = node.column.split(".")
+        path = f"{self.quote_identifier(node.parent_alias)}.{self.quote_identifier(parts[0])}"
+        for segment in parts[1:]:
+            path = f"({path}).{self.quote_identifier(segment)}"
+        return path
+
     def render_unnest(self, node: Unnest) -> str:
         """``LATERAL`` is not optional here; the alias is otherwise ordinary.
 

--- a/src/orionbelt/dialect/postgres.py
+++ b/src/orionbelt/dialect/postgres.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from orionbelt.ast.nodes import Cast, Expr, FunctionCall, Literal, OrderByItem
+from orionbelt.ast.nodes import Cast, Expr, FunctionCall, Literal, OrderByItem, Unnest
 from orionbelt.dialect.base import (
     Dialect,
     DialectCapabilities,
@@ -91,6 +91,23 @@ class PostgresDialect(Dialect):
 
     def _render_time_grain(self, column: Expr, grain: TimeGrain) -> Expr:
         return FunctionCall(name="date_trunc", args=[Literal.string(grain.value), column])
+
+    def render_unnest(self, node: Unnest) -> str:
+        """``LATERAL`` is not optional here; the alias is otherwise ordinary.
+
+        Without ``LATERAL`` the parent is invisible to the function: measured, a
+        plain ``LEFT JOIN unnest(C.x_Labels)`` fails with "missing FROM-clause
+        entry for table C".
+
+        The alias stays one-part, unlike DuckDB's. Postgres expands a composite
+        array into columns named after its fields, so ``L."Key"`` reads
+        directly - and the two-part ``AS t(col)`` form actively breaks that,
+        collapsing the element to its first field: "column notation .Key applied
+        to type text".
+        """
+        source = f"LATERAL UNNEST({self.unnest_path(node)})"
+        alias = self.quote_identifier(node.alias)
+        return f"LEFT JOIN {source} AS {alias} ON TRUE" if node.outer else f", {source} AS {alias}"
 
     def render_cast(self, expr: Expr, target_type: str) -> Expr:
         return Cast(expr=expr, type_name=target_type)

--- a/src/orionbelt/dialect/snowflake.py
+++ b/src/orionbelt/dialect/snowflake.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from orionbelt.ast.nodes import Cast, Expr, FunctionCall, Literal, UnionAll
+from orionbelt.ast.nodes import Cast, Expr, FunctionCall, Literal, UnionAll, Unnest
 from orionbelt.dialect.base import (
     Dialect,
     DialectCapabilities,
@@ -68,6 +68,19 @@ class SnowflakeDialect(Dialect):
 
     def _render_time_grain(self, column: Expr, grain: TimeGrain) -> Expr:
         return FunctionCall(name="DATE_TRUNC", args=[Literal.string(grain.value), column])
+
+    def render_unnest(self, node: Unnest) -> str:
+        """``LATERAL FLATTEN``, whose outer form is an argument rather than a
+        join type.
+
+        The element arrives as ``<alias>.value``, a VARIANT, so a column on a
+        Snowflake nested object is read with ``:field`` rather than ``.field``.
+        """
+        outer = ", outer => TRUE" if node.outer else ""
+        return (
+            f", LATERAL FLATTEN(input => {self.unnest_path(node)}{outer}) "
+            f"{self.quote_identifier(node.alias)}"
+        )
 
     def render_cast(self, expr: Expr, target_type: str) -> Expr:
         return Cast(expr=expr, type_name=target_type)

--- a/src/orionbelt/dialect/snowflake.py
+++ b/src/orionbelt/dialect/snowflake.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from orionbelt.ast.nodes import Cast, Expr, FunctionCall, Literal, UnionAll, Unnest
+from orionbelt.ast.nodes import Cast, Expr, FunctionCall, Literal, RawSQL, UnionAll, Unnest
 from orionbelt.dialect.base import (
     Dialect,
     DialectCapabilities,
@@ -68,6 +68,24 @@ class SnowflakeDialect(Dialect):
 
     def _render_time_grain(self, column: Expr, grain: TimeGrain) -> Expr:
         return FunctionCall(name="DATE_TRUNC", args=[Literal.string(grain.value), column])
+
+    def nested_field(self, alias: str, field: str, sql_type: str | None = None) -> Expr:
+        """``L.value:"Key"::string`` - a VARIANT path, not a column.
+
+        ``FLATTEN`` yields a row per element whose ``value`` column holds the
+        element itself, so the ordinary ``L."Key"`` every other engine accepts
+        does not compile here at all: measured, "SQL compilation error".
+
+        The field name is quoted inside the path so one containing a space is
+        addressable, and the cast is not optional: without it a string field
+        comes back as ``"team"`` with its JSON quotes still on.
+        """
+        escaped = field.replace('"', '""')
+        # RawSQL: Snowflake's `:` VARIANT path has no typed AST node, and the
+        # cast has to bind to the path rather than to a column reference.
+        return RawSQL(
+            sql=f'{self.quote_identifier(alias)}.value:"{escaped}"::{sql_type or "string"}'
+        )
 
     def render_unnest(self, node: Unnest) -> str:
         """``LATERAL FLATTEN``, whose outer form is an argument rather than a

--- a/src/orionbelt/dialect/snowflake.py
+++ b/src/orionbelt/dialect/snowflake.py
@@ -87,6 +87,20 @@ class SnowflakeDialect(Dialect):
             sql=f'{self.quote_identifier(alias)}.value:"{escaped}"::{sql_type or "string"}'
         )
 
+    def unnest_path(self, node: Unnest) -> str:
+        """Only the first segment is a column; the rest are VARIANT steps.
+
+        ``"C"."x_Project"."Ancestors"`` does not compile - the object's members
+        are reached with ``:`` rather than ``.``, the same operator
+        :meth:`nested_field` uses for a field of an element.
+        """
+        parts = node.column.split(".")
+        path = f"{self.quote_identifier(node.parent_alias)}.{self.quote_identifier(parts[0])}"
+        for segment in parts[1:]:
+            escaped = segment.replace('"', '""')
+            path = f'{path}:"{escaped}"'
+        return path
+
     def render_unnest(self, node: Unnest) -> str:
         """``LATERAL FLATTEN``, whose outer form is an argument rather than a
         join type.

--- a/tests/architecture/test_rawsql_guard.py
+++ b/tests/architecture/test_rawsql_guard.py
@@ -29,6 +29,12 @@ APPROVED_RAWSQL: dict[str, int] = {
     "src/orionbelt/dialect/mysql.py": 1,
     # BigQuery DATE_TRUNC date-part keyword (MONTH/ISOWEEK, not a quoted string).
     "src/orionbelt/dialect/bigquery.py": 1,
+    # Snowflake VARIANT path for a field of an unnested element:
+    # `L.value:"Key"::string`. FLATTEN yields the element under `value` rather
+    # than as columns, so the ordinary column reference every other engine takes
+    # does not compile there. The `:` path has no typed AST node, and the cast
+    # has to bind to the path rather than to a ColumnRef.
+    "src/orionbelt/dialect/snowflake.py": 1,
     # Week handling: each site re-wraps SQL the dialect just rendered, so that
     # one weekly floor serves the catalog function, the time-grain dimension
     # and the period-over-period spine rather than one implementation per

--- a/tests/integration/drift/vendor_exec/test_unnest_render_exec.py
+++ b/tests/integration/drift/vendor_exec/test_unnest_render_exec.py
@@ -1,0 +1,154 @@
+"""Every dialect's unnest rendering, executed against a real engine.
+
+The shapes are not variations on one another - a comma-lateral, an ``ARRAY
+JOIN``, a ``LATERAL VIEW``, a ``JSON_TABLE`` - so a rendering that looks right
+is worth nothing until the engine parses it. This module runs each dialect's
+own fragment against that dialect.
+
+Two rows, the second carrying an empty array, so both halves of ``outer`` are
+checked: the inner form drops that parent and the outer form keeps it. Empty
+arrays are the common case rather than an edge one - 61% of the charges in a
+real billing export carry no labels - which is why ``outer`` is the default.
+
+Dremio is absent because it has no FROM-clause unnest at all: ``FLATTEN`` is a
+projection function and needs a derived table, which the planner will build.
+``render_unnest`` refuses there, and ``test_nested_data_objects`` pins that.
+"""
+
+from __future__ import annotations
+
+import contextlib
+
+import pytest
+
+from orionbelt.ast.nodes import Unnest
+from orionbelt.dialect.registry import DialectRegistry
+
+from .conftest import VendorTarget
+
+pytestmark = pytest.mark.docker
+
+#: How each engine spells "a two-row table with an array-of-struct column, the
+#: second row's array empty". No portable literal exists for this, which is the
+#: reason the nested work needs seeded fixtures rather than expression tests.
+SOURCES = {
+    "duckdb": """(SELECT 1 AS @ID@, 100 AS @COST@,
+                         [{'Key':'team','Value':'core'},{'Key':'env','Value':'prod'}] AS @LABELS@
+                  UNION ALL SELECT 2, 50, [])""",
+    "postgres": """(SELECT 1 AS @ID@, 100 AS @COST@,
+                           ARRAY[ROW('team','core'),ROW('env','prod')]::kvpair[] AS @LABELS@
+                    UNION ALL SELECT 2, 50, ARRAY[]::kvpair[])""",
+    "clickhouse": """(SELECT 1 AS @ID@, 100 AS @COST@,
+                             CAST([('team','core'),('env','prod')] AS
+                                  Array(Tuple(Key String, Value String))) AS @LABELS@
+                      UNION ALL SELECT 2, 50,
+                             CAST([] AS Array(Tuple(Key String, Value String))))""",
+    "mysql": """(SELECT 1 AS @ID@, 100 AS @COST@,
+                        CAST('[{"Key":"team","Value":"core"},
+                                {"Key":"env","Value":"prod"}]' AS JSON) AS @LABELS@
+                 UNION ALL SELECT 2, 50, CAST('[]' AS JSON))""",
+    "bigquery": """(SELECT 1 AS @ID@, 100 AS @COST@,
+                           [STRUCT('team' AS Key,'core' AS Value), STRUCT('env','prod')] AS @LABELS@
+                    UNION ALL SELECT 2, 50, [])""",
+    "snowflake": """(SELECT 1 AS @ID@, 100 AS @COST@,
+                            ARRAY_CONSTRUCT(OBJECT_CONSTRUCT('Key','team','Value','core'),
+                                            OBJECT_CONSTRUCT('Key','env','Value','prod'))
+                                AS @LABELS@
+                     UNION ALL SELECT 2, 50, ARRAY_CONSTRUCT())""",
+    "databricks": """(SELECT 1 AS @ID@, 100 AS @COST@,
+                             array(named_struct('Key','team','Value','core'),
+                                   named_struct('Key','env','Value','prod')) AS @LABELS@
+                      UNION ALL SELECT 2, 50, array())""",
+}
+
+#: How the element's ``Key`` field is read once unnested. Snowflake hands back a
+#: VARIANT, so it is the one engine that needs a path rather than a field.
+KEY_EXPR = {
+    "snowflake": '"L".value:Key::string',
+    "clickhouse": '"L"."Key"',
+    "duckdb": '"L"."Key"',
+    "postgres": '"L"."Key"',
+    "mysql": "`L`.`Key`",
+    "bigquery": "`L`.`Key`",
+    "databricks": "`L`.`Key`",
+}
+
+
+def _prepare(target: VendorTarget) -> None:
+    """Postgres needs a composite type declared before an array of it exists."""
+    if target.dialect != "postgres":
+        return
+    create = 'CREATE TYPE kvpair AS ("Key" text, "Value" text)'
+    for stmt in ("DROP TYPE IF EXISTS kvpair CASCADE", create):
+        # DDL returns no cursor description for the fixture to read
+        with contextlib.suppress(TypeError):
+            target.execute(stmt)
+
+
+def _run(target: VendorTarget, outer: bool) -> list[dict]:
+    dialect = DialectRegistry.get(target.dialect)
+    node = Unnest(
+        parent_alias="C",
+        column="x_Labels",
+        alias="L",
+        columns=(("Key", "VARCHAR(64)"), ("Value", "VARCHAR(64)")),
+        outer=outer,
+    )
+    fragment = dialect.render_unnest(node)
+    q = dialect.quote_identifier
+    source = (
+        SOURCES[target.dialect]
+        .replace("@ID@", q("id"))
+        .replace("@COST@", q("cost"))
+        .replace("@LABELS@", q("x_Labels"))
+    )
+    sql = (
+        f"SELECT {q('C')}.{q('id')} AS {q('id')}, {KEY_EXPR[target.dialect]} AS {q('k')} "
+        f"FROM {source} AS {q('C')} {fragment} ORDER BY 1, 2"
+    )
+    return target.execute(sql)
+
+
+def _assert_both_forms(target: VendorTarget) -> None:
+    _prepare(target)
+
+    def ids(rows: list[dict]) -> list[int]:
+        return [next(v for k, v in r.items() if k.lower() == "id") for r in rows]
+
+    inner = _run(target, outer=False)
+    assert ids(inner) == [1, 1], (
+        f"{target.name}: the inner form should drop the parent whose array is empty: {inner}"
+    )
+
+    outer = _run(target, outer=True)
+    assert ids(outer) == [1, 1, 2], (
+        f"{target.name}: the outer form should keep it, with a NULL child: {outer}"
+    )
+
+
+def test_duckdb_unnest(vendor_duckdb: VendorTarget) -> None:
+    _assert_both_forms(vendor_duckdb)
+
+
+def test_postgres_unnest(vendor_postgres: VendorTarget) -> None:
+    _assert_both_forms(vendor_postgres)
+
+
+def test_mysql_unnest(vendor_mysql: VendorTarget) -> None:
+    _assert_both_forms(vendor_mysql)
+
+
+def test_clickhouse_unnest(vendor_clickhouse: VendorTarget) -> None:
+    _assert_both_forms(vendor_clickhouse)
+
+
+def test_bigquery_unnest(vendor_bigquery: VendorTarget) -> None:
+    _assert_both_forms(vendor_bigquery)
+
+
+def test_snowflake_unnest(vendor_snowflake: VendorTarget) -> None:
+    _assert_both_forms(vendor_snowflake)
+
+
+def test_databricks_unnest(vendor_databricks: VendorTarget) -> None:
+    _assert_both_forms(vendor_databricks)

--- a/tests/integration/drift/vendor_exec/test_unnest_render_exec.py
+++ b/tests/integration/drift/vendor_exec/test_unnest_render_exec.py
@@ -147,3 +147,41 @@ def test_snowflake_unnest(vendor_snowflake: VendorTarget) -> None:
 
 def test_databricks_unnest(vendor_databricks: VendorTarget) -> None:
     _assert_both_forms(vendor_databricks)
+
+
+#: Child field names that pass through two escaping regimes: a JSON-path
+#: expression inside a SQL string literal. ``DataObjectColumn.code`` is a
+#: physical field name and is unconstrained, so all of these are legal to
+#: declare.
+AWKWARD_CODES = ["plain", "has space", "a.b", 'q"t', "q't", "a\\b"]
+
+
+def test_mysql_json_paths_survive_awkward_field_names(vendor_mysql: VendorTarget) -> None:
+    """Escaping only the JSON layer failed three ways, and one was silent.
+
+    Measured against MySQL 8 before the fix: ``q"t`` gave an invalid JSON path,
+    ``q't`` a SQL syntax error, and ``a\\b`` **NULL instead of the value**. The
+    unit test asserts the strings; this asserts the engine accepts them and
+    returns the right field, which is the only thing that actually settles it.
+    """
+    import json
+
+    dialect = DialectRegistry.get("mysql")
+    doc = json.dumps([{name: f"v-{i}" for i, name in enumerate(AWKWARD_CODES)}])
+    node = Unnest(
+        parent_alias="C",
+        column="x_Labels",
+        alias="L",
+        columns=tuple((name, "VARCHAR(64)") for name in AWKWARD_CODES),
+        outer=False,
+    )
+    escaped_doc = doc.replace("\\", "\\\\").replace("'", "''")
+    source = f"(SELECT CAST('{escaped_doc}' AS JSON) AS `x_Labels`)"
+    projection = ", ".join(
+        f"{dialect.compile_expr(dialect.nested_field('L', name))} AS `c{i}`"
+        for i, name in enumerate(AWKWARD_CODES)
+    )
+    rows = vendor_mysql.execute(
+        f"SELECT {projection} FROM {source} AS `C` {dialect.render_unnest(node)}"
+    )
+    assert rows == [{f"c{i}": f"v-{i}" for i in range(len(AWKWARD_CODES))}], rows

--- a/tests/integration/drift/vendor_exec/test_unnest_render_exec.py
+++ b/tests/integration/drift/vendor_exec/test_unnest_render_exec.py
@@ -61,17 +61,11 @@ SOURCES = {
                       UNION ALL SELECT 2, 50, array())""",
 }
 
-#: How the element's ``Key`` field is read once unnested. Snowflake hands back a
-#: VARIANT, so it is the one engine that needs a path rather than a field.
-KEY_EXPR = {
-    "snowflake": '"L".value:Key::string',
-    "clickhouse": '"L"."Key"',
-    "duckdb": '"L"."Key"',
-    "postgres": '"L"."Key"',
-    "mysql": "`L`.`Key`",
-    "bigquery": "`L`.`Key`",
-    "databricks": "`L`.`Key`",
-}
+# The field accessor comes from the dialect rather than a table here. Hand
+# writing it is what let a real defect hide: this module used the correct
+# Snowflake path while ``nested_field`` did not exist, so the AST produced
+# `L."Key"`, which does not compile there at all (review of #344). Asking the
+# dialect means the test exercises what the planner will emit.
 
 
 def _prepare(target: VendorTarget) -> None:
@@ -102,8 +96,9 @@ def _run(target: VendorTarget, outer: bool) -> list[dict]:
         .replace("@COST@", q("cost"))
         .replace("@LABELS@", q("x_Labels"))
     )
+    key = dialect.compile_expr(dialect.nested_field("L", "Key"))
     sql = (
-        f"SELECT {q('C')}.{q('id')} AS {q('id')}, {KEY_EXPR[target.dialect]} AS {q('k')} "
+        f"SELECT {q('C')}.{q('id')} AS {q('id')}, {key} AS {q('k')} "
         f"FROM {source} AS {q('C')} {fragment} ORDER BY 1, 2"
     )
     return target.execute(sql)

--- a/tests/integration/drift/vendor_exec/test_unnest_render_exec.py
+++ b/tests/integration/drift/vendor_exec/test_unnest_render_exec.py
@@ -185,3 +185,85 @@ def test_mysql_json_paths_survive_awkward_field_names(vendor_mysql: VendorTarget
         f"SELECT {projection} FROM {source} AS `C` {dialect.render_unnest(node)}"
     )
     assert rows == [{f"c{i}": f"v-{i}" for i in range(len(AWKWARD_CODES))}], rows
+
+
+# ---------------------------------------------------------------------------
+# An array nested inside a struct: ``x_Project.Ancestors`` in the Google export.
+#
+# Built as real tables where the engine allows one, not inline literals. Two
+# dialects were nearly written off during this work because a literal failed to
+# parse while the engine itself was fine - ClickHouse here, and Dremio in the
+# design plan. A literal is not evidence about an engine's capabilities.
+# ---------------------------------------------------------------------------
+
+NESTED_DDL = {
+    "duckdb": [
+        "DROP TABLE IF EXISTS nested_probe",
+        "CREATE TABLE nested_probe (x_Project STRUCT(Id VARCHAR, "
+        "Ancestors STRUCT(DisplayName VARCHAR)[]))",
+        "INSERT INTO nested_probe VALUES ({'Id':'p1','Ancestors':[{'DisplayName':'Eng'}]})",
+    ],
+    "postgres": [
+        "DROP TABLE IF EXISTS nested_probe",
+        "DROP TYPE IF EXISTS anc CASCADE",
+        "DROP TYPE IF EXISTS proj CASCADE",
+        'CREATE TYPE anc AS ("DisplayName" text)',
+        'CREATE TYPE proj AS ("Id" text, "Ancestors" anc[])',
+        'CREATE TABLE nested_probe ("x_Project" proj)',
+        """INSERT INTO nested_probe VALUES (ROW('p1', ARRAY[ROW('Eng')::anc])::proj)""",
+    ],
+    "clickhouse": [
+        "DROP TABLE IF EXISTS nested_probe",
+        "CREATE TABLE nested_probe (x_Project Tuple(Id String, "
+        "Ancestors Array(Tuple(DisplayName String)))) ENGINE = Memory",
+        "INSERT INTO nested_probe VALUES (('p1',[('Eng')]))",
+    ],
+    "mysql": [
+        "DROP TABLE IF EXISTS nested_probe",
+        "CREATE TABLE nested_probe (x_Project JSON)",
+        """INSERT INTO nested_probe VALUES ('{"Id":"p1","Ancestors":[{"DisplayName":"Eng"}]}')""",
+    ],
+}
+
+
+def _assert_dotted_path(target: VendorTarget) -> None:
+    """``x_Project.Ancestors`` reaches the array inside the struct.
+
+    Three engines cannot read the dotted identifier chain the other four take,
+    and each fails differently: Postgres reports a missing FROM-clause entry,
+    MySQL an unknown column, Snowflake a compilation error. Each has its own
+    form, and this is the only thing that shows the right one was chosen.
+    """
+    for stmt in NESTED_DDL[target.dialect]:
+        with contextlib.suppress(TypeError):
+            target.execute(stmt)
+    dialect = DialectRegistry.get(target.dialect)
+    node = Unnest(
+        parent_alias="C",
+        column="x_Project.Ancestors",
+        alias="L",
+        columns=(("DisplayName", "VARCHAR(64)"),),
+        outer=False,
+    )
+    field = dialect.compile_expr(dialect.nested_field("L", "DisplayName"))
+    rows = target.execute(
+        f"SELECT {field} AS {dialect.quote_identifier('d')} "
+        f"FROM nested_probe AS {dialect.quote_identifier('C')} {dialect.render_unnest(node)}"
+    )
+    assert [next(iter(r.values())) for r in rows] == ["Eng"], rows
+
+
+def test_duckdb_dotted_path(vendor_duckdb: VendorTarget) -> None:
+    _assert_dotted_path(vendor_duckdb)
+
+
+def test_postgres_dotted_path(vendor_postgres: VendorTarget) -> None:
+    _assert_dotted_path(vendor_postgres)
+
+
+def test_clickhouse_dotted_path(vendor_clickhouse: VendorTarget) -> None:
+    _assert_dotted_path(vendor_clickhouse)
+
+
+def test_mysql_dotted_path(vendor_mysql: VendorTarget) -> None:
+    _assert_dotted_path(vendor_mysql)

--- a/tests/unit/test_unnest_ast.py
+++ b/tests/unit/test_unnest_ast.py
@@ -124,15 +124,35 @@ class TestMySQLJsonPaths:
     """
 
     @pytest.mark.parametrize("code", ["Label Key", "a.b", "plain"])
-    def test_the_member_is_quoted(self, code: str) -> None:
+    def test_the_member_is_quoted(self, code: str) -> None:  # noqa: D102
         node = Unnest(
             parent_alias="C", column="x", alias="L", columns=((code, "VARCHAR(64)"),), outer=True
         )
         assert f"""PATH '$."{code}"'""" in DialectRegistry.get("mysql").render_unnest(node)
 
-    def test_a_quote_in_the_name_is_escaped(self) -> None:
+    @pytest.mark.parametrize(
+        ("code", "expected"),
+        [
+            ("plain", """'$."plain"'"""),
+            ("has space", """'$."has space"'"""),
+            ("a.b", """'$."a.b"'"""),
+            # a double quote: escaped for JSON, then its backslash escaped again
+            # for the SQL literal it sits inside
+            ('q"t', """'$."q\\\\"t"'"""),
+            # an apostrophe: invisible to the JSON layer, closes the SQL literal
+            ("q't", """'$."q''t"'"""),
+            # a backslash: escaped by both layers, so four in the output
+            ("a\\b", """'$."a\\\\\\\\b"'"""),
+        ],
+    )
+    def test_the_path_is_escaped_for_both_layers(self, code: str, expected: str) -> None:
+        """The path is a JSON-path expression inside a SQL string literal.
+
+        Escaping only the JSON layer looked right and failed three ways against
+        MySQL 8 - an invalid path, a syntax error, and a silent NULL. Found in
+        review of #344, after the first fix covered only spaces and dots.
+        """
         node = Unnest(
-            parent_alias="C", column="x", alias="L", columns=(('q"t', "VARCHAR(64)"),), outer=True
+            parent_alias="C", column="x", alias="L", columns=((code, "VARCHAR(64)"),), outer=True
         )
-        expected = 'PATH \'$."q\\"t"\''
-        assert expected in DialectRegistry.get("mysql").render_unnest(node)
+        assert f"PATH {expected}" in DialectRegistry.get("mysql").render_unnest(node)

--- a/tests/unit/test_unnest_ast.py
+++ b/tests/unit/test_unnest_ast.py
@@ -156,3 +156,60 @@ class TestMySQLJsonPaths:
             parent_alias="C", column="x", alias="L", columns=((code, "VARCHAR(64)"),), outer=True
         )
         assert f"PATH {expected}" in DialectRegistry.get("mysql").render_unnest(node)
+
+
+class TestADottedColumnAddressesAnArrayInsideAStruct:
+    """``x_Project.Ancestors`` in the Google export, and three engines differ.
+
+    The dotted identifier chain is the majority form - measured working on
+    DuckDB, BigQuery, Databricks and ClickHouse. The other three each fail their
+    own way and need their own shape, found in review of #344:
+
+    * Postgres reads it as a three-part table name: "missing FROM-clause entry"
+    * MySQL reports an unknown column
+    * Snowflake raises a compilation error
+
+    ClickHouse was nearly written off here too, on a literal that would not
+    parse; against a real table the dotted chain is fine. A failing literal is
+    not evidence about an engine.
+    """
+
+    DOTTED = {
+        "duckdb": '"C"."x_Project"."Ancestors"',
+        "bigquery": "`C`.`x_Project`.`Ancestors`",
+        "databricks": "`C`.`x_Project`.`Ancestors`",
+        "clickhouse": '"C"."x_Project"."Ancestors"',
+        # composite field access needs the parentheses
+        "postgres": '("C"."x_Project")."Ancestors"',
+        # only the first segment is a column; the rest are VARIANT steps
+        "snowflake": '"C"."x_Project":"Ancestors"',
+    }
+
+    @pytest.mark.parametrize("dialect", sorted(DOTTED))
+    def test_the_path_matches_what_the_engine_accepts(self, dialect: str) -> None:
+        node = Unnest(parent_alias="C", column="x_Project.Ancestors", alias="L")
+        assert DialectRegistry.get(dialect).unnest_path(node) == self.DOTTED[dialect]
+
+    def test_mysql_moves_the_member_into_the_json_path(self) -> None:
+        """The only engine where a deeper segment changes *which argument* it
+        belongs to: the column stays the document and the member becomes the
+        row path, because a JSON array inside an object is not a deeper
+        identifier.
+        """
+        node = Unnest(
+            parent_alias="C",
+            column="x_Project.Ancestors",
+            alias="L",
+            columns=(("DisplayName", "VARCHAR(64)"),),
+        )
+        sql = DialectRegistry.get("mysql").render_unnest(node)
+        assert "JSON_TABLE(`C`.`x_Project`, '$.\"Ancestors\"[*]'" in sql, sql
+
+    def test_a_single_segment_column_is_unchanged_everywhere(self) -> None:
+        """The override must not alter the ordinary case."""
+        node = Unnest(parent_alias="C", column="x_Labels", alias="L")
+        for dialect in RENDERS:
+            dia = DialectRegistry.get(dialect)
+            path = dia.unnest_path(node)
+            assert path.endswith(dia.quote_identifier("x_Labels")), (dialect, path)
+            assert "(" not in path and ":" not in path, (dialect, path)

--- a/tests/unit/test_unnest_ast.py
+++ b/tests/unit/test_unnest_ast.py
@@ -1,0 +1,82 @@
+"""An unnest reaches the SQL through the AST, not only the dialect method.
+
+``Select.joins`` holds joins and unnests in one list, because the order between
+them matters: an unnest names its parent, so it has to follow whatever put that
+parent in scope. Keeping two lists would make the planner interleave them again
+at render time, from information it no longer has.
+
+Compile-only on purpose, so CI runs it. The per-dialect *fragments* are executed
+against real engines in
+``tests/integration/drift/vendor_exec/test_unnest_render_exec.py``, which CI
+does not run.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from orionbelt.ast.builder import QueryBuilder
+from orionbelt.ast.nodes import AliasedExpr, ColumnRef, FunctionCall, Unnest
+from orionbelt.dialect.base import UnsupportedNestedAccessError
+from orionbelt.dialect.registry import DialectRegistry
+
+RENDERS = ["bigquery", "clickhouse", "databricks", "duckdb", "mysql", "postgres", "snowflake"]
+
+
+def _ast(outer: bool = True):
+    return (
+        QueryBuilder()
+        .select(AliasedExpr(expr=ColumnRef(name="Key", table="L"), alias="Label Key"))
+        .select(
+            AliasedExpr(
+                expr=FunctionCall(name="SUM", args=[ColumnRef(name="cost", table="C")]),
+                alias="Cost",
+            )
+        )
+        .from_("charges", alias="C")
+        .unnest(
+            Unnest(
+                parent_alias="C",
+                column="x_Labels",
+                alias="L",
+                columns=(("Key", "VARCHAR(64)"),),
+                outer=outer,
+            )
+        )
+        .group_by(ColumnRef(name="Key", table="L"))
+        .build()
+    )
+
+
+@pytest.mark.parametrize("dialect", RENDERS)
+def test_the_unnest_reaches_the_sql(dialect: str) -> None:
+    sql = DialectRegistry.get(dialect).compile_select(_ast())
+    assert "x_Labels" in sql, sql
+
+
+@pytest.mark.parametrize("dialect", RENDERS)
+def test_it_lands_after_the_from_it_names(dialect: str) -> None:
+    """Ordering is the reason the two share a list. A fragment naming ``C``
+    before ``FROM ... AS C`` is a syntax error on every engine.
+    """
+    sql = DialectRegistry.get(dialect).compile_select(_ast())
+    assert sql.index("FROM") < sql.index("x_Labels"), sql
+
+
+@pytest.mark.parametrize("dialect", RENDERS)
+def test_both_forms_differ(dialect: str) -> None:
+    """Inner drops a parent whose array is empty; outer keeps it. If a dialect
+    rendered them identically, one of the two would be silently wrong.
+    """
+    outer = DialectRegistry.get(dialect).compile_select(_ast(outer=True))
+    inner = DialectRegistry.get(dialect).compile_select(_ast(outer=False))
+    assert outer != inner, f"{dialect} renders inner and outer the same: {outer}"
+
+
+def test_dremio_refuses_rather_than_emitting_something_that_will_not_parse() -> None:
+    """``FLATTEN`` is a projection function, so Dremio's unnest needs a derived
+    table rather than a FROM-clause fragment. That is a query restructure and
+    belongs with the planner; until then the error names the ``code`` fallback.
+    """
+    with pytest.raises(UnsupportedNestedAccessError, match="no FROM-clause unnest"):
+        DialectRegistry.get("dremio").compile_select(_ast())

--- a/tests/unit/test_unnest_ast.py
+++ b/tests/unit/test_unnest_ast.py
@@ -23,10 +23,15 @@ from orionbelt.dialect.registry import DialectRegistry
 RENDERS = ["bigquery", "clickhouse", "databricks", "duckdb", "mysql", "postgres", "snowflake"]
 
 
-def _ast(outer: bool = True):
+def _ast(outer: bool = True, dialect: str = "duckdb"):
+    # The field accessor is the dialect's, not a generic ColumnRef: on Snowflake
+    # the alias is a row whose `value` holds the element, so `L."Key"` does not
+    # compile at all. Building the AST with a hard-coded ColumnRef made this
+    # test pass while the SQL it described was invalid there (review of #344).
+    field = DialectRegistry.get(dialect).nested_field("L", "Key")
     return (
         QueryBuilder()
-        .select(AliasedExpr(expr=ColumnRef(name="Key", table="L"), alias="Label Key"))
+        .select(AliasedExpr(expr=field, alias="Label Key"))
         .select(
             AliasedExpr(
                 expr=FunctionCall(name="SUM", args=[ColumnRef(name="cost", table="C")]),
@@ -43,14 +48,14 @@ def _ast(outer: bool = True):
                 outer=outer,
             )
         )
-        .group_by(ColumnRef(name="Key", table="L"))
+        .group_by(field)
         .build()
     )
 
 
 @pytest.mark.parametrize("dialect", RENDERS)
 def test_the_unnest_reaches_the_sql(dialect: str) -> None:
-    sql = DialectRegistry.get(dialect).compile_select(_ast())
+    sql = DialectRegistry.get(dialect).compile_select(_ast(dialect=dialect))
     assert "x_Labels" in sql, sql
 
 
@@ -59,7 +64,7 @@ def test_it_lands_after_the_from_it_names(dialect: str) -> None:
     """Ordering is the reason the two share a list. A fragment naming ``C``
     before ``FROM ... AS C`` is a syntax error on every engine.
     """
-    sql = DialectRegistry.get(dialect).compile_select(_ast())
+    sql = DialectRegistry.get(dialect).compile_select(_ast(dialect=dialect))
     assert sql.index("FROM") < sql.index("x_Labels"), sql
 
 
@@ -68,8 +73,8 @@ def test_both_forms_differ(dialect: str) -> None:
     """Inner drops a parent whose array is empty; outer keeps it. If a dialect
     rendered them identically, one of the two would be silently wrong.
     """
-    outer = DialectRegistry.get(dialect).compile_select(_ast(outer=True))
-    inner = DialectRegistry.get(dialect).compile_select(_ast(outer=False))
+    outer = DialectRegistry.get(dialect).compile_select(_ast(outer=True, dialect=dialect))
+    inner = DialectRegistry.get(dialect).compile_select(_ast(outer=False, dialect=dialect))
     assert outer != inner, f"{dialect} renders inner and outer the same: {outer}"
 
 
@@ -79,4 +84,55 @@ def test_dremio_refuses_rather_than_emitting_something_that_will_not_parse() -> 
     belongs with the planner; until then the error names the ``code`` fallback.
     """
     with pytest.raises(UnsupportedNestedAccessError, match="no FROM-clause unnest"):
-        DialectRegistry.get("dremio").compile_select(_ast())
+        DialectRegistry.get("dremio").compile_select(_ast(dialect="duckdb"))
+
+
+class TestAddressingAFieldOfTheElement:
+    """``nested_field`` exists because one engine does not use column access.
+
+    Both cases below were found in review of #344, and both are the kind that a
+    string-shaped unit test passes while the SQL is invalid.
+    """
+
+    @pytest.mark.parametrize("dialect", [d for d in RENDERS if d != "snowflake"])
+    def test_most_engines_read_it_as_a_column(self, dialect: str) -> None:
+        dia = DialectRegistry.get(dialect)
+        assert dia.compile_expr(dia.nested_field("L", "Key")).endswith(dia.quote_identifier("Key"))
+
+    def test_snowflake_reads_a_variant_path_and_casts_it(self) -> None:
+        """``L."Key"`` does not compile there - measured, "SQL compilation
+        error" - and without the cast a string field comes back as ``"team"``
+        with its JSON quotes still attached.
+        """
+        dia = DialectRegistry.get("snowflake")
+        assert dia.compile_expr(dia.nested_field("L", "Key")) == '"L".value:"Key"::string'
+        assert dia.compile_expr(dia.nested_field("L", "n", "number")) == '"L".value:"n"::number'
+
+    def test_a_field_name_with_a_space_is_addressable_everywhere(self) -> None:
+        for dialect in RENDERS:
+            dia = DialectRegistry.get(dialect)
+            assert "Label Key" in dia.compile_expr(dia.nested_field("L", "Label Key"))
+
+
+class TestMySQLJsonPaths:
+    """``JSON_TABLE`` paths are quoted unconditionally.
+
+    Measured: ``$.Label Key`` raises "Invalid JSON path expression", and
+    ``$.a.b`` **silently returns NULL** by reading a nested key rather than the
+    literal one. The silent case is why this is not conditional on the name
+    looking unsafe.
+    """
+
+    @pytest.mark.parametrize("code", ["Label Key", "a.b", "plain"])
+    def test_the_member_is_quoted(self, code: str) -> None:
+        node = Unnest(
+            parent_alias="C", column="x", alias="L", columns=((code, "VARCHAR(64)"),), outer=True
+        )
+        assert f"""PATH '$."{code}"'""" in DialectRegistry.get("mysql").render_unnest(node)
+
+    def test_a_quote_in_the_name_is_escaped(self) -> None:
+        node = Unnest(
+            parent_alias="C", column="x", alias="L", columns=(('q"t', "VARCHAR(64)"),), outer=True
+        )
+        expected = 'PATH \'$."q\\"t"\''
+        assert expected in DialectRegistry.get("mysql").render_unnest(node)


### PR DESCRIPTION
The rendering layer for nested data objects, on top of the `nestedIn` surface merged in #342. **The planner does not call it yet** - that lands next, with the join graph and fanout changes.

## `Unnest` is its own AST node

Because the engines do not agree that it is a join:

| dialect | shape |
| --- | --- |
| BigQuery, DuckDB, Postgres, Snowflake | comma-lateral |
| Databricks | `LATERAL VIEW explode` |
| ClickHouse | `ARRAY JOIN` |
| MySQL | `JSON_TABLE` |

`compile_join` renders `<type> JOIN <source> ON <expr>` and cannot spell the rest, so this needs its own node and its own per-dialect renderer - the same shape as `render_time_grain`.

## Three renderings were wrong, and only execution found them

Every one runs against its own engine, on two rows with the second carrying an empty array.

| engine | what execution caught |
| --- | --- |
| **DuckDB** | aliases the *table*, not the element, so `AS "L"` makes `L.Key` a binder error. Needs the two-part `AS t(col)` form |
| **Postgres** | needs `LATERAL` - without it, "missing FROM-clause entry for table C". But must **not** take the two-part alias: Postgres expands a composite array into columns named after its fields, and `AS t(col)` collapses the element to its first field |
| **Snowflake** | identifier-casing mismatch in my fixture - a test bug, but invisible without running it |

Four passed first time; three did not. A unit test asserting the SQL string would have shipped all three.

## Both forms

Inner drops a parent row whose array is empty; outer keeps it with a NULL child. **Outer is the default**, because a charge with no labels still contributes its cost to an unfiltered total - measured, 61% of the rows in a real billing export carry none, so the wrong default silently loses most of the spend.

## Dremio refuses, deliberately

`FLATTEN` is a projection function: its unnest goes in the SELECT list of a derived table, which restructures the query rather than extending its FROM clause. That belongs with the planner. It is measured to work, including the outer form emulated by a `UNION ALL` - see `design/PLAN_nested_data_objects.md` - and the error names the `code` fallback as the way to reach the data meanwhile.

## Verification

Seven engines execute their own rendering, both forms: DuckDB, Postgres, MySQL, ClickHouse as containers; BigQuery, Snowflake, Databricks live. `ruff`, `mypy`, and the full non-docker suite (4,195) pass.