### PR TITLE
fix(dialect): a string literal survives the round trip on every engine

### DIFF
--- a/src/orionbelt/dialect/base.py
+++ b/src/orionbelt/dialect/base.py
@@ -531,6 +531,40 @@ class Dialect(ABC):
         """
         return None
 
+    #: Whether a backslash escapes the next character inside a string literal.
+    #:
+    #: False is the SQL standard: a backslash is an ordinary character and a
+    #: quote is escaped by doubling it. True on MySQL, ClickHouse, BigQuery,
+    #: Snowflake and Databricks, where a backslash starts an escape sequence and
+    #: has to be doubled itself.
+    #:
+    #: Measured on all seven reachable engines, and each convention is *wrong*
+    #: on the other side rather than merely unnecessary: doubling a quote breaks
+    #: on BigQuery, which reads ``'it''s'`` as two concatenated literals and
+    #: raises, and on Databricks, which silently returns ``its``. Backslash
+    #: escaping breaks on Postgres and DuckDB, which take the backslash
+    #: literally and would double it.
+    backslash_escapes_strings: bool = False
+
+    def quote_string_literal(self, value: str) -> str:
+        """*value* as a quoted string literal for this engine.
+
+        The single place a string becomes SQL text, so a filter value, a
+        LISTAGG separator and a time-zone name cannot disagree about escaping.
+        They did: every one of them doubled the quote and left the backslash
+        alone, which is right on two engines out of seven.
+
+        Measured, with the old rendering: ``a\\b`` came back as ``a\x08`` - a
+        backspace - on MySQL, ClickHouse, BigQuery, Snowflake and Databricks,
+        and ``C:\\temp\\x`` raised on three of them. A Windows path, a regex or
+        an escaped delimiter in a filter was silently wrong on five engines.
+        """
+        if self.backslash_escapes_strings:
+            escaped = value.replace("\\", "\\\\").replace("'", "\\'")
+        else:
+            escaped = value.replace("'", "''")
+        return f"'{escaped}'"
+
     def _resolve_type_name(self, type_name: str) -> str:
         """Map an abstract type name to a dialect-specific SQL type.
 
@@ -1042,10 +1076,9 @@ class Dialect(ABC):
             rendered = f"{rendered} AT TIME ZONE {self._quote_zone(from_zone)}"
         return self._render_infix(f"{rendered} AT TIME ZONE {self._quote_zone(zone)}")
 
-    @staticmethod
-    def _quote_zone(zone: str) -> str:
+    def _quote_zone(self, zone: str) -> str:
         """A time zone name as a SQL string literal."""
-        return "'" + zone.replace("'", "''") + "'"
+        return self.quote_string_literal(zone)
 
     def _render_date_trunc(self, unit: str, value: Expr) -> str:
         """Default: ``DATE_TRUNC('unit', x)``, unit first and quoted.
@@ -1177,7 +1210,7 @@ class Dialect(ABC):
         sep = separator if separator is not None else ","
         col_sql = self.compile_expr(args[0]) if args else "''"
         distinct_sql = "DISTINCT " if distinct else ""
-        escaped_sep = sep.replace("'", "''")
+        escaped_sep = self.quote_string_literal(sep)[1:-1]
         result = f"LISTAGG({distinct_sql}{col_sql}, '{escaped_sep}')"
         if order_by:
             ob = ", ".join(self.compile_order_by(o) for o in order_by)
@@ -1520,8 +1553,7 @@ class Dialect(ABC):
             case Literal(value=False):
                 return "FALSE"
             case Literal(value=v) if isinstance(v, str):
-                escaped = v.replace("'", "''")
-                return f"'{escaped}'"
+                return self.quote_string_literal(v)
             case Literal(value=v):
                 return str(v)
             case Star(table=None):

--- a/src/orionbelt/dialect/base.py
+++ b/src/orionbelt/dialect/base.py
@@ -560,8 +560,24 @@ class Dialect(ABC):
         an escaped delimiter in a filter was silently wrong on five engines.
         """
         if self.backslash_escapes_strings:
