### PR TITLE
ci: pin every Action to a commit SHA, scope permissions, verify the pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,16 +10,30 @@ permissions:
   contents: read
 
 jobs:
+  # Every `uses:` in this repo is pinned to a commit SHA with a `# vX.Y.Z`
+  # comment naming the release it came from. Nothing but this job keeps the two
+  # in agreement: a pull request could swap the hash for one from a fork, leave
+  # the comment alone, and read as a routine bump. The script resolves each tag
+  # upstream and fails when the commit it names is not the one pinned.
+  pins:
+    name: pins
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Verify every Action is pinned to its named release
+        run: ./scripts/check-action-pins.sh
+
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
 
@@ -65,10 +79,10 @@ jobs:
     env:
       COVERAGE_CORE: sysmon
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
 
@@ -97,10 +111,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
 
@@ -143,7 +157,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0 # the check diffs against the merge base
 
@@ -162,10 +176,10 @@ jobs:
     name: UI imports on shipped deps
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
 

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -18,19 +18,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout orionbelt-semantic-layer
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: docs-source
 
+      - name: Verify every Action is pinned to its named release
+        working-directory: docs-source
+        run: ./scripts/check-action-pins.sh
+
       - name: Checkout ralforion.github.io
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: ralforion/ralforion.github.io
           token: ${{ secrets.DOCS_DEPLOY_TOKEN }}
           path: main-site
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
 

--- a/.github/workflows/deprecate-old-images.yml
+++ b/.github/workflows/deprecate-old-images.yml
@@ -45,7 +45,7 @@ jobs:
           EOF
 
       - name: Sync deprecation notice to Docker Hub
-        uses: peter-evans/dockerhub-description@v5
+        uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5.0.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -41,20 +41,23 @@ jobs:
             port: 7860
             health_path: /
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Verify every Action is pinned to its named release
+        run: ./scripts/check-action-pins.sh
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       # Only the API image bakes the demo dataset (see Dockerfile). The .duckdb
       # seed is gitignored and regenerated here so a clean checkout can build it;
       # the UI and Flight images do not need it.
       - name: Set up uv
         if: matrix.image == 'orionbelt-semantic-layer-api'
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
 
@@ -63,7 +66,7 @@ jobs:
         run: uv run --no-project --with duckdb python scripts/build_demo_duckdb.py
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -82,7 +85,7 @@ jobs:
 
       - name: Extract metadata (tags, labels)
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ secrets.DOCKERHUB_USERNAME }}/${{ matrix.image }}
           tags: |
@@ -105,7 +108,7 @@ jobs:
       # only here (the runner is amd64), smoke it, then let the push step below
       # reuse the layers from the gha cache.
       - name: Build amd64 locally for smoke test
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: ${{ matrix.dockerfile }}
@@ -142,7 +145,7 @@ jobs:
           exit 1
 
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: ${{ matrix.dockerfile }}
@@ -156,7 +159,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=${{ matrix.image }}
 
       - name: Sync README to Docker Hub overview
-        uses: peter-evans/dockerhub-description@v5
+        uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5.0.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/notebook.yml
+++ b/.github/workflows/notebook.yml
@@ -63,10 +63,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
 
@@ -93,10 +93,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Python 3.12
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/ossie-schema-drift.yml
+++ b/.github/workflows/ossie-schema-drift.yml
@@ -13,13 +13,20 @@ on:
 
 permissions:
   contents: read
-  issues: write
 
 jobs:
   drift:
     runs-on: ubuntu-latest
+    # Only this job files the drift issue, so the write scope lives here rather
+    # than on the workflow.
+    permissions:
+      contents: read
+      issues: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Verify every Action is pinned to its named release
+        run: ./scripts/check-action-pins.sh
 
       - name: Check upstream Ossie schema drift
         id: drift
@@ -31,7 +38,7 @@ jobs:
 
       - name: Open or update tracking issue on drift
         if: steps.drift.outputs.code == '1'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -19,6 +19,12 @@ on:
     tags: ["v*.*.*"]
   workflow_dispatch:
 
