### PR TITLE
feat(motherduck): support MotherDuck as a DuckDB-dialect source

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -185,7 +185,15 @@ SESSION_RATE_LIMIT=10
 # BIGQUERY_CREDENTIALS_FILE=/path/to/service-account.json
 
 # -- DuckDB / MotherDuck --
+# A local file (or :memory:), OR a MotherDuck database as md:<name>.
 # DUCKDB_DATABASE=:memory:
+# DUCKDB_DATABASE=md:my_database
+# Required when DUCKDB_DATABASE is a md: database. The lowercase
+# motherduck_token that MotherDuck's own CLI exports is accepted too;
+# this spelling is canonical. Without a token the DuckDB extension falls
+# back to interactive browser auth, which hangs on a server, so OBSL
+# refuses to connect rather than let that happen.
+# MOTHERDUCK_ACCESS_TOKEN=
 
 # -- PostgreSQL --
 # POSTGRES_HOST=localhost

--- a/.env.template
+++ b/.env.template
@@ -188,10 +188,11 @@ SESSION_RATE_LIMIT=10
 # A local file (or :memory:), OR a MotherDuck database as md:<name>.
 # DUCKDB_DATABASE=:memory:
 # DUCKDB_DATABASE=md:my_database
-# Required when DUCKDB_DATABASE is a md: database. The lowercase
-# motherduck_token that MotherDuck's own CLI exports is accepted too;
-# this spelling is canonical. Without a token the DuckDB extension falls
-# back to interactive browser auth, which hangs on a server, so OBSL
+# Required when DUCKDB_DATABASE is a md: database. MOTHERDUCK_TOKEN and the
+# lowercase motherduck_token are accepted as aliases; this spelling is
+# canonical. Use a Read/Write token unless the deployment only ever queries -
+# a read-scaling token cannot seed. Without any token the DuckDB extension
+# falls back to interactive browser auth, which hangs on a server, so OBSL
 # refuses to connect rather than let that happen.
 # MOTHERDUCK_ACCESS_TOKEN=
 

--- a/docs/drivers.md
+++ b/docs/drivers.md
@@ -284,12 +284,12 @@ POSTGRES_PASSWORD=secret
 
 | DB_VENDOR    | Driver        | Credential Environment Variables                                                                                             |
 | ------------ | ------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `duckdb`     | ob-duckdb     | `DUCKDB_DATABASE`                                                                                                            |
+| `duckdb`     | ob-duckdb     | `DUCKDB_DATABASE` (a file, `:memory:`, or `md:<db>` for MotherDuck), `MOTHERDUCK_ACCESS_TOKEN` (required for `md:`)           |
 | `postgres`   | ob-postgres   | `POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_DBNAME`, `POSTGRES_USER`, `POSTGRES_PASSWORD`                                    |
 | `snowflake`  | ob-snowflake  | `SNOWFLAKE_ACCOUNT`, `SNOWFLAKE_USER`, `SNOWFLAKE_PASSWORD`, `SNOWFLAKE_DATABASE`, `SNOWFLAKE_SCHEMA`, `SNOWFLAKE_WAREHOUSE` |
 | `clickhouse` | ob-clickhouse | `CLICKHOUSE_HOST`, `CLICKHOUSE_PORT`, `CLICKHOUSE_USERNAME`, `CLICKHOUSE_PASSWORD`, `CLICKHOUSE_DATABASE`                    |
 | `dremio`     | ob-dremio     | `DREMIO_HOST`, `DREMIO_PORT`, `DREMIO_USERNAME`, `DREMIO_PASSWORD`                                                           |
-| `databricks` | ob-databricks | `DATABRICKS_SERVER_HOSTNAME`, `DATABRICKS_HTTP_PATH`, `DATABRICKS_ACCESS_TOKEN`                                              |
+| `databricks` | ob-databricks | `DATABRICKS_SERVER_HOSTNAME`, `DATABRICKS_HTTP_PATH`, `DATABRICKS_ACCESS_TOKEN` (or `DATABRICKS_TOKEN`)                       |
 
 ### Running Locally
 