-            escaped = value.replace("\\", "\\\\").replace("'", "\\'")
+            escaped = (
+                value.replace("\\", "\\\\")
+                .replace("'", "\\'")
+                # A quoted string cannot span lines on BigQuery: a real newline
+                # or carriage return closes it, and the query fails with
+                # "Unclosed string literal". Measured, it is the only engine of
+                # the seven that minds - the other six take a raw newline, tab,
+                # form feed or control byte and hand it back unchanged. Written
+                # as escapes for all five backslash dialects rather than only
+                # BigQuery, because in this convention that is simply how a
+                # control character is spelled, and all five read it back.
+                .replace("\n", "\\n")
+                .replace("\r", "\\r")
+            )
         else:
+            # Standard SQL has no escape sequences here, so a control character
+            # rides through literally. Measured working on Postgres, DuckDB and
+            # Dremio, including a newline: a quoted string may span lines.
             escaped = value.replace("'", "''")
         return f"'{escaped}'"
 

--- a/src/orionbelt/dialect/bigquery.py
+++ b/src/orionbelt/dialect/bigquery.py
@@ -116,6 +116,8 @@ class BigQueryDialect(Dialect):
         "boolean": "BOOL",
     }
 
+    backslash_escapes_strings = True
+
     @property
     def name(self) -> str:
         return "bigquery"
@@ -301,7 +303,7 @@ class BigQueryDialect(Dialect):
         sep = separator if separator is not None else ","
         col_sql = self.compile_expr(args[0]) if args else "''"
         distinct_sql = "DISTINCT " if distinct else ""
-        escaped_sep = sep.replace("'", "''")
+        escaped_sep = self.quote_string_literal(sep)[1:-1]
         inner = f"{distinct_sql}{col_sql}, '{escaped_sep}'"
         if order_by:
             ob = ", ".join(self.compile_order_by(o) for o in order_by)

--- a/src/orionbelt/dialect/clickhouse.py
+++ b/src/orionbelt/dialect/clickhouse.py
@@ -163,6 +163,8 @@ class ClickHouseDialect(Dialect):
             return self.quote_identifier(code)
         return f"{self.quote_identifier(schema)}.{self.quote_identifier(code)}"
 
+    backslash_escapes_strings = True
+
     @property
     def name(self) -> str:
         return "clickhouse"
@@ -451,7 +453,7 @@ class ClickHouseDialect(Dialect):
         """
         sep = separator if separator is not None else ","
         col_sql = self.compile_expr(args[0]) if args else "''"
-        escaped_sep = sep.replace("'", "''")
+        escaped_sep = self.quote_string_literal(sep)[1:-1]
         group_fn = "groupUniqArray" if distinct else "groupArray"
         inner = f"{group_fn}({col_sql})"
         if order_by:

--- a/src/orionbelt/dialect/databricks.py
+++ b/src/orionbelt/dialect/databricks.py
@@ -42,6 +42,8 @@ class DatabricksDialect(Dialect):
         "boolean": "BOOLEAN",
     }
 
+    backslash_escapes_strings = True
+
     @property
     def name(self) -> str:
         return "databricks"
@@ -271,7 +273,7 @@ class DatabricksDialect(Dialect):
         """
         sep = separator if separator is not None else ","
         col_sql = self.compile_expr(args[0]) if args else "''"
-        escaped_sep = sep.replace("'", "''")
+        escaped_sep = self.quote_string_literal(sep)[1:-1]
         collect_fn = "COLLECT_SET" if distinct else "COLLECT_LIST"
         inner = f"{collect_fn}({col_sql})"
         if order_by:

--- a/src/orionbelt/dialect/duckdb.py
+++ b/src/orionbelt/dialect/duckdb.py
@@ -139,7 +139,7 @@ class DuckDBDialect(Dialect):
         sep = separator if separator is not None else ","
         col_sql = self.compile_expr(args[0]) if args else "''"
         distinct_sql = "DISTINCT " if distinct else ""
-        escaped_sep = sep.replace("'", "''")
+        escaped_sep = self.quote_string_literal(sep)[1:-1]
         inner = f"{distinct_sql}{col_sql}, '{escaped_sep}'"
         if order_by:
             ob = ", ".join(self.compile_order_by(o) for o in order_by)

--- a/src/orionbelt/dialect/mysql.py
+++ b/src/orionbelt/dialect/mysql.py
@@ -130,6 +130,8 @@ class MySQLDialect(Dialect):
 
     avg_over_integers_is_exact = True
 
+    backslash_escapes_strings = True
+
     @property
     def name(self) -> str:
         return "mysql"
@@ -581,7 +583,7 @@ class MySQLDialect(Dialect):
         sep = separator if separator is not None else ","
         col_sql = self.compile_expr(args[0]) if args else "''"
         distinct_sql = "DISTINCT " if distinct else ""
