### PR TITLE
fix(db_router): accept DATABRICKS_TOKEN as well as DATABRICKS_ACCESS_TOKEN

### DIFF
--- a/drivers/ob-flight-extension/src/ob_flight/db_router.py
+++ b/drivers/ob-flight-extension/src/ob_flight/db_router.py
@@ -77,6 +77,20 @@ _CREDENTIAL_KEYS: dict[str, list[str]] = {
     ],
 }
 
+# Alternate spellings accepted for a credential env var, tried in order when
+# the canonical name is unset.
+#
+# ``DATABRICKS_TOKEN`` is the name Databricks' own CLI and SDK export, so it
+# is what people already have in their environment; ``.env.template`` and
+# ``docs/drivers.md`` document ``DATABRICKS_ACCESS_TOKEN``. Every other
+# consumer in the repo already accepts both (tests, seed and probe scripts) —
+# this router was the sole holdout, which meant an environment written to the
+# Databricks convention produced a connection with no token at all and no
+# indication why.
+_ENV_ALIASES: dict[str, tuple[str, ...]] = {
+    "DATABRICKS_ACCESS_TOKEN": ("DATABRICKS_TOKEN",),
+}
+
 # Env var name -> connect() kwarg name mapping
 _ENV_TO_KWARG: dict[str, str] = {
     "BIGQUERY_PROJECT": "project",
@@ -121,12 +135,19 @@ def get_credentials(dialect: str) -> dict[str, Any]:
     """Read vendor credentials from environment variables.
 
     Returns a dict of kwargs suitable for the vendor's connect() function.
-    Only includes env vars that are actually set.
+    Only includes env vars that are actually set. A canonical name that is
+    unset falls back to any alias in :data:`_ENV_ALIASES`, so the canonical
+    spelling always wins when both are present.
     """
     creds: dict[str, Any] = {}
     keys = _CREDENTIAL_KEYS.get(dialect, [])
     for env_key in keys:
         raw = os.getenv(env_key)
+        if raw is None:
+            for alias in _ENV_ALIASES.get(env_key, ()):
+                raw = os.getenv(alias)
+                if raw is not None:
+                    break
         if raw is not None:
             kwarg_name = _ENV_TO_KWARG.get(env_key, env_key.lower())
             # Convert port to int

--- a/drivers/ob-flight-extension/tests/test_db_router.py
+++ b/drivers/ob-flight-extension/tests/test_db_router.py
@@ -87,3 +87,58 @@ class TestConnect:
             connect("postgres", host="override-host")
             call_kwargs = mock_module.connect.call_args.kwargs
             assert call_kwargs["host"] == "override-host"
+
+
+class TestCredentialEnvAliases:
+    """A canonical credential name may fall back to an alternate spelling.
+
+    ``DATABRICKS_TOKEN`` is what Databricks' own CLI and SDK export, so it is
+    what people already have set; ``.env.template`` and ``docs/drivers.md``
+    document ``DATABRICKS_ACCESS_TOKEN``. Tests, the seed script and the probe
+    script all accepted both — this router did not, so an environment written
+    to the Databricks convention produced a connection with **no token** and
+    nothing to explain why.
+    """
+
+    def test_alias_supplies_the_token_when_canonical_is_unset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from ob_flight.db_router import get_credentials
+
+        monkeypatch.delenv("DATABRICKS_ACCESS_TOKEN", raising=False)
+        monkeypatch.setenv("DATABRICKS_SERVER_HOSTNAME", "example.databricks.com")
+        monkeypatch.setenv("DATABRICKS_HTTP_PATH", "/sql/1.0/warehouses/x")
+        monkeypatch.setenv("DATABRICKS_TOKEN", "from-alias")
+
+        creds = get_credentials("databricks")
+        assert creds["access_token"] == "from-alias"
+
+    def test_canonical_wins_when_both_are_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from ob_flight.db_router import get_credentials
+
+        monkeypatch.setenv("DATABRICKS_SERVER_HOSTNAME", "example.databricks.com")
+        monkeypatch.setenv("DATABRICKS_HTTP_PATH", "/sql/1.0/warehouses/x")
+        monkeypatch.setenv("DATABRICKS_TOKEN", "from-alias")
+        monkeypatch.setenv("DATABRICKS_ACCESS_TOKEN", "canonical")
+
+        assert get_credentials("databricks")["access_token"] == "canonical"
+
+    def test_no_token_set_yields_no_access_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from ob_flight.db_router import get_credentials
+
+        monkeypatch.delenv("DATABRICKS_ACCESS_TOKEN", raising=False)
+        monkeypatch.delenv("DATABRICKS_TOKEN", raising=False)
+        monkeypatch.setenv("DATABRICKS_SERVER_HOSTNAME", "example.databricks.com")
+
+        assert "access_token" not in get_credentials("databricks")
+
+    def test_dialects_without_aliases_are_unaffected(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from ob_flight.db_router import get_credentials
+
+        monkeypatch.setenv("POSTGRES_HOST", "localhost")
+        monkeypatch.setenv("POSTGRES_PORT", "5432")
+        creds = get_credentials("postgres")
+        assert creds["host"] == "localhost"
+        assert creds["port"] == 5432  # still coerced to int

--- a/scripts/probe_functions.py
+++ b/scripts/probe_functions.py
@@ -409,11 +409,17 @@ def run_bigquery() -> Iterator[Callable[[str], object]]:
 def run_databricks() -> Iterator[Callable[[str], object]]:
     from databricks import sql as dbsql
 
-    _require_env("DATABRICKS_SERVER_HOSTNAME", "DATABRICKS_HTTP_PATH", "DATABRICKS_TOKEN")
+    _require_env("DATABRICKS_SERVER_HOSTNAME", "DATABRICKS_HTTP_PATH")
+    # Accept either spelling, like every other consumer in the repo.
+    token = os.environ.get("DATABRICKS_ACCESS_TOKEN") or os.environ.get("DATABRICKS_TOKEN")
+    if not token:
+        raise SystemExit(
+            "Missing environment variables: DATABRICKS_ACCESS_TOKEN (or DATABRICKS_TOKEN)"
+        )
     con = dbsql.connect(
         server_hostname=os.environ["DATABRICKS_SERVER_HOSTNAME"],
         http_path=os.environ["DATABRICKS_HTTP_PATH"],
-        access_token=os.environ["DATABRICKS_TOKEN"],
+        access_token=token,
         catalog=os.environ.get("DATABRICKS_CATALOG"),
     )
 


### PR DESCRIPTION
## What

`db_router` read only `DATABRICKS_ACCESS_TOKEN`, so an environment written to the Databricks convention produced:

```
get_credentials('databricks') -> ['catalog', 'http_path', 'server_hostname']
access_token present: False
```

A connection with no token, and nothing to explain why.

## Why it mattered

Every other consumer already accepted both spellings and preferred `DATABRICKS_TOKEN`:

| Consumer | Behaviour before |
|---|---|
| `tests/integration/test_databricks_execution.py:87` | accepts both |
| `tests/integration/drift/vendor_exec/conftest.py:370` | accepts both |
| `scripts/seed_cloud_vendor.py:95` | accepts both |
| `scripts/probe_functions.py:412,416` | **hard-requires `DATABRICKS_TOKEN`** |
| `drivers/ob-flight-extension/src/ob_flight/db_router.py:67` | **hard-requires `DATABRICKS_ACCESS_TOKEN`** |

So the two ends disagreed, and the runtime execution path - the one place a missing token actually breaks a query - was the holdout. Standardising a `.env` on either name broke one of them.

## Change

`DATABRICKS_ACCESS_TOKEN` stays canonical: it is what `.env.template:222` and `docs/drivers.md:292` document. `DATABRICKS_TOKEN`, the name the Databricks CLI and SDK export, is accepted as a fallback.

An explicit `_ENV_ALIASES` map does the lookup, so the canonical name always wins when both are set. Threading precedence through `_CREDENTIAL_KEYS` ordering instead would have worked but been invisible at the call site.

`scripts/probe_functions.py` now accepts either too, with an error message naming both.

## Tests

Four cases in `drivers/ob-flight-extension/tests/test_db_router.py`: alias supplies the token, canonical wins when both are set, neither set yields no `access_token`, and a dialect without aliases is unaffected (including the `_PORT` int coercion). Verified the first fails when the fallback is removed.

Driver suite 188 passed, root suite 4648 passed / 1 xfailed, `ruff` and `mypy` clean.

## Provenance

Found while running the ADBC auth audit (Track I-1): the audit could not read the Databricks token through the runtime path even though the token was present in `.env`. Unrelated to ADBC itself.
