### PR TITLE
fix(duckdb): prefer the Arrow fetch on the native DuckDB path

### DIFF
--- a/src/orionbelt/api/query_cache.py
+++ b/src/orionbelt/api/query_cache.py
@@ -259,9 +259,18 @@ async def try_cache_set(
     ttl_seconds: int,
     datasource: str,
     model_id: str,
-    schema: Any = None,
+    schema: Any,
 ) -> None:
     """Encode and store the row data + column schema. Failures are logged.
+
+    ``schema`` is the executor's driver Arrow schema
+    (``ExecutionResult.arrow_schema``), or ``None`` when the result came from
+    a PEP 249 driver that has none. It is **required, not defaulted**: rows
+    alone cannot type an empty or all-null column, so a writer that omits it
+    silently stores an Arrow ``null`` column that a raw ``format=arrow`` hit
+    then serves verbatim against numeric column metadata. Making callers pass
+    it explicitly turns that omission into a signature error instead of a
+    payload that contradicts its own envelope.
 
     Only the row data (blob) and the result's column schema + row count (entry
     sidecar) are cached; the response envelope (sql, explain, timing, ``cached``

--- a/src/orionbelt/api/query_cache.py
+++ b/src/orionbelt/api/query_cache.py
@@ -259,6 +259,7 @@ async def try_cache_set(
     ttl_seconds: int,
     datasource: str,
     model_id: str,
+    schema: Any = None,
 ) -> None:
     """Encode and store the row data + column schema. Failures are logged.
 