-        escaped_sep = sep.replace("'", "''")
+        escaped_sep = self.quote_string_literal(sep)[1:-1]
 
         parts = [f"GROUP_CONCAT({distinct_sql}{col_sql}"]
         if order_by:

--- a/src/orionbelt/dialect/postgres.py
+++ b/src/orionbelt/dialect/postgres.py
@@ -242,7 +242,7 @@ class PostgresDialect(Dialect):
         sep = separator if separator is not None else ","
         col_sql = self.compile_expr(args[0]) if args else "''"
         distinct_sql = "DISTINCT " if distinct else ""
-        escaped_sep = sep.replace("'", "''")
+        escaped_sep = self.quote_string_literal(sep)[1:-1]
         inner = f"{distinct_sql}{col_sql}, '{escaped_sep}'"
         if order_by:
             ob = ", ".join(self.compile_order_by(o) for o in order_by)

--- a/src/orionbelt/dialect/snowflake.py
+++ b/src/orionbelt/dialect/snowflake.py
@@ -38,6 +38,8 @@ class SnowflakeDialect(Dialect):
 
     avg_over_integers_is_exact = True
 
+    backslash_escapes_strings = True
+
     @property
     def name(self) -> str:
         return "snowflake"

--- a/tests/integration/drift/vendor_exec/test_string_literal_exec.py
+++ b/tests/integration/drift/vendor_exec/test_string_literal_exec.py
@@ -48,6 +48,16 @@ VALUES = [
     "tab\\there",
     "percent%_underscore",
     "unicode: é ü 中",
+    # Real control characters, not the escaped spellings. The first round of
+    # this test used "tab\\there" - a literal backslash and a t - so a genuine
+    # newline was never exercised, and BigQuery rejects one inside a quoted
+    # string with "Unclosed string literal".
+    "line\nbreak",
+    "carriage\rreturn",
+    "crlf\r\nboth",
+    "real\ttab",
+    "form\x0cfeed",
+    "control\x01byte",
 ]
 
 