--- a/docs/guide/dialects.md
+++ b/docs/guide/dialects.md
@@ -27,14 +27,22 @@ MOTHERDUCK_ACCESS_TOKEN=<token>
 ```
 
 Create the token at [app.motherduck.com](https://app.motherduck.com) under
-your organization name → **Settings** → **Create token**. A **Read Scaling**
-token is the better fit than the default Read/Write one: OrionBelt only ever
-issues `SELECT`, and read-scaling tokens are built for concurrent readers.
+your organization name → **Settings** → **Create token**. The default
+**Read/Write** token is the right choice for most setups — a read-scaling
+token cannot create tables, so it cannot load fixtures or seed a database.
 
-The lowercase `motherduck_token` that MotherDuck's own CLI exports is accepted
-as an alias, so an environment already set up for the CLI needs no changes.
-`MOTHERDUCK_ACCESS_TOKEN` is the canonical spelling, matching the other vendor
-credentials.
+A **Read Scaling** token suits a query-only deployment: it grants `SELECT`
+and connects against the read replica pool, which is the better shape for
+many concurrent readers. It is not required in order to connect read-only —
+OrionBelt opens `read_only=True` connections happily with a normal
+read/write token.
+
+`MOTHERDUCK_ACCESS_TOKEN` is the canonical spelling, matching the other
+vendor credentials. `MOTHERDUCK_TOKEN` and the lowercase `motherduck_token`
+that MotherDuck's own tooling uses are both accepted as aliases, so an
+environment already set up for the MotherDuck CLI needs no changes. A token
+embedded directly in the database string — either `motherduck_token=` or
+`read_scaling_token=` — is left alone.
 
 !!! warning "A `md:` database without a token is refused"
 

--- a/docs/guide/dialects.md
+++ b/docs/guide/dialects.md
@@ -15,6 +15,40 @@ OrionBelt compiles semantic queries into SQL for eight database dialects. Each d
 | PostgreSQL | `postgres` | Standard PostgreSQL with strict GROUP BY |
 | Snowflake | `snowflake` | Cloud data warehouse with QUALIFY, semi-structured types |
 
+### Connecting to MotherDuck
+
+MotherDuck is DuckDB served remotely, so it needs no separate dialect — the
+`duckdb` codegen is what runs, and every DuckDB capability below applies
+unchanged. What differs is only the connection:
+
+```bash
+DUCKDB_DATABASE=md:my_database
+MOTHERDUCK_ACCESS_TOKEN=<token>
+```
+
+Create the token at [app.motherduck.com](https://app.motherduck.com) under
+your organization name → **Settings** → **Create token**. A **Read Scaling**
+token is the better fit than the default Read/Write one: OrionBelt only ever
+issues `SELECT`, and read-scaling tokens are built for concurrent readers.
+
+The lowercase `motherduck_token` that MotherDuck's own CLI exports is accepted
+as an alias, so an environment already set up for the CLI needs no changes.
+`MOTHERDUCK_ACCESS_TOKEN` is the canonical spelling, matching the other vendor
+credentials.
+
+!!! warning "A `md:` database without a token is refused"
+
+    OrionBelt raises `MotherDuckTokenMissingError` rather than connecting.
+    This is deliberate. Without an explicit token the DuckDB extension falls
+    back to **interactive browser authentication**, which on a server does not
+    fail — it *hangs*, so it surfaces as a stuck worker rather than a
+    configuration error. Refusing up front also prevents an ambient
+    `motherduck_token` in the environment from silently connecting to a
+    different account than the one you configured.
+
+`read_only` stays enabled for MotherDuck as it is for a local file: OrionBelt
+only reads, and a `md:` connection accepts it.
+
 ## Capabilities Matrix
 
 Each dialect declares capability flags that the compiler uses to choose SQL generation strategies.

--- a/drivers/ob-flight-extension/src/ob_flight/db_router.py
+++ b/drivers/ob-flight-extension/src/ob_flight/db_router.py
@@ -98,18 +98,27 @@ _CREDENTIAL_KEYS: dict[str, list[str]] = {
 # indication why.
 _ENV_ALIASES: dict[str, tuple[str, ...]] = {
     "DATABRICKS_ACCESS_TOKEN": ("DATABRICKS_TOKEN",),
-    # MotherDuck's own docs and CLI use the lowercase ``motherduck_token``,
-    # which the DuckDB extension also reads straight from the environment.
-    # Accepting it means someone set up for the MotherDuck CLI needs no extra
-    # configuration; the uppercase name stays canonical for consistency with
-    # every other vendor key here.
-    "MOTHERDUCK_ACCESS_TOKEN": ("motherduck_token",),
+    # MotherDuck's docs and examples use both ``MOTHERDUCK_TOKEN`` and the
+    # lowercase ``motherduck_token`` (the latter is what the DuckDB extension
+    # reads straight from the environment). Accepting both means an
+    # environment already set up for MotherDuck's own tooling needs no extra
+    # configuration; the ``_ACCESS_`` name stays canonical for consistency
+    # with every other vendor key here.
+    "MOTHERDUCK_ACCESS_TOKEN": (
+        "MOTHERDUCK_TOKEN",
+        "motherduck_token",  # noqa: SIM112 — MotherDuck's own lowercase spelling
+    ),
 }
 
 # A DuckDB database string beginning with this prefix is MotherDuck, not a
 # local file: remote, authenticated, and not subject to the file-lock
 # reasoning behind the read-only default.
 _MOTHERDUCK_PREFIX = "md:"
+
+# Token parameters MotherDuck accepts on the database string. A read-scaling
+# token authenticates against the read replica pool and is spelled
+# differently, so a URI already carrying one must not be treated as tokenless.
+_MOTHERDUCK_URI_TOKEN_PARAMS = ("motherduck_token", "read_scaling_token")
 
 # Env var name -> connect() kwarg name mapping
 _ENV_TO_KWARG: dict[str, str] = {
@@ -152,8 +161,15 @@ _ENV_TO_KWARG: dict[str, str] = {
 }
 
 
-def get_credentials(dialect: str) -> dict[str, Any]:
+def get_credentials(dialect: str, **overrides: Any) -> dict[str, Any]:
     """Read vendor credentials from environment variables.
+
+    ``overrides`` are applied *before* any dialect-specific post-processing,
+    so a caller-supplied value is what that processing sees. This matters for
+    MotherDuck: folding the token into the database string has to happen after
+    an override may have replaced the database, or ``connect()`` would raise
+    for an env-configured ``md:`` that the caller overrode away — and would
+    pass a tokenless ``md:`` when the caller supplied one.
 
     Returns a dict of kwargs suitable for the vendor's connect() function.
     Only includes env vars that are actually set. A canonical name that is
@@ -173,6 +189,7 @@ def get_credentials(dialect: str) -> dict[str, Any]:
             kwarg_name = _ENV_TO_KWARG.get(env_key, env_key.lower())
             # Convert port to int
             creds[kwarg_name] = int(raw) if env_key.endswith("_PORT") else raw
+    creds.update(overrides)
     if dialect == "duckdb":
         _apply_motherduck_token(creds)
     return creds
@@ -199,8 +216,8 @@ def _apply_motherduck_token(creds: dict[str, Any]) -> None:
     database = creds.get("database")
     if not isinstance(database, str) or not database.startswith(_MOTHERDUCK_PREFIX):
         return
-    if "motherduck_token=" in database:
-        return  # caller embedded it in DUCKDB_DATABASE already
+    if any(f"{name}=" in database for name in _MOTHERDUCK_URI_TOKEN_PARAMS):
+        return  # caller embedded a token in DUCKDB_DATABASE already
     if not token:
         raise MotherDuckTokenMissingError(
             f"DUCKDB_DATABASE is {database!r} (MotherDuck) but no token is set. "
@@ -223,8 +240,7 @@ def connect(dialect: str, **overrides: Any) -> Any:
     if dialect not in VENDOR_MAP:
         raise KeyError(f"Unsupported dialect: {dialect!r}. Supported: {sorted(VENDOR_MAP)}")
     module = importlib.import_module(VENDOR_MAP[dialect])
-    kwargs = get_credentials(dialect)
-    kwargs.update(overrides)
+    kwargs = get_credentials(dialect, **overrides)
     # DuckDB: open read-only to avoid cross-process file lock conflicts.
     # MotherDuck is remote, so no local file lock exists to conflict over --
     # but read-only is still correct for a semantic layer that only reads,

--- a/drivers/ob-flight-extension/src/ob_flight/db_router.py
+++ b/drivers/ob-flight-extension/src/ob_flight/db_router.py
@@ -106,7 +106,7 @@ _ENV_ALIASES: dict[str, tuple[str, ...]] = {
     # with every other vendor key here.
     "MOTHERDUCK_ACCESS_TOKEN": (
         "MOTHERDUCK_TOKEN",
-        "motherduck_token",  # noqa: SIM112 — MotherDuck's own lowercase spelling
+        "motherduck_token",
     ),
 }
 

--- a/drivers/ob-flight-extension/src/ob_flight/db_router.py
+++ b/drivers/ob-flight-extension/src/ob_flight/db_router.py
@@ -10,6 +10,15 @@ import threading
 from collections.abc import Generator
 from contextlib import contextmanager
 from typing import Any
+from urllib.parse import quote
+
+
+class MotherDuckTokenMissingError(RuntimeError):
+    """Raised when a ``md:`` database is configured without a token.
+
+    Its own type so callers can distinguish a configuration error from a
+    connection failure — the fix is an env var, not a retry.
+    """
 
 
 # Dialect name -> Python module name for the OB driver
@@ -31,7 +40,7 @@ _CREDENTIAL_KEYS: dict[str, list[str]] = {
         "BIGQUERY_LOCATION",
         "BIGQUERY_CREDENTIALS_FILE",
     ],
-    "duckdb": ["DUCKDB_DATABASE"],
+    "duckdb": ["DUCKDB_DATABASE", "MOTHERDUCK_ACCESS_TOKEN"],
     "postgres": [
         "POSTGRES_HOST",
         "POSTGRES_PORT",
@@ -89,7 +98,18 @@ _CREDENTIAL_KEYS: dict[str, list[str]] = {
 # indication why.
 _ENV_ALIASES: dict[str, tuple[str, ...]] = {
     "DATABRICKS_ACCESS_TOKEN": ("DATABRICKS_TOKEN",),
+    # MotherDuck's own docs and CLI use the lowercase ``motherduck_token``,
+    # which the DuckDB extension also reads straight from the environment.
+    # Accepting it means someone set up for the MotherDuck CLI needs no extra
+    # configuration; the uppercase name stays canonical for consistency with
+    # every other vendor key here.
+    "MOTHERDUCK_ACCESS_TOKEN": ("motherduck_token",),
 }
+
+# A DuckDB database string beginning with this prefix is MotherDuck, not a
+# local file: remote, authenticated, and not subject to the file-lock
+# reasoning behind the read-only default.
+_MOTHERDUCK_PREFIX = "md:"
 
 # Env var name -> connect() kwarg name mapping
 _ENV_TO_KWARG: dict[str, str] = {
@@ -97,6 +117,7 @@ _ENV_TO_KWARG: dict[str, str] = {
     "BIGQUERY_LOCATION": "location",
     "BIGQUERY_CREDENTIALS_FILE": "credentials_file",
     "DUCKDB_DATABASE": "database",
+    "MOTHERDUCK_ACCESS_TOKEN": "motherduck_token",
     "POSTGRES_HOST": "host",
     "POSTGRES_PORT": "port",
     "POSTGRES_DBNAME": "dbname",
@@ -152,7 +173,43 @@ def get_credentials(dialect: str) -> dict[str, Any]:
             kwarg_name = _ENV_TO_KWARG.get(env_key, env_key.lower())
             # Convert port to int
             creds[kwarg_name] = int(raw) if env_key.endswith("_PORT") else raw
+    if dialect == "duckdb":
+        _apply_motherduck_token(creds)
     return creds
+
+
+def _apply_motherduck_token(creds: dict[str, Any]) -> None:
+    """Fold a MotherDuck token into the ``md:`` database string, in place.
+
+    ``duckdb.connect`` takes no token argument — the token travels as a query
+    parameter on the database string — so the credential is resolved here
+    rather than at each call site. ``db_executor`` opens DuckDB three
+    different ways and all three read their credentials through this
+    function, so this is the one seam that covers them.
+
+    Fails loudly when a ``md:`` database has no token. That is deliberate:
+    the DuckDB extension falls back to *interactive browser authentication*
+    when a token is absent, which on a server does not raise — it **hangs**,
+    presenting as a stuck worker rather than a failed connection. It can also
+    silently pick up an ambient lowercase ``motherduck_token`` and connect to
+    whichever account that belongs to. Passing the token explicitly, always,
+    removes both.
+    """
+    token = creds.pop("motherduck_token", None)
+    database = creds.get("database")
+    if not isinstance(database, str) or not database.startswith(_MOTHERDUCK_PREFIX):
+        return
+    if "motherduck_token=" in database:
+        return  # caller embedded it in DUCKDB_DATABASE already
+    if not token:
+        raise MotherDuckTokenMissingError(
+            f"DUCKDB_DATABASE is {database!r} (MotherDuck) but no token is set. "
+            "Set MOTHERDUCK_ACCESS_TOKEN (or the lowercase motherduck_token that "
+            "MotherDuck's own CLI uses). Without one the DuckDB extension falls "
+            "back to interactive browser auth, which hangs on a server."
+        )
+    sep = "&" if "?" in database else "?"
+    creds["database"] = f"{database}{sep}motherduck_token={quote(str(token), safe='')}"
 
 
 def connect(dialect: str, **overrides: Any) -> Any:
@@ -168,7 +225,10 @@ def connect(dialect: str, **overrides: Any) -> Any:
     module = importlib.import_module(VENDOR_MAP[dialect])
     kwargs = get_credentials(dialect)
     kwargs.update(overrides)
-    # DuckDB: open read-only to avoid cross-process file lock conflicts
+    # DuckDB: open read-only to avoid cross-process file lock conflicts.
+    # MotherDuck is remote, so no local file lock exists to conflict over --
+    # but read-only is still correct for a semantic layer that only reads,
+    # and a `md:` connection accepts it, so the default is left in place.
     if dialect == "duckdb" and "read_only" not in kwargs:
         kwargs["read_only"] = True
     return module.connect(**kwargs)

--- a/drivers/ob-flight-extension/tests/test_db_router.py
+++ b/drivers/ob-flight-extension/tests/test_db_router.py
@@ -132,9 +132,7 @@ class TestCredentialEnvAliases:
 
         assert "access_token" not in get_credentials("databricks")
 
-    def test_dialects_without_aliases_are_unaffected(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_dialects_without_aliases_are_unaffected(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from ob_flight.db_router import get_credentials
 
         monkeypatch.setenv("POSTGRES_HOST", "localhost")
@@ -142,3 +140,92 @@ class TestCredentialEnvAliases:
         creds = get_credentials("postgres")
         assert creds["host"] == "localhost"
         assert creds["port"] == 5432  # still coerced to int
+
+
+class TestMotherDuckCredentials:
+    """A ``md:`` database needs its token folded into the database string.
+
+    ``duckdb.connect`` takes no token argument, so the token travels as a
+    query parameter. Getting this wrong is quiet rather than loud: without a
+    token the DuckDB extension falls back to interactive browser auth, which
+    on a server hangs instead of failing.
+    """
+
+    @staticmethod
+    def _clear(monkeypatch: pytest.MonkeyPatch) -> None:
+        for name in (
+            "DUCKDB_DATABASE",
+            "MOTHERDUCK_ACCESS_TOKEN",
+            "MOTHERDUCK_TOKEN",
+            "motherduck_token",
+        ):
+            monkeypatch.delenv(name, raising=False)
+
+    @pytest.mark.parametrize(
+        "env_name", ["MOTHERDUCK_ACCESS_TOKEN", "MOTHERDUCK_TOKEN", "motherduck_token"]
+    )
+    def test_every_accepted_spelling_supplies_the_token(
+        self, monkeypatch: pytest.MonkeyPatch, env_name: str
+    ) -> None:
+        from ob_flight.db_router import get_credentials
+
+        self._clear(monkeypatch)
+        monkeypatch.setenv("DUCKDB_DATABASE", "md:analytics")
+        monkeypatch.setenv(env_name, "abc")
+        assert get_credentials("duckdb")["database"] == "md:analytics?motherduck_token=abc"
+
+    def test_token_is_url_encoded(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from ob_flight.db_router import get_credentials
+
+        self._clear(monkeypatch)
+        monkeypatch.setenv("DUCKDB_DATABASE", "md:analytics")
+        monkeypatch.setenv("MOTHERDUCK_ACCESS_TOKEN", "a/b+c=d")
+        assert "motherduck_token=a%2Fb%2Bc%3Dd" in get_credentials("duckdb")["database"]
+
+    @pytest.mark.parametrize("param", ["motherduck_token", "read_scaling_token"])
+    def test_an_embedded_token_is_left_alone(
+        self, monkeypatch: pytest.MonkeyPatch, param: str
+    ) -> None:
+        """A read-scaling token is spelled differently and is still a token."""
+        from ob_flight.db_router import get_credentials
+
+        self._clear(monkeypatch)
+        monkeypatch.setenv("DUCKDB_DATABASE", f"md:analytics?{param}=abc")
+        assert get_credentials("duckdb")["database"] == f"md:analytics?{param}=abc"
+
+    def test_local_file_is_untouched(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from ob_flight.db_router import get_credentials
+
+        self._clear(monkeypatch)
+        monkeypatch.setenv("DUCKDB_DATABASE", "/tmp/local.duckdb")
+        assert get_credentials("duckdb") == {"database": "/tmp/local.duckdb"}
+
+    def test_tokenless_md_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from ob_flight.db_router import MotherDuckTokenMissingError, get_credentials
+
+        self._clear(monkeypatch)
+        monkeypatch.setenv("DUCKDB_DATABASE", "md:analytics")
+        with pytest.raises(MotherDuckTokenMissingError, match="MOTHERDUCK_ACCESS_TOKEN"):
+            get_credentials("duckdb")
+
+    def test_override_away_from_md_does_not_raise(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The override contract: a caller-supplied database wins outright.
+
+        Folding used to run before overrides were merged, so an env-configured
+        tokenless ``md:`` raised even when the caller passed a local file.
+        """
+        from ob_flight.db_router import get_credentials
+
+        self._clear(monkeypatch)
+        monkeypatch.setenv("DUCKDB_DATABASE", "md:prod")
+        assert get_credentials("duckdb", database=":memory:") == {"database": ":memory:"}
+
+    def test_override_into_md_gets_the_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """And the reverse: an overridden ``md:`` must still be authenticated."""
+        from ob_flight.db_router import get_credentials
+
+        self._clear(monkeypatch)
+        monkeypatch.setenv("DUCKDB_DATABASE", "/tmp/local.duckdb")
+        monkeypatch.setenv("MOTHERDUCK_ACCESS_TOKEN", "T")
+        creds = get_credentials("duckdb", database="md:analytics")
+        assert creds["database"] == "md:analytics?motherduck_token=T"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,6 +198,7 @@ markers = [
     "adbc: requires a reachable PostgreSQL via ADBC; run with: pytest -m adbc",
     "adbc_flight: drives the OBSL Flight SQL server through the ADBC flightsql driver (conformance harness); run with: pytest -m adbc_flight",
     "snowflake: requires a live Snowflake account (SNOWFLAKE_* env vars); run with: pytest -m snowflake",
+    "motherduck: requires a live MotherDuck database (DUCKDB_DATABASE=md:<db> + MOTHERDUCK_ACCESS_TOKEN); run with: pytest -m motherduck",
     "bigquery: requires a live BigQuery project (BIGQUERY_* env vars + ADC); run with: pytest -m bigquery",
     "databricks: requires a live Databricks workspace (DATABRICKS_* env vars); run with: pytest -m databricks",
     "spark: executes the Databricks dialect on a local PySpark session (needs pyspark + a JDK); run with: pytest -m spark",

--- a/scripts/seed_cloud_vendor.py
+++ b/scripts/seed_cloud_vendor.py
@@ -131,14 +131,27 @@ def _motherduck() -> tuple[Callable[[str], None], Callable[[str], list[tuple]], 
             "Missing environment: DUCKDB_DATABASE must be a MotherDuck database "
             f"(md:<name>), got {database!r}"
         )
-    # SIM112 wants an uppercase name; the lowercase spelling is MotherDuck's
-    # own documented variable and what its CLI exports, so it is accepted
-    # verbatim rather than renamed.
-    token = os.environ.get("MOTHERDUCK_ACCESS_TOKEN") or os.environ.get(
-        "motherduck_token"  # noqa: SIM112
+    # Same spellings db_router accepts. SIM112 wants an uppercase name; the
+    # lowercase one is MotherDuck's own documented variable and what its CLI
+    # exports, so it is accepted verbatim rather than renamed.
+    token = next(
+        (
+            v
+            for v in (
+                os.environ.get("MOTHERDUCK_ACCESS_TOKEN"),
+                os.environ.get("MOTHERDUCK_TOKEN"),
+                os.environ.get("motherduck_token"),  # noqa: SIM112
+            )
+            if v
+        ),
+        None,
     )
     if not token:
-        raise SystemExit("Missing environment: MOTHERDUCK_ACCESS_TOKEN (or motherduck_token)")
+        raise SystemExit(
+            "Missing environment: MOTHERDUCK_ACCESS_TOKEN "
+            "(or MOTHERDUCK_TOKEN / motherduck_token). Seeding writes, so this "
+            "must be a read/write token - a read-scaling token cannot create tables."
+        )
     sep = "&" if "?" in database else "?"
     # Seeding writes, so unlike the query path this connection is not read-only.
     conn = duckdb.connect(f"{database}{sep}motherduck_token={quote(token, safe='')}")

--- a/scripts/seed_cloud_vendor.py
+++ b/scripts/seed_cloud_vendor.py
@@ -18,6 +18,7 @@ Usage::
 
     uv run python scripts/seed_cloud_vendor.py snowflake
     uv run python scripts/seed_cloud_vendor.py --check snowflake
+    uv run python scripts/seed_cloud_vendor.py motherduck
 
 Credentials come from the environment (``.env`` is not read automatically -
 ``set -a && source .env && set +a`` first). This drops and recreates the
@@ -31,6 +32,7 @@ import os
 import sys
 from collections.abc import Callable, Iterator
 from pathlib import Path
+from urllib.parse import quote
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SEED_SQL = REPO_ROOT / "tests" / "integration" / "drift" / "vendor_exec" / "seed_sql"
@@ -38,10 +40,17 @@ SCHEMA = "orionbelt_1"
 EXPECTED_SALES_ROWS = 10000
 
 
+# Vendors whose seed dump lives under another dialect's directory. MotherDuck
+# *is* DuckDB served remotely and accepts the same SQL, so it reuses the
+# generated duckdb dump rather than carrying a byte-identical copy.
+_SEED_DIALECT = {"motherduck": "duckdb"}
+
+
 def statements(vendor: str) -> Iterator[tuple[str, str]]:
     """Yield ``(filename, statement)`` for a vendor's seed dump, comments stripped."""
+    dialect = _SEED_DIALECT.get(vendor, vendor)
     for name in ("01_schema.sql", "02_data.sql"):
-        path = SEED_SQL / vendor / name
+        path = SEED_SQL / dialect / name
         if not path.exists():
             raise SystemExit(f"No seed dump at {path}. Generate it with _seed.py first.")
         for chunk in path.read_text(encoding="utf-8").split(";\n"):
@@ -113,15 +122,46 @@ def _databricks() -> tuple[Callable[[str], None], Callable[[str], list[tuple]], 
     return execute, query, conn.close
 
 
+def _motherduck() -> tuple[Callable[[str], None], Callable[[str], list[tuple]], Callable[[], None]]:
+    import duckdb
+
+    database = os.environ.get("DUCKDB_DATABASE", "")
+    if not database.startswith("md:"):
+        raise SystemExit(
+            "Missing environment: DUCKDB_DATABASE must be a MotherDuck database "
+            f"(md:<name>), got {database!r}"
+        )
+    # SIM112 wants an uppercase name; the lowercase spelling is MotherDuck's
+    # own documented variable and what its CLI exports, so it is accepted
+    # verbatim rather than renamed.
+    token = os.environ.get("MOTHERDUCK_ACCESS_TOKEN") or os.environ.get(
+        "motherduck_token"  # noqa: SIM112
+    )
+    if not token:
+        raise SystemExit("Missing environment: MOTHERDUCK_ACCESS_TOKEN (or motherduck_token)")
+    sep = "&" if "?" in database else "?"
+    # Seeding writes, so unlike the query path this connection is not read-only.
+    conn = duckdb.connect(f"{database}{sep}motherduck_token={quote(token, safe='')}")
+
+    def execute(sql: str) -> None:
+        conn.execute(sql)
+
+    def query(sql: str) -> list[tuple]:
+        return list(conn.execute(sql).fetchall())
+
+    return execute, query, conn.close
+
+
 VENDORS: dict[str, Callable[[], tuple]] = {
     "bigquery": _bigquery,
     "databricks": _databricks,
+    "motherduck": _motherduck,
     "snowflake": _snowflake,
 }
 
 # Identifier quoting per vendor, for the row-count probe. The seed dumps
 # themselves already carry the right quoting.
-_QUOTE = {"bigquery": "`", "databricks": "`", "snowflake": '"'}
+_QUOTE = {"bigquery": "`", "databricks": "`", "motherduck": '"', "snowflake": '"'}
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/src/orionbelt/service/db_executor.py
+++ b/src/orionbelt/service/db_executor.py
@@ -754,6 +754,11 @@ def execute_sql(
         raise
     except KeyError as exc:
         raise ExecutionUnavailableError(str(exc)) from None
+    except _config_errors() as exc:
+        # A credential / configuration problem, not a warehouse failure: surfacing it as
+        # ExecutionError would render as a 502 and send the reader looking at
+        # the database instead of at their environment.
+        raise ExecutionUnavailableError(str(exc)) from None
     except Exception as exc:
         raise ExecutionError(f"Database execution failed: {exc}") from exc
 
@@ -962,6 +967,27 @@ def explain_sql(sql: str, *, dialect: str) -> str:
         raise ExecutionUnavailableError(str(exc)) from None
     except Exception as exc:
         raise ExecutionError(f"EXPLAIN failed: {exc}") from exc
+
+
+_CONFIG_ERROR_TYPES: tuple[type[BaseException], ...] | None = None
+
+
+def _config_errors() -> tuple[type[BaseException], ...]:
+    """Exception types that mean "misconfigured", not "the warehouse failed".
+
+    Resolved lazily and cached: ``ob_flight`` is an optional install, and the
+    core package must not import it at module scope. Returns an empty tuple
+    when it is absent, which makes the ``except`` clause a no-op.
+    """
+    global _CONFIG_ERROR_TYPES  # noqa: PLW0603
+    if _CONFIG_ERROR_TYPES is None:
+        try:
+            from ob_flight.db_router import MotherDuckTokenMissingError
+
+            _CONFIG_ERROR_TYPES = (MotherDuckTokenMissingError,)
+        except Exception:  # noqa: BLE001 — ob_flight not installed
+            _CONFIG_ERROR_TYPES = ()
+    return _CONFIG_ERROR_TYPES
 
 
 def _try_fetch_arrow(cursor: Any) -> Any:

--- a/src/orionbelt/service/db_executor.py
+++ b/src/orionbelt/service/db_executor.py
@@ -965,6 +965,11 @@ def explain_sql(sql: str, *, dialect: str) -> str:
         raise
     except KeyError as exc:
         raise ExecutionUnavailableError(str(exc)) from None
+    except _config_errors() as exc:
+        # Same contract as execute_sql: a credential / configuration problem
+        # is not an EXPLAIN failure, and reporting it as one sends the reader
+        # to the database instead of to their environment.
+        raise ExecutionUnavailableError(str(exc)) from None
     except Exception as exc:
         raise ExecutionError(f"EXPLAIN failed: {exc}") from exc
 

--- a/tests/integration/test_motherduck_execution.py
+++ b/tests/integration/test_motherduck_execution.py
@@ -45,10 +45,22 @@ LOCAL_COMMERCE = REPO_ROOT / "examples" / "orionbelt_1_commerce.duckdb"
 SCHEMA = "orionbelt_1"
 
 
+def _token_env_names() -> tuple[str, ...]:
+    """Every env var the router accepts for the MotherDuck token.
+
+    Read from ``_ENV_ALIASES`` rather than restated here. A local copy of the
+    list is exactly what went stale when ``MOTHERDUCK_TOKEN`` was added to the
+    router: the live fixture skipped for anyone using that spelling, and
+    ``test_missing_token_fails_fast`` failed because it never cleared it.
+    """
+    from ob_flight.db_router import _ENV_ALIASES
+
+    canonical = "MOTHERDUCK_ACCESS_TOKEN"
+    return (canonical, *_ENV_ALIASES.get(canonical, ()))
+
+
 def _token() -> str | None:
-    return os.environ.get("MOTHERDUCK_ACCESS_TOKEN") or os.environ.get(
-        "motherduck_token"  # noqa: SIM112 — MotherDuck's own documented spelling
-    )
+    return next((v for v in (os.environ.get(n) for n in _token_env_names()) if v), None)
 
 
 @pytest.fixture(scope="module")
@@ -122,8 +134,8 @@ class TestConnection:
         from ob_flight.db_router import MotherDuckTokenMissingError, get_credentials
 
         monkeypatch.setenv("DUCKDB_DATABASE", "md:some_db")
-        monkeypatch.delenv("MOTHERDUCK_ACCESS_TOKEN", raising=False)
-        monkeypatch.delenv("motherduck_token", raising=False)
+        for name in _token_env_names():
+            monkeypatch.delenv(name, raising=False)
 
         with pytest.raises(MotherDuckTokenMissingError, match="MOTHERDUCK_ACCESS_TOKEN"):
             get_credentials("duckdb")

--- a/tests/integration/test_motherduck_execution.py
+++ b/tests/integration/test_motherduck_execution.py
@@ -1,0 +1,205 @@
+"""Integration tests: compile + execute a semantic model on live MotherDuck.
+
+MotherDuck is DuckDB served remotely, so it needs **no new dialect** — the
+existing ``duckdb`` codegen is what runs. What is new is the connection path:
+a ``md:`` database string carrying an authentication token. These tests cover
+that path end to end, and use the **local** ``examples/orionbelt_1_commerce.duckdb``
+as the source of truth: any disagreement is a MotherDuck-vs-DuckDB behaviour
+difference, which is exactly what we want to catch early.
+
+Opt-in — requires a live account::
+
+    uv run pytest -m motherduck
+
+Required env vars (skipped if missing):
+
+    DUCKDB_DATABASE           ``md:<database>`` — the MotherDuck database
+    MOTHERDUCK_ACCESS_TOKEN   access token (or the lowercase ``motherduck_token``
+                              that MotherDuck's own CLI exports)
+
+Seeding is out of band, like the other cloud warehouses — the data is static
+and re-loading it per session would dominate the suite::
+
+    uv run python scripts/seed_cloud_vendor.py motherduck
+    uv run python scripts/seed_cloud_vendor.py --check motherduck
+
+That reuses the generated ``duckdb`` seed dump, because MotherDuck accepts the
+same SQL. **It drops and recreates the ``orionbelt_1`` schema**, so point it
+only at a database you own. Tests skip (rather than fail) when the schema is
+absent, so an unseeded account does not look like a regression.
+"""
+
+from __future__ import annotations
+
+import os
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytestmark = pytest.mark.motherduck
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LOCAL_COMMERCE = REPO_ROOT / "examples" / "orionbelt_1_commerce.duckdb"
+SCHEMA = "orionbelt_1"
+
+
+def _token() -> str | None:
+    return os.environ.get("MOTHERDUCK_ACCESS_TOKEN") or os.environ.get(
+        "motherduck_token"  # noqa: SIM112 — MotherDuck's own documented spelling
+    )
+
+
+@pytest.fixture(scope="module")
+def motherduck_env() -> dict[str, str]:
+    """Skip unless a MotherDuck database and token are configured."""
+    database = os.environ.get("DUCKDB_DATABASE", "")
+    if not database.startswith("md:"):
+        pytest.skip("DUCKDB_DATABASE is not a MotherDuck database (md:<name>)")
+    if not _token():
+        pytest.skip("MOTHERDUCK_ACCESS_TOKEN (or motherduck_token) is not set")
+    return {"database": database}
+
+
+@pytest.fixture(scope="module")
+def seeded(motherduck_env: dict[str, str]) -> None:
+    """Skip unless the commerce seed is present on the remote database."""
+    from orionbelt.service.db_executor import execute_sql
+
+    try:
+        result = execute_sql(f'SELECT COUNT(*) AS n FROM "{SCHEMA}"."sales"', dialect="duckdb")
+    except Exception as exc:  # noqa: BLE001 — any failure means "not seeded"
+        pytest.skip(
+            f"{SCHEMA} not loaded on MotherDuck ({str(exc)[:120]}). "
+            "Run: uv run python scripts/seed_cloud_vendor.py motherduck"
+        )
+    if not result.rows or not result.rows[0][0]:
+        pytest.skip(f"{SCHEMA}.sales is empty on MotherDuck; run the seeder")
+
+
+def _local(sql: str) -> list[tuple[Any, ...]]:
+    """Run the same SQL against the local commerce DuckDB — the truth side."""
+    import duckdb
+
+    if not LOCAL_COMMERCE.exists():
+        pytest.skip(f"local truth database missing: {LOCAL_COMMERCE}")
+    conn = duckdb.connect(str(LOCAL_COMMERCE), read_only=True)
+    try:
+        return list(conn.execute(sql).fetchall())
+    finally:
+        conn.close()
+
+
+class TestConnection:
+    """The connection path — the only genuinely new part for MotherDuck."""
+
+    def test_token_is_folded_into_the_database_string(self, motherduck_env: dict[str, str]) -> None:
+        """``duckdb.connect`` has no token argument, so it rides on the URI."""
+        from ob_flight.db_router import get_credentials
+
+        database = get_credentials("duckdb")["database"]
+        assert database.startswith("md:")
+        assert "motherduck_token=" in database
+
+    def test_missing_token_fails_fast(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A tokenless ``md:`` must raise, never reach interactive auth.
+
+        Without a token the DuckDB extension falls back to browser-based
+        authentication, which on a server does not error — it hangs. This is
+        the guard that turns that into a configuration error.
+        """
+        from ob_flight.db_router import MotherDuckTokenMissingError, get_credentials
+
+        monkeypatch.setenv("DUCKDB_DATABASE", "md:some_db")
+        monkeypatch.delenv("MOTHERDUCK_ACCESS_TOKEN", raising=False)
+        monkeypatch.delenv("motherduck_token", raising=False)
+
+        with pytest.raises(MotherDuckTokenMissingError, match="MOTHERDUCK_ACCESS_TOKEN"):
+            get_credentials("duckdb")
+
+    def test_round_trip_preserves_types(self, motherduck_env: dict[str, str]) -> None:
+        from orionbelt.service.db_executor import execute_sql
+
+        result = execute_sql(
+            "SELECT 1 AS n, 2.50::DECIMAL(18,2) AS d, DATE '2026-01-02' AS dt, 'x' AS s",
+            dialect="duckdb",
+        )
+        assert [c.type_hint for c in result.columns] == ["number", "number", "datetime", "string"]
+        assert result.rows == [[1, Decimal("2.50"), "2026-01-02", "x"]]
+
+
+class TestAgainstLocalTruth:
+    """Remote results must match the same query run locally."""
+
+    def test_row_count_matches(self, seeded: None) -> None:
+        from orionbelt.service.db_executor import execute_sql
+
+        sql = f'SELECT COUNT(*) AS n FROM "{SCHEMA}"."sales"'
+        remote = execute_sql(sql, dialect="duckdb").rows[0][0]
+        assert remote == _local(sql)[0][0]
+
+    def test_grouped_aggregate_matches(self, seeded: None) -> None:
+        """A shape the semantic layer actually emits: GROUP BY + SUM over DECIMAL."""
+        from orionbelt.service.db_executor import execute_sql
+
+        sql = (
+            'SELECT "salespaymenttype" AS pt, SUM("salesamount") AS amt '
+            f'FROM "{SCHEMA}"."sales" GROUP BY 1 ORDER BY 1'
+        )
+        remote = [tuple(r) for r in execute_sql(sql, dialect="duckdb").rows]
+        local = [(pt, amt) for pt, amt in _local(sql)]
+        assert remote == local, f"remote={remote[:3]} local={local[:3]}"
+
+
+class TestSemanticQuery:
+    """The full path: OBML -> compiled DuckDB SQL -> executed on MotherDuck."""
+
+    MODEL = f"""
+version: 1.0
+dataObjects:
+  Sales:
+    code: sales
+    database: md
+    schema: {SCHEMA}
+    columns:
+      Sales ID:      {{code: salesid, abstractType: string, primaryKey: true}}
+      Payment Type:  {{code: salespaymenttype, abstractType: string}}
+      Sales Amount:  {{code: salesamount, abstractType: float}}
+dimensions:
+  Payment Type:
+    dataObject: Sales
+    column: Payment Type
+    resultType: string
+measures:
+  Total Sales:
+    columns:
+      - {{dataObject: Sales, column: Sales Amount}}
+    resultType: float
+    aggregation: sum
+"""
+
+    def test_compiled_semantic_query_matches_local(self, seeded: None) -> None:
+        from orionbelt.compiler.pipeline import CompilationPipeline
+        from orionbelt.models.query import QueryObject, QuerySelect
+        from orionbelt.service.db_executor import execute_sql
+        from orionbelt.service.model_store import ModelStore
+
+        store = ModelStore()
+        loaded = store.load_model(self.MODEL, dedup=False)
+        model = store.get_model(loaded.model_id)
+
+        query = QueryObject(
+            select=QuerySelect(dimensions=["Payment Type"], measures=["Total Sales"])
+        )
+        compiled = CompilationPipeline().compile(query, model, "duckdb")
+
+        # The model qualifies as md.orionbelt_1.sales; the local truth database
+        # has no "md" catalog, so compare against the same shape unqualified.
+        remote = sorted(tuple(r) for r in execute_sql(compiled.sql, dialect="duckdb").rows)
+        local = sorted(
+            _local(
+                f'SELECT "salespaymenttype", SUM("salesamount") FROM "{SCHEMA}"."sales" GROUP BY 1'
+            )
+        )
+        assert remote == local, f"remote={remote[:3]} local={local[:3]}"

--- a/tests/integration/test_motherduck_execution.py
+++ b/tests/integration/test_motherduck_execution.py
@@ -78,6 +78,16 @@ def seeded(motherduck_env: dict[str, str]) -> None:
         pytest.skip(f"{SCHEMA}.sales is empty on MotherDuck; run the seeder")
 
 
+# ``examples/orionbelt_1_commerce.duckdb`` stores salesamount / salesquantity as
+# DOUBLE, while the generated seed dump narrows them to DECIMAL(18,2) — so the
+# remote tables are decimal and the local example is float. Summing the two is
+# exact-decimal arithmetic on one side and float accumulation on the other
+# (8305358.25 vs 8305358.249999998), which never matches byte-for-byte and is
+# not a MotherDuck difference. The local side casts to the dump's declared type
+# so both sides compute the same thing.
+_SEEDED_DECIMAL = "DECIMAL(18, 2)"
+
+
 def _local(sql: str) -> list[tuple[Any, ...]]:
     """Run the same SQL against the local commerce DuckDB — the truth side."""
     import duckdb
@@ -143,12 +153,16 @@ class TestAgainstLocalTruth:
         """A shape the semantic layer actually emits: GROUP BY + SUM over DECIMAL."""
         from orionbelt.service.db_executor import execute_sql
 
-        sql = (
+        remote_sql = (
             'SELECT "salespaymenttype" AS pt, SUM("salesamount") AS amt '
             f'FROM "{SCHEMA}"."sales" GROUP BY 1 ORDER BY 1'
         )
-        remote = [tuple(r) for r in execute_sql(sql, dialect="duckdb").rows]
-        local = [(pt, amt) for pt, amt in _local(sql)]
+        local_sql = (
+            f'SELECT "salespaymenttype" AS pt, SUM("salesamount"::{_SEEDED_DECIMAL}) AS amt '
+            f'FROM "{SCHEMA}"."sales" GROUP BY 1 ORDER BY 1'
+        )
+        remote = [tuple(r) for r in execute_sql(remote_sql, dialect="duckdb").rows]
+        local = [tuple(r) for r in _local(local_sql)]
         assert remote == local, f"remote={remote[:3]} local={local[:3]}"
 
 
@@ -199,7 +213,8 @@ measures:
         remote = sorted(tuple(r) for r in execute_sql(compiled.sql, dialect="duckdb").rows)
         local = sorted(
             _local(
-                f'SELECT "salespaymenttype", SUM("salesamount") FROM "{SCHEMA}"."sales" GROUP BY 1'
+                f'SELECT "salespaymenttype", SUM("salesamount"::{_SEEDED_DECIMAL}) '
+                f'FROM "{SCHEMA}"."sales" GROUP BY 1'
             )
         )
         assert remote == local, f"remote={remote[:3]} local={local[:3]}"

--- a/tests/integration/test_motherduck_execution.py
+++ b/tests/integration/test_motherduck_execution.py
@@ -59,19 +59,27 @@ def _token_env_names() -> tuple[str, ...]:
     return (canonical, *_ENV_ALIASES.get(canonical, ()))
 
 
-def _token() -> str | None:
-    return next((v for v in (os.environ.get(n) for n in _token_env_names()) if v), None)
-
-
 @pytest.fixture(scope="module")
 def motherduck_env() -> dict[str, str]:
-    """Skip unless a MotherDuck database and token are configured."""
+    """Skip unless the router considers MotherDuck configured.
+
+    "Configured" is asked of the router rather than re-derived here. The
+    token may arrive through any of three env vars *or* embedded directly in
+    ``DUCKDB_DATABASE`` as ``motherduck_token=`` / ``read_scaling_token=``;
+    a local rule that only looked at the env vars skipped the whole live
+    suite for the documented embedded forms even though the router accepted
+    them.
+    """
+    from ob_flight.db_router import MotherDuckTokenMissingError, get_credentials
+
     database = os.environ.get("DUCKDB_DATABASE", "")
     if not database.startswith("md:"):
         pytest.skip("DUCKDB_DATABASE is not a MotherDuck database (md:<name>)")
-    if not _token():
-        pytest.skip("MOTHERDUCK_ACCESS_TOKEN (or motherduck_token) is not set")
-    return {"database": database}
+    try:
+        creds = get_credentials("duckdb")
+    except MotherDuckTokenMissingError as exc:
+        pytest.skip(str(exc))
+    return {"database": str(creds["database"])}
 
 
 @pytest.fixture(scope="module")
@@ -118,11 +126,14 @@ class TestConnection:
 
     def test_token_is_folded_into_the_database_string(self, motherduck_env: dict[str, str]) -> None:
         """``duckdb.connect`` has no token argument, so it rides on the URI."""
-        from ob_flight.db_router import get_credentials
+        from ob_flight.db_router import _MOTHERDUCK_URI_TOKEN_PARAMS, get_credentials
 
         database = get_credentials("duckdb")["database"]
         assert database.startswith("md:")
-        assert "motherduck_token=" in database
+        # Either accepted parameter counts: a read-scaling token is spelled
+        # differently and is no less a token. Taken from the router so the
+        # assertion cannot narrow behind it.
+        assert any(f"{p}=" in database for p in _MOTHERDUCK_URI_TOKEN_PARAMS), database
 
     def test_missing_token_fails_fast(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """A tokenless ``md:`` must raise, never reach interactive auth.


### PR DESCRIPTION
## What

MotherDuck is DuckDB served remotely, so it needs **no new dialect** — the existing `duckdb` codegen is what runs. What was missing was the connection path: a `md:` database string carrying a token.

Verified live against a real MotherDuck database end to end, through `execute_sql`:

```
MOTHERDUCK via execute_sql: OK
  [('n','number'), ('d','number'), ('ts','datetime')]
  [[1, Decimal('2.50'), '2026-08-29T18:07:29.753415+02:00']]
