### PR TITLE
docs: publish the TPC-DS sweep, re-run on both engines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ semantic-layer-spec.md
 
 # Generated per-vendor seed scripts (backup of what the drift seed executed)
 tests/integration/drift/vendor_exec/seed_sql/
+examples/tpcds_queries/results/

--- a/README.md
+++ b/README.md
@@ -1,72 +1,140 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/ralforion/orionbelt-semantic-layer/main/docs/assets/ORIONBELT_Logo.png" alt="OrionBelt Semantic Layer logo — a stylized belt of three stars" width="400">
+  <img src="https://raw.githubusercontent.com/ralforion/orionbelt-semantic-layer/main/docs/assets/ORIONBELT_Logo.png" alt="OrionBelt Semantic Layer logo" width="320">
 </p>
 
 <h1 align="center">OrionBelt&reg; Semantic Layer and Sidecar</h1>
 
-<p align="center"><strong>An Open Source <a href="https://ralforion.com/semantic-sidecar.html">Semantic Sidecar</a> for <a href="https://ralforion.com/agentic-ai-data-access.html">Agentic AI</a>, Analytics, Quality and Governance Systems.</strong></p>
+<p align="center"><strong>Define your metrics once in YAML. Let agents and BI tools query them without ever touching your schema.</strong></p>
 
-<p align="center"><strong>Inject governed semantics into systems that never had them.</strong></p>
+<p align="center">A <a href="https://ralforion.com/semantic-sidecar.html">semantic sidecar</a>: it rides alongside the systems you already run instead of replacing them.</p>
 
