### PR TITLE
fix(types): exact decimals on Snowflake, naive timestamps on Postgres/Snowflake

### DIFF
--- a/drivers/ob-snowflake/src/ob_snowflake/__init__.py
+++ b/drivers/ob-snowflake/src/ob_snowflake/__init__.py
@@ -100,6 +100,15 @@ def connect(
     if authenticator is not None:
         connect_kwargs["authenticator"] = authenticator
 
+    # Without this, the connector converts every NUMBER with a scale to a
+    # float on the Arrow path: ``CAST(2.55 AS NUMBER(18, 2))`` comes back as
+    # ``double``, and ``NUMBER(19, 2)`` holding 12345678901234567.89 comes
+    # back 11 cents wrong. Snowflake is the only vendor whose driver drops a
+    # fixed-point type it was handed; every other ob-* driver returns
+    # ``decimal128``. A semantic layer whose measures are money cannot make
+    # that trade, so exactness is the default rather than an opt-in.
+    connect_kwargs["arrow_number_to_decimal"] = True
+
     native = snowflake.connector.connect(**connect_kwargs)
     return Connection(
         native,

--- a/drivers/ob-snowflake/tests/test_driver.py
+++ b/drivers/ob-snowflake/tests/test_driver.py
@@ -84,6 +84,20 @@ def test_connect_returns_connection() -> None:
         assert kwargs["password"] == "secret"
 
 
+def test_connect_asks_for_exact_decimals() -> None:
+    """NUMBER with a scale must arrive as ``decimal128``, not as a float.
+
+    Without ``arrow_number_to_decimal`` the connector converts every scaled
+    NUMBER to a double on the Arrow path: measured on a live account,
+    ``CAST(2.55 AS NUMBER(18, 2))`` came back as ``double`` and
+    ``NUMBER(19, 2)`` holding 12345678901234567.89 came back 11 cents wrong.
+    """
+    with patch("snowflake.connector.connect") as mock_connect:
+        mock_connect.return_value = _make_mock_native()
+        ob_snowflake.connect(account="xy12345", user="testuser", password="secret")
+        assert mock_connect.call_args.kwargs["arrow_number_to_decimal"] is True
+
+
 def test_connect_with_all_params() -> None:
     with patch("snowflake.connector.connect") as mock_connect:
         mock_connect.return_value = _make_mock_native()

--- a/scripts/probe_types.py
+++ b/scripts/probe_types.py
@@ -1,0 +1,227 @@
+"""Probe what Arrow type each driver returns for a declared OBML type.
+
+A semantic layer's promise is that a measure declared ``decimal(18, 2)``
+arrives as an exact fixed-point number. Whether it does is a property of the
+driver, not of the SQL: seven of the eight ``ob-*`` drivers already hand back
+an Arrow table, so the open question is not "is it Arrow" but "is the Arrow
+faithful" -- does the column come back as ``decimal128(18, 2)``, or as a
+float, or as a string?
+
+Each case is rendered through the engine's own ``cast_to_obml_type``, so what
+is measured is what OBSL emits rather than a hand-spelled approximation of it.
+Execution goes through ``ob_flight.db_router`` -- the same path
+``service/db_executor`` uses -- so the result is the driver's real
+``fetch_arrow_table()`` output.
+
+This is the type-fidelity companion to ``probe_functions.py``: that one asks
+what an engine *computes*, this one asks what its driver *returns*.
+
+Usage::
+
+    set -a && source .env && set +a
+    uv run python scripts/probe_types.py duckdb          # local, no credentials
+    uv run python scripts/probe_types.py postgres snowflake
+    uv run python scripts/probe_types.py all             # every reachable engine
+
+Each row prints a verdict, the Arrow type and the round-tripped value:
+
+* ``EXACT``   -- the declared type came back unchanged.
+* ``WIDENED`` -- still fixed-point, but a wider precision or scale. An engine
+  widening the result of a SUM is doing the right thing; a widened *cast* is
+  the engine's own decimal rules and is recorded, not judged.
+* ``FAMILY``  -- the right family, a different width (an int8 where the model
+  said integer). Value-dependent widths are worth knowing about: two pages of
+  one column can disagree.
+* ``LOSSY``   -- the fixed-point type became a float or a string. This is the
+  one that silently costs money.
+"""
+
+from __future__ import annotations
+
+import sys
+import traceback
+from typing import Any
+
+import pyarrow as pa
+
+#: ``(label, SQL literal spliced into the cast, OBML type, wrap in SUM)``.
+#: The aggregate cases are here because an aggregate is where an engine
+#: actually decides a result precision, and it is the shape every OBSL
+#: measure has.
+CASES: list[tuple[str, str, str, bool]] = [
+    ("decimal(18,2)", "2.55", "decimal(18, 2)", False),
+    ("decimal(38,9)", "2.123456789", "decimal(38, 9)", False),
+    ("decimal(18,2) big", "12345678901234567.89", "decimal(19, 2)", False),
+    ("SUM decimal(18,2)", "2.55", "decimal(18, 2)", True),
+    ("integer", "42", "integer", False),
+    ("bigint", "9007199254740993", "bigint", False),
+    ("double", "2.5", "double", False),
+    ("string", "'x'", "string", False),
+    ("boolean", "1", "boolean", False),
+    ("date", "'2026-08-15'", "date", False),
+    ("timestamp", "'2026-08-15 13:45:00'", "timestamp", False),
+]
+
+#: The Arrow type a faithful driver hands back for each non-decimal OBML type.
+#: ``timestamp`` is deliberately absent: any unit counts, but a zone does not,
+#: which :func:`_timestamp_verdict` checks separately.
+EXPECTED: dict[str, pa.DataType] = {
+    "integer": pa.int32(),
+    "bigint": pa.int64(),
+    "double": pa.float64(),
+    "string": pa.string(),
+    "boolean": pa.bool_(),
+    "date": pa.date32(),
+}
+
+#: Engines whose ``SELECT`` needs a FROM clause for a bare scalar expression.
+FROM_SUFFIX: dict[str, str] = {
+    "dremio": " FROM (VALUES (1))",
+}
+
+#: Engines that reject an aggregate over a constant with no FROM clause.
+NO_BARE_AGGREGATE = frozenset({"bigquery"})
+
+ENGINES = (
+    "duckdb",
+    "postgres",
+    "mysql",
+    "clickhouse",
+    "snowflake",
+    "bigquery",
+    "databricks",
+    "dremio",
+)
+
+
+def _family(t: pa.DataType) -> str:
+    for name, test in (
+        ("decimal", pa.types.is_decimal),
+        ("integer", pa.types.is_integer),
+        ("floating", pa.types.is_floating),
+        ("boolean", pa.types.is_boolean),
+        ("date", pa.types.is_date),
+        ("timestamp", pa.types.is_timestamp),
+        ("null", pa.types.is_null),
+    ):
+        if test(t):
+            return name
+    if pa.types.is_string(t) or pa.types.is_large_string(t):
+        return "string"
+    # ADBC wraps PostgreSQL NUMERIC as an opaque string extension type rather
+    # than narrowing it to decimal128, so the storage type is what matters.
+    storage = getattr(t, "storage_type", None)
+    if storage is not None and pa.types.is_string(storage):
+        return "string"
+    return str(t)
+
+
+def _decimal_verdict(obml: str, got: pa.DataType) -> str:
+    precision, scale = (int(x) for x in obml[obml.index("(") + 1 : -1].split(","))
+    if not pa.types.is_decimal(got):
+        return f"LOSSY   {_family(got)}"
+    if (got.precision, got.scale) == (precision, scale):
+        return "EXACT"
+    return f"WIDENED {got}"
+
+
+def _timestamp_verdict(got: pa.DataType) -> str:
+    if not pa.types.is_timestamp(got):
+        return f"LOSSY   {_family(got)}"
+    # OBML's cast vocabulary has one timestamp and it is the naive one, so a
+    # zone here is a zone the model never declared.
+    return "EXACT" if got.tz is None else f"ZONED   tz={got.tz}"
+
+
+def verdict(obml: str, got: pa.DataType) -> str:
+    """Judge the returned Arrow type against what the model declared."""
+    if obml.startswith("decimal"):
+        return _decimal_verdict(obml, got)
+    if obml == "timestamp":
+        return _timestamp_verdict(got)
+    want = {"integer": "integer", "bigint": "integer", "double": "floating"}.get(obml, obml)
+    if _family(got) != want:
+        return f"LOSSY   {_family(got)}"
+    expected = EXPECTED[obml]
+    return "EXACT" if got == expected else f"FAMILY  {got}"
+
+
+def render(engine: str) -> list[tuple[str, str, str]]:
+    """:data:`CASES` as *engine* would emit them: (label, OBML type, SQL)."""
+    from orionbelt.ast.nodes import FunctionCall, RawSQL
+    from orionbelt.dialect.registry import DialectRegistry
+    from orionbelt.models.types import parse_data_type
+
+    dialect = DialectRegistry.get(engine)
+    out: list[tuple[str, str, str]] = []
+    for label, literal, obml_type, aggregate in CASES:
+        if aggregate and engine in NO_BARE_AGGREGATE:
+            continue
+        expr: Any = dialect.cast_to_obml_type(RawSQL(sql=literal), parse_data_type(obml_type))
+        if aggregate:
+            expr = FunctionCall(name="SUM", args=[expr])
+        out.append((label, obml_type, dialect.compile_expr(expr)))
+    return out
+
+
+def fetch(engine: str, sql: str) -> pa.Table:
+    from ob_flight.db_router import get_connection
+
+    with get_connection(engine) as conn:
+        cursor = conn.cursor()
+        try:
+            cursor.execute(sql + FROM_SUFFIX.get(engine, ""))
+            return cursor.fetch_arrow_table()
+        finally:
+            cursor.close()
+
+
+def probe(engine: str) -> None:
+    print(f"\n===== {engine}")
+    cases = render(engine)
+    tables: dict[int, pa.Table] = {}
+    try:
+        combined = "SELECT " + ", ".join(f"{sql} AS c{i}" for i, (_, _, sql) in enumerate(cases))
+        table = fetch(engine, combined)
+        tables = {i: table.select([i]) for i in range(len(cases))}
+    except Exception:
+        # One unsupported cast must not blank the whole engine: retry per case
+        # so the rest of the matrix still gets filled in.
+        for i, (label, _, sql) in enumerate(cases):
+            try:
+                tables[i] = fetch(engine, f"SELECT {sql} AS c{i}")
+            except Exception as exc:  # noqa: BLE001 — a failure is a result here
+                detail = str(exc).splitlines()[0][:64] if str(exc).strip() else type(exc).__name__
+                print(f"  {label:19} ERR     {detail}")
+    for i, (label, obml_type, _) in enumerate(cases):
+        table = tables.get(i)
+        if table is None:
+            continue
+        arrow_type = table.schema.field(0).type
+        value = table.column(0)[0].as_py()
+        print(f"  {label:19} {verdict(obml_type, arrow_type):24} {str(arrow_type):28} {value!r}")
+
+
+def main(argv: list[str]) -> int:
+    requested = argv[1:]
+    if not requested:
+        print(f"usage: probe_types.py <{' | '.join(ENGINES)} | all>", file=sys.stderr)
+        return 2
+    engines = list(ENGINES) if requested == ["all"] else requested
+    unknown = [e for e in engines if e not in ENGINES]
+    if unknown:
+        print(f"unknown engine(s): {', '.join(unknown)}", file=sys.stderr)
+        return 2
+    for engine in engines:
+        try:
+            probe(engine)
+        except Exception:
+            # Unreachable is the normal state for an engine with no live
+            # target; print enough to tell that apart from a probe bug.
+            print(f"\n===== {engine}\n  UNREACHABLE")
+            traceback.print_exc(limit=2)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/src/orionbelt/dialect/postgres.py
+++ b/src/orionbelt/dialect/postgres.py
@@ -25,7 +25,14 @@ class PostgresDialect(Dialect):
         "integer": "INTEGER",
         "double": "DOUBLE PRECISION",
         "date": "DATE",
-        "timestamp": "TIMESTAMPTZ",
+        # OBML's cast vocabulary has one timestamp and it is the naive one:
+        # ``timestamp_tz`` exists as a column declaration but has no cast
+        # target (see ``resolution._CASTABLE_TEMPORAL_TYPES``). Rendering it
+        # as TIMESTAMPTZ invented a zone the model never declared, and
+        # PostgreSQL then moved the value: a dimension declaring ``resultType:
+        # timestamp`` over ``2026-08-15 13:45:00`` came back as 11:45 UTC.
+        # Every other dialect renders the naive type here.
+        "timestamp": "TIMESTAMP",
         "time": "TIME",
         "string": "TEXT",
         "boolean": "BOOLEAN",

--- a/src/orionbelt/dialect/snowflake.py
+++ b/src/orionbelt/dialect/snowflake.py
@@ -23,7 +23,11 @@ class SnowflakeDialect(Dialect):
         "integer": "NUMBER(38, 0)",
         "double": "FLOAT",
         "date": "DATE",
-        "timestamp": "TIMESTAMP_TZ",
+        # The naive type, matching every other dialect and this driver's own
+        # note to "use TIMESTAMP_NTZ for timezone-naive datetimes in generated
+        # SQL". TIMESTAMP_TZ attached the session zone to a value the model
+        # declared without one.
+        "timestamp": "TIMESTAMP_NTZ",
         "time": "TIME",
         "string": "VARCHAR",
         "boolean": "BOOLEAN",

--- a/tests/unit/test_data_types.py
+++ b/tests/unit/test_data_types.py
@@ -210,6 +210,35 @@ class TestDialectRendering:
         result = d.render_obml_type(DecimalType(50, 10))
         assert result == "NUMBER(38, 10)"
 
+    @pytest.mark.parametrize(
+        ("dialect_name", "expected"),
+        [
+            ("bigquery", "TIMESTAMP"),
+            ("clickhouse", "DateTime64(3)"),
+            ("databricks", "TIMESTAMP"),
+            ("dremio", "TIMESTAMP"),
+            ("duckdb", "TIMESTAMP"),
+            ("mysql", "TIMESTAMP"),
+            ("postgres", "TIMESTAMP"),
+            ("snowflake", "TIMESTAMP_NTZ"),
+        ],
+    )
+    def test_timestamp_renders_the_naive_type(self, dialect_name: str, expected: str) -> None:
+        """OBML's cast vocabulary has one timestamp, and it is the naive one.
+
+        ``timestamp_tz`` is a column declaration with no cast target (see
+        ``resolution._CASTABLE_TEMPORAL_TYPES``), so rendering ``timestamp`` as
+        a zoned type invents a zone the model never declared. PostgreSQL then
+        moved the value -- a dimension declaring ``resultType: timestamp`` over
+        ``2026-08-15 13:45:00`` came back as ``11:45 UTC`` -- and Snowflake
+        attached the session zone to it.
+        """
+        from orionbelt.dialect.registry import DialectRegistry
+
+        rendered = DialectRegistry.get(dialect_name).render_obml_type(SimpleType("timestamp"))
+        assert rendered == expected
+        assert rendered not in {"TIMESTAMPTZ", "TIMESTAMP_TZ", "TIMESTAMP WITH TIME ZONE"}
+
 
 class TestModelValidation:
     def test_valid_data_type_on_measure(self) -> None:


### PR DESCRIPTION
## What

Adds `scripts/probe_types.py`, which measures what Arrow type each driver actually returns for a declared OBML type, and fixes the two defects it found.

The probe renders every case through the engine's own `cast_to_obml_type` and executes through `ob_flight.db_router`, so what is measured is what OBSL emits on the path `service/db_executor` uses. It is the type-fidelity companion to `probe_functions.py`: that one asks what an engine *computes*, this one asks what its driver *returns*.

Measured against all eight dialects. Dremio came from `demo/dremio`, MySQL from a container.

## Why

Two things were wrong, both invisible from the SQL.

**Snowflake returned every scaled NUMBER as a float.** OBSL emits a correct `CAST(2.55 AS NUMBER(18, 2))` and the connector handed back `double`. Measured on the live account:

| | returned type | value |
|---|---|---|
| before | `double` | `1.2345678901234568e+16` for `NUMBER(19, 2)` holding 12345678901234567.89, 11 cents off |
| after | `decimal128(38, 2)` | `Decimal('12345678901234567.89')` |

Nothing downstream could repair this: by the time the value reaches the executor it is already an inexact double. `snowflake-connector-python` has a connection parameter for it, so exactness is now the default rather than an opt-in. Snowflake was the only vendor whose driver dropped a fixed-point type it had been handed.

**Postgres and Snowflake rendered OBML `timestamp` as a zoned type.** OBML's cast vocabulary has one timestamp and it is the naive one: `timestamp_tz` is a column declaration with no cast target (`resolution._CASTABLE_TEMPORAL_TYPES` says so explicitly). Rendering it as `TIMESTAMPTZ` / `TIMESTAMP_TZ` invented a zone the model never declared, and PostgreSQL then moved the value: a dimension declaring `resultType: timestamp` over `2026-08-15 13:45:00` came back as `11:45 UTC`. Both now render the naive type, as the other six dialects do, and as `ob-snowflake`'s own notes already prescribed ("use TIMESTAMP_NTZ for timezone-naive datetimes in generated SQL").

These two were the only dialects naming a zoned type in `_OBML_SIMPLE_TYPE_MAP`. The remaining zoned results (BigQuery `tz=UTC`, Databricks `tz=Etc/UTC`, ClickHouse `tz=Europe/Berlin`) come from those engines' own `TIMESTAMP` semantics rather than from a type OBSL asked for, so they are left alone here.

## Measured, before and after

`decimal(18, 2)`, all eight dialects:

| Dialect | Before | After |
|---|---|---|
| DuckDB | `decimal128(18,2)` | unchanged |
| Postgres | `arrow.opaque[string, numeric]` | unchanged (ADBC preserves NUMERIC's arbitrary precision as text; `db_executor.py:585` already re-parses it to `Decimal`) |
| MySQL | `decimal128(3,2)`, inferred per page | unchanged (tracked separately) |
| ClickHouse | `decimal128(18,2)` | unchanged |
| Snowflake | **`double`** | **`decimal128(38,2)`** |
| BigQuery | `decimal128(38,9)` | unchanged |
| Databricks | `decimal128(18,2)` | unchanged |
| Dremio | `decimal128(18,2)` | unchanged |

`timestamp` over `'2026-08-15 13:45:00'`:

| Dialect | Before | After |
|---|---|---|
| Postgres | `timestamp[us, tz=UTC]`, value 11:45 | `timestamp[us]`, value 13:45 |
| Snowflake | `timestamp[ns, tz=America/Los_Angeles]` | `timestamp[ns]` |

## Also found, not fixed here

- MySQL is the only driver that reconstructs Arrow from Python row tuples (`ob-mysql/src/ob_mysql/cursor.py:116`), so a column's type is inferred from whatever values are in the page: the same column gave `decimal128(3,2)` on one page and `decimal128(10,9)` on another, and an all-NULL page gives `null`.
- ClickHouse returned `12345678901234567.68` for a `decimal(19,2)` cast of `...67.89`, off by 0.21. Same `round()`-over-a-float family as #355.
- Snowflake narrows `integer` to `int8` based on the values present, so page widths can disagree there too.

## Test plan

- `uv run pytest` green: 4716 passed, 1006 skipped, 1 xfailed
- New: `test_timestamp_renders_the_naive_type` parametrized over all eight dialects, and `test_connect_asks_for_exact_decimals` on the driver
- `ruff check`, `ruff format`, `mypy src/` clean
- Re-run the matrix with `uv run python scripts/probe_types.py all`