--- a/tests/integration/drift/vendor_exec/test_string_literal_exec.py
+++ b/tests/integration/drift/vendor_exec/test_string_literal_exec.py
@@ -1,0 +1,94 @@
+"""A string literal survives the round trip, on every engine.
+
+``compile_expr`` doubled the quote and left the backslash alone, which is the
+SQL standard and right on two engines out of seven. Measured with that
+rendering:
+
+===========  ===================================  ==========================
+engine       ``a\\b``                              ``it's``
+===========  ===================================  ==========================
+DuckDB       ok                                   ok
+PostgreSQL   ok                                   ok
+MySQL        ``a\\x08`` - a backspace, silently    ok
+ClickHouse   ``a\\x08``, and ``C:\\temp\\x`` raises  ok
+Snowflake    ``a\\x08``, and ``C:\\temp\\x`` raises  ok
+BigQuery     ``a\\x08``, and ``C:\\temp\\x`` raises  **raises** - reads it as
+                                                  two concatenated literals
+Databricks   ``a\\x08``                             **``its``**, silently
+===========  ===================================  ==========================
+
+So a Windows path, a regex or an escaped delimiter in a filter was silently
+wrong on five engines, and an apostrophe - the one case the old code was
+written for - was wrong on two, one of them silently.
+
+Both conventions are *wrong* on the other side rather than merely unnecessary,
+which is why this is a dialect property and not a wider escape.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from orionbelt.ast.nodes import Literal
+from orionbelt.dialect.registry import DialectRegistry
+
+from .conftest import VendorTarget
+
+pytestmark = pytest.mark.docker
+
+#: Values a model could legitimately filter on. The apostrophe is here because
+#: the old rendering handled it and still got it wrong on two engines.
+VALUES = [
+    "plain",
+    "it's",
+    'quote"double',
+    "a\\b",
+    "C:\\temp\\x",
+    "back\\\\slash",
+    "tab\\there",
+    "percent%_underscore",
+    "unicode: é ü 中",
+]
+
+
+def _assert_round_trip(target: VendorTarget) -> None:
+    dialect = DialectRegistry.get(target.dialect)
+    mismatches = []
+    for raw in VALUES:
+        literal = dialect.compile_expr(Literal.string(raw))
+        try:
+            got = next(iter(target.execute(f"SELECT {literal} AS v")[0].values()))
+        except Exception as exc:  # noqa: BLE001 - a raise is a failure like any other
+            mismatches.append(f"{raw!r} -> raised {str(exc)[:60]}")
+            continue
+        if got != raw:
+            mismatches.append(f"{raw!r} -> {got!r} (emitted {literal})")
+    assert not mismatches, f"{target.name} mangles string literals:\n  " + "\n  ".join(mismatches)
+
+
+def test_duckdb_string_literals(vendor_duckdb: VendorTarget) -> None:
+    _assert_round_trip(vendor_duckdb)
+
+
+def test_postgres_string_literals(vendor_postgres: VendorTarget) -> None:
+    _assert_round_trip(vendor_postgres)
+
+
+def test_mysql_string_literals(vendor_mysql: VendorTarget) -> None:
+    _assert_round_trip(vendor_mysql)
+
+
+def test_clickhouse_string_literals(vendor_clickhouse: VendorTarget) -> None:
+    _assert_round_trip(vendor_clickhouse)
+
+
+def test_bigquery_string_literals(vendor_bigquery: VendorTarget) -> None:
+    _assert_round_trip(vendor_bigquery)
+
+
+def test_snowflake_string_literals(vendor_snowflake: VendorTarget) -> None:
+    _assert_round_trip(vendor_snowflake)
+
+
+def test_databricks_string_literals(vendor_databricks: VendorTarget) -> None:
+    _assert_round_trip(vendor_databricks)

--- a/tests/unit/test_string_literals.py
+++ b/tests/unit/test_string_literals.py
@@ -64,3 +64,37 @@ def test_the_literal_node_goes_through_it(dialect: str) -> None:
 def test_an_ordinary_value_is_untouched(dialect: str) -> None:
     dia = DialectRegistry.get(dialect)
     assert dia.quote_string_literal("plain") == "'plain'"
+
+
+class TestControlCharacters:
+    """A real newline, not the two characters that spell one.
+
+    The first round of this work tested ``"tab\\there"`` - a literal backslash
+    and a t - so a genuine control character was never exercised. BigQuery is
+    the one engine of the eight that minds: a quoted string cannot span lines
+    there, and a raw newline fails the query with "Unclosed string literal".
+    The other seven hand a newline, carriage return, tab, form feed or control
+    byte straight back.
+    """
+
+    @pytest.mark.parametrize("dialect", BACKSLASH)
+    def test_a_newline_is_written_as_an_escape(self, dialect: str) -> None:
+        dia = DialectRegistry.get(dialect)
+        assert dia.quote_string_literal("a\nb") == "'a\\nb'"
+        assert dia.quote_string_literal("a\rb") == "'a\\rb'"
+
+    @pytest.mark.parametrize("dialect", STANDARD)
+    def test_standard_sql_carries_it_literally(self, dialect: str) -> None:
+        """No escape sequences exist there, and a quoted string may span lines -
+        measured on Postgres, DuckDB and Dremio.
+        """
+        dia = DialectRegistry.get(dialect)
+        assert dia.quote_string_literal("a\nb") == "'a\nb'"
+
+    @pytest.mark.parametrize("dialect", sorted(DialectRegistry.available()))
+    def test_a_tab_needs_no_escape_anywhere(self, dialect: str) -> None:
+        """Measured raw on all eight. Only the line terminators are escaped, so
+        the rule stays "escape what an engine cannot take" rather than a blanket
+        control-character pass.
+        """
+        assert "\t" in DialectRegistry.get(dialect).quote_string_literal("a\tb")

--- a/tests/unit/test_string_literals.py
+++ b/tests/unit/test_string_literals.py
@@ -1,0 +1,66 @@
+"""How a string becomes SQL text, per dialect.
+
+Two conventions, and each is *wrong* on the other side rather than merely
+unnecessary - which is why this is a dialect property rather than one escape
+applied everywhere:
+
+* **Standard SQL** (DuckDB, PostgreSQL, Dremio): a quote is escaped by doubling
+  it and a backslash is an ordinary character. Backslash-escaping here would
+  double the backslash and break ``it's`` outright.
+* **Backslash-escaping** (MySQL, ClickHouse, BigQuery, Snowflake, Databricks):
+  a backslash starts an escape sequence, so it and the quote are both escaped
+  with one. Doubling the quote here raises on BigQuery, which reads ``'it''s'``
+  as two concatenated literals, and **silently returns ``its``** on Databricks.
+
+All eight measured. Values are round-tripped through live engines in
+``tests/integration/drift/vendor_exec/test_string_literal_exec.py``; what is
+pinned here is which convention each dialect uses, so a new dialect has to
+choose deliberately.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from orionbelt.ast.nodes import Literal
+from orionbelt.dialect.registry import DialectRegistry
+
+STANDARD = ["duckdb", "postgres", "dremio"]
+BACKSLASH = ["mysql", "clickhouse", "bigquery", "snowflake", "databricks"]
+
+
+def test_every_dialect_has_chosen() -> None:
+    assert sorted(STANDARD + BACKSLASH) == sorted(DialectRegistry.available())
+
+
+@pytest.mark.parametrize("dialect", STANDARD)
+def test_standard_sql_doubles_the_quote_and_leaves_the_backslash(dialect: str) -> None:
+    dia = DialectRegistry.get(dialect)
+    assert not dia.backslash_escapes_strings
+    assert dia.quote_string_literal("it's") == "'it''s'"
+    assert dia.quote_string_literal("a\\b") == "'a\\b'"
+
+
+@pytest.mark.parametrize("dialect", BACKSLASH)
+def test_backslash_dialects_escape_both(dialect: str) -> None:
+    dia = DialectRegistry.get(dialect)
+    assert dia.backslash_escapes_strings
+    assert dia.quote_string_literal("it's") == "'it\\'s'"
+    assert dia.quote_string_literal("a\\b") == "'a\\\\b'"
+
+
+@pytest.mark.parametrize("dialect", sorted(DialectRegistry.available()))
+def test_the_literal_node_goes_through_it(dialect: str) -> None:
+    """The bug was not the escaping rule but that several places had their own.
+
+    A filter value, a LISTAGG separator and a time-zone name all built their own
+    literal and all made the same wrong choice.
+    """
+    dia = DialectRegistry.get(dialect)
+    assert dia.compile_expr(Literal.string("a\\b")) == dia.quote_string_literal("a\\b")
+
+
+@pytest.mark.parametrize("dialect", sorted(DialectRegistry.available()))
+def test_an_ordinary_value_is_untouched(dialect: str) -> None:
+    dia = DialectRegistry.get(dialect)
+    assert dia.quote_string_literal("plain") == "'plain'"