+# Read-only by default. Only the two publishing jobs get id-token: write, and
+# they need contents: read spelled out alongside it, because a job-level
+# permissions block replaces the whole set rather than adding to it.
+permissions:
+  contents: read
+
 jobs:
   publish-osi:
     name: Publish osi-orionbelt
@@ -28,12 +34,16 @@ jobs:
       name: pypi
       url: https://pypi.org/project/osi-orionbelt/
     permissions:
+      contents: read
       id-token: write # required for Trusted Publishing
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Verify every Action is pinned to its named release
+        run: ./scripts/check-action-pins.sh
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           python-version: "3.12"
 
@@ -44,7 +54,7 @@ jobs:
         run: uvx twine check dist/*
 
       - name: Publish osi-orionbelt to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           # osi-orionbelt has its own version cadence; an unchanged version is
           # already on PyPI, so skip it instead of failing the release.
@@ -59,12 +69,13 @@ jobs:
       name: pypi
       url: https://pypi.org/project/orionbelt-semantic-layer/
     permissions:
+      contents: read
       id-token: write # required for Trusted Publishing
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           python-version: "3.12"
 
@@ -75,7 +86,7 @@ jobs:
         run: uvx twine check dist/*
 
       - name: Publish orionbelt-semantic-layer to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           # Idempotency backstop for re-runs against an already-published tag.
           skip-existing: true

--- a/README.md
+++ b/README.md
@@ -636,7 +636,34 @@ uv run mypy src/                  # type check
 
 # Docs
 uv sync --extra docs && uv run mkdocs serve  # docs on :8080
+
+# CI workflows
+./scripts/check-action-pins.sh              # verify every Action pin
+./scripts/check-action-pins.sh --offline    # skip the upstream tag lookups
 ```
+
+### GitHub Actions pinning
+
+Every `uses:` in `.github/workflows` is pinned to a 40-character commit SHA
+rather than a tag, because a tag such as `v7` is a movable label: it runs
+whichever commit its owner has pointed it at when the job starts. The
+`# vX.Y.Z` comment beside each SHA names the exact patch release that SHA was
+cut from, and it has to be a patch release, since a major tag moves with every
+upstream bump.
+
+Pinning fixes *which* code runs but makes the reference unreadable, so
+`scripts/check-action-pins.sh` keeps the SHA and its comment honest. It walks
+every `uses:` line and requires a commit SHA, an owner from its `ALLOWED_OWNERS`
+allowlist, and an exact-patch version comment, then resolves that tag upstream
+with `git ls-remote` and fails when the commit it names is not the one pinned.
+Container actions must be pinned by digest; local `./` actions are skipped.
+`--offline` checks only the SHA and comment format, with no network calls.
+
+The check runs as the `pins` job in CI, and as the first step after checkout in
+the workflows that publish (Docker, PyPI, docs), so a tag can never ship
+artifacts built by steps whose pins were never verified. Adding an owner to
+`ALLOWED_OWNERS` is a deliberate decision: a SHA matching its own tag says
+nothing about whether that action belongs in this repo at all.
 
 ---
 

--- a/scripts/check-action-pins.sh
+++ b/scripts/check-action-pins.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+#
+# Verify that every third-party Action used by the workflows is pinned to an
+# immutable commit SHA, comes from an owner we trust, and carries a version
+# comment that really does name the release that SHA was cut from.
+#
+#   ./scripts/check-action-pins.sh              # every check
+#   ./scripts/check-action-pins.sh --offline    # skip the upstream tag lookups
+#
+# A git tag is a movable label, so `uses: actions/checkout@v7` runs whichever
+# commit that label points at when the job starts, and the owner of the action
+# can repoint it at any time. Pinning to a SHA fixes the code, but it also
+# makes the reference unreadable to a human, and that is the weakness this
+# guards. A pull request can swap the hash for one taken from an attacker's
+# fork while leaving the reassuring `# v7.0.1` comment untouched, and the diff
+# then looks exactly like a routine Dependabot bump. Forks share object storage
+# with their parent, so such a commit is even reachable under the real
+# repository's URL. Only resolving the tag tells the two apart.
+#
+# Version comments must name exact patch releases, never major tags. A major
+# tag such as v7 moves with every release, so checking against it would turn CI
+# red the moment upstream ships v7.0.2, for a pin that is still perfectly good.
+# Patch tags never move, so this check stays quiet until something is wrong.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# Only actions published by these owners may appear in a workflow. This is the
+# check that carries the most weight: a SHA matching its own tag says nothing
+# about whether the action belongs here at all, because `evil/action@<sha>
+# # v1` verifies perfectly well against evil's own v1 tag.
+# Beyond `actions/` this repo runs: astral-sh (uv), docker (buildx/QEMU/login/
+# metadata/build-push), peter-evans (Docker Hub description sync) and pypa
+# (PyPI Trusted Publishing). Each was added deliberately; adding another owner
+# is a decision, not a formality.
+ALLOWED_OWNERS="actions astral-sh docker peter-evans pypa"
+
+offline=false
+case "${1:-}" in
+    --offline) offline=true ;;
+    "") ;;
+    *) echo "usage: $0 [--offline]" >&2; exit 2 ;;
+esac
+
+# Resolve a tag to the commit it names, following annotated tags through to
+# their target. git ls-remote needs no token and is not rate limited, unlike
+# the REST API, which matters because hosted runners share outbound addresses.
+#
+# Three outcomes have to stay distinguishable. A tag that resolves prints its
+# SHA. A tag that does not exist prints nothing and returns 0, because
+# ls-remote reports a missing ref as success. A lookup that could not be made
+# at all, from a network failure or a repository that is not there, returns
+# non-zero and writes the reason to stderr. Collapsing the last two would let
+# an unreachable network read as a verified pin, and swallowing the error under
+# set -e would kill the run with no file or line to point at.
+resolve_tag() {
+    out=$(git ls-remote "https://github.com/$1" "refs/tags/$2" "refs/tags/$2^{}" 2>&1) || {
+        status=$?
+        printf 'git ls-remote exit %s: %s\n' "$status" "$(printf '%s' "$out" | tr '\n' ' ')" >&2
+        return "$status"
+    }
+    printf '%s\n' "$out" |
+        awk '{ sha[$2] = $1 }
+             END { print (("refs/tags/'"$2"'^{}") in sha) \
+                          ? sha["refs/tags/'"$2"'^{}"] \
+                          : sha["refs/tags/'"$2"'"] }'
+}
+
+failures=0
+checked=0
+
+fail() {
+    echo "::error file=$1,line=$2::$3"
+    echo "  $1:$2: $3" >&2
+    failures=$((failures + 1))
+}
+
+# Every `uses:` line in every workflow, carrying its file and line number so a
+# failure points straight at the offending reference.
+while IFS=: read -r file line body; do
+    # `uses: owner/repo@ref  # comment`, with the step's leading "- " optional.
+    spec=$(printf '%s\n' "$body" | sed -E 's/^[[:space:]]*(-[[:space:]]+)?uses:[[:space:]]*//; s/[[:space:]]*#.*$//; s/[[:space:]]*$//')
+    comment=$(printf '%s\n' "$body" | sed -nE 's/.*#[[:space:]]*(v[0-9][^[:space:]]*).*/\1/p')
+
+    # Actions living in this repository are covered by our own review.
+    case "$spec" in
+        ./*|.\\*) continue ;;
+    esac
+
+    checked=$((checked + 1))
+
+    # A container action is third-party executable code exactly as a repository
+    # action is, and an image tag such as :latest is every bit as movable as a
+    # git tag, so one cannot simply be waved through for having no git ref to
+    # resolve. A digest is what pins an image, and anything else is rejected.
+    # Note the residual gap: a digest fixes which image runs without saying
+    # whether it ought to run here, because there is no registry equivalent of
+    # ALLOWED_OWNERS. Adding a container action stays a deliberate act.
+    case "$spec" in
+        docker://*)
+            if ! printf '%s\n' "$spec" | grep -qE '^docker://[^@[:space:]]+@sha256:[0-9a-f]{64}$'; then
+                fail "$file" "$line" "$spec is a container action that is not pinned by digest; write it as docker://image@sha256:<64 hex digits>"
+            fi
+            continue
+            ;;
+    esac
+
+    repo=${spec%%@*}
+    ref=${spec#*@}
+    owner=${repo%%/*}
+
+    # A subdirectory action such as owner/repo/path@ref still pins the whole
+    # repository, so trim the path before resolving anything.
+    repo=$(printf '%s\n' "$repo" | cut -d/ -f1,2)
+
+    allowed=false
+    for candidate in $ALLOWED_OWNERS; do
+        [ "$owner" = "$candidate" ] && allowed=true
+    done
+    if [ "$allowed" = false ]; then
+        fail "$file" "$line" "owner '$owner' is not in ALLOWED_OWNERS ($ALLOWED_OWNERS); add it deliberately in scripts/check-action-pins.sh if this action is meant to run here"
+        continue
+    fi
+
+    if ! printf '%s\n' "$ref" | grep -qE '^[0-9a-f]{40}$'; then
+        fail "$file" "$line" "$repo is pinned to '$ref', which is a movable tag; pin it to the 40-character commit SHA that tag points at"
+        continue
+    fi
+
+    if [ -z "$comment" ]; then
+        fail "$file" "$line" "$repo@${ref:0:8} has no version comment; append '# vX.Y.Z' naming the release this SHA was cut from"
+        continue
+    fi
+
+    if ! printf '%s\n' "$comment" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+        fail "$file" "$line" "$repo carries the comment '# $comment'; name an exact patch release such as v7.0.1, because major tags move with every release and would fail this check for a good pin"
+        continue
+    fi
+
+    [ "$offline" = true ] && continue
+
+    # Folding stderr into the capture keeps the reason in $actual when the
+    # lookup fails, and the condition context exempts this from set -e so one
+    # unreachable repository cannot mask the findings on every later pin.
+    if ! actual=$(resolve_tag "$repo" "$comment" 2>&1); then
+        fail "$file" "$line" "could not resolve $repo $comment upstream: $actual"
+    elif [ -z "$actual" ]; then
+        fail "$file" "$line" "$repo has no tag $comment upstream"
+    elif [ "$actual" != "$ref" ]; then
+        fail "$file" "$line" "$repo $comment is upstream commit $actual, but the workflow pins $ref"
+    fi
+done < <(grep -rnE '^[[:space:]]*(-[[:space:]]+)?uses:' .github/workflows)
+
+if [ "$failures" -gt 0 ]; then
+    echo >&2
+    echo "$failures of $checked action pin(s) failed verification" >&2
+    exit 1
+fi
+
+echo "all $checked action pin(s) verified$([ "$offline" = true ] && echo " (offline: SHA and comment format only)")"


### PR DESCRIPTION
Ports the workflow hardening from [qvd2parquet#55](https://github.com/ralforion/qvd2parquet/pull/55) and [#56](https://github.com/ralforion/qvd2parquet/pull/56) to this repo.

## Part 1: pin every Action, scope permissions

`uses: actions/checkout@v7` runs whichever commit the `v7` label points at when the job starts, and the owner of the action can repoint that label at any time. A SHA cannot move. All 34 references across 7 workflows are now pinned to a 40-character commit SHA with a `# vX.Y.Z` comment naming the exact patch release it was cut from.

| Action | Pin | Release |
|---|---|---|
| `actions/checkout` | `3d3c42e5` | v7.0.1 |
| `actions/setup-python` | `5fda3b95` | v7.0.0 |
| `actions/github-script` | `3a2844b7` | v9.0.0 |
| `astral-sh/setup-uv` | `37802adc` | v7.6.0 |
| `docker/setup-qemu-action` | `96fe6ef7` | v4.2.0 |
| `docker/setup-buildx-action` | `37fe6310` | v4.3.0 |
| `docker/login-action` | `dbcb8138` | v4.6.0 |
| `docker/metadata-action` | `dc802804` | v6.2.0 |
| `docker/build-push-action` | `53b7df96` | v7.3.0 |
| `peter-evans/dockerhub-description` | `1b9a80c0` | v5.0.0 |
| `pypa/gh-action-pypi-publish` | `dc37677b` | v1.14.2 |

`pypa/gh-action-pypi-publish` was on the `release/v1` **branch**, which is as movable as a tag. Its head is currently v1.14.2, so the pin is a no-op today.

Permissions were mostly already right (5 of 7 workflows had `contents: read`). Two did not:

| Workflow | Before | After |
|---|---|---|
| `pypi-publish.yml` | no `permissions:` at all; jobs held only `id-token: write` | `contents: read` on the workflow; jobs hold `contents: read` + `id-token: write` |
| `ossie-schema-drift.yml` | `issues: write` on the workflow | `issues: write` on the `drift` job only |

The job-level `contents: read` in `pypi-publish.yml` matters: a job-level `permissions:` block replaces the whole set rather than adding to it, so `id-token: write` on its own was leaving `contents: none` for the checkout step.

## Part 2: verify the pins actually match their comments

Part 1 fixed *which* code runs. It also made every reference unreadable, and nothing keeps the SHA and the comment beside it in agreement.

That is the reviewable gap. A pull request can swap the hash for one taken from a fork, leave the comment saying `# v9.0.0`, and the diff looks exactly like a routine Dependabot bump. Forks share object storage with their parent, so such a commit is reachable under the real repository's URL as well. Only resolving the tag tells the two apart, and no human does that by eye on 40 hex characters.

`scripts/check-action-pins.sh` (copied from qvd2parquet, repo-agnostic) walks every `uses:` line and requires a commit SHA, an owner in `ALLOWED_OWNERS`, and a version comment naming an exact patch release, then resolves that tag upstream with `git ls-remote` and fails when the commit it names is not the one pinned. Container actions must be pinned by digest; local `./` actions are skipped. `--offline` skips the upstream lookups.

Tags resolve via `git ls-remote` rather than the REST API, so the check needs no token, parses no JSON, and is not rate limited on hosted runners that share outbound addresses. It fails closed: a lookup that could not be made at all is a failure, not a pass, and one unreachable repository does not stop the loop and hide a forged pin behind it.

`ALLOWED_OWNERS` is set to `actions astral-sh docker peter-evans pypa` for this repo, each added deliberately. That check carries the most weight of the three: a SHA matching its own tag says nothing about whether the action belongs here at all, because `evil/action@<sha> # v1.0.0` verifies perfectly well against evil's own tag.

### Wiring

- A `pins` job in `ci.yml`.
- First step after checkout in the four workflows that write outward: `docker-publish.yml`, `pypi-publish.yml` (in `publish-osi`, which `publish-main` depends on), `deploy-docs.yml` (it holds a cross-repo write token) and `ossie-schema-drift.yml`.

Ordering is the point. An action that has already executed could have rewritten the workspace, this script included, so a verifier placed after it would be checking whatever that action left behind. Checkout still runs unverified and has to: nothing can be checked before the tree it fetches exists.

`deprecate-old-images.yml` is pinned but not gated. It never checks the repo out, so there is nothing for the script to run against; it is manual-only and one-shot.

## Verification

```
$ ./scripts/check-action-pins.sh
all 35 action pin(s) verified

$ ./scripts/check-action-pins.sh --offline
all 35 action pin(s) verified (offline: SHA and comment format only)
```

Negative test, one SHA replaced with 40 zeros:

```
::error file=.github/workflows/ossie-schema-drift.yml,line=41::actions/github-script v9.0.0 is
upstream commit 3a2844b7e9c422d3c10d287c895573f7108da1b3, but the workflow pins 0000...0000
1 of 37 action pin(s) failed verification
exit=1
```

All 7 workflows re-parse as valid YAML.

## What this does not do

- It does not judge whether an action is safe, only that the hash matches its own label. A pinned SHA of a genuinely malicious release passes.
- It does not stop a downgrade. Pinning to a real but ancient `# v6.0.0` passes, because that SHA does match that tag.
- It says nothing about upstream being compromised. If a tag is repointed you are pinned to the old code and correctly unaffected.
- A digest fixes which container image runs, not whether it ought to run here. There is no registry equivalent of `ALLOWED_OWNERS`.
- `actions/checkout` runs before the check and is therefore unverified. That is an irreducible bootstrap dependency, not an oversight.

## Follow-up after merge

`pins` needs adding to the required status checks for `main`. It cannot be added before this merges: the job does not exist on `main` until then, so any PR opened first would wait forever on a context that never reports.

Also documented in the README under Development.