### PR TITLE
chore(license): correct the SPDX identifier and add third-party notices

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -28,7 +28,10 @@ tests/
 docs/
 mkdocs.yml
 CLAUDE.md
-LICENSE
+# LICENSE is NOT excluded: pyproject declares license-files = ["LICENSE"], so
+# a build without it produces a wheel with no License-File metadata and an
+# empty dist-info/licenses/ - silently, since hatchling does not fail on a
+# missing licence file.
 .mcpregistry_github_token
 .mcpregistry_registry_token
 # NOTE: drivers/ used to be excluded because the published image only

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 # can resolve the workspace graph. The flight* extras pull the osi-orionbelt
 # member under packages/, so it must be present at this first sync.
 ARG OB_EXTRA=flight-duckdb-only
-COPY pyproject.toml uv.lock README.md ./
+COPY pyproject.toml uv.lock README.md LICENSE ./
 COPY drivers/ drivers/
 COPY packages/ packages/
 RUN uv sync --no-dev --no-install-project --frozen --extra ${OB_EXTRA}

--- a/Dockerfile.flight
+++ b/Dockerfile.flight
@@ -10,7 +10,7 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 # Copy workspace members first (cached layer). The flight extra depends on the
 # osi-orionbelt workspace member under packages/, so it must be present before
 # the first sync resolves that extra.
-COPY pyproject.toml uv.lock README.md ./
+COPY pyproject.toml uv.lock README.md LICENSE ./
 COPY drivers/ drivers/
 COPY packages/ packages/
 RUN uv sync --no-dev --no-install-project --extra flight --frozen

--- a/Dockerfile.flight.dockerignore
+++ b/Dockerfile.flight.dockerignore
@@ -28,7 +28,10 @@ tests/
 docs/
 mkdocs.yml
 CLAUDE.md
-LICENSE
+# LICENSE is NOT excluded: pyproject declares license-files = ["LICENSE"], so
+# a build without it produces a wheel with no License-File metadata and an
+# empty dist-info/licenses/. Docker reads this file instead of .dockerignore
+# for `-f Dockerfile.flight`, so the exclusion has to be lifted in both.
 .mcpregistry_github_token
 .mcpregistry_registry_token
 Dockerfile

--- a/Dockerfile.ui
+++ b/Dockerfile.ui
@@ -8,7 +8,7 @@ WORKDIR /app
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 
 # Install dependencies first (cached layer — only reruns when pyproject.toml/uv.lock change)
-COPY pyproject.toml uv.lock README.md ./
+COPY pyproject.toml uv.lock README.md LICENSE ./
 RUN uv sync --no-dev --extra ui --no-install-project --frozen
 
 # Copy source and install the project itself. The UI proxies OSI conversion to

--- a/LICENSE
+++ b/LICENSE
@@ -3,8 +3,8 @@ Business Source License 1.1
 Parameters
 
 Licensor:             RALFORION d.o.o.
-Licensed Work:        OrionBelt Semantic Layer 1.0
-                      The Licensed Work is (c) 2025 RALFORION d.o.o.
+Licensed Work:        OrionBelt Semantic Layer (all versions)
+                      The Licensed Work is (c) 2025-2026 RALFORION d.o.o.
 Additional Use Grant: You may use the Licensed Work for any purpose,
                       including production use, PROVIDED THAT you may
                       not embed OrionBelt in a commercial product or

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 <a href="https://pypi.org/project/orionbelt-semantic-layer/"><img src="https://img.shields.io/pypi/v/orionbelt-semantic-layer?logo=pypi&logoColor=white" alt="PyPI"></a>
 <a href="https://hub.docker.com/r/ralforion/orionbelt-semantic-layer-api"><img src="https://img.shields.io/docker/pulls/ralforion/orionbelt-semantic-layer-api?logo=docker&logoColor=white&color=2496ED" alt="Docker pulls"></a>
 <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.12+-blue.svg" alt="Python 3.12+"></a>
-<a href="https://github.com/ralforion/orionbelt-semantic-layer/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-BSL_1.1-orange.svg" alt="License: BSL 1.1"></a>
+<a href="https://github.com/ralforion/orionbelt-semantic-layer/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-BUSL--1.1-orange.svg" alt="License: BUSL-1.1"></a>
 </p>
 
 ---