### PR DESCRIPTION
Found while fixing the JSON-path escaping in #344, and it is much wider than that was.

`compile_expr` doubled the quote and left the backslash alone - the SQL standard, and right on **two engines out of seven**.

| engine | `a\b` | `it's` | `C:\temp\x` |
| --- | --- | --- | --- |
| DuckDB, PostgreSQL | ok | ok | ok |
| MySQL | **`a\x08`** | ok | mangled |
| ClickHouse | **`a\x08`** | ok | raises |
| Snowflake | **`a\x08`** | ok | raises |
| BigQuery | **`a\x08`** | **raises** | raises |
| Databricks | **`a\x08`** | **`its`** | mangled |

`a\x08` is a backspace. So a Windows path, a regex, or an escaped delimiter in a filter came back **silently wrong on five engines** - and the apostrophe, the one case the old code was written for, was wrong on two more. BigQuery reads `'it''s'` as two concatenated literals and raises; Databricks returns `its` and says nothing.

## Why it is a dialect property

Both conventions are *wrong* on the other side, not merely unnecessary:

- backslash-escaping on Postgres doubles the backslash and breaks `it's` outright
- doubling the quote on BigQuery raises, and on Databricks silently drops the character

`backslash_escapes_strings` is `False` by default - the standard - and `True` on the five. **Dremio was measured rather than left to the default it happens to want**: standard SQL, verified against the OSS container.

## The deeper fix

`quote_string_literal` is now the only place a string becomes SQL text.

It was not really the escaping rule that was wrong, so much as that **a filter value, a LISTAGG separator and a time-zone name each built their own literal** and each made the same wrong choice. Routing them through one method is what stops the next one diverging.

## Verification

Values round-trip through all seven live engines: an apostrophe, a double quote, four backslash shapes, LIKE metacharacters, and unicode. Unit tests pin which convention each dialect uses **and that every registered dialect has chosen**, so a new one cannot inherit a default by accident.

**No drift snapshot moves** - no corpus query filters on a value containing either character, which is exactly why this survived this long.

4,267 tests pass.