```

## Credentials

`MOTHERDUCK_ACCESS_TOKEN` joins `_CREDENTIAL_KEYS['duckdb']`, with the lowercase `motherduck_token` that MotherDuck's own CLI exports accepted as an alias through the `_ENV_ALIASES` map added in #383. The uppercase spelling stays canonical, matching every other vendor key.

`duckdb.connect` takes no token argument — the token travels as a query parameter on the database string — so it is folded in inside `get_credentials`. `db_executor` opens DuckDB three different ways (`:478`, `:734`, `:939`) and all three read credentials through that function, so it is the one seam that covers them. Checked first that nothing logs credentials or the database string.

## The fail-fast guard is the important part

A `md:` database with no token now raises `MotherDuckTokenMissingError`.

Without a token the DuckDB extension falls back to **interactive browser authentication**, which on a server does not raise — it *hangs*, presenting as a stuck worker rather than a failed connection. (This is not theoretical: it hung a probe during the audit until it was killed.) It can also silently pick up an ambient lowercase `motherduck_token` and connect to whichever account that belongs to — the same shape as the Databricks bug in #383, a credential resolved somewhere other than where you are looking.

Passing the token explicitly, always, removes both.

## One expected blocker that was not one

`read_only=True` is hard-coded for DuckDB and was expected to be rejected by `md:`. It is accepted — verified live — so the default is unchanged.

## Seeding

`scripts/seed_cloud_vendor.py motherduck` reuses the generated `duckdb` seed dump through a `_SEED_DIALECT` mapping, since MotherDuck accepts the same SQL; no byte-identical second copy. It connects read-write, unlike the query path.

## Tests

New `motherduck` marker. Skips cleanly without credentials, and skips **rather than fails** when the schema is unseeded, with a message naming the seeder — an unseeded account should not look like a regression.

| Test | Covers |
|---|---|
| token folded into the database string | the connection path |
| missing token fails fast | the hang guard |
| round trip preserves types | DECIMAL / DATE / VARCHAR |
| row count, grouped aggregate | agreement with local commerce DuckDB |
| compiled semantic query | OBML → duckdb SQL → MotherDuck, vs local truth |

Local DuckDB is the source of truth, so any divergence is a MotherDuck-vs-DuckDB behaviour difference.

Live run: 3 passed, 3 skipped (pending a seeder run). Root suite 4649 passed / 1 xfailed, driver suite 188. `ruff` and `mypy` clean.

## Docs

`.env.template` gains the `md:` form and the token, with the hang caveat. `docs/drivers.md` env-var table updated for both `duckdb` (md: + token) and `databricks` (the `DATABRICKS_TOKEN` alias from #383).