@@ -370,7 +370,7 @@ Also works with Copilot, Cursor, and Windsurf. See the [MCP repo](https://github
 | **Multi-fact queries** | Star Schema + CFL planner (fan-trap prevention) | Limited | Pre-aggregations | Automatic joins |
 | **Integration surface** | REST API + MCP + Gradio UI | dbt Cloud API | REST + GraphQL | VS Code extension |
 | **Deployment** | Self-host anywhere, single binary | SaaS (Cloud) | SaaS or self-host | Library |
-| **License** | BSL 1.1 (converts to Apache 2.0) | Apache 2.0 | AGPL / proprietary | MIT |
+| **License** | BUSL-1.1 (converts to Apache 2.0) | Apache 2.0 | AGPL / proprietary | MIT |
 
 ---
 
@@ -646,7 +646,9 @@ Copyright © 2026 [RALFORION d.o.o.](https://ralforion.com)
 
 OrionBelt® is a registered trademark of RALFORION d.o.o.
 
-Licensed under the [Business Source License 1.1](LICENSE). The Licensed Work will convert to Apache License 2.0 on 2030-03-16.
+Licensed under the [Business Source License 1.1](LICENSE) (SPDX: `BUSL-1.1`). The Licensed Work will convert to Apache License 2.0 on 2030-03-16.
+
+Third-party works redistributed by OrionBelt, and their terms, are listed in [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).
 
 By contributing to this project, you agree to the [Contributor License Agreement](CLA.md).
 

--- a/README.md
+++ b/README.md
@@ -593,7 +593,7 @@ API_BASE_URL=http://remote-api:8080 orionbelt-ui           # point UI to a remot
 
 ## Commercial Offerings
 
-OrionBelt Semantic Layer is open by default — the OSS distribution has full parity on the shipped v2.6 surface and is production-grade for self-hosted use. For teams that want production support, a managed runtime, or embedded analytics terms, RALFORION offers:
+OrionBelt Semantic Layer is source-available under BUSL-1.1 until its Apache-2.0 conversion — the free distribution has full parity on the shipped v2.6 surface and is production-grade for self-hosted use. For teams that want production support, a managed runtime, or embedded analytics terms, RALFORION offers:
 
 - **Embedded analytics license** — relicensing terms for shipping OBSL inside a commercial product
 - **Commercial cloud offering** — managed OrionBelt runtime with SLAs

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -28,40 +28,63 @@ third-party: the JSON Schemas under `orionbelt/schema/` and the ontology under
 
 ## Bundled in the container images
 
-`ralforion/orionbelt-api`, `ralforion/orionbelt-ui` and
-`ralforion/orionbelt-flight` contain the full installed dependency tree, so
-publishing them is redistribution of those packages too. Each keeps its own
-licence text in its `dist-info/licenses/` directory inside the image; the table
-below records the direct runtime dependencies and their terms.
+Publishing an image redistributes everything installed inside it, so the images
+carry more than the wheel does. Each is built from a different optional-
+dependency group, so they differ from one another too; the tables list what
+each group adds **on top of** the runtime dependencies above.
+
+Every package keeps its own licence text in its `dist-info/licenses/`
+directory inside the image.
+
+### `ralforion/orionbelt-semantic-layer-api`
+
+Built from `Dockerfile` with `OB_EXTRA` defaulting to `flight-duckdb-only`.
 
 | Package | Licence |
 |---|---|
-| fastapi | MIT |
-| httpx | BSD-3-Clause |
-| jsonschema | MIT |
-| networkx | BSD-3-Clause |
-| opentelemetry-api | Apache-2.0 |
-| pydantic | MIT |
-| pydantic-settings | MIT |
-| pytz | MIT |
-| pyyaml | MIT |
-| rdflib | BSD-3-Clause |
-| ruamel.yaml | MIT |
-| sqlglot | MIT |
-| structlog | MIT OR Apache-2.0 |
-| typer | MIT |
-| tzdata | Apache-2.0 |
-| uvicorn | BSD-3-Clause |
+| pyarrow | Apache-2.0 |
+| ob-flight-extension, ob-driver-core, ob-duckdb, osi-orionbelt | OrionBelt's own — see below |
 
-All are permissive (MIT, BSD-3-Clause, Apache-2.0). None is copyleft, so none
-imposes a licensing obligation on OrionBelt's own source. Optional extras
-(`ui`, `flight`, `drivers`, `docs`) and the vendor database drivers pull in
-further packages under the same kinds of terms; they are installed by pip from
-PyPI rather than copied into this repository.
+### `ralforion/orionbelt-semantic-layer-flight`
 
-Transitive dependencies are not enumerated here. They are resolved and pinned
-in [`uv.lock`](uv.lock), which records the exact version of every package in a
+Built from `Dockerfile.flight` with the `flight` extra, which adds every vendor
+driver.
+
+| Package | Licence |
+|---|---|
+| pyarrow | Apache-2.0 |
+| ob-flight-extension, ob-driver-core, osi-orionbelt, and the nine `ob-<vendor>` drivers | OrionBelt's own — see below |
+
+The vendor drivers each depend on that vendor's own client SDK
+(`snowflake-connector-python`, `databricks-sql-connector`,
+`google-cloud-bigquery`, `clickhouse-connect`, `mysql-connector-python`,
+`duckdb`, `adbc-driver-postgresql`), so this image carries the largest
+third-party tree of the three.
+
+### `ralforion/orionbelt-semantic-layer-ui`
+
+Built from `Dockerfile.ui` with the `ui` extra. It proxies execution to the
+API, so it carries no drivers and no converter.
+
+| Package | Licence |
+|---|---|
+| gradio | Apache-2.0 |
+| pyarrow | Apache-2.0 |
+
+### Transitive dependencies
+
+Not enumerated here — including the vendor client SDKs the drivers pull in, and
+everything `gradio` brings with it. They are resolved and pinned in
+[`uv.lock`](uv.lock), which records the exact version of every package in a
 build, and each carries its own licence in its distribution metadata.
+
+For an authoritative per-image list, read the metadata inside the image rather
+than trusting this file to stay current:
+
+```bash
+docker run --rm ralforion/orionbelt-semantic-layer-api \
+  python -c "import importlib.metadata as m; [print(d.name, d.version) for d in m.distributions()]"
+```
 
 ## Not redistributed
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -26,6 +26,36 @@ It powers the Ontology Graph tab in the Gradio UI. Nothing else in the wheel is
 third-party: the JSON Schemas under `orionbelt/schema/` and the ontology under
 `ontology/` are OrionBelt's own work.
 
+## Python runtime dependencies
+
+Installed by every distribution path, and present in all three container
+images. Licences are read from each distribution's metadata.
+
+| Package | Licence |
+|---|---|
+| fastapi | MIT |
+| httpx | BSD-3-Clause |
+| jsonschema | MIT |
+| networkx | BSD-3-Clause |
+| opentelemetry-api | Apache-2.0 |
+| pydantic | MIT |
+| pydantic-settings | MIT |
+| pytz | MIT |
+| pyyaml | MIT |
+| rdflib | BSD-3-Clause |
+| ruamel.yaml | MIT |
+| sqlglot | MIT |
+| structlog | MIT OR Apache-2.0 |
+| typer | MIT |
+| tzdata | Apache-2.0 |
+| uvicorn | BSD-3-Clause |
+
+All permissive (MIT, BSD-3-Clause, Apache-2.0). None is copyleft, so none
+imposes a licensing obligation on OrionBelt's own source.
+
+Installing from PyPI does not redistribute these — pip fetches them itself.
+They are listed because the container images below *do* contain them.
+
 ## Bundled in the container images
 
 Publishing an image redistributes everything installed inside it, so the images
@@ -53,7 +83,7 @@ driver.
 | Package | Licence |
 |---|---|
 | pyarrow | Apache-2.0 |
-| ob-flight-extension, ob-driver-core, osi-orionbelt, and the nine `ob-<vendor>` drivers | OrionBelt's own — see below |
+| ob-flight-extension, ob-driver-core, osi-orionbelt, and the eight `ob-<vendor>` drivers | OrionBelt's own — see below |
 
 The vendor drivers each depend on that vendor's own client SDK
 (`snowflake-connector-python`, `databricks-sql-connector`,

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -64,9 +64,20 @@ dependency group, so they differ from one another too; the tables list what
 each group adds **on top of** the runtime dependencies above.
 
 Most packages ship their own licence text in `dist-info/licenses/` inside the
-image — 71 of 73 distributions in the UI image when this was written. A few
-declare a licence in metadata but ship no licence file at all (`ffmpy`,
-`gradio_client`); for those the upstream project is the authoritative source.
+image. A few declare a licence in metadata and ship no file at all; for those
+the upstream project is the authoritative source. Measured per image when this
+was written — the images differ, so a single figure would be wrong for two of
+them:
+
+| Image | Carry licence text | Ship none |
+|---|---|---|
+| `…-api` | 50 of 50 | — |
+| `…-flight` | 109 of 112 | `et_xmlfile`, `openpyxl`, `thrift` |
+| `…-ui` | 71 of 73 | `ffmpy`, `gradio_client` |
+
+Those counts move with every dependency bump. The command under *Transitive
+dependencies* below reads the current state out of an image, which is
+authoritative where this table is a snapshot.
 
 ### `ralforion/orionbelt-semantic-layer-api`
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -63,8 +63,10 @@ carry more than the wheel does. Each is built from a different optional-
 dependency group, so they differ from one another too; the tables list what
 each group adds **on top of** the runtime dependencies above.
 
-Every package keeps its own licence text in its `dist-info/licenses/`
-directory inside the image.
+Most packages ship their own licence text in `dist-info/licenses/` inside the
+image — 71 of 73 distributions in the UI image when this was written. A few
+declare a licence in metadata but ship no licence file at all (`ffmpy`,
+`gradio_client`); for those the upstream project is the authoritative source.
 
 ### `ralforion/orionbelt-semantic-layer-api`
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,92 @@
+# Third-party notices
+
+OrionBelt Semantic Layer is distributed under the [Business Source License 1.1](LICENSE)
+(SPDX: `BUSL-1.1`), converting to Apache License 2.0 on 2030-03-16.
+
+This document covers third-party works that OrionBelt **redistributes**, with
+their sources, licences, and where their licence text lives. Attribution
+obligations attach to redistribution, so the two cases are listed separately:
+what ships inside the wheel, and what ships inside the container images.
+
+## Bundled in the Python wheel
+
+One third-party file is copied into the package and published on PyPI as part
+of `orionbelt-semantic-layer`.
+
+| Shipped as | Upstream | Version | Licence | Text |
+|---|---|---|---|---|
+| `orionbelt/ui/static/vis-network.min.js` | [vis-network](https://visjs.github.io/vis-network/) | 9.1.2 | Apache-2.0 OR MIT (redistributed under MIT) | `orionbelt/ui/static/vis-network.LICENSE.txt` |
+
+vis-network is dual licensed and may be distributed under either licence;
+OrionBelt redistributes it under the MIT License. The minified file carries a
+header naming both licences but **not** their text, which MIT requires to
+accompany redistribution — hence the adjacent `.LICENSE.txt`.
+
+It powers the Ontology Graph tab in the Gradio UI. Nothing else in the wheel is
+third-party: the JSON Schemas under `orionbelt/schema/` and the ontology under
+`ontology/` are OrionBelt's own work.
+
+## Bundled in the container images
+
+`ralforion/orionbelt-api`, `ralforion/orionbelt-ui` and
+`ralforion/orionbelt-flight` contain the full installed dependency tree, so
+publishing them is redistribution of those packages too. Each keeps its own
+licence text in its `dist-info/licenses/` directory inside the image; the table
+below records the direct runtime dependencies and their terms.
+
+| Package | Licence |
+|---|---|
+| fastapi | MIT |
+| httpx | BSD-3-Clause |
+| jsonschema | MIT |
+| networkx | BSD-3-Clause |
+| opentelemetry-api | Apache-2.0 |
+| pydantic | MIT |
+| pydantic-settings | MIT |
+| pytz | MIT |
+| pyyaml | MIT |
+| rdflib | BSD-3-Clause |
+| ruamel.yaml | MIT |
+| sqlglot | MIT |
+| structlog | MIT OR Apache-2.0 |
+| typer | MIT |
+| tzdata | Apache-2.0 |
+| uvicorn | BSD-3-Clause |
+
+All are permissive (MIT, BSD-3-Clause, Apache-2.0). None is copyleft, so none
+imposes a licensing obligation on OrionBelt's own source. Optional extras
+(`ui`, `flight`, `drivers`, `docs`) and the vendor database drivers pull in
+further packages under the same kinds of terms; they are installed by pip from
+PyPI rather than copied into this repository.
+
+Transitive dependencies are not enumerated here. They are resolved and pinned
+in [`uv.lock`](uv.lock), which records the exact version of every package in a
+build, and each carries its own licence in its distribution metadata.
+
+## Not redistributed
+
+Installing `orionbelt-semantic-layer` from PyPI pulls its dependencies from
+PyPI directly — OrionBelt does not vendor or re-publish them, so that path
+redistributes nothing but OrionBelt's own code and the one bundled file above.
+
+## Where these terms came from
+
+- vis-network: the `@license` header of the bundled `vis-network.min.js`
+  (version 9.1.2, dated 2022-03-28) and the upstream project page.
+- Python packages: the `License-Expression`, `License`, and `License ::`
+  classifier fields of each installed distribution's metadata, read from the
+  resolved environment rather than transcribed by hand.
+
+## OrionBelt's own components
+
+The workspace publishes several packages under their own terms:
+
+| Package | Licence |
+|---|---|
+| `orionbelt-semantic-layer` | BUSL-1.1 |
+| `ob-driver-core`, `ob-bigquery`, `ob-clickhouse`, `ob-databricks`, `ob-dremio`, `ob-duckdb`, `ob-flight-extension`, `ob-mysql`, `ob-postgres`, `ob-snowflake` | BUSL-1.1 |
+| `osi-orionbelt` | Apache-2.0 |
+
+`osi-orionbelt` is deliberately Apache-2.0: it implements the Apache Ossie
+(formerly OSI) interchange format and is meant to be usable by anyone working
+with that specification, independently of OrionBelt.

--- a/docs/comparison/atscale.md
+++ b/docs/comparison/atscale.md
@@ -7,8 +7,8 @@ A feature comparison between **OrionBelt Semantic Layer (OBSL)** and **AtScale**
 ## TL;DR
 
 - **AtScale wins on**: enterprise OLAP capabilities (true hierarchies, parent-child, ragged, time-intelligence), **native MDX support** for Excel pivot tables and SSAS-protocol clients (no other peer in this comparison set has this), **DAX support** for Power BI live connections, **autonomous aggregates** (machine-learned auto-rollups similar to Cube pre-aggregations but more automated), enterprise governance (RLS, perspectives, lineage), and broad legacy/cloud warehouse coverage.
-- **OBSL wins on**: being **open-source and self-hostable for production with no licensing tier** (AtScale offers a free Developer Community Edition for evaluation, but production multi-user deployments require an enterprise license), a **simple JSON Query API** consumable by any client, **first-class declarative metric types** for cumulative (with `partitionBy`), period-over-period, and **window** (rank / lag / lead / ntile / first_value / last_value), **9 statistical aggregates** (CORR / COVAR_* / REGR_* / STDDEV_* / VAR_*), an **RDF/SPARQL graph view** of the model, **named secondary join paths**, **multi-rooted DAG topology with the CFL planner**, an **interactive ontology-graph playground**, **OSI v0.2 ↔ OBML format conversion**, and a much smaller operational footprint.
-- **Different niches**: AtScale is "the enterprise OLAP semantic layer for Excel/PowerBI/Tableau shops that need MDX." OBSL is "the open-source, embeddable semantic compiler for apps, agents, and modern BI tools that speak Arrow Flight SQL or REST."
+- **OBSL wins on**: being **source-available (BUSL-1.1) and self-hostable for production with no licensing tier** (AtScale offers a free Developer Community Edition for evaluation, but production multi-user deployments require an enterprise license), a **simple JSON Query API** consumable by any client, **first-class declarative metric types** for cumulative (with `partitionBy`), period-over-period, and **window** (rank / lag / lead / ntile / first_value / last_value), **9 statistical aggregates** (CORR / COVAR_* / REGR_* / STDDEV_* / VAR_*), an **RDF/SPARQL graph view** of the model, **named secondary join paths**, **multi-rooted DAG topology with the CFL planner**, an **interactive ontology-graph playground**, **OSI v0.2 ↔ OBML format conversion**, and a much smaller operational footprint.
+- **Different niches**: AtScale is "the enterprise OLAP semantic layer for Excel/PowerBI/Tableau shops that need MDX." OBSL is "the source-available, embeddable semantic compiler for apps, agents, and modern BI tools that speak Arrow Flight SQL or REST."
 
 AtScale is the only peer in this comparison set that natively speaks **MDX**, the OLAP wire protocol that Excel and SSAS clients use. That's a real moat for organizations standardized on Microsoft BI tooling. OBSL doesn't compete on that axis.
 
@@ -24,7 +24,7 @@ AtScale is the only peer in this comparison set that natively speaks **MDX**, th
 | OLAP primitives | Time grain on dimensions, no first-class hierarchies | First-class **hierarchies** (multiple per dimension), **levels**, **parent-child** dimensions, **ragged** hierarchies |
 | Repeated columns (`ARRAY<STRUCT>`) | Declared as a data object with `nestedIn`; unnested per dialect — see [Nested data objects](../guide/model-format.md#nested-data-objects-nestedin) | Flatten upstream; the modeller works from relational tables |
 | Templating | None | Limited; some calculated-member expressions |
-| Runtime | OSS, self-hosted (single Python service) | Proprietary AtScale Engine — on-prem, cloud-hosted, or AtScale-managed |
+| Runtime | Source-available (BUSL-1.1), self-hosted (single Python service) | Proprietary AtScale Engine — on-prem, cloud-hosted, or AtScale-managed |
 
 **Key cultural difference**: AtScale carries OLAP heritage from the SSAS/MDX world — it thinks in cubes, hierarchies, and calculated members. OBSL thinks in data objects, joins, and metrics. The model overlap is real but the conceptual frames differ.
 
@@ -195,19 +195,19 @@ AtScale's MDX/DAX support is unique and a genuine advantage for Microsoft-stack 
 
 ---
 
-## 9. Open-source vs. proprietary
+## 9. Licensing vs. proprietary
 
 | | OBSL | AtScale |
 |---|---|---|
 | License | Source-available (BUSL-1.1) | Proprietary; **free Developer Community Edition** for non-production / individual use |
 | Self-hostable | ✅ (one Python service) | ✅ — Developer Edition is free to install; production deployment requires enterprise license |
-| Pricing | OSS is free for self-hosted production; commercial tiers available for embedded analytics, managed cloud, and enterprise features | **Developer Edition: free** (with feature/scale limits). Enterprise: typical six-figure annual licensing for production |
+| Pricing | Free for self-hosted production under BUSL-1.1; commercial tiers available for embedded analytics, managed cloud, and enterprise features | **Developer Edition: free** (with feature/scale limits). Enterprise: typical six-figure annual licensing for production |
 | Commercial offering | Embedded analytics license · commercial cloud offering · enterprise features · consulting + support | Enterprise license — production deployments, autonomous aggregates at scale, enterprise governance, vendor support |
 | Vendor lock-in | None (plain YAML, OSI-portable) | High — model lives in AtScale's proprietary format (mitigated for OSI-aware exports) |
 | Air-gapped deploy | ✅ supported | ✅ supported (enterprise) |
-| Self-host parity | OSS has full parity on the shipped v2.6 surface; enterprise tier adds enterprise-specific capabilities on top | Full features in licensed enterprise tier; Developer Edition has feature/scale restrictions |
+| Self-host parity | The free tier has full parity on the shipped v2.6 surface; enterprise tier adds enterprise-specific capabilities on top | Full features in licensed enterprise tier; Developer Edition has feature/scale restrictions |
 
-The free **Developer Community Edition** lowers AtScale's barrier for evaluation, prototyping, and individual learning — you can model, run MDX queries from Excel, and explore AtScale without a contract. For production multi-user deployments, autonomous aggregates at scale, or enterprise governance/support, the licensed AtScale tier is required. For OBSL the OSS tier is fully production-grade for self-hosted use; commercial offerings (embedded analytics license, managed cloud, enterprise features, consulting + support) are available alongside if you want them, not as an upgrade gate for OSS capabilities.
+The free **Developer Community Edition** lowers AtScale's barrier for evaluation, prototyping, and individual learning — you can model, run MDX queries from Excel, and explore AtScale without a contract. For production multi-user deployments, autonomous aggregates at scale, or enterprise governance/support, the licensed AtScale tier is required. For OBSL the free tier is fully production-grade for self-hosted use; commercial offerings (embedded analytics license, managed cloud, enterprise features, consulting + support) are available alongside if you want them, not as an upgrade gate for OSS capabilities.
 
 ---
 
@@ -239,7 +239,7 @@ The free **Developer Community Edition** lowers AtScale's barrier for evaluation
 | MCP server (LLM/agent) | ✅ first-party | ✅ first-party (AtScale MCP Server) |
 | Built-in caching | ✅ file cache based on freshness inheritance (TTL derived from per-`dataObject` `refresh:` contracts; ETL heartbeat invalidation) | ✅ result cache + autonomous aggregates (warehouse-side) |
 | Visual model designer | ❌ | ✅ Design Center (polished) |
-| Open source / self-host without license | ✅ | ❌ |
+| Source-available / self-host without license | ✅ | ❌ |
 
 ---
 
@@ -258,7 +258,7 @@ The free **Developer Community Edition** lowers AtScale's barrier for evaluation
 
 ### Pick **OBSL** when:
 
-- You need an **open-source, self-hostable, embeddable** semantic layer with **no production licensing tier** — OBML is plain YAML, the runtime is one Python service, and the same OSS bits run in production as in development. AtScale's free Community Edition is great for evaluation, but production multi-user deployments still need an enterprise contract.
+- You need a **source-available, self-hostable, embeddable** semantic layer with **no production licensing tier** — OBML is plain YAML, the runtime is one Python service, and the same bits run in production as in development. AtScale's free Community Edition is great for evaluation, but production multi-user deployments still need an enterprise contract.
 - Your consumers are **applications, agents, or LLMs** — a stable JSON/Arrow Flight SQL API beats requiring callers to know MDX/DAX.
 - You need **multi-rooted DAG modeling** for messy real-world warehouses with multiple fact tables and ambiguous join paths.
 - You want **first-class declarative cumulative and period-over-period metric types** rather than expressing them as MDX calculated members.

--- a/docs/comparison/atscale.md
+++ b/docs/comparison/atscale.md
@@ -289,7 +289,7 @@ In a Microsoft-stack enterprise: AtScale serves the human BI audience (Excel, Po
 
 ### To match OBSL, AtScale would need:
 
-1. **Open-source / self-hostable runtime in production** — the free Developer Community Edition is welcome for evaluation, but production deployments still require an enterprise license. A truly OSS production tier would be the structural unlock.
+1. **Source-available / self-hostable runtime in production** — the free Developer Community Edition is welcome for evaluation, but production deployments still require an enterprise license. A truly OSS production tier would be the structural unlock.
 2. **Multi-rooted DAG modeling with explicit CFL multi-fact planning** — the ability to query across genuinely independent fact tables in one go without pre-designing a cube.
 3. **First-class declarative cumulative & period-over-period metric types** — turnkey alternatives to writing MDX calculated members.
 4. **RDF/SPARQL graph surface** for governance/lineage tooling outside the proprietary platform.

--- a/docs/comparison/atscale.md
+++ b/docs/comparison/atscale.md
@@ -207,7 +207,7 @@ AtScale's MDX/DAX support is unique and a genuine advantage for Microsoft-stack 
 | Air-gapped deploy | ✅ supported | ✅ supported (enterprise) |
 | Self-host parity | The free tier has full parity on the shipped v2.6 surface; enterprise tier adds enterprise-specific capabilities on top | Full features in licensed enterprise tier; Developer Edition has feature/scale restrictions |
 
-The free **Developer Community Edition** lowers AtScale's barrier for evaluation, prototyping, and individual learning — you can model, run MDX queries from Excel, and explore AtScale without a contract. For production multi-user deployments, autonomous aggregates at scale, or enterprise governance/support, the licensed AtScale tier is required. For OBSL the free tier is fully production-grade for self-hosted use; commercial offerings (embedded analytics license, managed cloud, enterprise features, consulting + support) are available alongside if you want them, not as an upgrade gate for OSS capabilities.
+The free **Developer Community Edition** lowers AtScale's barrier for evaluation, prototyping, and individual learning — you can model, run MDX queries from Excel, and explore AtScale without a contract. For production multi-user deployments, autonomous aggregates at scale, or enterprise governance/support, the licensed AtScale tier is required. For OBSL the free tier is fully production-grade for self-hosted use; commercial offerings (embedded analytics license, managed cloud, enterprise features, consulting + support) are available alongside if you want them, not as an upgrade gate for the free tier's capabilities.
 
 ---
 
@@ -293,7 +293,7 @@ In a Microsoft-stack enterprise: AtScale serves the human BI audience (Excel, Po
 2. **Multi-rooted DAG modeling with explicit CFL multi-fact planning** — the ability to query across genuinely independent fact tables in one go without pre-designing a cube.
 3. **First-class declarative cumulative & period-over-period metric types** — turnkey alternatives to writing MDX calculated members.
 4. **RDF/SPARQL graph surface** for governance/lineage tooling outside the proprietary platform.
-5. **A modern OSS SQL wire protocol surface for BI tools** — OBSL ships both **PostgreSQL wire** (Tableau / DBeaver / Superset / Power BI / `psql` / Dremio's Postgres-source connector, v2.5.0+) and **Apache Arrow Flight SQL** (gRPC, columnar, JDBC/ODBC via Flight SQL drivers) side-by-side; AtScale's BI-tool surface is JDBC/ODBC + MDX/DAX through the enterprise gateway.
+5. **A modern, open-protocol SQL wire surface for BI tools** — OBSL ships both **PostgreSQL wire** (Tableau / DBeaver / Superset / Power BI / `psql` / Dremio's Postgres-source connector, v2.5.0+) and **Apache Arrow Flight SQL** (gRPC, columnar, JDBC/ODBC via Flight SQL drivers) side-by-side; AtScale's BI-tool surface is JDBC/ODBC + MDX/DAX through the enterprise gateway.
 6. **First-class DB-API 2.0 drivers** for direct programmatic access from Python.
 7. ~~MCP server (first-party)~~ — **closed**: AtScale ships its own containerized MCP Server exposing models, hierarchies, and metrics under role-based access.
 8. **Plain-text portable model format** — OBML is a static YAML file that diffs in Git; AtScale models are richer but harder to version-control as plain text.

--- a/docs/comparison/atscale.md
+++ b/docs/comparison/atscale.md
@@ -199,7 +199,7 @@ AtScale's MDX/DAX support is unique and a genuine advantage for Microsoft-stack 
 
 | | OBSL | AtScale |
 |---|---|---|
-| License | Source-available (BSL) | Proprietary; **free Developer Community Edition** for non-production / individual use |
+| License | Source-available (BUSL-1.1) | Proprietary; **free Developer Community Edition** for non-production / individual use |
 | Self-hostable | ✅ (one Python service) | ✅ — Developer Edition is free to install; production deployment requires enterprise license |
 | Pricing | OSS is free for self-hosted production; commercial tiers available for embedded analytics, managed cloud, and enterprise features | **Developer Edition: free** (with feature/scale limits). Enterprise: typical six-figure annual licensing for production |
 | Commercial offering | Embedded analytics license · commercial cloud offering · enterprise features · consulting + support | Enterprise license — production deployments, autonomous aggregates at scale, enterprise governance, vendor support |

--- a/docs/comparison/cube.md
+++ b/docs/comparison/cube.md
@@ -25,7 +25,7 @@ Cube is the closest peer to OBSL in the OSS space — both are self-hostable, bo
 | Repeated columns (`ARRAY<STRUCT>`) | Declared as a data object with `nestedIn`; unnested per dialect — see [Nested data objects](../guide/model-format.md#nested-data-objects-nestedin) | Flatten in the cube's `sql` / a pre-aggregation |
 | Object scoping | Each `DataObject` has `columns:`; dimensions/measures/metrics live at model scope | Measures and dimensions live *inside* each `cube`; `view`s expose a curated subset for end users |
 | Templating | None (static YAML) | Twig (Jinja2-like) — `COMPILE_CONTEXT` for compile-time multi-tenancy, dynamic SQL, masking |
-| Runtime | OSS, self-hosted (single Python service) | OSS Cube Core (Node.js + Cube Store + optional Redis) **or** Cube Cloud (managed, paid). Since v1.7 the **Tesseract** planner and the native query orchestrator are on by default |
+| Runtime | Source-available (BUSL-1.1), self-hosted (single Python service) | OSS Cube Core (Node.js + Cube Store + optional Redis) **or** Cube Cloud (managed, paid). Since v1.7 the **Tesseract** planner and the native query orchestrator are on by default |
 | Curation layer | None — one global namespace of dimensions / measures / metrics / filters | `views` are the primary consumer-facing surface: curated members, folders, view groups, hierarchies, access policies, AI context |
 
 ---
@@ -269,7 +269,7 @@ Cube's SQL API is a structural advantage for BI-tool connectivity. OBSL's RDF/SP
 
 ---
 
-## 9. Open-source vs. commercial story
+## 9. Licensing vs. commercial story
 
 Both projects ship a free OSS core and offer commercial extensions, but the split is different:
 
@@ -279,7 +279,7 @@ Both projects ship a free OSS core and offer commercial extensions, but the spli
 | Self-hostable | ✅ (one Python service) | ✅ (Cube Core: Node.js + optional Cube Store + optional Redis) |
 | Commercial offering | Embedded analytics license · commercial cloud offering · enterprise features · consulting + support | Cube Cloud — managed runtime, multi-cluster, advanced security, Studio IDE, paid |
 | Operational footprint | Light: one process, in-memory sessions, optional file-backed result cache (DuckDB metadata + Parquet) on local disk | Heavier: API server + Cube Store + Redis (optional) + scheduler + refresh workers in production |
-| Self-host parity | OSS has full parity on the shipped v2.6 surface; enterprise tier adds enterprise-specific capabilities on top | Many advanced features (Studio, advanced workspaces, AI features) are Cube Cloud-only |
+| Self-host parity | The free tier has full parity on the shipped v2.6 surface; enterprise tier adds enterprise-specific capabilities on top | Many advanced features (Studio, advanced workspaces, AI features) are Cube Cloud-only |
 
 For a small embedded-analytics use case OBSL is operationally simpler. For high-throughput multi-tenant production with heavy caching across replicas, Cube's architecture is purpose-built and Cube Cloud provides the managed experience. OBSL's file cache based on freshness inheritance (v2.2.0) covers single-replica result-caching workloads — agents, dev/staging, modest production — without standing up Redis or a rollup store.
 

--- a/docs/comparison/cube.md
+++ b/docs/comparison/cube.md
@@ -275,7 +275,7 @@ Both projects ship a free OSS core and offer commercial extensions, but the spli
 
 | | OBSL | Cube |
 |---|---|---|
-| Core license | Source-available (BSL 1.1) | Apache 2.0 |
+| Core license | Source-available (BUSL-1.1) | Apache 2.0 |
 | Self-hostable | ✅ (one Python service) | ✅ (Cube Core: Node.js + optional Cube Store + optional Redis) |
 | Commercial offering | Embedded analytics license · commercial cloud offering · enterprise features · consulting + support | Cube Cloud — managed runtime, multi-cluster, advanced security, Studio IDE, paid |
 | Operational footprint | Light: one process, in-memory sessions, optional file-backed result cache (DuckDB metadata + Parquet) on local disk | Heavier: API server + Cube Store + Redis (optional) + scheduler + refresh workers in production |

--- a/docs/comparison/cube.md
+++ b/docs/comparison/cube.md
@@ -11,7 +11,7 @@ A feature comparison between **OrionBelt Semantic Layer (OBSL)** and **Cube** (f
 - **Changed since the 2026-05 capture**: multi-fact modeling is **no longer an OBSL-only capability**. Cube Core v1.7 made **Tesseract** the default planner and graduated **multi-fact views** to GA — a view spanning several fact tables now compiles to one aggregating subquery per fact, `FULL JOIN`ed on the shared dimensions. The remaining topology difference is narrower and more specific (see [§6](#6-data-modeling-topology-still-a-differentiator-but-a-narrower-one)).
 - **Different niches**: Cube is "the production semantic-layer + caching + API gateway" — built to serve high-volume embedded analytics with millisecond response times. OBSL is "an embeddable semantic compiler with a clean REST surface and rich modeling primitives" — best when you don't need pre-aggregation infrastructure and want a smaller dependency footprint.
 
-Cube is the closest peer to OBSL in the OSS space — both are self-hostable, both target embedded analytics, both expose REST/MCP. The interesting differences are in modeling topology, metric expressivity, and the caching/pre-aggregation layer.
+Cube is the closest peer to OBSL — both are self-hostable, both target embedded analytics, both expose REST/MCP. The interesting differences are in modeling topology, metric expressivity, and the caching/pre-aggregation layer.
 
 ---
 
@@ -271,7 +271,7 @@ Cube's SQL API is a structural advantage for BI-tool connectivity. OBSL's RDF/SP
 
 ## 9. Licensing vs. commercial story
 
-Both projects ship a free OSS core and offer commercial extensions, but the split is different:
+Both projects ship a free, self-hostable core and offer commercial extensions, but the split is different:
 
 | | OBSL | Cube |
 |---|---|---|
@@ -338,7 +338,7 @@ For a small embedded-analytics use case OBSL is operationally simpler. For high-
 - You want a **graph view of the model** (RDF/SPARQL) for governance/lineage tooling.
 - You need **OSI interoperability** for moving models between semantic layer formats.
 - Your operational appetite is small — **one Python service**, no Redis, no scheduler, no separate query orchestrator.
-- You're targeting **Dremio** or otherwise want full feature parity in self-hosted OSS without a Cloud upgrade path.
+- You're targeting **Dremio** or otherwise want full feature parity self-hosted without a Cloud upgrade path.
 - Your consumers are **agents/LLMs** primarily — both projects expose MCP, but OBSL's smaller surface is easier to point an agent at without query-shape ambiguity.
 
 ### They could coexist

--- a/docs/comparison/dbt.md
+++ b/docs/comparison/dbt.md
@@ -21,7 +21,7 @@ A feature comparison between **OrionBelt Semantic Layer (OBSL)** and the **dbt S
 | Object scoping | Each `DataObject` has its own `columns:`; dimensions/measures/metrics live at model scope and reference `{[DataObject].[Column]}` | Dimensions/measures/entities are scoped *inside* each `semantic_model`; metrics reference measures |
 | Identity for joins | Explicit `joins` between data objects with `columnsFrom`/`columnsTo`, `joinType`, `secondary`, `pathName` | Implicit: `entities` of type `primary`/`foreign`/`unique`/`natural`; MetricFlow auto-resolves joins by matching entity names |
 | Repeated columns (`ARRAY<STRUCT>`) | Declared as a data object with `nestedIn`; unnested per dialect — see [Nested data objects](../guide/model-format.md#nested-data-objects-nestedin) | Flatten upstream in a dbt model first |
-| Deployment | Self-hosted FastAPI service, MCP server, Gradio UI; OSS | Definitions in dbt Core OSS; **query API gated behind dbt Cloud** |
+| Deployment | Self-hosted FastAPI service, MCP server, Gradio UI; source-available (BUSL-1.1) | Definitions in dbt Core OSS; **query API gated behind dbt Cloud** |
 
 ---
 
@@ -258,7 +258,7 @@ OBSL validates column arity at model-load time and gates dialect support at comp
 | Caching | Result cache based on freshness inheritance (file backend, off by default): TTL derived from per-`dataObject` `refresh:` contract; ETL `POST /v1/heartbeat` invalidates dependent entries by physical table | dbt Cloud query cache |
 | Versioned governance, lineage to upstream models | No (model is standalone) | Strong — inherits dbt's lineage, tests, docs, exposures |
 | Filter ergonomics | `MeasureFilter`, `FilterContext`, `GrainOverride`, query-level `where`/`having` | Per-metric `filter:`, `metric_time` |
-| Vendor-agnostic | Yes — pure OSS | Practical lock-in: production query APIs require dbt Cloud |
+| Vendor-agnostic | Yes — self-hostable, no vendor runtime | Practical lock-in: production query APIs require dbt Cloud |
 
 ---
 

--- a/docs/comparison/index.md
+++ b/docs/comparison/index.md
@@ -12,7 +12,7 @@ How OrionBelt Semantic Layer (OBSL) stacks up against the leading semantic layer
 
 | | OBSL | dbt SL | Malloy | LookML | Cube | AtScale |
 |---|---|---|---|---|---|---|
-| License | Source-available (BSL) | Definitions OSS; runtime in dbt Cloud | Open source | Proprietary | Apache 2.0 (core) + Cube Cloud | Proprietary; **free Developer Community Edition** for non-prod |
+| License | Source-available (BUSL-1.1) | Definitions OSS; runtime in dbt Cloud | Open source | Proprietary | Apache 2.0 (core) + Cube Cloud | Proprietary; **free Developer Community Edition** for non-prod |
 | Self-hostable | ✅ | Definitions yes, runtime no | ✅ | ❌ | ✅ | ✅ (licensed) |
 | Standalone (no transformation tool dep.) | ✅ | ❌ requires dbt | ✅ | ✅ | ✅ | ✅ |
 | Format | YAML (`OBML`) | YAML on dbt models | DSL (`.malloy`) | DSL (`.lkml`) | YAML / JS + Twig | Visual designer |

--- a/docs/comparison/index.md
+++ b/docs/comparison/index.md
@@ -159,7 +159,7 @@ AtScale's conformed-dimensions-within-a-Cube + virtual cubes, and Cube's multi-f
 - **Multi-tenant** semantic models with TTL-scoped sessions.
 - **LLM/agent integration** via MCP — a clean, schema-driven query surface beats teaching the agent a new language.
 - **Modern cloud warehouses** including ClickHouse, Databricks, Dremio, and DuckDB.
-- **Open-source / self-hostable / air-gapped** deployments.
+- **Source-available / self-hostable / air-gapped** deployments.
 
 ## Where another tool may be a better fit
 

--- a/docs/comparison/lookml.md
+++ b/docs/comparison/lookml.md
@@ -216,7 +216,7 @@ Looker is broader on enterprise legacy databases; OBSL is competitive on modern 
 
 ---
 
-## 9. Open source vs. proprietary
+## 9. Licensing vs. proprietary
 
 This is the most consequential difference and worth calling out separately.
 
@@ -276,7 +276,7 @@ For embedded SaaS, multi-tenant analytics, or air-gapped/on-prem use cases, OBSL
 
 ### Pick **OBSL** when:
 
-- You need an **open-source, self-hostable, embeddable** semantic layer — no vendor lock-in.
+- You need a **source-available, self-hostable, embeddable** semantic layer — no vendor lock-in.
 - Your consumers are **applications, agents, or LLMs** — a stable JSON Query API beats requiring callers to know LookML.
 - You need first-class, *reusable* **cumulative** and **period-over-period** metric types instead of expressing them as table calculations.
 - You target ClickHouse, Databricks, Dremio, or DuckDB.
@@ -304,7 +304,7 @@ A common hybrid: ship Looker for the human BI audience and run OBSL alongside it
 
 ### To match OBSL, LookML/Looker would need:
 
-1. **Open-source / self-hostable runtime** (the structural blocker).
+1. **Source-available / self-hostable runtime** (the structural blocker).
 2. **First-class cumulative & period-over-period metric types** — declarative versions of what's currently table calculations.
 3. **Named secondary join paths** with per-query selection.
 4. **RDF/SPARQL graph surface** for governance/lineage.

--- a/docs/comparison/lookml.md
+++ b/docs/comparison/lookml.md
@@ -222,7 +222,7 @@ This is the most consequential difference and worth calling out separately.
 
 | | OBSL | LookML |
 |---|---|---|
-| License | Source-available (BSL) | Proprietary (Google Cloud / Looker) |
+| License | Source-available (BUSL-1.1) | Proprietary (Google Cloud / Looker) |
 | Self-hostable | Yes — runs anywhere Python runs | Limited: Looker is a hosted SaaS; "Looker (original)" had a self-hosted option but is being deprecated |
 | Cost | OSS is free for self-hosted production; commercial tiers available for embedded analytics, managed cloud, and enterprise features | Per-user licensing on the Looker platform |
 | Commercial offering | Embedded analytics license · commercial cloud offering · enterprise features · consulting + support | Looker platform — per-user licensing, hosted by Google Cloud |

--- a/docs/comparison/lookml.md
+++ b/docs/comparison/lookml.md
@@ -7,7 +7,7 @@ A feature comparison between **OrionBelt Semantic Layer (OBSL)** and **LookML**,
 ## TL;DR
 
 - **LookML wins on**: deep BI integration (drill fields, parameters, Liquid templating, PDTs, access filters/grants), `dimension_group` auto-timeframe expansion, symmetric aggregates (Looker invented the term), the broadest warehouse connector portfolio, and a polished proprietary IDE/UI.
-- **OBSL wins on**: being **open-source and self-hostable** (LookML is Looker-only — proprietary, paid, vendor-locked), a **language-agnostic JSON Query API** consumable by any client, **richer modeling topologies** (multi-rooted DAG with first-class named secondary join paths) where LookML's explore is a single-rooted tree, **first-class metric types** for cumulative (with `partitionBy`), period-over-period, and **window** (rank / lag / lead / ntile / first_value / last_value) where LookML expresses these via table calculations or filtered measures — not declarative metric types, **9 statistical aggregates** (CORR / COVAR_* / REGR_* / STDDEV_* / VAR_*), an **RDF/SPARQL graph view** of the model, and an explicit **CFL multi-fact planner**. (An MCP server is no longer an OBSL differentiator here: Looker shipped a managed MCP server in 2026, alongside the LookML Agent for AI-assisted modeling and a GA Conversational Analytics API.)
+- **OBSL wins on**: being **source-available (BUSL-1.1) and self-hostable** (LookML is Looker-only — proprietary, paid, vendor-locked), a **language-agnostic JSON Query API** consumable by any client, **richer modeling topologies** (multi-rooted DAG with first-class named secondary join paths) where LookML's explore is a single-rooted tree, **first-class metric types** for cumulative (with `partitionBy`), period-over-period, and **window** (rank / lag / lead / ntile / first_value / last_value) where LookML expresses these via table calculations or filtered measures — not declarative metric types, **9 statistical aggregates** (CORR / COVAR_* / REGR_* / STDDEV_* / VAR_*), an **RDF/SPARQL graph view** of the model, and an explicit **CFL multi-fact planner**. (An MCP server is no longer an OBSL differentiator here: Looker shipped a managed MCP server in 2026, alongside the LookML Agent for AI-assisted modeling and a GA Conversational Analytics API.)
 - **Different niches**: LookML is "the modeling language for Looker, your BI platform." OBSL is "an embeddable semantic compiler that exposes metrics over a stable API to apps, agents, and BI tools you didn't have to buy."
 
 LookML and Looker are inseparable in practice — you cannot run LookML without Looker. So this is also a comparison of build-vs-buy on the runtime.
@@ -23,7 +23,7 @@ LookML and Looker are inseparable in practice — you cannot run LookML without 
 | Top-level constructs | `dataObjects`, `dimensions`, `measures`, `metrics`, `filters` | `connection`, `model`, `view`, `explore`, `dimension`, `dimension_group`, `measure`, `parameter`, `filter`, `derived_table`, `access_filter`, `access_grant` |
 | Object scoping | Each `DataObject` has `columns:`; dimensions/measures/metrics live at model scope | Dimensions and measures are *inside* `view`s; joins live in `explore`s in `model` files |
 | Repeated columns (`ARRAY<STRUCT>`) | Declared as a data object with `nestedIn`; unnested per dialect — see [Nested data objects](../guide/model-format.md#nested-data-objects-nestedin) | An `UNNEST` derived table, or a view whose `sql_table_name` unnests |
-| Runtime | OSS, self-hosted | **Looker proprietary platform only** (Google Cloud) |
+| Runtime | Source-available (BUSL-1.1), self-hosted | **Looker proprietary platform only** (Google Cloud) |
 
 ---
 
@@ -224,9 +224,9 @@ This is the most consequential difference and worth calling out separately.
 |---|---|---|
 | License | Source-available (BUSL-1.1) | Proprietary (Google Cloud / Looker) |
 | Self-hostable | Yes — runs anywhere Python runs | Limited: Looker is a hosted SaaS; "Looker (original)" had a self-hosted option but is being deprecated |
-| Cost | OSS is free for self-hosted production; commercial tiers available for embedded analytics, managed cloud, and enterprise features | Per-user licensing on the Looker platform |
+| Cost | Free for self-hosted production under BUSL-1.1; commercial tiers available for embedded analytics, managed cloud, and enterprise features | Per-user licensing on the Looker platform |
 | Commercial offering | Embedded analytics license · commercial cloud offering · enterprise features · consulting + support | Looker platform — per-user licensing, hosted by Google Cloud |
-| Self-host parity | OSS has full parity on the shipped v2.6 surface; enterprise tier adds enterprise-specific capabilities on top | n/a — Looker is not self-hostable in the modern offering |
+| Self-host parity | The free tier has full parity on the shipped v2.6 surface; enterprise tier adds enterprise-specific capabilities on top | n/a — Looker is not self-hostable in the modern offering |
 | Vendor lock-in | None | LookML files only run inside Looker |
 | Air-gapped deploy | Possible | Not supported |
 | Format portability | OBML is plain YAML, can be read by any tool | LookML is a Looker-specific DSL with no widely-adopted external parser other than `pylookml` |
@@ -258,7 +258,7 @@ For embedded SaaS, multi-tenant analytics, or air-gapped/on-prem use cases, OBSL
 | AI-assisted model authoring | ❌ | ✅ LookML Agent in the Looker VS Code extension (natural language → LookML, model generation from BigQuery/AlloyDB datasets) |
 | Conversational analytics | ❌ | ✅ Conversational Analytics API (GA) with SDK and iframe embedding |
 | Reads other vendors' semantic models | OSI ↔ OBML conversion | ✅ reads BigQuery graph definitions and Snowflake semantic views natively |
-| OSS / self-hostable | ✅ | ❌ |
+| Source-available / self-hostable | ✅ | ❌ |
 | Built-in BI front-end | ❌ | ✅ |
 
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 ---
-description: OrionBelt Semantic Layer is an open-source Semantic Sidecar for agentic AI, analytics, data quality, and governance. YAML models compile to SQL across 8 dialects, exposed via REST, MCP, Arrow Flight SQL, and Postgres wire.
+description: OrionBelt Semantic Layer is a source-available Semantic Sidecar for agentic AI, analytics, data quality, and governance. YAML models compile to SQL across 8 dialects, exposed via REST, MCP, Arrow Flight SQL, and Postgres wire.
 ---
 
 <p align="center">
@@ -8,7 +8,7 @@ description: OrionBelt Semantic Layer is an open-source Semantic Sidecar for age
 
 # OrionBelt&reg; Semantic Layer and Sidecar
 
-**An open-source Semantic Sidecar for agentic AI, analytics, data quality, and governance systems.**
+**A source-available Semantic Sidecar for agentic AI, analytics, data quality, and governance systems.**
 
 **Inject governed semantics into systems that never had them.**
 
@@ -27,7 +27,7 @@ OBSL applies the same pattern to **semantics**:
 - It's a **runtime, not a rewrite.** Existing BI tools, AI agents, governance systems, and DQ pipelines keep talking to their databases — OBSL attaches a governed semantic interface alongside them.
 - It's **multi-surface by design.** The same model is reachable over REST (for agents and apps), MCP (for LLM clients), Arrow Flight SQL + PostgreSQL wire (for BI tools), and direct DB-API drivers (for Python). One model, many channels.
 - It's **opinionated about correctness, not deployment.** Dialect-aware SQL generation, fan-trap-safe joins, and dimensional metrics are non-negotiable; where to run OBSL — embedded in your app, alongside a warehouse, behind a proxy, in a single container — is your call.
-- It's **open by default.** BUSL-1.1 today, converts to Apache 2.0 in 2030. No SaaS lock-in is required to use the full v2.6 surface.
+- It's **source-available, with a clock on it.** BUSL-1.1 today, converts to Apache 2.0 in 2030. No SaaS lock-in is required to use the full v2.6 surface.
 
 ## The OrionBelt trio
 
@@ -183,7 +183,7 @@ Ready to dive in? Start with [Installation](getting-started/installation.md) and
 
 ## Commercial Offerings
 
-OrionBelt Semantic Layer is open by default — the OSS distribution has full parity on the shipped v2.6 surface and is production-grade for self-hosted use. For teams that want production support, a managed runtime, or embedded analytics terms, RALFORION offers:
+OrionBelt Semantic Layer is source-available under BUSL-1.1 until its Apache-2.0 conversion — the free distribution has full parity on the shipped v2.6 surface and is production-grade for self-hosted use. For teams that want production support, a managed runtime, or embedded analytics terms, RALFORION offers:
 
 - **Embedded analytics license** — relicensing terms for shipping OBSL inside a commercial product
 - **Commercial cloud offering** — managed OrionBelt runtime with SLAs

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ OBSL applies the same pattern to **semantics**:
 - It's a **runtime, not a rewrite.** Existing BI tools, AI agents, governance systems, and DQ pipelines keep talking to their databases — OBSL attaches a governed semantic interface alongside them.
 - It's **multi-surface by design.** The same model is reachable over REST (for agents and apps), MCP (for LLM clients), Arrow Flight SQL + PostgreSQL wire (for BI tools), and direct DB-API drivers (for Python). One model, many channels.
 - It's **opinionated about correctness, not deployment.** Dialect-aware SQL generation, fan-trap-safe joins, and dimensional metrics are non-negotiable; where to run OBSL — embedded in your app, alongside a warehouse, behind a proxy, in a single container — is your call.
-- It's **open by default.** BSL 1.1 today, converts to Apache 2.0 in 2030. No SaaS lock-in is required to use the full v2.6 surface.
+- It's **open by default.** BUSL-1.1 today, converts to Apache 2.0 in 2030. No SaaS lock-in is required to use the full v2.6 surface.
 
 ## The OrionBelt trio
 
@@ -197,7 +197,7 @@ Contact [RALFORION d.o.o.](https://ralforion.com) for details.
 <p align="center">
   <a href="https://ralforion.com"><img src="assets/RALFORION_doo_Logo.png" alt="RALFORION d.o.o." width="200"></a>
   <br>
-  Copyright &copy; 2026 RALFORION d.o.o. &mdash; Licensed under BSL 1.1
+  Copyright &copy; 2026 RALFORION d.o.o. &mdash; Licensed under BUSL-1.1
   <br>
   OrionBelt&reg; is a registered trademark of RALFORION d.o.o.
 </p>

--- a/drivers/ob-bigquery/AGENTS.md
+++ b/drivers/ob-bigquery/AGENTS.md
@@ -12,7 +12,7 @@ compilation to `ob-driver-core`; it does not use a direct in-process
 
 **OB dialect string:** `"bigquery"`
 **Author:** Ralf Becher / RALFORION d.o.o. (info@orionbelt.ai)
-**License:** BSL-1.1
+**License:** BUSL-1.1
 
 ---
 

--- a/drivers/ob-bigquery/LICENSE
+++ b/drivers/ob-bigquery/LICENSE
@@ -3,8 +3,8 @@ Business Source License 1.1
 Parameters
 
 Licensor:             RALFORION d.o.o.
-Licensed Work:        OrionBelt Semantic Layer 1.0
-                      The Licensed Work is (c) 2025 RALFORION d.o.o.
+Licensed Work:        OrionBelt Semantic Layer (all versions)
+                      The Licensed Work is (c) 2025-2026 RALFORION d.o.o.
 Additional Use Grant: You may use the Licensed Work for any purpose,
                       including production use, PROVIDED THAT you may
                       not embed OrionBelt in a commercial product or

--- a/drivers/ob-bigquery/README.md
+++ b/drivers/ob-bigquery/README.md
@@ -12,4 +12,4 @@ pip install ob-bigquery
 
 ## License
 
-BSL-1.1 — see [LICENSE](LICENSE) for details.
+BUSL-1.1 — see [LICENSE](LICENSE) for details.

--- a/drivers/ob-bigquery/pyproject.toml
+++ b/drivers/ob-bigquery/pyproject.toml
@@ -6,7 +6,8 @@ build-backend = "hatchling.build"
 name = "ob-bigquery"
 version = "2.6.1"
 description = "OrionBelt Semantic Layer driver for BigQuery (DB-API 2.0)"
-license = { text = "BSL-1.1" }
+license = "BUSL-1.1"
+license-files = ["LICENSE"]
 readme = "README.md"
 authors = [{ name = "Ralf Becher", email = "info@orionbelt.ai" }]
 keywords = ["bigquery", "semantic-layer", "obml", "db-api", "orionbelt"]

--- a/drivers/ob-clickhouse/LICENSE
+++ b/drivers/ob-clickhouse/LICENSE
@@ -3,8 +3,8 @@ Business Source License 1.1
 Parameters
 
 Licensor:             RALFORION d.o.o.
-Licensed Work:        OrionBelt Semantic Layer 1.0
-                      The Licensed Work is (c) 2025 RALFORION d.o.o.
+Licensed Work:        OrionBelt Semantic Layer (all versions)
+                      The Licensed Work is (c) 2025-2026 RALFORION d.o.o.
 Additional Use Grant: You may use the Licensed Work for any purpose,
                       including production use, PROVIDED THAT you may
                       not embed OrionBelt in a commercial product or

--- a/drivers/ob-clickhouse/README.md
+++ b/drivers/ob-clickhouse/README.md
@@ -12,4 +12,4 @@ pip install ob-clickhouse
 
 ## License
 
-BSL-1.1 — see [LICENSE](LICENSE) for details.
+BUSL-1.1 — see [LICENSE](LICENSE) for details.

--- a/drivers/ob-clickhouse/pyproject.toml
+++ b/drivers/ob-clickhouse/pyproject.toml
@@ -6,7 +6,8 @@ build-backend = "hatchling.build"
 name = "ob-clickhouse"
 version = "2.6.1"
 description = "OrionBelt Semantic Layer driver for ClickHouse (DB-API 2.0)"
-license = { text = "BSL-1.1" }
+license = "BUSL-1.1"
+license-files = ["LICENSE"]
 readme = "README.md"
 authors = [{ name = "Ralf Becher", email = "info@orionbelt.ai" }]
 keywords = ["clickhouse", "semantic-layer", "obml", "db-api", "orionbelt"]

--- a/drivers/ob-databricks/LICENSE
+++ b/drivers/ob-databricks/LICENSE
@@ -3,8 +3,8 @@ Business Source License 1.1
 Parameters
 
 Licensor:             RALFORION d.o.o.
-Licensed Work:        OrionBelt Semantic Layer 1.0
-                      The Licensed Work is (c) 2025 RALFORION d.o.o.
+Licensed Work:        OrionBelt Semantic Layer (all versions)
+                      The Licensed Work is (c) 2025-2026 RALFORION d.o.o.
 Additional Use Grant: You may use the Licensed Work for any purpose,
                       including production use, PROVIDED THAT you may
                       not embed OrionBelt in a commercial product or

--- a/drivers/ob-databricks/README.md
+++ b/drivers/ob-databricks/README.md
@@ -12,4 +12,4 @@ pip install ob-databricks
 
 ## License
 
-BSL-1.1 — see [LICENSE](LICENSE) for details.
+BUSL-1.1 — see [LICENSE](LICENSE) for details.

--- a/drivers/ob-databricks/pyproject.toml
+++ b/drivers/ob-databricks/pyproject.toml
@@ -6,7 +6,8 @@ build-backend = "hatchling.build"
 name = "ob-databricks"
 version = "2.6.1"
 description = "OrionBelt Semantic Layer driver for Databricks (DB-API 2.0)"
-license = { text = "BSL-1.1" }
+license = "BUSL-1.1"
+license-files = ["LICENSE"]
 readme = "README.md"
 authors = [{ name = "Ralf Becher", email = "info@orionbelt.ai" }]
 keywords = ["databricks", "semantic-layer", "obml", "db-api", "orionbelt"]

--- a/drivers/ob-dremio/LICENSE
+++ b/drivers/ob-dremio/LICENSE
@@ -3,8 +3,8 @@ Business Source License 1.1
 Parameters
 
 Licensor:             RALFORION d.o.o.
-Licensed Work:        OrionBelt Semantic Layer 1.0
-                      The Licensed Work is (c) 2025 RALFORION d.o.o.
+Licensed Work:        OrionBelt Semantic Layer (all versions)
+                      The Licensed Work is (c) 2025-2026 RALFORION d.o.o.
 Additional Use Grant: You may use the Licensed Work for any purpose,
                       including production use, PROVIDED THAT you may
                       not embed OrionBelt in a commercial product or

--- a/drivers/ob-dremio/README.md
+++ b/drivers/ob-dremio/README.md
@@ -12,4 +12,4 @@ pip install ob-dremio
 
 ## License
 
-BSL-1.1 — see [LICENSE](LICENSE) for details.
+BUSL-1.1 — see [LICENSE](LICENSE) for details.

--- a/drivers/ob-dremio/pyproject.toml
+++ b/drivers/ob-dremio/pyproject.toml
@@ -6,7 +6,8 @@ build-backend = "hatchling.build"
 name = "ob-dremio"
 version = "2.6.1"
 description = "OrionBelt Semantic Layer driver for Dremio (DB-API 2.0)"
-license = { text = "BSL-1.1" }
+license = "BUSL-1.1"
+license-files = ["LICENSE"]
 readme = "README.md"
 authors = [{ name = "Ralf Becher", email = "info@orionbelt.ai" }]
 keywords = ["dremio", "semantic-layer", "obml", "db-api", "orionbelt"]

--- a/drivers/ob-driver-core/LICENSE
+++ b/drivers/ob-driver-core/LICENSE
@@ -3,8 +3,8 @@ Business Source License 1.1
 Parameters
 
 Licensor:             RALFORION d.o.o.
-Licensed Work:        OrionBelt Semantic Layer 1.0
-                      The Licensed Work is (c) 2025 RALFORION d.o.o.
+Licensed Work:        OrionBelt Semantic Layer (all versions)
+                      The Licensed Work is (c) 2025-2026 RALFORION d.o.o.
 Additional Use Grant: You may use the Licensed Work for any purpose,
                       including production use, PROVIDED THAT you may
                       not embed OrionBelt in a commercial product or

--- a/drivers/ob-driver-core/README.md
+++ b/drivers/ob-driver-core/README.md
@@ -12,4 +12,4 @@ pip install ob-driver-core
 
 ## License
 
-BSL-1.1 — see [LICENSE](LICENSE) for details.
+BUSL-1.1 — see [LICENSE](LICENSE) for details.

--- a/drivers/ob-driver-core/pyproject.toml
+++ b/drivers/ob-driver-core/pyproject.toml
@@ -6,7 +6,8 @@ build-backend = "hatchling.build"
 name = "ob-driver-core"
 version = "2.6.1"
 description = "Shared foundation for OrionBelt DB-API 2.0 drivers (PEP 249 types, OBML detection, compilation bridge)"
-license = { text = "BSL-1.1" }
+license = "BUSL-1.1"
+license-files = ["LICENSE"]
 readme = "README.md"
 authors = [{ name = "Ralf Becher", email = "info@orionbelt.ai" }]
 keywords = ["semantic-layer", "obml", "db-api", "orionbelt", "pep249"]

--- a/drivers/ob-duckdb/LICENSE
+++ b/drivers/ob-duckdb/LICENSE
@@ -3,8 +3,8 @@ Business Source License 1.1
 Parameters
 
 Licensor:             RALFORION d.o.o.
-Licensed Work:        OrionBelt Semantic Layer 1.0
-                      The Licensed Work is (c) 2025 RALFORION d.o.o.
+Licensed Work:        OrionBelt Semantic Layer (all versions)
+                      The Licensed Work is (c) 2025-2026 RALFORION d.o.o.
 Additional Use Grant: You may use the Licensed Work for any purpose,
                       including production use, PROVIDED THAT you may
                       not embed OrionBelt in a commercial product or

--- a/drivers/ob-duckdb/README.md
+++ b/drivers/ob-duckdb/README.md
@@ -12,4 +12,4 @@ pip install ob-duckdb
 
 ## License
 
-BSL-1.1 — see [LICENSE](LICENSE) for details.
+BUSL-1.1 — see [LICENSE](LICENSE) for details.

--- a/drivers/ob-duckdb/pyproject.toml
+++ b/drivers/ob-duckdb/pyproject.toml
@@ -6,7 +6,8 @@ build-backend = "hatchling.build"
 name = "ob-duckdb"
 version = "2.6.1"
 description = "OrionBelt Semantic Layer driver for DuckDB (DB-API 2.0)"
-license = { text = "BSL-1.1" }
+license = "BUSL-1.1"
+license-files = ["LICENSE"]
 readme = "README.md"
 authors = [{ name = "Ralf Becher", email = "info@orionbelt.ai" }]
 keywords = ["duckdb", "semantic-layer", "obml", "db-api", "orionbelt"]

--- a/drivers/ob-flight-extension/LICENSE
+++ b/drivers/ob-flight-extension/LICENSE
@@ -3,8 +3,8 @@ Business Source License 1.1
 Parameters
 
 Licensor:             RALFORION d.o.o.
-Licensed Work:        OrionBelt Semantic Layer 1.0
-                      The Licensed Work is (c) 2025 RALFORION d.o.o.
+Licensed Work:        OrionBelt Semantic Layer (all versions)
+                      The Licensed Work is (c) 2025-2026 RALFORION d.o.o.
 Additional Use Grant: You may use the Licensed Work for any purpose,
                       including production use, PROVIDED THAT you may
                       not embed OrionBelt in a commercial product or

--- a/drivers/ob-flight-extension/README.md
+++ b/drivers/ob-flight-extension/README.md
@@ -12,4 +12,4 @@ pip install ob-flight-extension
 
 ## License
 
-BSL-1.1 — see [LICENSE](LICENSE) for details.
+BUSL-1.1 — see [LICENSE](LICENSE) for details.

--- a/drivers/ob-flight-extension/pyproject.toml
+++ b/drivers/ob-flight-extension/pyproject.toml
@@ -6,7 +6,8 @@ build-backend = "hatchling.build"
 name = "ob-flight-extension"
 version = "2.6.1"
 description = "Arrow Flight SQL server extension for orionbelt-api (DBeaver, Tableau, Power BI)"
-license = { text = "BSL-1.1" }
+license = "BUSL-1.1"
+license-files = ["LICENSE"]
 readme = "README.md"
 authors = [{ name = "Ralf Becher", email = "info@orionbelt.ai" }]
 keywords = ["arrow", "flight-sql", "dbeaver", "tableau", "orionbelt", "semantic-layer"]

--- a/drivers/ob-mysql/LICENSE
+++ b/drivers/ob-mysql/LICENSE
@@ -3,8 +3,8 @@ Business Source License 1.1
 Parameters
 
 Licensor:             RALFORION d.o.o.
-Licensed Work:        OrionBelt Semantic Layer 1.0
-                      The Licensed Work is (c) 2025 RALFORION d.o.o.
+Licensed Work:        OrionBelt Semantic Layer (all versions)
+                      The Licensed Work is (c) 2025-2026 RALFORION d.o.o.
 Additional Use Grant: You may use the Licensed Work for any purpose,
                       including production use, PROVIDED THAT you may
                       not embed OrionBelt in a commercial product or

--- a/drivers/ob-mysql/README.md
+++ b/drivers/ob-mysql/README.md
@@ -12,4 +12,4 @@ pip install ob-mysql
 
 ## License
 
-BSL-1.1 — see [LICENSE](LICENSE) for details.
+BUSL-1.1 — see [LICENSE](LICENSE) for details.

--- a/drivers/ob-mysql/pyproject.toml
+++ b/drivers/ob-mysql/pyproject.toml
@@ -6,7 +6,8 @@ build-backend = "hatchling.build"
 name = "ob-mysql"
 version = "2.6.1"
 description = "OrionBelt Semantic Layer driver for MySQL 8.0+ (DB-API 2.0)"
-license = { text = "BSL-1.1" }
+license = "BUSL-1.1"
+license-files = ["LICENSE"]
 readme = "README.md"
 authors = [{ name = "Ralf Becher", email = "info@orionbelt.ai" }]
 keywords = ["mysql", "semantic-layer", "obml", "db-api", "orionbelt"]

--- a/drivers/ob-postgres/LICENSE
+++ b/drivers/ob-postgres/LICENSE
@@ -3,8 +3,8 @@ Business Source License 1.1
 Parameters
 
 Licensor:             RALFORION d.o.o.
-Licensed Work:        OrionBelt Semantic Layer 1.0
-                      The Licensed Work is (c) 2025 RALFORION d.o.o.
+Licensed Work:        OrionBelt Semantic Layer (all versions)
+                      The Licensed Work is (c) 2025-2026 RALFORION d.o.o.
 Additional Use Grant: You may use the Licensed Work for any purpose,
                       including production use, PROVIDED THAT you may
                       not embed OrionBelt in a commercial product or

--- a/drivers/ob-postgres/README.md
+++ b/drivers/ob-postgres/README.md
@@ -12,4 +12,4 @@ pip install ob-postgres
 
 ## License
 
-BSL-1.1 — see [LICENSE](LICENSE) for details.
+BUSL-1.1 — see [LICENSE](LICENSE) for details.

--- a/drivers/ob-postgres/pyproject.toml
+++ b/drivers/ob-postgres/pyproject.toml
@@ -6,7 +6,8 @@ build-backend = "hatchling.build"
 name = "ob-postgres"
 version = "2.6.1"
 description = "OrionBelt Semantic Layer driver for PostgreSQL (DB-API 2.0)"
-license = { text = "BSL-1.1" }
+license = "BUSL-1.1"
+license-files = ["LICENSE"]
 readme = "README.md"
 authors = [{ name = "Ralf Becher", email = "info@orionbelt.ai" }]
 keywords = ["postgres", "semantic-layer", "obml", "db-api", "orionbelt"]

--- a/drivers/ob-snowflake/LICENSE
+++ b/drivers/ob-snowflake/LICENSE
@@ -3,8 +3,8 @@ Business Source License 1.1
 Parameters
 
 Licensor:             RALFORION d.o.o.
-Licensed Work:        OrionBelt Semantic Layer 1.0
-                      The Licensed Work is (c) 2025 RALFORION d.o.o.
+Licensed Work:        OrionBelt Semantic Layer (all versions)
+                      The Licensed Work is (c) 2025-2026 RALFORION d.o.o.
 Additional Use Grant: You may use the Licensed Work for any purpose,
                       including production use, PROVIDED THAT you may
                       not embed OrionBelt in a commercial product or

--- a/drivers/ob-snowflake/README.md
+++ b/drivers/ob-snowflake/README.md
@@ -12,4 +12,4 @@ pip install ob-snowflake
 
 ## License
 
-BSL-1.1 — see [LICENSE](LICENSE) for details.
+BUSL-1.1 — see [LICENSE](LICENSE) for details.

--- a/drivers/ob-snowflake/pyproject.toml
+++ b/drivers/ob-snowflake/pyproject.toml
@@ -6,7 +6,8 @@ build-backend = "hatchling.build"
 name = "ob-snowflake"
 version = "2.6.1"
 description = "OrionBelt Semantic Layer driver for Snowflake (DB-API 2.0)"
-license = { text = "BSL-1.1" }
+license = "BUSL-1.1"
+license-files = ["LICENSE"]
 readme = "README.md"
 authors = [{ name = "Ralf Becher", email = "info@orionbelt.ai" }]
 keywords = ["snowflake", "semantic-layer", "obml", "db-api", "orionbelt"]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_description: "Open-source Semantic Sidecar for agentic AI, analytics, data 
 site_url: https://ralforion.com/orionbelt-semantic-layer/
 repo_url: https://github.com/ralforion/orionbelt-semantic-layer
 repo_name: orionbelt-semantic-layer
-copyright: Copyright &copy; 2026 RALFORION d.o.o., BSL 1.1 &mdash; OrionBelt&reg; is a registered trademark of RALFORION d.o.o.
+copyright: Copyright &copy; 2026 RALFORION d.o.o., BUSL-1.1 &mdash; OrionBelt&reg; is a registered trademark of RALFORION d.o.o.
 
 dev_addr: 127.0.0.1:8080
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: OrionBelt® Semantic Layer
-site_description: "Open-source Semantic Sidecar for agentic AI, analytics, data quality, and governance: inject governed business semantics into systems that never had them. YAML models compile to SQL across 8 dialects, surfaced via REST, MCP, Arrow Flight SQL, and PostgreSQL wire."
+site_description: "Source-available Semantic Sidecar for agentic AI, analytics, data quality, and governance: inject governed business semantics into systems that never had them. YAML models compile to SQL across 8 dialects, surfaced via REST, MCP, Arrow Flight SQL, and PostgreSQL wire."
 site_url: https://ralforion.com/orionbelt-semantic-layer/
 repo_url: https://github.com/ralforion/orionbelt-semantic-layer
 repo_name: orionbelt-semantic-layer

--- a/packages/osi-orionbelt/pyproject.toml
+++ b/packages/osi-orionbelt/pyproject.toml
@@ -6,7 +6,8 @@ build-backend = "hatchling.build"
 name = "osi-orionbelt"
 version = "0.3.0"
 description = "Bidirectional OBML <-> OSI (Open Semantic Interchange) converter for OrionBelt semantic models"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 readme = "README.md"
 authors = [{ name = "Ralf Becher", email = "info@orionbelt.ai" }]
 keywords = ["osi", "open-semantic-interchange", "obml", "semantic-layer", "orionbelt", "converter"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,8 @@
 name = "orionbelt-semantic-layer"
 version = "2.26.0"
 description = "OrionBelt Semantic Layer - Compiles and executes YAML semantic models as analytical SQL"
-license = {text = "BSL-1.1"}
+license = "BUSL-1.1"
+license-files = ["LICENSE"]
 authors = [{name = "Ralf Becher, RALFORION d.o.o.", email = "info@ralforion.com"}]
 requires-python = ">=3.12"
 readme = "README.md"
@@ -29,7 +30,6 @@ classifiers = [
     "Framework :: Pydantic :: 2",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
-    "License :: Other/Proprietary License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",

--- a/src/orionbelt/ui/static/vis-network.LICENSE.txt
+++ b/src/orionbelt/ui/static/vis-network.LICENSE.txt
@@ -1,0 +1,33 @@
+vis-network 9.1.2
+https://visjs.github.io/vis-network/
+
+Copyright (c) 2011-2017 Almende B.V, http://almende.com
+Copyright (c) 2017-2019 visjs contributors, https://github.com/visjs
+
+vis.js is dual licensed under both the Apache License 2.0 and the MIT
+License, and may be distributed under either. OrionBelt redistributes the
+bundled `vis-network.min.js` under the **MIT License**, reproduced below.
+
+The bundled file carries a header naming both licences but not their text;
+this file supplies the text that redistribution requires.
+
+--------------------------------------------------------------------------
+The MIT License (MIT)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## SPDX identifier was invalid

The metadata said `BSL-1.1`, which is not a valid SPDX identifier — `BSL-1.0` is the Boost Software License, and the Business Source License 1.1 is `BUSL-1.1`. Every package in the workspace carried the wrong one.

Moved to the PEP 639 form across the root, the ten drivers, and `osi-orionbelt`:

```toml
license = "BUSL-1.1"          # Apache-2.0 for osi-orionbelt
license-files = ["LICENSE"]
```

The deprecated `License :: Other/Proprietary License` classifier is dropped: PEP 639 replaces it, and some backends reject it alongside the new field.

Verified against a real build rather than assumed — the wheel now carries:

```
Metadata-Version: 2.5
License-Expression: BUSL-1.1
License-File: LICENSE
license files in wheel: ['…dist-info/licenses/LICENSE']
```

Badge and prose updated in README, the mkdocs copyright, `docs/index.md`, the four comparison pages, and every driver README / AGENTS file. CHANGELOG is left alone — it is an append-only record of what was said at the time.

## Do we need to deliver licence files? Yes, for one thing

OBSL redistributes exactly one third-party work: `src/orionbelt/ui/static/vis-network.min.js` (9.1.2, dual Apache-2.0 OR MIT), which ships inside the wheel and powers the Ontology Graph tab.

Its minified header names both licences but carries **neither text**, and MIT requires the text and copyright notice to accompany redistribution. So `vis-network.LICENSE.txt` now ships beside it, stating that OBSL redistributes under MIT and reproducing the text. Confirmed both files land in the built wheel.

## THIRD_PARTY_NOTICES.md

Modelled on the ontology-builder file, but it separates two obligations that are genuinely different:

- **The wheel** bundles exactly one third-party file (above).
- **The container images** contain the whole installed dependency tree, so publishing them redistributes those packages too.

Both are listed. Licences were read from distribution metadata rather than transcribed by hand. All sixteen direct runtime dependencies are permissive:

| | |
|---|---|
| MIT | fastapi, jsonschema, pydantic, pydantic-settings, pytz, pyyaml, ruamel.yaml, sqlglot, typer |
| BSD-3-Clause | httpx, networkx, rdflib, uvicorn |
| Apache-2.0 | opentelemetry-api, tzdata |
| MIT OR Apache-2.0 | structlog |

None is copyleft, so none reaches OBSL's own terms. Transitive dependencies are not enumerated — `uv.lock` pins them exactly and each carries its own metadata.

The file also states the case that is easy to leave implicit: **installing from PyPI redistributes nothing but OBSL's own code and that one bundled file**, because pip fetches dependencies itself.

## Checks

`uv build` clean for all 12 workspace packages, root suite 4649 passed / 1 xfailed, `ruff` clean, `mkdocs build --strict` clean.