@@ -274,7 +275,7 @@ async def try_cache_set(
     from orionbelt.cache import key as cache_key_mod
 
     try:
-        payload = encode_data([c.name for c in columns], rows)
+        payload = encode_data([c.name for c in columns], rows, schema)
     except Exception:
         logger.debug("cache encode failed", exc_info=True)
         return
@@ -416,6 +417,10 @@ async def execute_query_with_cache(
         override_db_tz=override_db_tz,
     )
     columns = build_result_columns(model, exec_result)
+    # Read before ``rows`` is touched below; ``arrow_schema`` is captured at
+    # construction so this is safe regardless, but keeping it explicit
+    # documents that the encoders want the driver's declared types.
+    arrow_schema = exec_result.arrow_schema
 
     if (
         cacheable
@@ -435,6 +440,7 @@ async def execute_query_with_cache(
             ttl_seconds=ttl_outcome.ttl.seconds,
             datasource=ds,
             model_id=model_id,
+            schema=arrow_schema,
         )
 
     return CachedExecution(

--- a/src/orionbelt/api/routers/oneshot.py
+++ b/src/orionbelt/api/routers/oneshot.py
@@ -437,6 +437,7 @@ async def _run_query(
                 model_id=model_id,
                 dialect=dialect,
                 physical_tables=physical_tables,
+                schema=exec_result.arrow_schema,
             )
         elif ttl_outcome.no_cache_reason is not None:
             ttl_source = (
@@ -672,8 +673,16 @@ async def _try_oneshot_cache_set(
     model_id: str,
     dialect: str,
     physical_tables: list[str],
+    schema: Any = None,
 ) -> None:
-    """Best-effort cache set for oneshot batch entries (row data only)."""
+    """Best-effort cache set for oneshot batch entries (row data only).
+
+    ``schema`` is the executor's driver Arrow schema. The envelope has
+    already reduced the result to JSON rows, so without it an empty or
+    all-null column would be stored as Arrow ``null`` — and this writer
+    populates the *shared* cache, so a later raw ``format=arrow`` hit would
+    serve that blob verbatim against numeric column metadata.
+    """
     await try_cache_set(
         cache=cache,
         key=key,
@@ -686,4 +695,5 @@ async def _try_oneshot_cache_set(
         ttl_seconds=ttl_seconds,
         datasource=datasource,
         model_id=model_id,
+        schema=schema,
     )

--- a/src/orionbelt/api/services/query_execution.py
+++ b/src/orionbelt/api/services/query_execution.py
@@ -170,6 +170,7 @@ def _render_response(
     timezone: str | None,
     cached: bool = False,
     cached_at: str | None = None,
+    arrow_schema: Any = None,
 ) -> QueryExecuteResponse | Response:
     """Render already-resolved columns + RAW rows into the requested surface.
 
@@ -206,7 +207,13 @@ def _render_response(
             ]
         else:
             arrow_rows = rows
-        gzipped_data = result_codec.encode_data(column_names, arrow_rows)
+        # ``arrow_schema`` keeps an empty / all-null column from decoding as
+        # ``null`` while the envelope's column metadata calls it numeric. It
+        # is irrelevant under format_values, where every cell is a display
+        # string by construction.
+        gzipped_data = result_codec.encode_data(
+            column_names, arrow_rows, None if format_values else arrow_schema
+        )
         meta = _arrow_envelope_dict(
             columns_meta=columns_meta,
             sql=sql,
@@ -345,6 +352,7 @@ def _build_execute_response(
         accept_encoding=accept_encoding,
         columns_meta=columns_meta,
         rows=exec_result.rows,
+        arrow_schema=exec_result.arrow_schema,
         fmt_map=fmt_map,
         type_map=type_map,
         sql=format_sql(compile_result.sql, compile_result.dialect),

--- a/src/orionbelt/cache/result_codec.py
+++ b/src/orionbelt/cache/result_codec.py
@@ -23,6 +23,7 @@ Two deliberate choices, both measured in the plan:
 
 from __future__ import annotations
 
+import contextlib
 import gzip
 from typing import Any
 
@@ -37,13 +38,50 @@ _GZIP_LEVEL = 6
 _MAX_CHUNKSIZE = 100_000
 
 
-def build_result_table(column_names: list[str], rows: list[list[Any]]) -> Any:
+def _serialized_field_type(arrow_type: Any) -> Any:
+    """The Arrow type a column has *after* the executor serialises its cells.
+
+    ``encode_data`` is handed rows that already went through
+    ``_serialize_value``: temporals become ISO strings, binary becomes base64,
+    intervals become ``str(timedelta)``. Numerics, booleans, strings and
+    ``Decimal`` pass through untouched. This maps a driver's Arrow type onto
+    the type its *serialised* values carry, so a hint derived from the
+    executor's schema agrees with what a non-empty result would infer.
+    """
+    import pyarrow as pa
+
+    try:
+        if (
+            pa.types.is_integer(arrow_type)
+            or pa.types.is_floating(arrow_type)
+            or pa.types.is_boolean(arrow_type)
+            or pa.types.is_decimal(arrow_type)
+        ):
+            return arrow_type
+    except (AttributeError, TypeError):
+        return pa.string()
+    return pa.string()
+
+
+def build_result_table(column_names: list[str], rows: list[list[Any]], schema: Any = None) -> Any:
     """Build a pyarrow Table from result column names + list-of-lists rows.
 
     Rows are padded to the column arity and transposed into columns. Types are
     inferred by pyarrow from the (already JSON-serializable) cell values — the
     same typed, locale-neutral shape the executor produces, so a cached entry
     and a fresh execution serialize identically.
+
+    ``schema`` is an optional *driver* Arrow schema (from ``ExecutionResult``)
+    used **only** to rescue columns inference would otherwise type as ``null``:
+    an empty result, or one whose every cell is NULL. Without it, a
+    ``SELECT 1::BIGINT AS n WHERE false`` blob decodes as ``n: null`` while the
+    envelope's sidecar says the column is numeric — one payload contradicting
+    itself, and a raw-arrow cache hit serves that blob verbatim.
+
+    Deliberately narrow: a column whose inferred type is already concrete keeps
+    it, so no existing value representation can change. Types are matched by
+    position, since the caller's ``column_names`` are the model-decorated names
+    for the same columns in the same order.
     """
     import pyarrow as pa
 
@@ -57,7 +95,20 @@ def build_result_table(column_names: list[str], rows: list[list[Any]]) -> Any:
         ]
     else:
         cols_data = [[] for _ in column_names]
-    arrays = [pa.array(col, from_pandas=False) for col in cols_data]
+
+    hints: list[Any] = []
+    if schema is not None and len(schema) == width:
+        hints = [_serialized_field_type(f.type) for f in schema]
+
+    arrays = []
+    for i, col in enumerate(cols_data):
+        arr = pa.array(col, from_pandas=False)
+        if hints and pa.types.is_null(arr.type) and not pa.types.is_null(hints[i]):
+            # Every cell is NULL (or there are none), so re-typing cannot alter
+            # a value — but it does keep the declared type visible to clients.
+            with contextlib.suppress(pa.ArrowInvalid, pa.ArrowTypeError, TypeError, ValueError):
+                arr = pa.array(col, type=hints[i], from_pandas=False)
+        arrays.append(arr)
     return pa.Table.from_arrays(arrays, names=list(column_names))
 
 
@@ -80,16 +131,18 @@ def to_ipc_stream(table: Any) -> bytes:
     return raw
 
 
-def encode_data(column_names: list[str], rows: list[list[Any]]) -> bytes:
+def encode_data(column_names: list[str], rows: list[list[Any]], schema: Any = None) -> bytes:
     """Serialize row data as a gzip'd Arrow IPC stream blob (data only).
 
     No response envelope is baked in — the blob is a pure Arrow data stream. The
     caller stores this in the cache; metadata is rebuilt fresh on every read.
     Types are inferred from the row values (see :func:`build_result_table`); a
     caller that already holds a fully-typed table should use
-    :func:`encode_table` instead to preserve the exact schema.
+    :func:`encode_table` instead to preserve the exact schema. ``schema`` is
+    the executor's driver Arrow schema, used only to keep empty / all-null
+    columns from decoding as ``null``.
     """
-    table = build_result_table(column_names, rows)
+    table = build_result_table(column_names, rows, schema)
     return gzip.compress(to_ipc_stream(table), _GZIP_LEVEL)
 
 

--- a/src/orionbelt/pgwire/catalog.py
+++ b/src/orionbelt/pgwire/catalog.py
@@ -1215,6 +1215,14 @@ def _duckdb_desc_to_hint(description_row: tuple[Any, ...]) -> str:
         # a DECIMAL model column agrees with information_schema.columns and the
         # query result's RowDescription (issue #116).
         return "decimal"
+    if "interval" in name:
+        # Must precede the numeric check: "interval" contains "int", so the
+        # substring match below classified a duration as a number and
+        # advertised OID_FLOAT8 for it. "datetime" is the bucket the rest of
+        # the codebase puts intervals in — ``db_executor._duckdb_type_hint``,
+        # ``_arrow_type_to_hint`` and ADBC's ``coarse_hint_from_type_name``
+        # all agree on it.
+        return "datetime"
     if any(token in name for token in ("int", "float", "double", "real")):
         return "number"
     if any(token in name for token in ("timestamp", "date", "time")):

--- a/src/orionbelt/service/db_executor.py
+++ b/src/orionbelt/service/db_executor.py
@@ -701,6 +701,16 @@ def _execute_duckdb(
 
     Uses the native ``duckdb`` package with ``read_only=True`` to avoid
     cross-process file lock conflicts with the notebook process.
+
+    Prefers an Arrow-native fetch, like :func:`_fetch_result` does for the
+    pooled drivers. DuckDB already holds the result columnar, so
+    ``fetchall()`` builds a Python object per cell only for
+    ``ExecutionResult`` to hand most callers back to Arrow — and the
+    round trip *re-infers* types, which collapses an empty or all-null
+    ``int64`` column to ``null``. Carrying the table through preserves the
+    exact schema and defers row materialisation to
+    ``ExecutionResult.rows``. Falls back to the PEP 249 path when
+    :func:`_try_fetch_arrow` declines (pyarrow not loaded).
     """
     import duckdb
 
@@ -714,6 +724,26 @@ def _execute_duckdb(
             db_tz = _detect_db_timezone(conn, "duckdb")
             effective_tz = db_tz or tz
         result = conn.execute(sql)
+
+        arrow_table = _try_fetch_arrow(result)
+        if arrow_table is not None:
+            arrow_columns = [
+                ColumnMeta(
+                    name=f.name,
+                    type_hint=_arrow_type_to_hint(f.type),
+                    default_format=_default_format_for_arrow_type(f.type),
+                )
+                for f in arrow_table.schema
+            ]
+            elapsed_ms = (time.monotonic() - t0) * 1000
+            return ExecutionResult(
+                columns=arrow_columns,
+                arrow_table=arrow_table,
+                row_count=arrow_table.num_rows,
+                execution_time_ms=round(elapsed_ms, 2),
+                tz=effective_tz,
+            )
+
         rows_raw = result.fetchall()
         desc = result.description or []
         columns = [

--- a/src/orionbelt/service/db_executor.py
+++ b/src/orionbelt/service/db_executor.py
@@ -291,6 +291,19 @@ def _arrow_type_to_hint(arrow_type: Any) -> str:
             pa.types.is_timestamp(arrow_type)
             or pa.types.is_date(arrow_type)
             or pa.types.is_time(arrow_type)
+            # DuckDB hands an INTERVAL back as month_day_nano_interval, and a
+            # duration column as duration[unit]. Neither is a point in time,
+            # but "datetime" is the bucket this codebase already puts
+            # intervals in: ``_duckdb_type_hint`` classifies INTERVAL that
+            # way, and ADBC's Postgres driver reaches the same answer via
+            # ``coarse_hint_from_type_name("interval")`` (see
+            # ``test_opaque_interval_maps_to_datetime``). Without these two
+            # branches the same interval column would be "datetime" on the
+            # PEP 249 path and "string" on the Arrow path, so a client would
+            # see a different Postgres OID depending only on whether pyarrow
+            # happened to be imported.
+            or pa.types.is_interval(arrow_type)
+            or pa.types.is_duration(arrow_type)
         ):
             return "datetime"
         if pa.types.is_binary(arrow_type) or pa.types.is_large_binary(arrow_type):
@@ -689,6 +702,88 @@ def execute_sql(
         raise ExecutionError(f"Database execution failed: {exc}") from exc
 
 
+def _duckdb_fetch_arrow(result: Any) -> Any:
+    """Arrow fetch for a DuckDB result, or ``None``.
+
+    DuckDB deprecated ``fetch_arrow_table()`` in favour of
+    ``to_arrow_table()``; calling the old name emits a
+    ``DeprecationWarning`` on every query. Prefer the new name and fall
+    back to :func:`_try_fetch_arrow` for older ``duckdb`` releases
+    (``pyproject`` allows ``>=1.0``), which also keeps the
+    "pyarrow must already be imported" guard in one place.
+    """
+    import sys
+
+    if "pyarrow" not in sys.modules:
+        return None
+    fetch_fn = getattr(result, "to_arrow_table", None)
+    if fetch_fn is not None:
+        try:
+            return fetch_fn()
+        except Exception:  # noqa: BLE001 — never fail a query on a fetch probe
+            return None
+    return _try_fetch_arrow(result)
+
+
+def duckdb_execution_result(
+    result: Any, t0: float, *, tz: ZoneInfo | None = None
+) -> ExecutionResult:
+    """Build an :class:`ExecutionResult` from an executed DuckDB result.
+
+    Prefers an Arrow-native fetch, like :func:`_fetch_result` does for the
+    pooled drivers. DuckDB already holds the result columnar, so
+    ``fetchall()`` builds a Python object per cell only for
+    ``ExecutionResult`` to hand most callers back to Arrow — and the
+    round trip *re-infers* types, which collapses an empty or all-null
+    ``int64`` column to ``null``. Carrying the table through preserves the
+    exact schema and defers row materialisation to
+    ``ExecutionResult.rows``. Falls back to the PEP 249 path when the
+    Arrow fetch declines (pyarrow not loaded).
+
+    Public (no leading underscore) so integration tests that must run
+    against their own DuckDB connection can share this exact code rather
+    than reimplementing it and silently drifting from production.
+    """
+    arrow_table = _duckdb_fetch_arrow(result)
+    if arrow_table is not None:
+        arrow_columns = [
+            ColumnMeta(
+                name=f.name,
+                type_hint=_arrow_type_to_hint(f.type),
+                default_format=_default_format_for_arrow_type(f.type),
+            )
+            for f in arrow_table.schema
+        ]
+        elapsed_ms = (time.monotonic() - t0) * 1000
+        return ExecutionResult(
+            columns=arrow_columns,
+            arrow_table=arrow_table,
+            row_count=arrow_table.num_rows,
+            execution_time_ms=round(elapsed_ms, 2),
+            tz=tz,
+        )
+
+    rows_raw = result.fetchall()
+    desc = result.description or []
+    columns = [
+        ColumnMeta(
+            name=d[0],
+            type_hint=_duckdb_type_hint(d[1]) if len(d) > 1 else "string",
+            default_format=(_default_format_for_duckdb_type(d[1]) if len(d) > 1 else None),
+        )
+        for d in desc
+    ]
+    rows = [_serialize_row(r, tz) for r in rows_raw]
+    elapsed_ms = (time.monotonic() - t0) * 1000
+    return ExecutionResult(
+        columns=columns,
+        raw_rows=rows,
+        row_count=len(rows),
+        execution_time_ms=round(elapsed_ms, 2),
+        tz=tz,
+    )
+
+
 def _execute_duckdb(
     sql: str,
     creds: dict[str, Any],
@@ -700,17 +795,8 @@ def _execute_duckdb(
     """Execute SQL directly via native duckdb.
 
     Uses the native ``duckdb`` package with ``read_only=True`` to avoid
-    cross-process file lock conflicts with the notebook process.
-
-    Prefers an Arrow-native fetch, like :func:`_fetch_result` does for the
-    pooled drivers. DuckDB already holds the result columnar, so
-    ``fetchall()`` builds a Python object per cell only for
-    ``ExecutionResult`` to hand most callers back to Arrow — and the
-    round trip *re-infers* types, which collapses an empty or all-null
-    ``int64`` column to ``null``. Carrying the table through preserves the
-    exact schema and defers row materialisation to
-    ``ExecutionResult.rows``. Falls back to the PEP 249 path when
-    :func:`_try_fetch_arrow` declines (pyarrow not loaded).
+    cross-process file lock conflicts with the notebook process. Result
+    shaping lives in :func:`duckdb_execution_result`.
     """
     import duckdb
 
@@ -723,46 +809,7 @@ def _execute_duckdb(
         else:
             db_tz = _detect_db_timezone(conn, "duckdb")
             effective_tz = db_tz or tz
-        result = conn.execute(sql)
-
-        arrow_table = _try_fetch_arrow(result)
-        if arrow_table is not None:
-            arrow_columns = [
-                ColumnMeta(
-                    name=f.name,
-                    type_hint=_arrow_type_to_hint(f.type),
-                    default_format=_default_format_for_arrow_type(f.type),
-                )
-                for f in arrow_table.schema
-            ]
-            elapsed_ms = (time.monotonic() - t0) * 1000
-            return ExecutionResult(
-                columns=arrow_columns,
-                arrow_table=arrow_table,
-                row_count=arrow_table.num_rows,
-                execution_time_ms=round(elapsed_ms, 2),
-                tz=effective_tz,
-            )
-
-        rows_raw = result.fetchall()
-        desc = result.description or []
-        columns = [
-            ColumnMeta(
-                name=d[0],
-                type_hint=_duckdb_type_hint(d[1]) if len(d) > 1 else "string",
-                default_format=(_default_format_for_duckdb_type(d[1]) if len(d) > 1 else None),
-            )
-            for d in desc
-        ]
-        rows = [_serialize_row(r, effective_tz) for r in rows_raw]
-        elapsed_ms = (time.monotonic() - t0) * 1000
-        return ExecutionResult(
-            columns=columns,
-            raw_rows=rows,
-            row_count=len(rows),
-            execution_time_ms=round(elapsed_ms, 2),
-            tz=effective_tz,
-        )
+        return duckdb_execution_result(conn.execute(sql), t0, tz=effective_tz)
     finally:
         conn.close()
 

--- a/src/orionbelt/service/db_executor.py
+++ b/src/orionbelt/service/db_executor.py
@@ -83,11 +83,28 @@ class ExecutionResult:
         self._arrow_table = arrow_table
         self._rows = raw_rows
         self._tz = tz
+        # Captured up front, because ``rows`` drops the table to free memory.
+        # Keeping the *schema* costs nothing and lets the response and cache
+        # writers preserve declared types without having to read the table
+        # before anything touches ``rows`` — an ordering hazard that would
+        # otherwise be invisible at the call site.
+        self._arrow_schema = getattr(arrow_table, "schema", None)
 
     @property
     def timezone(self) -> str | None:
         """IANA timezone name used to label naive timestamps, or None."""
         return str(self._tz) if self._tz is not None else None
+
+    @property
+    def arrow_schema(self) -> Any | None:
+        """The driver's Arrow schema, or ``None`` for a PEP 249 result.
+
+        Survives ``rows`` materialisation. Encoders use it so an empty or
+        all-null column keeps its declared type instead of decoding as
+        ``null`` — otherwise a raw-arrow payload contradicts the column
+        metadata in its own envelope.
+        """
+        return self._arrow_schema
 
     @property
     def rows(self) -> list[list[Any]]:

--- a/src/orionbelt/service/db_executor.py
+++ b/src/orionbelt/service/db_executor.py
@@ -15,7 +15,7 @@ import contextlib
 import logging
 import re
 import time
-from datetime import UTC, date, datetime
+from datetime import UTC, date, datetime, timedelta
 from datetime import time as dt_time
 from decimal import Decimal, InvalidOperation
 from typing import Any
@@ -602,6 +602,40 @@ def _is_string_stored_numeric_arrow_type(arrow_type: Any) -> bool:
         return False
 
 
+def _is_interval_arrow_type(arrow_type: Any) -> bool:
+    """True for Arrow interval / duration types."""
+    try:
+        import pyarrow as pa
+
+        return bool(pa.types.is_interval(arrow_type) or pa.types.is_duration(arrow_type))
+    except (AttributeError, TypeError, ImportError):
+        return False
+
+
+def _interval_to_timedelta(val: Any) -> Any:
+    """Normalise an Arrow interval cell to ``timedelta``, as DuckDB does.
+
+    ``month_day_nano_interval`` comes out of ``to_pylist()`` as a
+    ``MonthDayNano`` namedtuple, whose ``str()`` is
+    ``"MonthDayNano(months=0, days=1, nanoseconds=0)"`` — while the PEP 249
+    path returns a ``timedelta`` that serialises to ``"1 day, 0:00:00"``.
+    The same query would then render differently depending only on whether
+    pyarrow was imported.
+
+    DuckDB's own PEP 249 conversion counts a month as 30 days (``INTERVAL 3
+    MONTH`` -> ``timedelta(days=90)``, ``INTERVAL 1 YEAR`` -> 360 days), so
+    reproducing that rule makes the two paths agree exactly. Arrow
+    ``duration`` cells are already ``timedelta`` and pass through.
+    """
+    months = getattr(val, "months", None)
+    if months is None:
+        return val
+    return timedelta(
+        days=months * 30 + val.days,
+        microseconds=val.nanoseconds // 1000,
+    )
+
+
 def _arrow_to_rows(table: Any, tz: ZoneInfo | None = None) -> list[list[Any]]:
     """Convert an Arrow Table to a list of JSON-serializable rows.
 
@@ -618,6 +652,9 @@ def _arrow_to_rows(table: Any, tz: ZoneInfo | None = None) -> list[list[Any]]:
     string_numeric_cols: set[str] = {
         field.name for field in table.schema if _is_string_stored_numeric_arrow_type(field.type)
     }
+    interval_cols: set[str] = {
+        field.name for field in table.schema if _is_interval_arrow_type(field.type)
+    }
 
     result: list[list[Any]] = []
     for i in range(n_rows):
@@ -627,6 +664,8 @@ def _arrow_to_rows(table: Any, tz: ZoneInfo | None = None) -> list[list[Any]]:
             if name in string_numeric_cols and isinstance(val, str):
                 with contextlib.suppress(TypeError, ValueError, InvalidOperation):
                     val = Decimal(val)
+            elif name in interval_cols:
+                val = _interval_to_timedelta(val)
             row.append(_serialize_value(val, tz))
         result.append(row)
     return result

--- a/tests/integration/test_duckdb_execution.py
+++ b/tests/integration/test_duckdb_execution.py
@@ -7,6 +7,7 @@ multi-measure, filtered, total (window), metric, and CFL (multi-fact) queries.
 
 from __future__ import annotations
 
+from decimal import Decimal
 from typing import Any
 from unittest.mock import patch
 
@@ -31,7 +32,7 @@ from orionbelt.models.query import (  # noqa: E402
 from orionbelt.models.semantic import SemanticModel  # noqa: E402
 from orionbelt.parser.loader import TrackedLoader  # noqa: E402
 from orionbelt.parser.resolver import ReferenceResolver  # noqa: E402
-from orionbelt.service.db_executor import ColumnMeta, ExecutionResult  # noqa: E402
+from orionbelt.service.db_executor import ExecutionResult  # noqa: E402
 from orionbelt.service.session_manager import SessionManager  # noqa: E402
 from orionbelt.settings import Settings  # noqa: E402
 from tests.conftest import SALES_MODEL_DIR, SAMPLE_MODEL_YAML  # noqa: E402
@@ -726,46 +727,25 @@ INSERT INTO PUBLIC.ORDERS VALUES
 def _make_execute_sql(conn: duckdb.DuckDBPyConnection):
     """Create a mock execute_sql that uses the test DuckDB connection.
 
-    Mirrors the production duckdb-local path so column metadata (type_hint
-    + default_format) lines up with what the real ``execute_sql`` would
-    produce — keeps integration tests honest about the auto-default
-    pipeline.
+    Delegates result shaping to the production helper
+    (``duckdb_execution_result``) so column metadata and row
+    serialisation are literally the same code the real ``execute_sql``
+    runs. Only the connection differs: these tests must query the
+    fixture's in-memory database rather than one opened from credentials.
+
+    Sharing the helper is deliberate — this mock previously reimplemented
+    the shaping and went stale the moment the production path learned to
+    prefer an Arrow fetch.
     """
 
     import time
-    from decimal import Decimal as _Decimal
 
-    from orionbelt.service.db_executor import (
-        _default_format_for_duckdb_type,
-        _duckdb_type_hint,
-    )
-
-    def _coerce(v: Any) -> Any:
-        return float(v) if isinstance(v, _Decimal) else v
+    from orionbelt.service.db_executor import duckdb_execution_result
 
     def execute_sql(
         sql: str, *, dialect: str, tz: Any = None, override_db_tz: bool = False
     ) -> ExecutionResult:
-        t0 = time.monotonic()
-        result = conn.execute(sql)
-        raw_rows = result.fetchall()
-        desc = result.description or []
-        columns = [
-            ColumnMeta(
-                name=d[0],
-                type_hint=_duckdb_type_hint(d[1]) if len(d) > 1 else "string",
-                default_format=(_default_format_for_duckdb_type(d[1]) if len(d) > 1 else None),
-            )
-            for d in desc
-        ]
-        rows = [[_coerce(v) for v in r] for r in raw_rows]
-        elapsed_ms = (time.monotonic() - t0) * 1000
-        return ExecutionResult(
-            columns=columns,
-            raw_rows=rows,
-            row_count=len(rows),
-            execution_time_ms=round(elapsed_ms, 2),
-        )
+        return duckdb_execution_result(conn.execute(sql), time.monotonic(), tz=tz)
 
     return execute_sql
 
@@ -1005,8 +985,11 @@ class TestAPIExecuteEndpoint:
             col_names = [c["name"] for c in data["columns"]]
             rows_as_dicts = [dict(zip(col_names, row, strict=False)) for row in data["rows"]]
             by_country = {r["Customer Country"]: r for r in rows_as_dicts}
-            assert by_country["US"]["Total Revenue"] == pytest.approx(150.0)
-            assert by_country["UK"]["Total Revenue"] == pytest.approx(75.0)
+            # The REST/JSON surface delivers a DECIMAL measure as an exact
+            # decimal *string*, never a lossy float (see ``_serialize_value``
+            # and ``api.schemas.ColumnMetadata.type``, issue #136).
+            assert Decimal(by_country["US"]["Total Revenue"]) == Decimal("150.00")
+            assert Decimal(by_country["UK"]["Total Revenue"]) == Decimal("75.00")
         finally:
             reset_session_manager()
 
@@ -1318,7 +1301,15 @@ class TestAPIExecuteEndpoint:
             env, table = _split_result_frame(arrow_resp.content)
             data = json_resp.json()
             assert table.column_names == [c["name"] for c in data["columns"]]
-            assert table.to_pylist() == [
+
+            # Same values, deliberately different encodings: Arrow carries a
+            # DECIMAL measure as decimal128 (``Decimal``), JSON as an exact
+            # decimal string. Normalise before comparing rather than assert
+            # one surface uses the other's representation.
+            def _norm(v: Any) -> Any:
+                return str(v) if isinstance(v, Decimal) else v
+
+            assert [{k: _norm(v) for k, v in r.items()} for r in table.to_pylist()] == [
                 dict(zip(table.column_names, row, strict=True)) for row in data["rows"]
             ]
             assert env["sql"] == data["sql"]
@@ -1380,8 +1371,10 @@ class TestAPIExecuteEndpoint:
 
             raw_rev = raw_tbl.column("Total Revenue").to_pylist()
             fmt_rev = fmt_tbl.column("Total Revenue").to_pylist()
-            # Raw arrow ships typed numeric values (UI round trip formats client-side).
-            assert all(isinstance(v, (int, float)) for v in raw_rev if v is not None)
+            # Raw arrow ships typed numeric values (UI round trip formats
+            # client-side). A DECIMAL measure arrives as decimal128, so the
+            # Python value is ``Decimal`` -- exact by design, not a float.
+            assert all(isinstance(v, (int, float, Decimal)) for v in raw_rev if v is not None)
             # format_values bakes locale-aware display strings into the data,
             # exactly as the shared value_formatting helper would render them.
             from orionbelt.service.value_formatting import format_number

--- a/tests/integration/test_duckdb_execution.py
+++ b/tests/integration/test_duckdb_execution.py
@@ -227,6 +227,12 @@ def pipeline() -> CompilationPipeline:
     return CompilationPipeline()
 
 
+def pa_types_is_null(t) -> bool:
+    import pyarrow as pa
+
+    return bool(pa.types.is_null(t))
+
+
 def _split_result_frame(content: bytes):
     """Split the ``format=arrow`` result frame into (json envelope, arrow table).
 
@@ -1316,6 +1322,64 @@ class TestAPIExecuteEndpoint:
             assert env["dialect"] == data["dialect"]
             assert env["columns"] == data["columns"]
             assert env["row_count"] == data["row_count"]
+        finally:
+            reset_session_manager()
+
+    async def test_execute_format_arrow_empty_result_keeps_declared_types(
+        self, api_duckdb: duckdb.DuckDBPyConnection
+    ) -> None:
+        """An empty result must not decode as null-typed Arrow columns.
+
+        The blob is type-inferred from row values, so a zero-row result had
+        every column come back as ``null`` while the envelope's column
+        metadata still described them as numeric -- one payload contradicting
+        itself, and a raw-arrow cache hit serves that blob verbatim. The
+        executor's Arrow schema now rescues exactly those columns.
+        """
+        pytest.importorskip("pyarrow", reason="pyarrow required for arrow format")
+        settings = Settings(session_ttl_seconds=3600, session_cleanup_interval=9999)
+        app = create_app(settings=settings)
+        mgr = SessionManager(
+            ttl_seconds=settings.session_ttl_seconds,
+            cleanup_interval=settings.session_cleanup_interval,
+        )
+        init_session_manager(mgr, query_execute_enabled=True, db_vendor="duckdb")
+        try:
+            mock_exec = _make_execute_sql(api_duckdb)
+            body = {
+                "model_id": None,
+                "query": {
+                    "select": {
+                        "dimensions": ["Customer Country"],
+                        "measures": ["Total Revenue"],
+                    },
+                    # No country matches, so the result is empty.
+                    "where": [{"field": "Customer Country", "op": "equals", "value": "__none__"}],
+                },
+                "dialect": "duckdb",
+            }
+            with patch("orionbelt.api.query_cache.execute_sql", mock_exec):
+                transport = ASGITransport(app=app)
+                async with AsyncClient(transport=transport, base_url="http://test") as c:
+                    sid = (await c.post("/v1/sessions")).json()["session_id"]
+                    mid = (
+                        await c.post(
+                            f"/v1/sessions/{sid}/models",
+                            json={"model_yaml": SAMPLE_MODEL_YAML},
+                        )
+                    ).json()["model_id"]
+                    body["model_id"] = mid
+                    resp = await c.post(f"/v1/sessions/{sid}/query/execute?format=arrow", json=body)
+
+            assert resp.status_code == 200, resp.text
+            env, table = _split_result_frame(resp.content)
+            assert table.num_rows == 0
+            assert env["row_count"] == 0
+            # The blob's schema must agree with the envelope, not collapse to null.
+            assert [f.name for f in table.schema] == [c["name"] for c in env["columns"]]
+            assert not any(pa_types_is_null(f.type) for f in table.schema), [
+                (f.name, str(f.type)) for f in table.schema
+            ]
         finally:
             reset_session_manager()
 

--- a/tests/integration/test_oneshot_batch.py
+++ b/tests/integration/test_oneshot_batch.py
@@ -403,3 +403,79 @@ class TestOneshotBatchSettings:
             w["code"] == "MAX_PARALLELISM_CAPPED" or "max_parallelism reduced" in w["message"]
             for w in data["batch_warnings"]
         )
+
+
+# ---------------------------------------------------------------------------
+# Cache writes preserve declared Arrow types
+# ---------------------------------------------------------------------------
+
+
+class _CapturingCache:
+    """Minimal Cache stand-in that records the payload it was handed."""
+
+    def __init__(self) -> None:
+        self.payload: bytes | None = None
+
+    async def set(self, key: str, payload: bytes, **kwargs: object) -> None:  # noqa: ARG002
+        self.payload = payload
+
+
+class TestOneshotCacheSchemaPreservation:
+    """The one-shot writer feeds the *shared* cache, so it must store types.
+
+    Its envelope has already reduced the result to JSON rows, which cannot
+    type an empty or all-null column. Without the executor's Arrow schema the
+    blob stores ``null`` — and a later raw ``format=arrow`` hit serves that
+    blob verbatim against numeric column metadata.
+    """
+
+    async def test_schema_is_forwarded_to_the_encoder(self) -> None:
+        pa = pytest.importorskip("pyarrow")
+
+        from types import SimpleNamespace
+
+        from orionbelt.api.routers.oneshot import _try_oneshot_cache_set
+        from orionbelt.api.schemas import ColumnMetadata
+        from orionbelt.cache.result_codec import decode_data
+
+        envelope = SimpleNamespace(
+            columns=[ColumnMetadata(name="n", type="number")],
+            rows=[],
+            sql="SELECT 1",
+            dialect="duckdb",
+            row_count=0,
+        )
+        schema = pa.schema([pa.field("n", pa.int64())])
+
+        async def _write(schema_arg: object) -> object:
+            cache = _CapturingCache()
+            await _try_oneshot_cache_set(
+                cache=cache,
+                key="k",
+                envelope=envelope,
+                ttl_seconds=60,
+                datasource="duckdb",
+                model_id="m",
+                dialect="duckdb",
+                physical_tables=[],
+                schema=schema_arg,
+            )
+            assert cache.payload is not None
+            return decode_data(cache.payload).schema.field(0).type
+
+        assert str(await _write(schema)) == "int64"
+        # Guard the test itself: without the schema the defect reproduces.
+        assert str(await _write(None)) == "null"
+
+    def test_try_cache_set_requires_schema(self) -> None:
+        """``schema`` has no default, so a new writer cannot silently omit it.
+
+        Every cache writer must decide what to pass. Defaulting it to None is
+        what let the one-shot path store null-typed payloads unnoticed.
+        """
+        import inspect
+
+        from orionbelt.api.query_cache import try_cache_set
+
+        param = inspect.signature(try_cache_set).parameters["schema"]
+        assert param.default is inspect.Parameter.empty

--- a/tests/unit/test_db_executor.py
+++ b/tests/unit/test_db_executor.py
@@ -232,10 +232,14 @@ class TestExecuteSql:
 
     @_needs_ob_flight
     def test_duckdb_direct_execution(self) -> None:
-        """DuckDB uses a direct native path (no get_connection)."""
+        """DuckDB falls back to the PEP 249 path when Arrow is unavailable."""
         mock_result = MagicMock()
         mock_result.fetchall.return_value = [("US", 100)]
         mock_result.description = [("country",), ("revenue",)]
+        # A MagicMock answers every attribute, so it would claim Arrow
+        # support it does not have and route this test down the Arrow
+        # branch. Delete it to model a cursor without an Arrow fetch.
+        del mock_result.fetch_arrow_table
 
         mock_conn = MagicMock()
         mock_conn.execute.return_value = mock_result
@@ -253,6 +257,44 @@ class TestExecuteSql:
         assert isinstance(result, ExecutionResult)
         assert result.row_count == 1
         assert result.rows == [["US", 100]]
+        mock_conn.close.assert_called_once()
+
+    @_needs_ob_flight
+    def test_duckdb_direct_execution_arrow(self) -> None:
+        """DuckDB prefers the Arrow fetch and carries the exact schema.
+
+        The zero-row case is the one that matters: rebuilding a table from
+        Python rows re-infers types and would collapse an empty ``int64``
+        column to ``null``, so a cached entry would no longer match the
+        schema a fresh read advertises.
+        """
+        pa = pytest.importorskip("pyarrow")
+
+        table = pa.table(
+            {"country": pa.array([], type=pa.string()), "revenue": pa.array([], type=pa.int64())}
+        )
+        mock_result = MagicMock()
+        mock_result.fetch_arrow_table.return_value = table
+
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value = mock_result
+
+        with (
+            patch(
+                "ob_flight.db_router.get_credentials",
+                return_value={"database": ":memory:"},
+                create=True,
+            ),
+            patch("duckdb.connect", return_value=mock_conn),
+        ):
+            result = execute_sql("SELECT 1", dialect="duckdb")
+
+        assert isinstance(result, ExecutionResult)
+        assert result.row_count == 0
+        assert result.rows == []
+        assert [c.name for c in result.columns] == ["country", "revenue"]
+        assert [c.type_hint for c in result.columns] == ["string", "number"]
+        mock_result.fetchall.assert_not_called()
         mock_conn.close.assert_called_once()
 
     @_needs_ob_flight

--- a/tests/unit/test_db_executor.py
+++ b/tests/unit/test_db_executor.py
@@ -238,7 +238,9 @@ class TestExecuteSql:
         mock_result.description = [("country",), ("revenue",)]
         # A MagicMock answers every attribute, so it would claim Arrow
         # support it does not have and route this test down the Arrow
-        # branch. Delete it to model a cursor without an Arrow fetch.
+        # branch. Delete both probed names to model a result without an
+        # Arrow fetch.
+        del mock_result.to_arrow_table
         del mock_result.fetch_arrow_table
 
         mock_conn = MagicMock()
@@ -274,7 +276,9 @@ class TestExecuteSql:
             {"country": pa.array([], type=pa.string()), "revenue": pa.array([], type=pa.int64())}
         )
         mock_result = MagicMock()
-        mock_result.fetch_arrow_table.return_value = table
+        # ``to_arrow_table`` is the non-deprecated name and the one the
+        # DuckDB path probes first.
+        mock_result.to_arrow_table.return_value = table
 
         mock_conn = MagicMock()
         mock_conn.execute.return_value = mock_result
@@ -296,6 +300,37 @@ class TestExecuteSql:
         assert [c.type_hint for c in result.columns] == ["string", "number"]
         mock_result.fetchall.assert_not_called()
         mock_conn.close.assert_called_once()
+
+    def test_interval_hint_agrees_across_mappings(self) -> None:
+        """INTERVAL classifies the same whichever path produced it.
+
+        Four mappings can see an interval: ``_duckdb_type_hint`` (PEP 249
+        fallback), ``_arrow_type_to_hint`` (Arrow fetch, both DuckDB's
+        month_day_nano_interval and a duration), pgwire's
+        ``_duckdb_desc_to_hint`` (catalog), and ADBC's
+        ``coarse_hint_from_type_name`` for the Postgres driver's opaque
+        "interval" (see ``test_opaque_interval_maps_to_datetime``). They
+        must agree, or the same column is advertised with a different
+        Postgres OID depending only on which driver answered.
+
+        ``_duckdb_desc_to_hint`` used to return "number" here, because
+        "interval" contains "int" and the numeric substring check ran
+        first.
+        """
+        pa = pytest.importorskip("pyarrow")
+
+        from orionbelt.pgwire.catalog import _duckdb_desc_to_hint
+        from orionbelt.service.db_executor import _arrow_type_to_hint, _duckdb_type_hint
+
+        assert _duckdb_type_hint("INTERVAL") == "datetime"
+        assert _arrow_type_to_hint(pa.month_day_nano_interval()) == "datetime"
+        assert _arrow_type_to_hint(pa.duration("us")) == "datetime"
+        assert _duckdb_desc_to_hint(("v", "INTERVAL")) == "datetime"
+
+        # Genuine integers still read as numbers despite sharing the "int"
+        # substring that used to swallow INTERVAL.
+        for name in ("INTEGER", "BIGINT", "TINYINT", "HUGEINT"):
+            assert _duckdb_desc_to_hint(("v", name)) == "number"
 
     @_needs_ob_flight
     def test_db_error_raises_execution_error(self) -> None:

--- a/tests/unit/test_db_executor.py
+++ b/tests/unit/test_db_executor.py
@@ -301,6 +301,55 @@ class TestExecuteSql:
         mock_result.fetchall.assert_not_called()
         mock_conn.close.assert_called_once()
 
+    def test_interval_values_agree_across_paths(self) -> None:
+        """An interval renders the same whether or not the Arrow path ran.
+
+        ``to_pylist()`` yields a ``MonthDayNano`` namedtuple whose ``str()``
+        is ``"MonthDayNano(months=0, days=1, nanoseconds=0)"``, while the
+        PEP 249 path yields a ``timedelta`` serialising to
+        ``"1 day, 0:00:00"``. Normalising in ``_arrow_to_rows`` keeps
+        JSON / TSV / pgwire output stable regardless of whether pyarrow
+        happened to be imported.
+
+        The month->day rule mirrors DuckDB's own conversion: 30 days per
+        month, so ``INTERVAL 3 MONTH`` is 90 days and ``INTERVAL 1 YEAR``
+        is 360.
+        """
+        pa = pytest.importorskip("pyarrow")
+
+        from datetime import timedelta
+
+        from orionbelt.service.db_executor import _arrow_to_rows
+
+        table = pa.table(
+            {
+                "one_day": pa.array(
+                    [pa.MonthDayNano([0, 1, 0])], type=pa.month_day_nano_interval()
+                ),
+                "three_months": pa.array(
+                    [pa.MonthDayNano([3, 0, 0])], type=pa.month_day_nano_interval()
+                ),
+                "ninety_min": pa.array(
+                    [pa.MonthDayNano([0, 0, 5_400_000_000_000])],
+                    type=pa.month_day_nano_interval(),
+                ),
+                "duration": pa.array([timedelta(hours=2)], type=pa.duration("us")),
+                "null_interval": pa.array([None], type=pa.month_day_nano_interval()),
+            }
+        )
+
+        expected = _serialize_row(
+            (
+                timedelta(days=1),
+                timedelta(days=90),
+                timedelta(minutes=90),
+                timedelta(hours=2),
+                None,
+            )
+        )
+        assert _arrow_to_rows(table) == [expected]
+        assert expected[0] == "1 day, 0:00:00"
+
     def test_interval_hint_agrees_across_mappings(self) -> None:
         """INTERVAL classifies the same whichever path produced it.
 


### PR DESCRIPTION
## What

`_execute_duckdb` was the only backend path that discarded a columnar result. DuckDB holds the result as Arrow internally, `fetchall()` built a Python object per cell, and `ExecutionResult` (which already accepts `arrow_table=` and materialises rows lazily via `_arrow_to_rows`) never saw it. Every other dialect goes through `_fetch_result`, which tries Arrow first.

This reuses that same `_try_fetch_arrow` call and keeps the PEP 249 path as the fallback for when it declines (pyarrow not loaded). The existing guard is left untouched.

## Why it is more than a speed fix

Rebuilding a table from Python rows re-infers types, which collapses an empty or all-null `int64` column to `null`. A cache entry written that way no longer matches the schema a fresh read advertises. This is the same class of bug that made Flight cache hits stream null-typed columns before 2.21.1, and `encode_table` exists precisely to avoid it: this change makes the DuckDB path eligible for it.

## Verification

Old and new paths run side by side against a real DuckDB file (int, double, decimal(18,2), date, timestamp, varchar, boolean, null bigint):

```
typed:   cols equal=True  rows equal=True  n=1
empty:   cols equal=True  rows equal=True  n=0
allnull: cols equal=True  rows equal=True  n=1
```

Column metadata is identical because `_arrow_type_to_hint` / `_default_format_for_arrow_type` agree with their DuckDB counterparts on every type in that set. Rows are identical because both paths end in `_serialize_value` with the same resolved timezone.

Full suite: 4619 passed, 1002 skipped. `ruff check`, `ruff format`, `mypy` clean.

## Test change

`test_duckdb_direct_execution` failed in a combined run but passed in isolation. Not a production issue: `MagicMock` auto-creates `fetch_arrow_table`, so the mock claimed Arrow support it did not have, and which branch ran depended on whether an earlier test had imported pyarrow. It is now pinned to the fallback with the `del mock.fetch_arrow_table` idiom already used elsewhere in that file, and `test_duckdb_direct_execution_arrow` covers the new branch with a real zero-row `pa.table`.

## Not in scope

- `tests/integration/test_duckdb_execution.py:726` has a `_make_execute_sql` mock whose docstring says it mirrors the production duckdb-local path. It now mirrors the previous one. Self-contained, so harmless, but stale.
- DuckDB `INTERVAL` maps to `"datetime"` via `_duckdb_type_hint` but to `"string"` via `_arrow_type_to_hint`. Nothing the compiler emits returns an INTERVAL column, so no test covers it; raw mode could in principle.

## Context

First step of the Arrow/ADBC work: it removes the last backend that is columnar at the source and row-based in our hands, with no new dependency.
