### PR TITLE
fix(examples): read a ClickHouse FixedString by value, not by storage

### DIFF
--- a/examples/tpcds_queries/sweep.py
+++ b/examples/tpcds_queries/sweep.py
@@ -238,7 +238,16 @@ def norm(v, nd=2):
         return v
     if isinstance(v, (int, float, Decimal)):
         return round(float(v), nd)
-    return str(v).strip()
+    if isinstance(v, (bytes, bytearray)):
+        # ClickHouse's TPC-DS schema types the CHAR columns as FixedString(N),
+        # which arrives NUL-padded as bytes: i_class comes back as
+        # b'travel\x00\x00...' for 44 more bytes. Left alone it renders as a
+        # Python repr, which makes first_diff unreadable, and it compares by
+        # *storage* rather than by value - the same 'travel' read as a String,
+        # which is what a CAST or a function wrapper would produce, would not
+        # match the FixedString the reference query returns.
+        v = bytes(v).decode("utf-8", "replace")
+    return str(v).rstrip("\x00").strip()
 
 
 def diff(got_cols, got_rows, ref_cols, ref_rows, keep_got=None, keep_ref=None, nd=2) -> dict:


### PR DESCRIPTION
ClickHouse's TPC-DS schema types the CHAR columns as `FixedString(N)`, so `i_item_id`, `i_class` and `i_category` arrive NUL-padded as bytes. `norm()` in the sweep had no branch for them and fell through to `str(v)`, which renders the Python repr.

Every text column in a `first_diff` read like this:

```
col2  same  got=b'Books\x00\x00\x00\x00\x00\x00\x00\x00\x00...'   ref=b'Books\x00\x00\x00...'
col3  same  got=b'travel\x00\x00\x00\x00\x00\x00\x00\x00...'      ref=b'travel\x00\x00\x00...'
col6  DIFF  got=0.43                                  ref=0.42
```

Q98's actual difference, one ratio column, was buried in 44 bytes of padding per column.

## Beyond legibility

This compared by **storage** rather than by value. The same `travel` arriving as a `String`, which is what a CAST or a function wrapper produces, does not equal the `FixedString` the reference query returns, so a query would have been reported as mismatching on identical values. Nothing hits that today, both sides reading the columns unwrapped, but it was a live trap for any future query that wraps one of those columns.

## After

```
col2  same  got=Books    ref=Books
col3  same  got=travel   ref=travel
col6  DIFF  got=0.43     ref=0.42
```

## Verdicts unchanged

Bytes are decoded and the padding stripped. Verdicts can only ever move toward match, since both sides pass through the same normaliser and this can make values equal that were not, never the reverse.

- DuckDB: still 39 of 40, with Q99 the known reference variant
- ClickHouse: still reports Q20, Q40 and Q98 as the three known reference variants

Both re-run to confirm. `examples/tpcds_queries/results/` is gitignored, so no published output changes.