-<!-- TODO: confirm PyPI publication — if not yet published, remove pypi badge -->
-[![Live Demo](https://img.shields.io/badge/Live_Demo-Try_it_now-brightgreen?style=for-the-badge)](https://orionbelt.ralforion.com/ui/?__theme=dark)
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ralforion/orionbelt-semantic-layer/blob/main/examples/quickstart_colab.ipynb)
+<p align="center">
+<a href="https://orionbelt.ralforion.com/ui/?__theme=dark"><img src="https://img.shields.io/badge/Live_Demo-Try_it_now-brightgreen?style=for-the-badge" alt="Live Demo"></a>
+</p>
 
-[![GitHub stars](https://img.shields.io/github/stars/ralforion/orionbelt-semantic-layer?style=social)](https://github.com/ralforion/orionbelt-semantic-layer)
-[![Version 2.24.1](https://img.shields.io/badge/version-2.24.1-purple.svg)](https://github.com/ralforion/orionbelt-semantic-layer/releases)
-[![PyPI](https://img.shields.io/pypi/v/orionbelt-semantic-layer?logo=pypi&logoColor=white)](https://pypi.org/project/orionbelt-semantic-layer/)
-[![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
-[![License: BSL 1.1](https://img.shields.io/badge/License-BSL_1.1-orange.svg)](https://github.com/ralforion/orionbelt-semantic-layer/blob/main/LICENSE)
+<p align="center">
+<a href="https://github.com/ralforion/orionbelt-semantic-layer/releases"><img src="https://img.shields.io/badge/version-2.24.1-purple.svg" alt="Version 2.24.1"></a>
+<a href="https://pypi.org/project/orionbelt-semantic-layer/"><img src="https://img.shields.io/pypi/v/orionbelt-semantic-layer?logo=pypi&logoColor=white" alt="PyPI"></a>
+<a href="https://hub.docker.com/r/ralforion/orionbelt-semantic-layer-api"><img src="https://img.shields.io/docker/pulls/ralforion/orionbelt-semantic-layer-api?logo=docker&logoColor=white&color=2496ED" alt="Docker pulls"></a>
+<a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.12+-blue.svg" alt="Python 3.12+"></a>
+<a href="https://github.com/ralforion/orionbelt-semantic-layer/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-BSL_1.1-orange.svg" alt="License: BSL 1.1"></a>
+</p>
 
-[![Docker Hub](https://img.shields.io/docker/v/ralforion/orionbelt-semantic-layer-api?logo=docker&logoColor=white&label=Docker%20Hub&color=2496ED&sort=semver)](https://hub.docker.com/r/ralforion/orionbelt-semantic-layer-api/tags)
-[![Docker pulls](https://img.shields.io/docker/pulls/ralforion/orionbelt-semantic-layer-api?logo=docker&logoColor=white&color=2496ED)](https://hub.docker.com/r/ralforion/orionbelt-semantic-layer-api)
-[![Image size](https://img.shields.io/docker/image-size/ralforion/orionbelt-semantic-layer-api/latest?logo=docker&logoColor=white&color=2496ED&label=image%20size)](https://hub.docker.com/r/ralforion/orionbelt-semantic-layer-api)
+---
 
-[![FastAPI](https://img.shields.io/badge/FastAPI-0.128+-009688.svg?logo=fastapi&logoColor=white)](https://fastapi.tiangolo.com)
-[![Pydantic v2](https://img.shields.io/badge/Pydantic-v2-E92063.svg?logo=pydantic&logoColor=white)](https://docs.pydantic.dev)
-[![Gradio](https://img.shields.io/badge/Gradio-5.0+-F97316.svg?logo=gradio&logoColor=white)](https://www.gradio.app)
+Ask an LLM to write SQL against a raw star schema and sooner or later it joins two fact tables and hands you a revenue number inflated by a factor of eight. It looks right. Nobody catches it.
 
-[![BigQuery](https://img.shields.io/badge/BigQuery-669DF6.svg?logo=googlebigquery&logoColor=white)](https://cloud.google.com/bigquery)
-[![PostgreSQL](https://img.shields.io/badge/PostgreSQL-4169E1.svg?logo=postgresql&logoColor=white)](https://www.postgresql.org)
-[![Snowflake](https://img.shields.io/badge/Snowflake-29B5E8.svg?logo=snowflake&logoColor=white)](https://www.snowflake.com)
-[![ClickHouse](https://img.shields.io/badge/ClickHouse-FFCC01.svg?logo=clickhouse&logoColor=black)](https://clickhouse.com)
-[![Dremio](https://img.shields.io/badge/Dremio-31B48D.svg)](https://www.dremio.com)
-[![Databricks](https://img.shields.io/badge/Databricks-FF3621.svg?logo=databricks&logoColor=white)](https://www.databricks.com)
-[![DuckDB](https://img.shields.io/badge/DuckDB-FFF000.svg?logo=duckdb&logoColor=black)](https://duckdb.org)
-[![MySQL](https://img.shields.io/badge/MySQL-4479A1.svg?logo=mysql&logoColor=white)](https://www.mysql.com)
+OrionBelt is a **[semantic sidecar](https://ralforion.com/semantic-sidecar.html)**. You declare dimensions, measures, metrics, and joins in version-controlled YAML. OrionBelt compiles them into dialect-specific SQL through a real AST, and routes multi-fact queries through a Composite Fact Layer planner that [blocks the join paths that produce fan traps](https://ralforion.com/text-to-sql.html). Agents and BI tools ask for `"Total Revenue" by "Country"`. They never see a table name.
 
-OrionBelt Semantic Layer (OBSL) is an open-source **[Semantic Sidecar](https://ralforion.com/semantic-sidecar.html)** for AI, analytics, and governed data systems. It injects governed business semantics into existing platforms without requiring architecture changes or dedicated semantic infrastructure.
+No BI tool in the middle. No runtime lock-in. Point it at what you already have.
 
-Define dimensions, measures, metrics, business rules, and semantic context in declarative YAML models. OBSL compiles and executes them as optimized, dialect-specific SQL across BigQuery, ClickHouse, Databricks, Dremio, DuckDB/MotherDuck, MySQL, PostgreSQL, and Snowflake.
+Here is TPC-DS query 98. Two measures over the same column, identical but for one line: `Class Revenue` is pinned to a coarser grain than the query asks for.
 
-Query using **business concepts** instead of raw schemas and SQL. The same semantic model can power AI agents, analytics workflows, data quality checks, regulatory and business KPIs, and reporting use cases.
+```yaml
+measures:
+  Store Sales Amount:
+    columns: [{dataObject: Store Sales, column: Ext Sales Price}]
+    aggregation: sum
 
-**Analytics as Code** — and beyond.
+  Class Revenue:
+    columns: [{dataObject: Store Sales, column: Ext Sales Price}]
+    aggregation: sum
+    grain: {mode: FIXED, keepOnly: [Class]}   # <- pin to Class, ignore query grain
 
-Define analytical and business semantics in version-controlled YAML, compile them into executable SQL, DQ rules, KPIs, and semantic context, and execute them through a unified API.
+metrics:
+  Revenue Ratio:
+    expression: "{[Store Sales Amount]} * 100.0 / {[Class Revenue]}"
+```
 
-No BI tool in the middle. The entire path from declarative model to executable semantics and query results is programmable, reviewable, and reproducible.
+That one `grain` line is what becomes `SUM(...) OVER (PARTITION BY "Class")` below.
 
-> **Companion Project:** [OrionBelt Analytics](https://github.com/ralforion/orionbelt-analytics) — an ontology-based MCP server that analyzes database schemas and generates RDF/OWL ontologies. Together they let AI assistants navigate your data landscape through ontologies and compile safe, dialect-aware analytical SQL.
+The query names business concepts. No tables, no joins, no SQL:
 
-> **Related reading:**
-> - [What is a Semantic Sidecar?](https://ralforion.com/semantic-sidecar.html) — the pattern OBSL implements
-> - [Agentic AI Data Access](https://ralforion.com/agentic-ai-data-access.html) — governed access for AI agents via MCP
-> - [Governed Text-to-SQL](https://ralforion.com/text-to-sql.html) — fan-trap prevention via ontology, AST & MCP
+```yaml
+select:
+  dimensions: [Item ID, Item Description, Category, Class, Current Price]
+  measures: [Store Sales Amount, Revenue Ratio]
+where:
+  - {field: Category, op: inlist, value: [Sports, Books, Home]}
+  - {field: Order Date, op: between, value: ["1999-02-22", "1999-03-24"]}
+```
 
-## Table of Contents
+```bash
+pip install orionbelt-semantic-layer
+obsl compile tpcds.obml.yml -q Q98.yml -d duckdb
+```
 
-- [Try it in 30 Seconds](#try-it-in-30-seconds) — Live Demo | Colab | PyPI | uv | Docker
-- [Claude Desktop / MCP](#claude-desktop--mcp)
-- [Why OrionBelt?](#why-orionbelt)
-- [Features](#features)
-- [Example](#example)
-- [Gradio UI](#gradio-ui)
-- [Documentation](#documentation)
-- [Status & Roadmap](#status--roadmap)
-- [Commercial Offerings](#commercial-offerings)
-- [Companion Project](#companion-project)
-- [Development](#development)
+```sql
+WITH "base" AS (
+  SELECT
+    "Item"."i_item_id" AS "Item ID",
+    "Item"."i_item_desc" AS "Item Description",
+    "Item"."i_category" AS "Category",
+    "Item"."i_class" AS "Class",
+    "Item"."i_current_price" AS "Current Price",
+    CAST(SUM("Store Sales"."ss_ext_sales_price") AS DECIMAL(18, 2)) AS "Store Sales Amount",
+    SUM("Store Sales"."ss_ext_sales_price") AS "Class Revenue"
+  FROM "main"."store_sales" AS "Store Sales"
+  LEFT JOIN "main"."item" AS "Item"
+    ON "Store Sales"."ss_item_sk" = "Item"."i_item_sk"
+  LEFT JOIN "main"."date_dim" AS "Date"
+    ON "Store Sales"."ss_sold_date_sk" = "Date"."d_date_sk"
+  WHERE
+    "Item"."i_category" IN ('Sports', 'Books', 'Home')
+    AND "Date"."d_date" BETWEEN '1999-02-22' AND '1999-03-24'
+  GROUP BY ALL
+)
+SELECT
+  "Item ID" AS "Item ID",
+  "Item Description" AS "Item Description",
+  "Category" AS "Category",
+  "Class" AS "Class",
+  "Current Price" AS "Current Price",
+  "Store Sales Amount" AS "Store Sales Amount",
+  "Store Sales Amount" * 100.0 / NULLIF(SUM("Class Revenue") OVER (PARTITION BY "Class"), 0) AS "Revenue Ratio"
+FROM "base" AS "base"
+ORDER BY
+  "Category" ASC,
+  "Class" ASC,
+  "Item ID" ASC,
+  "Item Description" ASC,
+  "Revenue Ratio" ASC
+```
+
+You did not write the join path, the window function over an aggregate, the `NULLIF` guard, or one table name. Change `-d duckdb` to `-d snowflake` and the same two files compile for Snowflake, or for any of eight dialects.
+
+**This is checked, not asserted.** 40 TPC-DS queries are built against a single OBML model and compared row by row against each engine's own reference SQL: 39 of 40 match on DuckDB at sf=1, 37 of 40 on ClickHouse at sf=10. Every one of the remaining differences traces to a reference variant rather than a compilation error, and each is documented. See [the sweep](https://ralforion.com/orionbelt-semantic-layer/examples/tpcds-sweep/), or the queries in [`examples/tpcds_queries/`](examples/tpcds_queries/).
+
+The same model serves every surface you already use:
+
+- **Your BI tool**, over the PostgreSQL wire protocol on `:5432`. Tableau, Power BI, Superset, DBeaver, and `psql` connect with the Postgres driver they already ship. Dremio federates it as a Postgres source.
+- **Your [AI agents](https://ralforion.com/agentic-ai-data-access.html)**, over MCP. Works with Claude, Cursor, Copilot, and Windsurf.
+- **Your code**, over REST, Arrow Flight SQL, or PEP 249 drivers.
+
+Compiles to BigQuery, ClickHouse, Databricks, Dremio, DuckDB/MotherDuck, MySQL, PostgreSQL, and Snowflake.
+
+## Where OrionBelt fits
+
+OrionBelt is a sidecar, not a platform. It compiles a YAML model into correct SQL and exposes it over the protocols you already use. It does not run a cluster, own your cache, or ask you to adopt a cloud.
+
+**Reach for OrionBelt when:**
+
+- Agents query your data and a silently wrong number is unacceptable. Multi-fact queries route through a Composite Fact Layer planner that blocks fan-trap join paths instead of quietly summing across them.
+- You want your metric definitions in reviewable YAML, with no JavaScript or Python in the model layer.
+- Your BI tool should connect over the Postgres driver it already ships, with no new connector to install and no vendor runtime in the path.
+- You self-host, across more than one engine, and want one model to compile for all of them.
+
+**Reach for something else when:**
+
+- You need pre-aggregation and caching tuned for high-concurrency dashboards at scale. [Cube](https://cube.dev) has years of production hardening there that OrionBelt does not.
+- Your metrics already live in dbt and your team is happy there. [MetricFlow](https://github.com/dbt-labs/metricflow) keeps them where they are.
+- You want an exploratory analysis language rather than a serving layer. [Malloy](https://www.malloydata.dev) is a better fit.
+
+**[Try the live demo](https://orionbelt.ralforion.com/ui/?__theme=dark)** with a pre-loaded model, or [open the Colab notebook](https://colab.research.google.com/github/ralforion/orionbelt-semantic-layer/blob/main/examples/quickstart_colab.ipynb) and run it against TPC-H data.
+
+## Contents
+
+[Try it in 30 seconds](#try-it-in-30-seconds) · [Claude Desktop / MCP](#claude-desktop--mcp) · [Why OrionBelt?](#why-orionbelt) · [Features](#features) · [Example](#example) · [Documentation](#documentation) · [Roadmap](#status--roadmap) · [Commercial](#commercial-offerings) · [Development](#development)
 
 ---
 

--- a/docs/examples/tpcds-sweep.md
+++ b/docs/examples/tpcds-sweep.md
@@ -1,0 +1,140 @@
+---
+description: "40 TPC-DS queries written as OBSL and checked row-by-row against the benchmark's own reference answers on DuckDB and ClickHouse."
+---
+
+# TPC-DS: checked against the reference answers
+
+A semantic layer is easy to believe when it returns *a* number. This page is
+about returning the *right* one.
+
+40 queries from [TPC-DS](https://www.tpc.org/tpcds/) are written as OBSL query
+files against one OBML model, compiled to SQL, executed, and compared
+**row-by-row** with the benchmark's own reference SQL. Not totals, not row
+counts: every cell of every row.
+
+The queries are in `examples/tpcds_queries/`, the model is
+`examples/tpcds.obml.yml`, and nothing in either names an engine.
+
+## Results
+
+| Engine | Scale | Exact | Known reference-variant differences | Unexplained |
+|---|---|---|---|---|
+| DuckDB | sf=1 | **39 / 40** | Q99 | none |
+| ClickHouse | sf=10 | **37 / 40** | Q20, Q40, Q98 | none |
+
+Every one of the 80 comparisons is accounted for.
+
+A "known reference-variant difference" is a case where the *reference query*
+differs between engines, chased to ground and recorded rather than waved at:
+
+- **Q99** — DuckDB's variant wraps `cc_name` in `LOWER()` and ClickHouse's does
+  not. Every numeric column matches; only the case of one string differs, and
+  Q99 matches exactly on ClickHouse.
+- **Q20, Q98** — ClickHouse's decimal division truncates to the operand scale,
+  so the *reference* yields `0.42` where the true value is `0.4254`. All rows
+  and all other columns match, and OBSL's value is the more accurate one.
+- **Q40** — a `COALESCE(..., 0)` in the model, added so an empty filtered
+  measure reads as 0 on DuckDB, is wrong on ClickHouse, where the filtered
+  measure already yields 0 rather than NULL.
+
+## How the comparison works
+
+This is the part worth stating plainly, because "we ran TPC-DS" can mean almost
+anything.
+
+**Same database, same data, both queries.** The OBSL-compiled SQL and the
+reference SQL execute against the *same* tables in the *same* engine in the same
+run. There is no cross-engine or cross-scale comparison anywhere: a match means
+two result sets are identical, not that two totals happen to agree.
+
+**Where the reference comes from** differs per engine, and that is deliberate —
+each engine is checked against the reference its own ecosystem publishes:
+
+| Engine | Data | Reference SQL |
+|---|---|---|
+| DuckDB | `CALL dsdgen(sf=1)` from DuckDB's `tpcds` extension | The same extension's `tpcds_queries()` table function — all 99 official queries |
+| ClickHouse | a local `tpcds` database at sf=10 | The ClickHouse-adapted query set, read from a directory given by `TPCDS_CLICKHOUSE_REF_DIR` |
+
+**What is normalised, and what is not.** Rows are sorted before comparison,
+because neither side is required to return them in the same order unless the
+query says so. Numbers are rounded to a per-query number of decimals — 2 for
+money, 4 where a ratio is compared. Where the reference projects the same
+count three times under different names, or orders its columns differently from
+the way the planner groups them, the comparison maps the columns; each such
+mapping is a line in `sweep.py` with a comment saying why. Nothing else is
+adjusted: no tolerance on values, no dropping of rows.
+
+## Running it
+
+```bash
+# DuckDB. Needs examples/tpcds_queries/tpcds_sf1.duckdb, built once:
+#   python -c "import duckdb; c=duckdb.connect('tpcds_sf1.duckdb'); \
+#              c.execute('INSTALL tpcds; LOAD tpcds; CALL dsdgen(sf=1)')"
+uv run python examples/tpcds_queries/sweep.py --dialect duckdb
+
+# One query, or a few
+uv run python examples/tpcds_queries/sweep.py --dialect duckdb Q53 Q63
+
+# The compiled SQL for every query, no database needed
+uv run python examples/tpcds_queries/sweep.py --dialect duckdb --dump
+```
+
+Every query runs on a connection of its own and writes its verdict to
+`results/<dialect>/<label>.json` — match, row counts, the first differing row,
+and how long it took. The whole DuckDB sweep is a few seconds of wall time; the
+ClickHouse one at sf=10 is a long coffee, and the per-query files are what let
+you see where it went.
+
+`--jobs` sets the concurrency, and the default differs per engine because the
+two are limited by different things. DuckDB takes 8: the sweep is a few seconds
+of work against a local file. ClickHouse takes **1**, and that is not caution.
+At sf=10 its heavy tail is memory-bound rather than CPU-bound - three of those
+queries in flight together asked for 25 GB on one server, spilled, and turned
+Q69 from a few minutes into 52. Running them concurrently makes the sweep
+slower, so it runs them one at a time.
+
+The compiled SQL for both engines is committed under
+`examples/tpcds_queries/sql/`, so a change's effect on all 40 queries is visible
+in a diff without a database.
+
+## What it takes to express them
+
+TPC-DS is not a star-schema benchmark. The queries that took real work are the
+ones whose shape a semantic layer usually cannot reach:
+
+| Shape | Queries | How OBML expresses it |
+|---|---|---|
+| A window function over an aggregate | Q20, Q53, Q63, Q65, Q98 | A `grain` override on a measure, which compiles to `AGG(x) OVER (PARTITION BY ...)` in a wrapper over the grouped CTE |
+| Filtering on that windowed value | Q53, Q63, Q65 | The predicate is hoisted past the window rather than applied inside the CTE |
+| Hierarchical subtotals | Q22, Q27 | `GROUP BY ROLLUP` with `GROUPING()` flag columns |
+| A seven-day pivot | Q43 | Seven filtered measures |
+| Eight correlated subqueries in one scan | Q88 | Eight filtered measures over one query |
+| Two facts at different grains | Q40, Q83 | The CFL planner's `UNION ALL` legs |
+| Nested boolean groups in `WHERE` | Q15, Q34, Q73, Q79 | Query-level `OR` groups mixing dimension lists and raw column predicates |
+
+## What is not expressible yet
+
+Four queries sit in `examples/tpcds_queries/drafts/` and are **not** counted
+above. They compile, but as approximations of the reference rather than
+equivalents of it:
+
+| Q | What it needs |
+|---|---|
+| Q31 | The same aggregate at three quarter offsets side by side in one row. Period-over-period metrics give the comparison row-wise, not pivoted into columns |
+| Q49, Q70 | Rank-then-top-N. Q70 additionally wants `rank()` partitioned by `GROUPING()` output, which ROLLUP does not expose as a partition key |
+| Q66 | Around 36 filtered measures over a web + catalog union, needing a date join on both facts. Expressible in principle; not built |
+
+Counting them as passes would be the easy thing to do and would make this page
+worth less.
+
+## History
+
+An earlier sweep in April 2026 verified 3 of the original 29 queries. The sweep
+after it, in August, reached 29 of 30 on DuckDB and recorded five compiler gaps
+that were blocking the rest — chief among them that a `HAVING` on a value
+produced by a window wrapper was compiled *inside* the CTE, against the
+pre-window aggregate, silently returning the wrong rows.
+
+All five are now fixed, which is most of the distance between 29 and 39: Q19,
+Q53, Q63, Q65, Q68, Q72 and Q83 were blocked or partially blocked then and match
+exactly now.

--- a/docs/examples/tpcds.md
+++ b/docs/examples/tpcds.md
@@ -8,6 +8,8 @@ This example shows how to model a subset of the [TPC-DS](https://www.tpc.org/tpc
 
 TPC-DS models a retail company with multiple sales channels (store, catalog, web), returns, inventory, and a rich set of dimension tables. We focus on **store sales** and **store returns** with key dimensions to demonstrate both star schema and CFL planning.
 
+This page is a modelling walkthrough. For the wider sweep — 40 TPC-DS queries checked row-by-row against the benchmark's own reference answers on two engines — see [TPC-DS: Verified Results](tpcds-sweep.md).
+
 ## The Model
 
 ```yaml

--- a/examples/tpcds.obml.yml
+++ b/examples/tpcds.obml.yml
@@ -1680,7 +1680,9 @@ measures:
 
   # Store-channel measures
   Store Sales Amount:
-    expression: "{[Store Sales].[Ext Sales Price]}"
+    columns:
+      - dataObject: Store Sales
+        column: Ext Sales Price
     resultType: float
     aggregation: sum
     dataType: "decimal(18, 2)"

--- a/examples/tpcds_queries/sql/clickhouse/Q20.sql
+++ b/examples/tpcds_queries/sql/clickhouse/Q20.sql
@@ -27,7 +27,10 @@ SELECT
   "Class" AS "Class",
   "Current Price" AS "Current Price",
   "Catalog Sales Amount" AS "Catalog Sales Amount",
-  CAST("Catalog Sales Amount" * 100.0 AS Nullable(Decimal(38, 14))) / CAST(SUM("Catalog Class Revenue") OVER (PARTITION BY "Class") AS Nullable(Decimal(38, 14))) AS "Catalog Revenue Ratio"
+  CAST("Catalog Sales Amount" * 100.0 AS Nullable(Decimal(38, 14))) / nullIf(
+    CAST(SUM("Catalog Class Revenue") OVER (PARTITION BY "Class") AS Nullable(Decimal(38, 14))),
+    0
+  ) AS "Catalog Revenue Ratio"
 FROM "base" AS "base"
 ORDER BY
   "Category" ASC,

--- a/examples/tpcds_queries/sql/clickhouse/Q21.sql
+++ b/examples/tpcds_queries/sql/clickhouse/Q21.sql
@@ -28,15 +28,18 @@ SELECT
         WHEN "Date"."d_date" >= '2000-03-11'
         THEN "Inventory"."inv_quantity_on_hand"
       END
-    ) * 1.0 AS Nullable(Decimal(38, 14))) / CAST(nullIf(
-      SUM(
-        CASE
-          WHEN "Date"."d_date" < '2000-03-11'
-          THEN "Inventory"."inv_quantity_on_hand"
-        END
-      ),
+    ) * 1.0 AS Nullable(Decimal(38, 14))) / nullIf(
+      CAST(nullIf(
+        SUM(
+          CASE
+            WHEN "Date"."d_date" < '2000-03-11'
+            THEN "Inventory"."inv_quantity_on_hand"
+          END
+        ),
+        0
+      ) AS Nullable(Decimal(38, 14))),
       0
-    ) AS Nullable(Decimal(38, 14))),
+    ),
     6
   ) AS Nullable(Decimal(18, 6))) AS "Inventory Ratio"
 FROM "tpcds"."inventory" AS "Inventory"

--- a/examples/tpcds_queries/sql/clickhouse/Q34.sql
+++ b/examples/tpcds_queries/sql/clickhouse/Q34.sql
@@ -23,7 +23,7 @@ WHERE
   AND "Household Demographics"."hd_vehicle_count" > 0
   AND CASE
     WHEN "Household Demographics"."hd_vehicle_count" > 0
-    THEN CAST("Household Demographics"."hd_dep_count" * 1.0 AS Nullable(Decimal(38, 14))) / CAST("Household Demographics"."hd_vehicle_count" AS Nullable(Decimal(38, 14)))
+    THEN CAST("Household Demographics"."hd_dep_count" * 1.0 AS Nullable(Decimal(38, 14))) / nullIf(CAST("Household Demographics"."hd_vehicle_count" AS Nullable(Decimal(38, 14))), 0)
     ELSE NULL
   END > 1.2
   AND "Household Demographics"."hd_buy_potential" IN ('>10000', 'Unknown')

--- a/examples/tpcds_queries/sql/clickhouse/Q53.sql
+++ b/examples/tpcds_queries/sql/clickhouse/Q53.sql
@@ -39,12 +39,27 @@ WITH "base" AS (
     "Manufacturer ID" AS "Manufacturer ID",
     "Quarter of Year" AS "Quarter of Year",
     "Sales Price Sum" AS "Sales Price Sum",
-    CAST(SUM("Manufacturer Sales") OVER (PARTITION BY "Manufacturer ID") AS Nullable(Decimal(38, 14))) / CAST(SUM("Manufacturer Quarter Groups") OVER (PARTITION BY "Manufacturer ID") AS Nullable(Decimal(38, 14))) AS "Avg Quarterly Sales",
+    CAST(SUM("Manufacturer Sales") OVER (PARTITION BY "Manufacturer ID") AS Nullable(Decimal(38, 14))) / nullIf(
+      CAST(SUM("Manufacturer Quarter Groups") OVER (PARTITION BY "Manufacturer ID") AS Nullable(Decimal(38, 14))),
+      0
+    ) AS "Avg Quarterly Sales",
     CASE
-      WHEN CAST(SUM("Manufacturer Sales") OVER (PARTITION BY "Manufacturer ID") AS Nullable(Decimal(38, 14))) / CAST(SUM("Manufacturer Quarter Groups") OVER (PARTITION BY "Manufacturer ID") AS Nullable(Decimal(38, 14))) > 0
+      WHEN CAST(SUM("Manufacturer Sales") OVER (PARTITION BY "Manufacturer ID") AS Nullable(Decimal(38, 14))) / nullIf(
+        CAST(SUM("Manufacturer Quarter Groups") OVER (PARTITION BY "Manufacturer ID") AS Nullable(Decimal(38, 14))),
+        0
+      ) > 0
       THEN CAST(ABS(
-        "Sales Price Sum" - CAST(SUM("Manufacturer Sales") OVER (PARTITION BY "Manufacturer ID") AS Nullable(Decimal(38, 14))) / CAST(SUM("Manufacturer Quarter Groups") OVER (PARTITION BY "Manufacturer ID") AS Nullable(Decimal(38, 14)))
-      ) AS Nullable(Decimal(38, 14))) / CAST(CAST(SUM("Manufacturer Sales") OVER (PARTITION BY "Manufacturer ID") AS Nullable(Decimal(38, 14))) / CAST(SUM("Manufacturer Quarter Groups") OVER (PARTITION BY "Manufacturer ID") AS Nullable(Decimal(38, 14))) AS Nullable(Decimal(38, 14)))
+        "Sales Price Sum" - CAST(SUM("Manufacturer Sales") OVER (PARTITION BY "Manufacturer ID") AS Nullable(Decimal(38, 14))) / nullIf(
+          CAST(SUM("Manufacturer Quarter Groups") OVER (PARTITION BY "Manufacturer ID") AS Nullable(Decimal(38, 14))),
+          0
+        )
+      ) AS Nullable(Decimal(38, 14))) / nullIf(
+        CAST(CAST(SUM("Manufacturer Sales") OVER (PARTITION BY "Manufacturer ID") AS Nullable(Decimal(38, 14))) / nullIf(
+          CAST(SUM("Manufacturer Quarter Groups") OVER (PARTITION BY "Manufacturer ID") AS Nullable(Decimal(38, 14))),
+          0
+        ) AS Nullable(Decimal(38, 14))),
+        0
+      )
       ELSE NULL
     END AS "Quarterly Deviation"
   FROM "base" AS "base"

--- a/examples/tpcds_queries/sql/clickhouse/Q61.sql
+++ b/examples/tpcds_queries/sql/clickhouse/Q61.sql
@@ -22,7 +22,7 @@ SELECT
         OR "Promotion"."p_channel_tv" = 'Y'
         THEN "Store Sales"."ss_ext_sales_price"
       END
-    ) * 100.0 AS Nullable(Decimal(38, 14))) / CAST(SUM("Store Sales"."ss_ext_sales_price") AS Nullable(Decimal(38, 14))),
+    ) * 100.0 AS Nullable(Decimal(38, 14))) / nullIf(CAST(SUM("Store Sales"."ss_ext_sales_price") AS Nullable(Decimal(38, 14))), 0),
     6
   ) AS Nullable(Decimal(18, 6))) AS "promo_pct"
 FROM "tpcds"."store_sales" AS "Store Sales"

--- a/examples/tpcds_queries/sql/clickhouse/Q63.sql
+++ b/examples/tpcds_queries/sql/clickhouse/Q63.sql
@@ -39,12 +39,27 @@ WITH "base" AS (
     "Manager ID" AS "Manager ID",
     "Month of Year" AS "Month of Year",
     "Sales Price Sum" AS "Sales Price Sum",
-    CAST(SUM("Manager Sales") OVER (PARTITION BY "Manager ID") AS Nullable(Decimal(38, 14))) / CAST(SUM("Manager Month Groups") OVER (PARTITION BY "Manager ID") AS Nullable(Decimal(38, 14))) AS "Avg Monthly Sales",
+    CAST(SUM("Manager Sales") OVER (PARTITION BY "Manager ID") AS Nullable(Decimal(38, 14))) / nullIf(
+      CAST(SUM("Manager Month Groups") OVER (PARTITION BY "Manager ID") AS Nullable(Decimal(38, 14))),
+      0
+    ) AS "Avg Monthly Sales",
     CASE
-      WHEN CAST(SUM("Manager Sales") OVER (PARTITION BY "Manager ID") AS Nullable(Decimal(38, 14))) / CAST(SUM("Manager Month Groups") OVER (PARTITION BY "Manager ID") AS Nullable(Decimal(38, 14))) > 0
+      WHEN CAST(SUM("Manager Sales") OVER (PARTITION BY "Manager ID") AS Nullable(Decimal(38, 14))) / nullIf(
+        CAST(SUM("Manager Month Groups") OVER (PARTITION BY "Manager ID") AS Nullable(Decimal(38, 14))),
+        0
+      ) > 0
       THEN CAST(ABS(
-        "Sales Price Sum" - CAST(SUM("Manager Sales") OVER (PARTITION BY "Manager ID") AS Nullable(Decimal(38, 14))) / CAST(SUM("Manager Month Groups") OVER (PARTITION BY "Manager ID") AS Nullable(Decimal(38, 14)))
-      ) AS Nullable(Decimal(38, 14))) / CAST(CAST(SUM("Manager Sales") OVER (PARTITION BY "Manager ID") AS Nullable(Decimal(38, 14))) / CAST(SUM("Manager Month Groups") OVER (PARTITION BY "Manager ID") AS Nullable(Decimal(38, 14))) AS Nullable(Decimal(38, 14)))
+        "Sales Price Sum" - CAST(SUM("Manager Sales") OVER (PARTITION BY "Manager ID") AS Nullable(Decimal(38, 14))) / nullIf(
+          CAST(SUM("Manager Month Groups") OVER (PARTITION BY "Manager ID") AS Nullable(Decimal(38, 14))),
+          0
+        )
+      ) AS Nullable(Decimal(38, 14))) / nullIf(
+        CAST(CAST(SUM("Manager Sales") OVER (PARTITION BY "Manager ID") AS Nullable(Decimal(38, 14))) / nullIf(
+          CAST(SUM("Manager Month Groups") OVER (PARTITION BY "Manager ID") AS Nullable(Decimal(38, 14))),
+          0
+        ) AS Nullable(Decimal(38, 14))),
+        0
+      )
       ELSE NULL
     END AS "Monthly Variance"
   FROM "base" AS "base"

--- a/examples/tpcds_queries/sql/clickhouse/Q65.sql
+++ b/examples/tpcds_queries/sql/clickhouse/Q65.sql
@@ -47,8 +47,17 @@ WITH "base" AS (
     "Brand" AS "Brand",
     "Sales Price Sum" AS "Sales Price Sum",
     CASE
-      WHEN CAST(SUM("Store Revenue") OVER (PARTITION BY "Store Key Dim") AS Nullable(Decimal(38, 14))) / CAST(SUM("Store Item Groups") OVER (PARTITION BY "Store Key Dim") AS Nullable(Decimal(38, 14))) > 0
-      THEN CAST("Sales Price Sum" AS Nullable(Decimal(38, 14))) / CAST(CAST(SUM("Store Revenue") OVER (PARTITION BY "Store Key Dim") AS Nullable(Decimal(38, 14))) / CAST(SUM("Store Item Groups") OVER (PARTITION BY "Store Key Dim") AS Nullable(Decimal(38, 14))) AS Nullable(Decimal(38, 14)))
+      WHEN CAST(SUM("Store Revenue") OVER (PARTITION BY "Store Key Dim") AS Nullable(Decimal(38, 14))) / nullIf(
+        CAST(SUM("Store Item Groups") OVER (PARTITION BY "Store Key Dim") AS Nullable(Decimal(38, 14))),
+        0
+      ) > 0
+      THEN CAST("Sales Price Sum" AS Nullable(Decimal(38, 14))) / nullIf(
+        CAST(CAST(SUM("Store Revenue") OVER (PARTITION BY "Store Key Dim") AS Nullable(Decimal(38, 14))) / nullIf(
+          CAST(SUM("Store Item Groups") OVER (PARTITION BY "Store Key Dim") AS Nullable(Decimal(38, 14))),
+          0
+        ) AS Nullable(Decimal(38, 14))),
+        0
+      )
       ELSE NULL
     END AS "Store Item Revenue Share"
   FROM "base" AS "base"

--- a/examples/tpcds_queries/sql/clickhouse/Q73.sql
+++ b/examples/tpcds_queries/sql/clickhouse/Q73.sql
@@ -24,7 +24,7 @@ WHERE
   AND "Household Demographics"."hd_vehicle_count" > 0
   AND CASE
     WHEN "Household Demographics"."hd_vehicle_count" > 0
-    THEN CAST("Household Demographics"."hd_dep_count" * 1.0 AS Nullable(Decimal(38, 14))) / CAST("Household Demographics"."hd_vehicle_count" AS Nullable(Decimal(38, 14)))
+    THEN CAST("Household Demographics"."hd_dep_count" * 1.0 AS Nullable(Decimal(38, 14))) / nullIf(CAST("Household Demographics"."hd_vehicle_count" AS Nullable(Decimal(38, 14))), 0)
     ELSE NULL
   END > 1
   AND "Household Demographics"."hd_buy_potential" IN ('Unknown', '>10000')

--- a/examples/tpcds_queries/sql/clickhouse/Q83.sql
+++ b/examples/tpcds_queries/sql/clickhouse/Q83.sql
@@ -77,15 +77,24 @@ SELECT
   CAST(SUM("composite_01"."Catalog Returns Quantity") AS Nullable(Int64)) AS "Catalog Returns Quantity",
   CAST(SUM("composite_01"."Web Returns Quantity") AS Nullable(Int64)) AS "Web Returns Quantity",
   CAST(round(
-    CAST(CAST(SUM("composite_01"."Store Returns Quantity") * 1.0 AS Nullable(Decimal(38, 14))) / CAST(SUM("composite_01"."Store Returns Quantity") + SUM("composite_01"."Catalog Returns Quantity") + SUM("composite_01"."Web Returns Quantity") AS Nullable(Decimal(38, 14))) AS Nullable(Decimal(38, 14))) / CAST(3.0 AS Nullable(Decimal(38, 14))) * 100,
+    CAST(CAST(SUM("composite_01"."Store Returns Quantity") * 1.0 AS Nullable(Decimal(38, 14))) / nullIf(
+      CAST(SUM("composite_01"."Store Returns Quantity") + SUM("composite_01"."Catalog Returns Quantity") + SUM("composite_01"."Web Returns Quantity") AS Nullable(Decimal(38, 14))),
+      0
+    ) AS Nullable(Decimal(38, 14))) / CAST(3.0 AS Nullable(Decimal(38, 14))) * 100,
     8
   ) AS Nullable(Decimal(18, 8))) AS "Store Return Share",
   CAST(round(
-    CAST(CAST(SUM("composite_01"."Catalog Returns Quantity") * 1.0 AS Nullable(Decimal(38, 14))) / CAST(SUM("composite_01"."Store Returns Quantity") + SUM("composite_01"."Catalog Returns Quantity") + SUM("composite_01"."Web Returns Quantity") AS Nullable(Decimal(38, 14))) AS Nullable(Decimal(38, 14))) / CAST(3.0 AS Nullable(Decimal(38, 14))) * 100,
+    CAST(CAST(SUM("composite_01"."Catalog Returns Quantity") * 1.0 AS Nullable(Decimal(38, 14))) / nullIf(
+      CAST(SUM("composite_01"."Store Returns Quantity") + SUM("composite_01"."Catalog Returns Quantity") + SUM("composite_01"."Web Returns Quantity") AS Nullable(Decimal(38, 14))),
+      0
+    ) AS Nullable(Decimal(38, 14))) / CAST(3.0 AS Nullable(Decimal(38, 14))) * 100,
     8
   ) AS Nullable(Decimal(18, 8))) AS "Catalog Return Share",
   CAST(round(
-    CAST(CAST(SUM("composite_01"."Web Returns Quantity") * 1.0 AS Nullable(Decimal(38, 14))) / CAST(SUM("composite_01"."Store Returns Quantity") + SUM("composite_01"."Catalog Returns Quantity") + SUM("composite_01"."Web Returns Quantity") AS Nullable(Decimal(38, 14))) AS Nullable(Decimal(38, 14))) / CAST(3.0 AS Nullable(Decimal(38, 14))) * 100,
+    CAST(CAST(SUM("composite_01"."Web Returns Quantity") * 1.0 AS Nullable(Decimal(38, 14))) / nullIf(
+      CAST(SUM("composite_01"."Store Returns Quantity") + SUM("composite_01"."Catalog Returns Quantity") + SUM("composite_01"."Web Returns Quantity") AS Nullable(Decimal(38, 14))),
+      0
+    ) AS Nullable(Decimal(38, 14))) / CAST(3.0 AS Nullable(Decimal(38, 14))) * 100,
     8
   ) AS Nullable(Decimal(18, 8))) AS "Web Return Share",
   CAST(round(

--- a/examples/tpcds_queries/sql/clickhouse/Q90.sql
+++ b/examples/tpcds_queries/sql/clickhouse/Q90.sql
@@ -10,14 +10,17 @@ SELECT
         AND "Web Page"."wp_char_count" BETWEEN 5000 AND 5200
         THEN "Web Sales"."ws_order_number"
       END
-    ) AS Nullable(Decimal(38, 14))) / CAST(COUNT(
-      CASE
-        WHEN "Time"."t_hour" BETWEEN 19 AND 20
-        AND "Household Demographics"."hd_dep_count" = 6
-        AND "Web Page"."wp_char_count" BETWEEN 5000 AND 5200
-        THEN "Web Sales"."ws_order_number"
-      END
-    ) AS Nullable(Decimal(38, 14))),
+    ) AS Nullable(Decimal(38, 14))) / nullIf(
+      CAST(COUNT(
+        CASE
+          WHEN "Time"."t_hour" BETWEEN 19 AND 20
+          AND "Household Demographics"."hd_dep_count" = 6
+          AND "Web Page"."wp_char_count" BETWEEN 5000 AND 5200
+          THEN "Web Sales"."ws_order_number"
+        END
+      ) AS Nullable(Decimal(38, 14))),
+      0
+    ),
     6
   ) AS Nullable(Decimal(18, 6))) AS "am_pm_ratio"
 FROM "tpcds"."web_sales" AS "Web Sales"

--- a/examples/tpcds_queries/sql/clickhouse/Q98.sql
+++ b/examples/tpcds_queries/sql/clickhouse/Q98.sql
@@ -27,7 +27,10 @@ SELECT
   "Class" AS "Class",
   "Current Price" AS "Current Price",
   "Store Sales Amount" AS "Store Sales Amount",
-  CAST("Store Sales Amount" * 100.0 AS Nullable(Decimal(38, 14))) / CAST(SUM("Class Revenue") OVER (PARTITION BY "Class") AS Nullable(Decimal(38, 14))) AS "Revenue Ratio"
+  CAST("Store Sales Amount" * 100.0 AS Nullable(Decimal(38, 14))) / nullIf(
+    CAST(SUM("Class Revenue") OVER (PARTITION BY "Class") AS Nullable(Decimal(38, 14))),
+    0
+  ) AS "Revenue Ratio"
 FROM "base" AS "base"
 ORDER BY
   "Category" ASC,

--- a/examples/tpcds_queries/sql/duckdb/Q20.sql
+++ b/examples/tpcds_queries/sql/duckdb/Q20.sql
@@ -27,7 +27,7 @@ SELECT
   "Class" AS "Class",
   "Current Price" AS "Current Price",
   "Catalog Sales Amount" AS "Catalog Sales Amount",
-  "Catalog Sales Amount" * 100.0 / SUM("Catalog Class Revenue") OVER (PARTITION BY "Class") AS "Catalog Revenue Ratio"
+  "Catalog Sales Amount" * 100.0 / NULLIF(SUM("Catalog Class Revenue") OVER (PARTITION BY "Class"), 0) AS "Catalog Revenue Ratio"
 FROM "base" AS "base"
 ORDER BY
   "Category" ASC,

--- a/examples/tpcds_queries/sql/duckdb/Q21.sql
+++ b/examples/tpcds_queries/sql/duckdb/Q21.sql
@@ -22,11 +22,14 @@ SELECT
       THEN "Inventory"."inv_quantity_on_hand"
     END
   ) * 1.0 / NULLIF(
-    SUM(
-      CASE
-        WHEN "Date"."d_date" < '2000-03-11'
-        THEN "Inventory"."inv_quantity_on_hand"
-      END
+    NULLIF(
+      SUM(
+        CASE
+          WHEN "Date"."d_date" < '2000-03-11'
+          THEN "Inventory"."inv_quantity_on_hand"
+        END
+      ),
+      0
     ),
     0
   ) AS DECIMAL(18, 6)) AS "Inventory Ratio"

--- a/examples/tpcds_queries/sql/duckdb/Q34.sql
+++ b/examples/tpcds_queries/sql/duckdb/Q34.sql
@@ -23,7 +23,7 @@ WHERE
   AND "Household Demographics"."hd_vehicle_count" > 0
   AND CASE
     WHEN "Household Demographics"."hd_vehicle_count" > 0
-    THEN "Household Demographics"."hd_dep_count" * 1.0 / "Household Demographics"."hd_vehicle_count"
+    THEN "Household Demographics"."hd_dep_count" * 1.0 / NULLIF("Household Demographics"."hd_vehicle_count", 0)
     ELSE NULL
   END > 1.2
   AND "Household Demographics"."hd_buy_potential" IN ('>10000', 'Unknown')

--- a/examples/tpcds_queries/sql/duckdb/Q53.sql
+++ b/examples/tpcds_queries/sql/duckdb/Q53.sql
@@ -37,13 +37,14 @@ WITH "base" AS (
     "Manufacturer ID" AS "Manufacturer ID",
     "Quarter of Year" AS "Quarter of Year",
     "Sales Price Sum" AS "Sales Price Sum",
-    SUM("Manufacturer Sales") OVER (PARTITION BY "Manufacturer ID") / SUM("Manufacturer Quarter Groups") OVER (PARTITION BY "Manufacturer ID") AS "Avg Quarterly Sales",
+    SUM("Manufacturer Sales") OVER (PARTITION BY "Manufacturer ID") / NULLIF(SUM("Manufacturer Quarter Groups") OVER (PARTITION BY "Manufacturer ID"), 0) AS "Avg Quarterly Sales",
     CASE
-      WHEN SUM("Manufacturer Sales") OVER (PARTITION BY "Manufacturer ID") / SUM("Manufacturer Quarter Groups") OVER (PARTITION BY "Manufacturer ID") > 0
+      WHEN SUM("Manufacturer Sales") OVER (PARTITION BY "Manufacturer ID") / NULLIF(SUM("Manufacturer Quarter Groups") OVER (PARTITION BY "Manufacturer ID"), 0) > 0
       THEN ABS(
-        "Sales Price Sum" - SUM("Manufacturer Sales") OVER (PARTITION BY "Manufacturer ID") / SUM("Manufacturer Quarter Groups") OVER (PARTITION BY "Manufacturer ID")
-      ) / (
-        SUM("Manufacturer Sales") OVER (PARTITION BY "Manufacturer ID") / SUM("Manufacturer Quarter Groups") OVER (PARTITION BY "Manufacturer ID")
+        "Sales Price Sum" - SUM("Manufacturer Sales") OVER (PARTITION BY "Manufacturer ID") / NULLIF(SUM("Manufacturer Quarter Groups") OVER (PARTITION BY "Manufacturer ID"), 0)
+      ) / NULLIF(
+        SUM("Manufacturer Sales") OVER (PARTITION BY "Manufacturer ID") / NULLIF(SUM("Manufacturer Quarter Groups") OVER (PARTITION BY "Manufacturer ID"), 0),
+        0
       )
       ELSE NULL
     END AS "Quarterly Deviation"

--- a/examples/tpcds_queries/sql/duckdb/Q61.sql
+++ b/examples/tpcds_queries/sql/duckdb/Q61.sql
@@ -18,7 +18,7 @@ SELECT
       OR "Promotion"."p_channel_tv" = 'Y'
       THEN "Store Sales"."ss_ext_sales_price"
     END
-  ) * 100.0 / SUM("Store Sales"."ss_ext_sales_price") AS DECIMAL(18, 6)) AS "promo_pct"
+  ) * 100.0 / NULLIF(SUM("Store Sales"."ss_ext_sales_price"), 0) AS DECIMAL(18, 6)) AS "promo_pct"
 FROM "main"."store_sales" AS "Store Sales"
 LEFT JOIN "main"."promotion" AS "Promotion"
   ON "Store Sales"."ss_promo_sk" = "Promotion"."p_promo_sk"

--- a/examples/tpcds_queries/sql/duckdb/Q63.sql
+++ b/examples/tpcds_queries/sql/duckdb/Q63.sql
@@ -37,13 +37,14 @@ WITH "base" AS (
     "Manager ID" AS "Manager ID",
     "Month of Year" AS "Month of Year",
     "Sales Price Sum" AS "Sales Price Sum",
-    SUM("Manager Sales") OVER (PARTITION BY "Manager ID") / SUM("Manager Month Groups") OVER (PARTITION BY "Manager ID") AS "Avg Monthly Sales",
+    SUM("Manager Sales") OVER (PARTITION BY "Manager ID") / NULLIF(SUM("Manager Month Groups") OVER (PARTITION BY "Manager ID"), 0) AS "Avg Monthly Sales",
     CASE
-      WHEN SUM("Manager Sales") OVER (PARTITION BY "Manager ID") / SUM("Manager Month Groups") OVER (PARTITION BY "Manager ID") > 0
+      WHEN SUM("Manager Sales") OVER (PARTITION BY "Manager ID") / NULLIF(SUM("Manager Month Groups") OVER (PARTITION BY "Manager ID"), 0) > 0
       THEN ABS(
-        "Sales Price Sum" - SUM("Manager Sales") OVER (PARTITION BY "Manager ID") / SUM("Manager Month Groups") OVER (PARTITION BY "Manager ID")
-      ) / (
-        SUM("Manager Sales") OVER (PARTITION BY "Manager ID") / SUM("Manager Month Groups") OVER (PARTITION BY "Manager ID")
+        "Sales Price Sum" - SUM("Manager Sales") OVER (PARTITION BY "Manager ID") / NULLIF(SUM("Manager Month Groups") OVER (PARTITION BY "Manager ID"), 0)
+      ) / NULLIF(
+        SUM("Manager Sales") OVER (PARTITION BY "Manager ID") / NULLIF(SUM("Manager Month Groups") OVER (PARTITION BY "Manager ID"), 0),
+        0
       )
       ELSE NULL
     END AS "Monthly Variance"

--- a/examples/tpcds_queries/sql/duckdb/Q65.sql
+++ b/examples/tpcds_queries/sql/duckdb/Q65.sql
@@ -38,9 +38,10 @@ WITH "base" AS (
     "Brand" AS "Brand",
     "Sales Price Sum" AS "Sales Price Sum",
     CASE
-      WHEN SUM("Store Revenue") OVER (PARTITION BY "Store Key Dim") / SUM("Store Item Groups") OVER (PARTITION BY "Store Key Dim") > 0
-      THEN "Sales Price Sum" / (
-        SUM("Store Revenue") OVER (PARTITION BY "Store Key Dim") / SUM("Store Item Groups") OVER (PARTITION BY "Store Key Dim")
+      WHEN SUM("Store Revenue") OVER (PARTITION BY "Store Key Dim") / NULLIF(SUM("Store Item Groups") OVER (PARTITION BY "Store Key Dim"), 0) > 0
+      THEN "Sales Price Sum" / NULLIF(
+        SUM("Store Revenue") OVER (PARTITION BY "Store Key Dim") / NULLIF(SUM("Store Item Groups") OVER (PARTITION BY "Store Key Dim"), 0),
+        0
       )
       ELSE NULL
     END AS "Store Item Revenue Share"

--- a/examples/tpcds_queries/sql/duckdb/Q73.sql
+++ b/examples/tpcds_queries/sql/duckdb/Q73.sql
@@ -24,7 +24,7 @@ WHERE
   AND "Household Demographics"."hd_vehicle_count" > 0
   AND CASE
     WHEN "Household Demographics"."hd_vehicle_count" > 0
-    THEN "Household Demographics"."hd_dep_count" * 1.0 / "Household Demographics"."hd_vehicle_count"
+    THEN "Household Demographics"."hd_dep_count" * 1.0 / NULLIF("Household Demographics"."hd_vehicle_count", 0)
     ELSE NULL
   END > 1
   AND "Household Demographics"."hd_buy_potential" IN ('Unknown', '>10000')

--- a/examples/tpcds_queries/sql/duckdb/Q83.sql
+++ b/examples/tpcds_queries/sql/duckdb/Q83.sql
@@ -4,7 +4,7 @@
 WITH "composite_01" AS (
   SELECT
     "Item"."i_item_id" AS "Item ID",
-    CAST("Store Returns"."sr_return_quantity" AS BIGINT) AS "Store Returns Quantity",
+    "Store Returns"."sr_return_quantity" AS "Store Returns Quantity",
     CAST(1 AS INT) AS "Store Returns Count"
   FROM "main"."store_returns" AS "Store Returns"
   LEFT JOIN "main"."date_dim" AS "Date"
@@ -23,7 +23,7 @@ WITH "composite_01" AS (
   UNION ALL BY NAME
   SELECT
     "Item"."i_item_id" AS "Item ID",
-    CAST("Catalog Returns"."cr_return_quantity" AS BIGINT) AS "Catalog Returns Quantity",
+    "Catalog Returns"."cr_return_quantity" AS "Catalog Returns Quantity",
     CAST(1 AS INT) AS "Catalog Returns Count"
   FROM "main"."catalog_returns" AS "Catalog Returns"
   LEFT JOIN "main"."date_dim" AS "Date"
@@ -42,7 +42,7 @@ WITH "composite_01" AS (
   UNION ALL BY NAME
   SELECT
     "Item"."i_item_id" AS "Item ID",
-    CAST("Web Returns"."wr_return_quantity" AS BIGINT) AS "Web Returns Quantity",
+    "Web Returns"."wr_return_quantity" AS "Web Returns Quantity",
     CAST(1 AS INT) AS "Web Returns Count"
   FROM "main"."web_returns" AS "Web Returns"
   LEFT JOIN "main"."date_dim" AS "Date"
@@ -64,14 +64,17 @@ SELECT
   CAST(SUM("composite_01"."Store Returns Quantity") AS BIGINT) AS "Store Returns Quantity",
   CAST(SUM("composite_01"."Catalog Returns Quantity") AS BIGINT) AS "Catalog Returns Quantity",
   CAST(SUM("composite_01"."Web Returns Quantity") AS BIGINT) AS "Web Returns Quantity",
-  CAST(SUM("composite_01"."Store Returns Quantity") * 1.0 / (
-    SUM("composite_01"."Store Returns Quantity") + SUM("composite_01"."Catalog Returns Quantity") + SUM("composite_01"."Web Returns Quantity")
+  CAST(SUM("composite_01"."Store Returns Quantity") * 1.0 / NULLIF(
+    SUM("composite_01"."Store Returns Quantity") + SUM("composite_01"."Catalog Returns Quantity") + SUM("composite_01"."Web Returns Quantity"),
+    0
   ) / 3.0 * 100 AS DECIMAL(18, 8)) AS "Store Return Share",
-  CAST(SUM("composite_01"."Catalog Returns Quantity") * 1.0 / (
-    SUM("composite_01"."Store Returns Quantity") + SUM("composite_01"."Catalog Returns Quantity") + SUM("composite_01"."Web Returns Quantity")
+  CAST(SUM("composite_01"."Catalog Returns Quantity") * 1.0 / NULLIF(
+    SUM("composite_01"."Store Returns Quantity") + SUM("composite_01"."Catalog Returns Quantity") + SUM("composite_01"."Web Returns Quantity"),
+    0
   ) / 3.0 * 100 AS DECIMAL(18, 8)) AS "Catalog Return Share",
-  CAST(SUM("composite_01"."Web Returns Quantity") * 1.0 / (
-    SUM("composite_01"."Store Returns Quantity") + SUM("composite_01"."Catalog Returns Quantity") + SUM("composite_01"."Web Returns Quantity")
+  CAST(SUM("composite_01"."Web Returns Quantity") * 1.0 / NULLIF(
+    SUM("composite_01"."Store Returns Quantity") + SUM("composite_01"."Catalog Returns Quantity") + SUM("composite_01"."Web Returns Quantity"),
+    0
   ) / 3.0 * 100 AS DECIMAL(18, 8)) AS "Web Return Share",
   CAST((
     SUM("composite_01"."Store Returns Quantity") + SUM("composite_01"."Catalog Returns Quantity") + SUM("composite_01"."Web Returns Quantity")

--- a/examples/tpcds_queries/sql/duckdb/Q90.sql
+++ b/examples/tpcds_queries/sql/duckdb/Q90.sql
@@ -9,13 +9,16 @@ SELECT
       AND "Web Page"."wp_char_count" BETWEEN 5000 AND 5200
       THEN "Web Sales"."ws_order_number"
     END
-  ) / COUNT(
-    CASE
-      WHEN "Time"."t_hour" BETWEEN 19 AND 20
-      AND "Household Demographics"."hd_dep_count" = 6
-      AND "Web Page"."wp_char_count" BETWEEN 5000 AND 5200
-      THEN "Web Sales"."ws_order_number"
-    END
+  ) / NULLIF(
+    COUNT(
+      CASE
+        WHEN "Time"."t_hour" BETWEEN 19 AND 20
+        AND "Household Demographics"."hd_dep_count" = 6
+        AND "Web Page"."wp_char_count" BETWEEN 5000 AND 5200
+        THEN "Web Sales"."ws_order_number"
+      END
+    ),
+    0
   ) AS DECIMAL(18, 6)) AS "am_pm_ratio"
 FROM "main"."web_sales" AS "Web Sales"
 LEFT JOIN "main"."household_demographics" AS "Household Demographics"

--- a/examples/tpcds_queries/sql/duckdb/Q98.sql
+++ b/examples/tpcds_queries/sql/duckdb/Q98.sql
@@ -27,7 +27,7 @@ SELECT
   "Class" AS "Class",
   "Current Price" AS "Current Price",
   "Store Sales Amount" AS "Store Sales Amount",
-  "Store Sales Amount" * 100.0 / SUM("Class Revenue") OVER (PARTITION BY "Class") AS "Revenue Ratio"
+  "Store Sales Amount" * 100.0 / NULLIF(SUM("Class Revenue") OVER (PARTITION BY "Class"), 0) AS "Revenue Ratio"
 FROM "base" AS "base"
 ORDER BY
   "Category" ASC,

--- a/examples/tpcds_queries/sweep.py
+++ b/examples/tpcds_queries/sweep.py
@@ -21,9 +21,12 @@ Reference SQL comes from REF_DIR below.
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import re
 import sys
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from decimal import Decimal
 from pathlib import Path
 
@@ -185,6 +188,17 @@ class ClickHouseEngine:
             username=os.environ.get("CLICKHOUSE_USERNAME", "default"),
             password=os.environ.get("CLICKHOUSE_PASSWORD", ""),
             database="tpcds",
+            # sf=10 with the reference query running beside ours: minutes, not
+            # seconds. The default client timeout gives up long before that and
+            # the sweep counts it as a mismatch.
+            send_receive_timeout=3600,
+            # No session id. The client otherwise generates one and pins every
+            # query to it, and the server refuses a second query while the
+            # first is still running on that session - which is what the heavy
+            # tail of this sweep does. It surfaced as SESSION_IS_LOCKED on the
+            # eight queries after Q83 and was counted as eight result
+            # mismatches, which is a far more alarming thing than it was.
+            autogenerate_session_id=False,
         )
 
     def run(self, sql: str):
@@ -201,6 +215,18 @@ class ClickHouseEngine:
 
 ENGINES = {"duckdb": DuckDBEngine, "clickhouse": ClickHouseEngine}
 
+#: How many queries to run at once, per engine. Not one number, because the two
+#: engines are limited by different things.
+#:
+#: DuckDB reads a local file at sf=1 and the whole sweep is a few seconds of
+#: work, so it takes whatever concurrency the machine has.
+#:
+#: ClickHouse at sf=10 is **memory**-bound in its tail, not CPU-bound. Measured
+#: on one local server: three of the heavy queries in flight together asked for
+#: 25 GB, spilled, and Q69 - a few minutes on its own - took 52. Concurrency
+#: there makes the sweep slower, not faster, so it runs one at a time.
+DEFAULT_JOBS = {"duckdb": 8, "clickhouse": 1}
+
 
 # ---------------------------------------------------------------------- comparison
 
@@ -215,7 +241,14 @@ def norm(v, nd=2):
     return str(v).strip()
 
 
-def diff(got_cols, got_rows, ref_cols, ref_rows, keep_got=None, keep_ref=None, nd=2) -> bool:
+def diff(got_cols, got_rows, ref_cols, ref_rows, keep_got=None, keep_ref=None, nd=2) -> dict:
+    """Compare two result sets and return a verdict.
+
+    Returns rather than prints, because the sweep runs its queries concurrently
+    and interleaved output belongs to no query in particular. The caller writes
+    each verdict to its own file.
+    """
+
     def project(rows, keep):
         idx = keep if keep is not None else range(len(rows[0]) if rows else 0)
         return sorted(
@@ -224,19 +257,22 @@ def diff(got_cols, got_rows, ref_cols, ref_rows, keep_got=None, keep_ref=None, n
         )
 
     g, r = project(got_rows, keep_got), project(ref_rows, keep_ref)
-    print(f"  got {len(g):>6} rows x {len(got_cols)} cols")
-    print(f"  ref {len(r):>6} rows x {len(ref_cols)} cols")
-    if g == r:
-        print("  ✅ EXACT MATCH")
-        return True
-    print("  ❌ DIFF")
+    verdict = {
+        "match": g == r,
+        "got_rows": len(g),
+        "got_cols": len(got_cols),
+        "ref_rows": len(r),
+        "ref_cols": len(ref_cols),
+    }
+    if verdict["match"]:
+        return verdict
     for i, (a, b) in enumerate(zip(g, r, strict=False)):
         if a != b:
-            print(f"   row {i}:\n     got {a}\n     ref {b}")
+            verdict["first_diff"] = {"row": i, "got": list(a), "ref": list(b)}
             break
     if len(g) != len(r):
-        print(f"   row count differs: {len(g)} vs {len(r)}")
-    return False
+        verdict["row_count_differs"] = [len(g), len(r)]
+    return verdict
 
 
 def strip_limit(sql: str) -> str:
@@ -279,6 +315,62 @@ def dump_sql(labels: list[str], dialect: str) -> int:
 # --------------------------------------------------------------------------- main
 
 
+RESULTS = HERE / "results"
+
+
+def run_one(label: str, dialect: str) -> dict:
+    """Compile, execute and compare one query, on a connection of its own.
+
+    One engine per query rather than one per sweep. That is what makes the run
+    parallel, and it also removes the failure that made this worth doing: the
+    ClickHouse client pins every query to one session, and the server refuses a
+    second query while the first is still running on it. Eight queries after the
+    heavy Q83 came back SESSION_IS_LOCKED and were counted as eight result
+    mismatches.
+    """
+    started = time.monotonic()
+    engine = ENGINES[dialect]()
+    try:
+        unlimited = label not in PARTIAL and CASES[label][3]
+        sql = compile_query(label, dialect, drop_limit=unlimited)
+        got = engine.run(sql)
+        ref_text = engine.reference(label)
+        if label in PARTIAL:
+            kg, kr, nd = PARTIAL[label]
+            end = min(i for i in (ref_text.find(") AS tmp1"), ref_text.find(") tmp1")) if i > 0)
+            start = re.search(r"\(\s*SELECT", ref_text).start() + 1
+            ref = engine.run(ref_text[start:end])
+        else:
+            kg, kr, nd, _ = CASES[label]
+            ref = engine.run(strip_limit(ref_text) if unlimited else ref_text)
+        verdict = diff(*got, *ref, keep_got=kg, keep_ref=kr, nd=nd)
+    except Exception as e:  # noqa: BLE001
+        verdict = {"match": False, "error": f"{type(e).__name__}: {str(e)[:300]}"}
+    finally:
+        engine.close()
+    verdict |= {"query": label, "dialect": dialect, "seconds": round(time.monotonic() - started, 1)}
+    return verdict
+
+
+def run_sweep(labels: list[str], dialect: str, jobs: int) -> tuple[list[str], list[str]]:
+    """Run every query concurrently, writing one result file each."""
+    out = RESULTS / dialect
+    out.mkdir(parents=True, exist_ok=True)
+    ok: list[str] = []
+    bad: list[str] = []
+    with ThreadPoolExecutor(max_workers=jobs) as pool:
+        futures = {pool.submit(run_one, label, dialect): label for label in labels}
+        for future in as_completed(futures):
+            v = future.result()
+            label = v["query"]
+            (out / f"{label}.json").write_text(json.dumps(v, indent=1, default=str) + "\n")
+            (ok if v["match"] else bad).append(label)
+            mark = "OK  " if v["match"] else "DIFF"
+            detail = v.get("error") or f'{v.get("got_rows")} vs {v.get("ref_rows")} rows'
+            print(f"  {mark} {label:<5} {v['seconds']:>6.1f}s  {detail}", flush=True)
+    return sorted(ok), sorted(bad)
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("labels", nargs="*", help="e.g. Q98 Q63 (default: all)")
@@ -288,6 +380,15 @@ def main() -> int:
         "--dump",
         action="store_true",
         help="write compiled SQL to sql/<dialect>/<label>.sql and stop (no database needed)",
+    )
+    ap.add_argument(
+        "--jobs",
+        type=int,
+        default=None,
+        help=(
+            "queries to run concurrently, each on its own connection. Defaults "
+            f"per engine ({DEFAULT_JOBS}); see the note there before raising it"
+        ),
     )
     args = ap.parse_args()
 
@@ -301,31 +402,8 @@ def main() -> int:
     if args.dump:
         return dump_sql(wanted, args.dialect)
 
-    engine = ENGINES[args.dialect]()
-    ok, bad = [], []
-    try:
-        for label in wanted:
-            print(f"===== {label}" + (" (inner aggregate block only)" if label in PARTIAL else ""))
-            try:
-                unlimited = label not in PARTIAL and CASES[label][3]
-                got = engine.run(compile_query(label, args.dialect, drop_limit=unlimited))
-                ref_text = engine.reference(label)
-                if label in PARTIAL:
-                    kg, kr, nd = PARTIAL[label]
-                    end = min(
-                        i for i in (ref_text.find(") AS tmp1"), ref_text.find(") tmp1")) if i > 0
-                    )
-                    start = re.search(r"\(\s*SELECT", ref_text).start() + 1
-                    ref = engine.run(ref_text[start:end])
-                else:
-                    kg, kr, nd, _ = CASES[label]
-                    ref = engine.run(strip_limit(ref_text) if unlimited else ref_text)
-                (ok if diff(*got, *ref, keep_got=kg, keep_ref=kr, nd=nd) else bad).append(label)
-            except Exception as e:  # noqa: BLE001
-                print(f"  ERROR {type(e).__name__}: {str(e)[:200]}")
-                bad.append(label)
-    finally:
-        engine.close()
+    jobs = args.jobs or DEFAULT_JOBS.get(args.dialect, 4)
+    ok, bad = run_sweep(wanted, args.dialect, jobs)
 
     expected = EXPECTED_DIFF.get(args.dialect, set())
     known = [label for label in bad if label in expected]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -156,6 +156,7 @@ nav:
       - Multi-Dialect Output: examples/multi-dialect.md
       - "Multi-Fact: Sales & Returns": examples/multi-fact.md
       - TPC-DS Benchmark: examples/tpcds.md
+      - "TPC-DS: Verified Results": examples/tpcds-sweep.md
       - "FinOps on FOCUS": examples/finops-focus.md
   - Comparison:
       - Overview: comparison/index.md


### PR DESCRIPTION
The TPC-DS findings lived in a 532-line running log in `examples/`, and most of it had gone stale. This re-runs the sweep, publishes the findings as a docs page, and fixes what the re-run exposed.

## Results, re-run rather than restated

| Engine | Scale | Exact | Known reference-variant | Unexplained |
|---|---|---|---|---|
| DuckDB | sf=1 | **39 / 40** | Q99 | none |
| ClickHouse | sf=10 | **37 / 40** | Q20, Q40, Q98 | none |

All 80 comparisons are accounted for. The previous report said 29/30 on DuckDB.

Most of the distance is one fix: a `HAVING` on a value produced by a window wrapper used to compile *inside* the CTE, against the pre-window aggregate, and silently returned the wrong rows. **All five compiler gaps the old report recorded as open are now fixed** — I verified each one rather than assuming. Q19, Q53, Q63, Q65, Q68, Q72 and Q83 were blocked or partial then and match exactly now.

## The page leads with the methodology

Because "we ran TPC-DS" can mean almost anything, and the answer is the interesting part:

- OBSL's SQL and the benchmark's own reference SQL run **against the same tables in the same engine in the same run**. No cross-engine or cross-scale comparison anywhere.
- DuckDB's reference is its own `tpcds` extension (`tpcds_queries()`); ClickHouse's is the ClickHouse-adapted set.
- Every cell of every row is compared after sorting. What is normalised is listed explicitly; nothing else is.

## Two harness bugs that were faking failures

Both reported as wrong answers, which is the worst way for a harness to be broken:

1. **`SESSION_IS_LOCKED`** — the ClickHouse client pinned every query to one session, so everything after the heavy Q83 was refused. Counted as 8 mismatches.
2. **Client timeout** — the default gave up on long sf=10 queries. Counted as 2 more.

## Per-query result files, and per-engine concurrency

Each query now runs on its own connection and writes `results/<dialect>/<label>.json` — verdict, row counts, first differing row, timing. That is what made the above diagnosable.

Concurrency now defaults **per engine**, and the difference is not small:

- **DuckDB: 8.** 105s of query work, ~4s of wall time.
- **ClickHouse: 1.** At sf=10 the tail is memory-bound, not CPU-bound. Three heavy queries in flight together asked for **25 GB** on one server, spilled, and turned Q69 from a few minutes into **52**. Concurrency there makes the sweep slower.

## Also

- **The rendered SQL drift**: 22 files regenerated, entirely the division-by-zero `NULLIF` guard, which the snapshots predated. No result changed.
- **`examples/tpcds.obml.yml`**: drops the last measure wrapping a single column in an `expression:`. Byte-identical SQL on every query and every dialect (checked on DuckDB and ClickHouse), and it leaves one canonical form for a simple measure instead of two.
- **README**: the shortened head, with the sweep numbers corrected to the measured ones and the SQL example fixed — it was a ClickHouse render shown under a `-d duckdb` command line, so the schema was wrong.
- `REPORT.md` is an 18-line pointer instead of a stale duplicate.

## Checks

`mkdocs build --strict` clean. The sweep re-runs green on DuckDB after the defaults change.
