### PR TITLE
fix(mysql): build the Arrow schema from column metadata, not from the rows

### DIFF
--- a/drivers/ob-mysql/src/ob_mysql/arrow_types.py
+++ b/drivers/ob-mysql/src/ob_mysql/arrow_types.py
@@ -1,0 +1,220 @@
+"""Build a PyArrow schema from MySQL's own column metadata.
+
+``mysql-connector-python`` has no native Arrow result format, so this driver
+assembles the table itself. Letting PyArrow infer the types from the row
+values -- which is what it used to do -- makes a column's type a property of
+the rows that happened to come back: one result set typed a ``DECIMAL(18, 2)``
+column as ``decimal128(3, 2)`` and another typed the same column as
+``decimal128(10, 9)``, an empty result typed every column as string, and an
+all-NULL column came back as Arrow's ``null`` type. Consumers that carry a
+schema across calls (Flight's ``FlightInfo``, the result cache) cannot work
+with a type that moves.
+
+MySQL states the type in the column-definition packet, so the type comes from
+``cursor.description`` instead: entry 1 is the field type and entry 7 the flag
+bits, which together fix the Arrow type before a single value is read.
+
+The one thing ``description`` will not give up is decimal width. MySQL sends a
+column length and a scale in that packet, but ``MySQLProtocol.parse_column``
+unpacks them into throwaway locals, so ``description`` reports ``precision``
+and ``scale`` as ``None`` on both the pure-Python and the C-extension paths.
+The scale survives elsewhere: the connector builds each value from MySQL's
+decimal text, which carries the column's own scale, so ``DECIMAL(18, 2)``
+yields ``Decimal('10.00')`` rather than ``Decimal('10')``. Taking the widest
+scale in the column recovers the declared one for any non-empty result, and
+the precision is widened to the decimal128 limit rather than guessed, so the
+type can never claim the column holds fewer digits than it does.
+"""
+
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+from typing import Any
+
+import pyarrow as pa
+
+# MySQL field types, from the wire protocol. ``type_codes.MYSQL_TYPE_MAP``
+# groups these into PEP 249 type objects; Arrow needs the exact width.
+_DECIMAL = 0
+_TINY = 1
+_SHORT = 2
+_LONG = 3
+_FLOAT = 4
+_DOUBLE = 5
+_NULL = 6
+_TIMESTAMP = 7
+_LONGLONG = 8
+_INT24 = 9
+_DATE = 10
+_TIME = 11
+_DATETIME = 12
+_YEAR = 13
+_NEWDATE = 14
+_VARCHAR = 15
+_BIT = 16
+_JSON = 245
+_NEWDECIMAL = 246
+_ENUM = 247
+_SET = 248
+_TINY_BLOB = 249
+_MEDIUM_BLOB = 250
+_LONG_BLOB = 251
+_BLOB = 252
+_VAR_STRING = 253
+_STRING = 254
+_GEOMETRY = 255
+
+#: ``FieldFlag.UNSIGNED``. A ``BIGINT UNSIGNED`` does not fit ``int64``, so the
+#: flag decides the signedness rather than the values deciding it.
+_UNSIGNED_FLAG = 32
+
+#: ``charsetnr`` for the binary collation. The string and blob types are one
+#: type each on the wire; this is what separates text from bytes.
+_BINARY_CHARSET = 63
+
+_SIGNED_INTS: dict[int, pa.DataType] = {
+    _TINY: pa.int8(),
+    _SHORT: pa.int16(),
+    _INT24: pa.int32(),
+    _LONG: pa.int32(),
+    _LONGLONG: pa.int64(),
+}
+
+_UNSIGNED_INTS: dict[int, pa.DataType] = {
+    _TINY: pa.uint8(),
+    _SHORT: pa.uint16(),
+    _INT24: pa.uint32(),
+    _LONG: pa.uint32(),
+    _LONGLONG: pa.uint64(),
+}
+
+_FIXED_TYPES: dict[int, pa.DataType] = {
+    _FLOAT: pa.float32(),
+    _DOUBLE: pa.float64(),
+    _NULL: pa.null(),
+    _DATE: pa.date32(),
+    _NEWDATE: pa.date32(),
+    _YEAR: pa.int16(),
+    # The connector returns TIME as a ``timedelta``: it is a signed interval of
+    # up to 838 hours, not a clock reading, so it is a duration and not
+    # ``time64``.
+    _TIME: pa.duration("us"),
+    _DATETIME: pa.timestamp("us"),
+    _TIMESTAMP: pa.timestamp("us"),
+    _JSON: pa.string(),
+    _ENUM: pa.string(),
+    _SET: pa.string(),
+    _BIT: pa.binary(),
+    _GEOMETRY: pa.binary(),
+}
+
+#: Types whose Arrow mapping depends on ``charsetnr``: text unless the column
+#: carries the binary collation.
+_TEXT_OR_BINARY = frozenset(
+    {_VARCHAR, _VAR_STRING, _STRING, _TINY_BLOB, _MEDIUM_BLOB, _LONG_BLOB, _BLOB}
+)
+
+_DECIMALS = frozenset({_DECIMAL, _NEWDECIMAL})
+
+#: Widest decimal128 / decimal256 precision. MySQL's own DECIMAL maximum is 65
+#: digits, so decimal256 covers every value the server can send.
+_DECIMAL128_MAX_PRECISION = 38
+_DECIMAL256_MAX_PRECISION = 76
+
+#: Scale for a decimal column with no values to read it from. Only reachable
+#: for an empty or all-NULL result, where no value can be misrepresented by it.
+_DEFAULT_DECIMAL_SCALE = 0
+
+
+def _decimal_type(values: list[Any]) -> pa.DataType:
+    """The narrowest decimal type that holds every value in *values* exactly."""
+    scale = _DEFAULT_DECIMAL_SCALE
+    integral_digits = 1
+    for value in values:
+        if not isinstance(value, Decimal):
+            continue
+        sign, digits, exponent = value.as_tuple()
+        if not isinstance(exponent, int):
+            # NaN and the infinities have a symbolic exponent and no scale.
+            continue
+        scale = max(scale, -exponent if exponent < 0 else 0)
+        integral_digits = max(integral_digits, len(digits) + min(exponent, 0))
+    precision = max(integral_digits + scale, 1)
+    if precision <= _DECIMAL128_MAX_PRECISION:
+        return pa.decimal128(_DECIMAL128_MAX_PRECISION, scale)
+    if precision <= _DECIMAL256_MAX_PRECISION:
+        return pa.decimal256(_DECIMAL256_MAX_PRECISION, scale)
+    # Unreachable against a MySQL server (DECIMAL tops out at 65 digits), but a
+    # value Arrow cannot hold is better rendered than raised on.
+    return pa.string()
+
+
+def arrow_type_for(description_entry: tuple[Any, ...], values: list[Any]) -> pa.DataType:
+    """The Arrow type for one column of a result set.
+
+    *description_entry* is one entry of ``cursor.description``; *values* is
+    that column's values, read only to recover a decimal's scale.
+    """
+    field_type = description_entry[1]
+    flags = description_entry[7] if len(description_entry) > 7 else 0
+    charset = description_entry[8] if len(description_entry) > 8 else None
+
+    if field_type in _DECIMALS:
+        return _decimal_type(values)
+    if field_type in _SIGNED_INTS:
+        unsigned = bool((flags or 0) & _UNSIGNED_FLAG)
+        return (_UNSIGNED_INTS if unsigned else _SIGNED_INTS)[field_type]
+    if field_type in _TEXT_OR_BINARY:
+        return pa.binary() if charset == _BINARY_CHARSET else pa.string()
+    fixed = _FIXED_TYPES.get(field_type)
+    if fixed is not None:
+        return fixed
+    # An unmapped field type keeps the old behaviour rather than guessing: let
+    # PyArrow read the values. Reached only if MySQL adds a type.
+    return _infer(values)
+
+
+def _infer(values: list[Any]) -> pa.DataType:
+    try:
+        return pa.array(values).type
+    except (pa.ArrowInvalid, pa.ArrowTypeError, pa.ArrowNotImplementedError):
+        return pa.string()
+
+
+def _coerce(value: object, arrow_type: pa.DataType) -> object:
+    """Nudge the few values whose Python type does not match *arrow_type*."""
+    # A DATETIME column can hold a DATE-only value, which the connector returns
+    # as ``date``. Arrow will not put a ``date`` in a timestamp column.
+    if (
+        pa.types.is_timestamp(arrow_type)
+        and isinstance(value, datetime.date)
+        and not isinstance(value, datetime.datetime)
+    ):
+        return datetime.datetime(value.year, value.month, value.day)
+    return value
+
+
+def table_from_rows(rows: list[Any], description: list[tuple[Any, ...]]) -> pa.Table:
+    """Assemble a PyArrow Table whose schema comes from *description*.
+
+    The schema is the same for a given column whether the result has a
+    thousand rows, one row, or none.
+    """
+    names = [entry[0] for entry in description]
+    columns: list[list[Any]] = [[] for _ in names]
+    for row in rows:
+        for index in range(len(names)):
+            columns[index].append(row[index])
+
+    arrays: list[pa.Array] = []
+    for index, entry in enumerate(description):
+        arrow_type = arrow_type_for(entry, columns[index])
+        values = [_coerce(value, arrow_type) for value in columns[index]]
+        try:
+            arrays.append(pa.array(values, type=arrow_type))
+        except (pa.ArrowInvalid, pa.ArrowTypeError, pa.ArrowNotImplementedError):
+            # A value the declared type cannot hold must not cost the caller
+            # the whole result set.
+            arrays.append(pa.array(values))
+    return pa.Table.from_arrays(arrays, names=names)

--- a/drivers/ob-mysql/src/ob_mysql/arrow_types.py
+++ b/drivers/ob-mysql/src/ob_mysql/arrow_types.py
@@ -33,7 +33,7 @@ property of the rows.
 **A decimal column with no value to read the scale from is the exception.** An
 empty result or an all-NULL column falls back to
 :data:`_DEFAULT_DECIMAL_SCALE`, so ``DECIMAL(18, 2)`` reports
-``decimal128(38, 0)`` there and ``decimal128(38, 2)`` once a value arrives. A
+``decimal256(76, 0)`` there and ``decimal256(76, 2)`` once a value arrives. A
 fixed scale would remove the difference, but not for free: it would rescale
 every value, and ``Decimal('10.00')`` carried at a fixed scale of 30 reaches
 JSON and TSV with thirty decimal places. No value is misrepresented by the

--- a/drivers/ob-mysql/src/ob_mysql/arrow_types.py
+++ b/drivers/ob-mysql/src/ob_mysql/arrow_types.py
@@ -14,16 +14,32 @@ MySQL states the type in the column-definition packet, so the type comes from
 ``cursor.description`` instead: entry 1 is the field type and entry 7 the flag
 bits, which together fix the Arrow type before a single value is read.
 
-The one thing ``description`` will not give up is decimal width. MySQL sends a
-column length and a scale in that packet, but ``MySQLProtocol.parse_column``
-unpacks them into throwaway locals, so ``description`` reports ``precision``
-and ``scale`` as ``None`` on both the pure-Python and the C-extension paths.
-The scale survives elsewhere: the connector builds each value from MySQL's
-decimal text, which carries the column's own scale, so ``DECIMAL(18, 2)``
-yields ``Decimal('10.00')`` rather than ``Decimal('10')``. Taking the widest
-scale in the column recovers the declared one for any non-empty result, and
-the precision is widened to the decimal128 limit rather than guessed, so the
-type can never claim the column holds fewer digits than it does.
+The one thing ``description`` will not give up is decimal width, and it is the
+one place this module cannot deliver on the rule above. MySQL sends a column
+length and a scale in that packet, but ``MySQLProtocol.parse_column`` unpacks
+both into throwaway locals and its caller drops the packet, so ``description``
+reports ``precision`` and ``scale`` as ``None`` on the pure-Python and the
+C-extension paths alike.
+
+The scale survives only in the values. The connector builds each value from
+MySQL's decimal text, which carries the column's own scale, so
+``DECIMAL(18, 2)`` yields ``Decimal('10.00')`` rather than ``Decimal('10')``.
+Taking the widest scale in the column recovers the declared one for any result
+holding at least one non-null value, and the precision is widened to the
+decimal128 limit rather than guessed, so the type can never claim the column
+holds fewer digits than it does.
+
+**A decimal column with no value to read the scale from is the exception.** An
+empty result or an all-NULL column falls back to
+:data:`_DEFAULT_DECIMAL_SCALE`, so ``DECIMAL(18, 2)`` reports
+``decimal128(38, 0)`` there and ``decimal128(38, 2)`` once a value arrives. A
+fixed scale would remove the difference, but not for free: it would rescale
+every value, and ``Decimal('10.00')`` carried at a fixed scale of 30 reaches
+JSON and TSV with thirty decimal places. No value is misrepresented by the
+fallback, since in both cases there is no value; what it costs is a schema a
+consumer cannot compare across an empty and a non-empty result. A consumer
+needing one stable schema has to take it from the model rather than from the
+driver, which is what the Flight surface already does.
 """
 
 from __future__ import annotations
@@ -69,6 +85,12 @@ _GEOMETRY = 255
 #: flag decides the signedness rather than the values deciding it.
 _UNSIGNED_FLAG = 32
 
+#: ``FieldFlag.SET``. MySQL sends a SET column as ``STRING`` carrying this flag
+#: rather than as the ``SET`` type code, and mysql-connector-python turns the
+#: value into a Python ``set``. Reading the flag is the only way to know that
+#: before a value arrives.
+_SET_FLAG = 2048
+
 #: ``charsetnr`` for the binary collation. The string and blob types are one
 #: type each on the wire; this is what separates text from bytes.
 _BINARY_CHARSET = 63
@@ -103,10 +125,16 @@ _FIXED_TYPES: dict[int, pa.DataType] = {
     _DATETIME: pa.timestamp("us"),
     _TIMESTAMP: pa.timestamp("us"),
     _JSON: pa.string(),
+    # Measured: mysql-connector-python returns BIT as a Python ``int``, not as
+    # bytes -- ``BIT(8)`` holding b'10101010' arrives as 170. BIT tops out at 64
+    # bits and the column carries the UNSIGNED flag, so uint64 holds every value.
+    _BIT: pa.uint64(),
+    _GEOMETRY: pa.binary(),
+    # ENUM and SET have their own type codes in the protocol, but MySQL does not
+    # use them on the wire: both arrive as STRING with a flag. Mapped anyway so a
+    # server that does send them is not pushed onto the inference path.
     _ENUM: pa.string(),
     _SET: pa.string(),
-    _BIT: pa.binary(),
-    _GEOMETRY: pa.binary(),
 }
 
 #: Types whose Arrow mapping depends on ``charsetnr``: text unless the column
@@ -165,6 +193,12 @@ def arrow_type_for(description_entry: tuple[Any, ...], values: list[Any]) -> pa.
     if field_type in _SIGNED_INTS:
         unsigned = bool((flags or 0) & _UNSIGNED_FLAG)
         return (_UNSIGNED_INTS if unsigned else _SIGNED_INTS)[field_type]
+    if (flags or 0) & _SET_FLAG:
+        # A SET arrives as a Python ``set``, which no string array will take.
+        # ``_coerce`` renders it back to the comma-separated form MySQL itself
+        # prints, so the column is one scalar per row rather than a list whose
+        # type would depend on what came back.
+        return pa.string()
     if field_type in _TEXT_OR_BINARY:
         return pa.binary() if charset == _BINARY_CHARSET else pa.string()
     fixed = _FIXED_TYPES.get(field_type)
@@ -183,7 +217,11 @@ def _infer(values: list[Any]) -> pa.DataType:
 
 
 def _coerce(value: object, arrow_type: pa.DataType) -> object:
-    """Nudge the few values whose Python type does not match *arrow_type*."""
+    """Nudge the few values whose Python type does not match *arrow_type*.
+
+    Without this the array build would fail and fall through to inference,
+    which is the row-dependence this module exists to remove.
+    """
     # A DATETIME column can hold a DATE-only value, which the connector returns
     # as ``date``. Arrow will not put a ``date`` in a timestamp column.
     if (
@@ -192,6 +230,11 @@ def _coerce(value: object, arrow_type: pa.DataType) -> object:
         and not isinstance(value, datetime.datetime)
     ):
         return datetime.datetime(value.year, value.month, value.day)
+    # A SET is a Python ``set``, and an unordered one: the connector has already
+    # dropped the definition order MySQL prints, so sorting is what is left to
+    # make the rendering deterministic rather than a choice against it.
+    if isinstance(value, (set, frozenset)) and pa.types.is_string(arrow_type):
+        return ",".join(sorted(str(member) for member in value))
     return value
 
 

--- a/drivers/ob-mysql/src/ob_mysql/arrow_types.py
+++ b/drivers/ob-mysql/src/ob_mysql/arrow_types.py
@@ -25,9 +25,10 @@ The scale survives only in the values. The connector builds each value from
 MySQL's decimal text, which carries the column's own scale, so
 ``DECIMAL(18, 2)`` yields ``Decimal('10.00')`` rather than ``Decimal('10')``.
 Taking the widest scale in the column recovers the declared one for any result
-holding at least one non-null value, and the precision is widened to the
-decimal128 limit rather than guessed, so the type can never claim the column
-holds fewer digits than it does.
+holding at least one non-null value. The precision is not measured at all: it is
+fixed at the decimal256 limit, which no MySQL DECIMAL can overflow, because
+choosing a narrower type when the values happened to fit made the width a
+property of the rows.
 
 **A decimal column with no value to read the scale from is the exception.** An
 empty result or an all-NULL column falls back to
@@ -145,10 +146,18 @@ _TEXT_OR_BINARY = frozenset(
 
 _DECIMALS = frozenset({_DECIMAL, _NEWDECIMAL})
 
-#: Widest decimal128 / decimal256 precision. MySQL's own DECIMAL maximum is 65
-#: digits, so decimal256 covers every value the server can send.
-_DECIMAL128_MAX_PRECISION = 38
-_DECIMAL256_MAX_PRECISION = 76
+#: The precision every decimal column reports, chosen once rather than per
+#: result. MySQL's DECIMAL tops out at 65 digits with a scale of at most 30, so
+#: a value has at most 65 significant digits, and ``decimal256`` carries 76:
+#: whatever the scale, ``76 - scale`` integer digits is more than the ``65 -
+#: scale`` MySQL can supply, so no value can overflow it.
+#:
+#: Picking the narrower ``decimal128`` when the values happen to fit is what a
+#: previous version did, and it made the width a property of the rows: a real
+#: ``DECIMAL(65, 2)`` column reported ``decimal128(38, 2)`` for the rows below
+#: 10^36 and ``decimal256(76, 2)`` for the rows above it. The cost of fixing it
+#: here is 32 bytes a value instead of 16, paid by every decimal column.
+_DECIMAL_PRECISION = 76
 
 #: Scale for a decimal column with no values to read it from. Only reachable
 #: for an empty or all-NULL result, where no value can be misrepresented by it.
@@ -156,26 +165,24 @@ _DEFAULT_DECIMAL_SCALE = 0
 
 
 def _decimal_type(values: list[Any]) -> pa.DataType:
-    """The narrowest decimal type that holds every value in *values* exactly."""
+    """A decimal wide enough for any MySQL DECIMAL, at the column's own scale.
+
+    The precision is fixed (see :data:`_DECIMAL_PRECISION`) rather than measured,
+    so it cannot move with the rows. Only the scale is read from the values, and
+    only because MySQL discards it before ``description`` is built; it is stable
+    for any result holding at least one non-null value, since the connector
+    renders every value at the column's declared scale.
+    """
     scale = _DEFAULT_DECIMAL_SCALE
-    integral_digits = 1
     for value in values:
         if not isinstance(value, Decimal):
             continue
-        sign, digits, exponent = value.as_tuple()
+        exponent = value.as_tuple().exponent
         if not isinstance(exponent, int):
             # NaN and the infinities have a symbolic exponent and no scale.
             continue
         scale = max(scale, -exponent if exponent < 0 else 0)
-        integral_digits = max(integral_digits, len(digits) + min(exponent, 0))
-    precision = max(integral_digits + scale, 1)
-    if precision <= _DECIMAL128_MAX_PRECISION:
-        return pa.decimal128(_DECIMAL128_MAX_PRECISION, scale)
-    if precision <= _DECIMAL256_MAX_PRECISION:
-        return pa.decimal256(_DECIMAL256_MAX_PRECISION, scale)
-    # Unreachable against a MySQL server (DECIMAL tops out at 65 digits), but a
-    # value Arrow cannot hold is better rendered than raised on.
-    return pa.string()
+    return pa.decimal256(_DECIMAL_PRECISION, scale)
 
 
 def arrow_type_for(description_entry: tuple[Any, ...], values: list[Any]) -> pa.DataType:

--- a/drivers/ob-mysql/src/ob_mysql/cursor.py
+++ b/drivers/ob-mysql/src/ob_mysql/cursor.py
@@ -117,28 +117,16 @@ class Cursor:
         """Fetch all remaining rows as a PyArrow Table.
 
         mysql-connector-python has no native Arrow support, so this method
-        fetches all rows via ``fetchall()`` and converts them to a PyArrow
-        Table using column names from ``description``.
+        assembles the table from ``fetchall()``. The schema comes from
+        ``cursor.description`` rather than from the values, so a column's type
+        does not change with the rows that happen to come back -- see
+        :mod:`ob_mysql.arrow_types`.
         """
-        import pyarrow as pa
+        from ob_mysql.arrow_types import table_from_rows
 
         self._check_open()
         rows = self._native.fetchall()
-        desc = self._native.description or []
-        col_names = [col[0] for col in desc]
-
-        if not rows:
-            # Return empty table with correct schema
-            arrays = [pa.array([], type=pa.utf8()) for _ in col_names]
-            return pa.table(dict(zip(col_names, arrays, strict=True)))
-
-        # Transpose rows to columns and let PyArrow infer types
-        columns: dict[str, list[Any]] = {name: [] for name in col_names}
-        for row in rows:
-            for i, name in enumerate(col_names):
-                columns[name].append(row[i])
-
-        return pa.table(columns)
+        return table_from_rows(rows, list(self._native.description or []))
 
     def close(self) -> None:
         """Close the cursor."""

--- a/drivers/ob-mysql/tests/test_arrow_types.py
+++ b/drivers/ob-mysql/tests/test_arrow_types.py
@@ -1,0 +1,133 @@
+"""The Arrow schema must come from MySQL's column metadata, not from the rows.
+
+Letting PyArrow infer the types made a column's type a property of whichever
+values came back: one result set typed a ``DECIMAL(18, 2)`` column as
+``decimal128(3, 2)`` and another typed the same column as ``decimal128(10, 9)``,
+an empty result typed every column as string, and an all-NULL column came back
+as Arrow's ``null`` type.
+"""
+
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+
+import pyarrow as pa
+
+from ob_mysql.arrow_types import table_from_rows
+
+
+def _column(
+    name: str,
+    type_code: int,
+    *,
+    flags: int = 0,
+    charset: int | None = None,
+) -> tuple[object, ...]:
+    """One ``cursor.description`` entry, as mysql-connector-python builds it."""
+    return (name, type_code, None, None, None, None, 1, flags, charset)
+
+
+LONG = 3
+DOUBLE = 5
+DATE = 10
+TIME = 11
+DATETIME = 12
+NEWDECIMAL = 246
+BLOB = 252
+VAR_STRING = 253
+BINARY_CHARSET = 63
+UNSIGNED_FLAG = 32
+LONGLONG = 8
+
+
+def _type_of(rows: list[tuple[object, ...]], description: list[tuple[object, ...]]) -> pa.DataType:
+    return table_from_rows(rows, description).schema.field(0).type
+
+
+class TestSchemaDoesNotFollowTheValues:
+    def test_decimal_precision_is_stable_across_result_sets(self) -> None:
+        """The same column must not change width with the rows it returns."""
+        description = [_column("amount", NEWDECIMAL)]
+        two_dp = _type_of([(Decimal("2.55"),), (Decimal("1.10"),)], description)
+        one_row = _type_of([(Decimal("12345.67"),)], description)
+        assert two_dp == one_row == pa.decimal128(38, 2)
+
+    def test_decimal_scale_comes_from_the_declared_scale(self) -> None:
+        """MySQL renders a decimal with its column's scale, zeros included.
+
+        ``DECIMAL(18, 2)`` yields ``Decimal('10.00')`` rather than
+        ``Decimal('10')``, so the widest scale in the column is the declared
+        one -- the only place the scale survives, since the connector drops the
+        wire's scale byte.
+        """
+        description = [_column("amount", NEWDECIMAL)]
+        assert _type_of([(Decimal("10.00"),)], description) == pa.decimal128(38, 2)
+        assert _type_of([(Decimal("2.500000000"),)], description) == pa.decimal128(38, 9)
+
+    def test_decimal_widens_past_decimal128(self) -> None:
+        """MySQL DECIMAL runs to 65 digits; decimal128 stops at 38."""
+        wide = Decimal("1" * 40)
+        assert _type_of([(wide,)], [_column("amount", NEWDECIMAL)]) == pa.decimal256(76, 0)
+
+    def test_integer_width_comes_from_the_field_type(self) -> None:
+        """A small value in an INT column is still an int32."""
+        assert _type_of([(42,)], [_column("n", LONG)]) == pa.int32()
+
+    def test_unsigned_flag_decides_signedness(self) -> None:
+        """``BIGINT UNSIGNED`` does not fit int64, and the flag says so."""
+        description = [_column("big", LONGLONG, flags=UNSIGNED_FLAG)]
+        table = table_from_rows([(18446744073709551615,)], description)
+        assert table.schema.field(0).type == pa.uint64()
+        assert table.column(0)[0].as_py() == 18446744073709551615
+
+    def test_binary_charset_separates_bytes_from_text(self) -> None:
+        assert _type_of([(b"x",)], [_column("b", BLOB, charset=BINARY_CHARSET)]) == pa.binary()
+        assert _type_of([("x",)], [_column("s", VAR_STRING)]) == pa.string()
+
+
+class TestEmptyAndNullResults:
+    def test_empty_result_keeps_its_column_types(self) -> None:
+        """Every column used to come back as string when there were no rows."""
+        description = [
+            _column("n", LONG),
+            _column("d", DATE),
+            _column("ts", DATETIME),
+            _column("f", DOUBLE),
+        ]
+        schema = table_from_rows([], description).schema
+        assert [field.type for field in schema] == [
+            pa.int32(),
+            pa.date32(),
+            pa.timestamp("us"),
+            pa.float64(),
+        ]
+
+    def test_all_null_column_keeps_its_type(self) -> None:
+        """An all-NULL column used to come back as Arrow's null type."""
+        table = table_from_rows([(None,), (None,)], [_column("n", LONG)])
+        assert table.schema.field(0).type == pa.int32()
+        assert table.column(0).to_pylist() == [None, None]
+
+
+class TestValuesSurvive:
+    def test_time_is_a_duration_not_a_clock_reading(self) -> None:
+        """MySQL TIME is a signed interval of up to 838 hours."""
+        table = table_from_rows([(datetime.timedelta(seconds=3723),)], [_column("t", TIME)])
+        assert table.schema.field(0).type == pa.duration("us")
+        assert table.column(0)[0].as_py() == datetime.timedelta(seconds=3723)
+
+    def test_date_only_value_in_a_datetime_column(self) -> None:
+        """A DATETIME column can hold a DATE, which Arrow will not take as-is."""
+        table = table_from_rows([(datetime.date(2026, 8, 15),)], [_column("ts", DATETIME)])
+        assert table.schema.field(0).type == pa.timestamp("us")
+        assert table.column(0)[0].as_py() == datetime.datetime(2026, 8, 15, 0, 0)
+
+    def test_short_description_entries_are_tolerated(self) -> None:
+        """PEP 249 promises seven entries; mysql-connector-python sends nine."""
+        seven = ("n", LONG, None, None, None, None, 1)
+        assert table_from_rows([(1,)], [seven]).schema.field(0).type == pa.int32()
+
+    def test_unknown_field_type_falls_back_to_inference(self) -> None:
+        table = table_from_rows([("x",)], [_column("mystery", 199)])
+        assert table.schema.field(0).type == pa.string()

--- a/drivers/ob-mysql/tests/test_arrow_types.py
+++ b/drivers/ob-mysql/tests/test_arrow_types.py
@@ -51,7 +51,28 @@ class TestSchemaDoesNotFollowTheValues:
         description = [_column("amount", NEWDECIMAL)]
         two_dp = _type_of([(Decimal("2.55"),), (Decimal("1.10"),)], description)
         one_row = _type_of([(Decimal("12345.67"),)], description)
-        assert two_dp == one_row == pa.decimal128(38, 2)
+        assert two_dp == one_row == pa.decimal256(76, 2)
+
+    def test_precision_does_not_follow_the_magnitude_of_the_rows(self) -> None:
+        """A wide column must not narrow because this page happened to be small.
+
+        Measuring the precision and picking decimal128 when it fit made the
+        width a property of the rows: a real ``DECIMAL(65, 2)`` reported
+        ``decimal128(38, 2)`` for the values below 10^36 and
+        ``decimal256(76, 2)`` for the ones above it, so two filters over one
+        column disagreed.
+        """
+        description = [_column("amount", NEWDECIMAL)]
+        small = _type_of([(Decimal("1.50"),)], description)
+        large = _type_of([(Decimal("9" * 40 + ".99"),)], description)
+        assert small == large == pa.decimal256(76, 2)
+
+    def test_the_fixed_precision_holds_the_widest_mysql_decimal(self) -> None:
+        """DECIMAL(65, 30) is MySQL's widest, and it has to fit without loss."""
+        widest = Decimal("9" * 35 + "." + "9" * 30)
+        table = table_from_rows([(widest,)], [_column("amount", NEWDECIMAL)])
+        assert table.schema.field(0).type == pa.decimal256(76, 30)
+        assert table.column(0)[0].as_py() == widest
 
     def test_decimal_scale_comes_from_the_declared_scale(self) -> None:
         """MySQL renders a decimal with its column's scale, zeros included.
@@ -62,13 +83,8 @@ class TestSchemaDoesNotFollowTheValues:
         wire's scale byte.
         """
         description = [_column("amount", NEWDECIMAL)]
-        assert _type_of([(Decimal("10.00"),)], description) == pa.decimal128(38, 2)
-        assert _type_of([(Decimal("2.500000000"),)], description) == pa.decimal128(38, 9)
-
-    def test_decimal_widens_past_decimal128(self) -> None:
-        """MySQL DECIMAL runs to 65 digits; decimal128 stops at 38."""
-        wide = Decimal("1" * 40)
-        assert _type_of([(wide,)], [_column("amount", NEWDECIMAL)]) == pa.decimal256(76, 0)
+        assert _type_of([(Decimal("10.00"),)], description) == pa.decimal256(76, 2)
+        assert _type_of([(Decimal("2.500000000"),)], description) == pa.decimal256(76, 9)
 
     def test_integer_width_comes_from_the_field_type(self) -> None:
         """A small value in an INT column is still an int32."""

--- a/tests/integration/test_ob_mysql_driver.py
+++ b/tests/integration/test_ob_mysql_driver.py
@@ -13,6 +13,7 @@ Skipped automatically when:
 
 from __future__ import annotations
 
+from decimal import Decimal
 from typing import Any
 
 import pytest
@@ -252,3 +253,107 @@ class TestOBMySQLDriver:
         assert "Revenue" in col_names
         cur.fetchall()  # consume results before close (MySQL requires this)
         cur.close()
+
+
+# ---------------------------------------------------------------------------
+# Arrow schema stability across every MySQL type
+# ---------------------------------------------------------------------------
+
+_ALL_TYPES_DDL = """CREATE TABLE alltypes (
+  c_dec DECIMAL(18,2), c_tiny TINYINT, c_bool TINYINT(1), c_small SMALLINT,
+  c_medium MEDIUMINT, c_int INT, c_big BIGINT, c_ubig BIGINT UNSIGNED,
+  c_float FLOAT, c_double DOUBLE, c_bit BIT(8), c_date DATE, c_time TIME,
+  c_dt DATETIME, c_ts TIMESTAMP NULL, c_year YEAR, c_char CHAR(4),
+  c_vchar VARCHAR(20), c_text TEXT, c_blob BLOB, c_enum ENUM('a','b'),
+  c_set SET('a','b'), c_json JSON, c_bin BINARY(4))"""
+
+_ALL_TYPES_ROW = """INSERT INTO alltypes VALUES (2.55, 1, 1, 2, 3, 4, 5,
+  18446744073709551615, 1.5, 2.5, b'10101010', '2026-08-15', '01:02:03',
+  '2026-08-15 13:45:00', '2026-08-15 13:45:00', 2026, 'ab', 'x', 'y', 'z',
+  'a', 'a,b', '{"k": 1}', 'bin')"""
+
+
+@pytest.fixture(scope="module")
+def alltypes_conn(mysql_conn):
+    """The same connection, with a table covering every MySQL column type."""
+    cur = mysql_conn.cursor()
+    cur.execute("DROP TABLE IF EXISTS alltypes")
+    cur.execute(_ALL_TYPES_DDL)
+    cur.execute(_ALL_TYPES_ROW)
+    cur.close()
+    return mysql_conn
+
+
+def _schema_of(conn, sql: str) -> pa.Schema:
+    cur = conn.cursor()
+    cur.execute(sql)
+    schema = cur.fetch_arrow_table().schema
+    cur.close()
+    return schema
+
+
+class TestArrowSchemaComesFromMetadata:
+    """A column's Arrow type must not change with the rows that come back.
+
+    The mappings are asserted against a live server rather than a hand-written
+    ``description`` tuple, because two of them were wrong in a way only the
+    server could show: MySQL sends BIT as an integer rather than as bytes, and
+    sends SET as ``STRING`` plus a flag, with the value arriving as a Python
+    ``set``. Both built an array that the declared type would not take, which
+    fell through to inference and put the row-dependence back.
+    """
+
+    def test_every_type_survives_an_empty_result_unchanged(self, alltypes_conn) -> None:
+        """Populated and empty results agree on every column but the decimal."""
+        populated = _schema_of(alltypes_conn, "SELECT * FROM alltypes")
+        empty = _schema_of(alltypes_conn, "SELECT * FROM alltypes WHERE 1=0")
+
+        drifted = {
+            field.name: (str(field.type), str(empty.field(field.name).type))
+            for field in populated
+            if field.type != empty.field(field.name).type
+        }
+        # The decimal is the documented exception: MySQL discards the scale
+        # before ``description`` is built, so an empty result has nothing to
+        # read it from. Pinned here so the exception stays the only one.
+        assert set(drifted) == {"c_dec"}, f"columns drifted with the rows: {drifted}"
+        assert drifted["c_dec"] == ("decimal128(38, 2)", "decimal128(38, 0)")
+
+    def test_all_null_column_keeps_the_type_of_a_populated_one(self, alltypes_conn) -> None:
+        cur = alltypes_conn.cursor()
+        cur.execute("INSERT INTO alltypes (c_int) VALUES (NULL)")
+        cur.close()
+        nulls = _schema_of(alltypes_conn, "SELECT c_bit, c_set, c_blob FROM alltypes WHERE 1=0")
+        populated = _schema_of(alltypes_conn, "SELECT c_bit, c_set, c_blob FROM alltypes")
+        assert nulls == populated
+
+    def test_the_mappings_measured_against_the_server(self, alltypes_conn) -> None:
+        """Each of these was read off a live MySQL, not off the documentation."""
+        schema = _schema_of(alltypes_conn, "SELECT * FROM alltypes")
+        by_name = {field.name: field.type for field in schema}
+        assert by_name["c_bit"] == pa.uint64(), "BIT arrives as an int, not as bytes"
+        assert by_name["c_set"] == pa.string(), "SET arrives as a Python set"
+        assert by_name["c_enum"] == pa.string()
+        assert by_name["c_ubig"] == pa.uint64()
+        assert by_name["c_int"] == pa.int32()
+        assert by_name["c_tiny"] == pa.int8()
+        assert by_name["c_year"] == pa.int16()
+        assert by_name["c_float"] == pa.float32()
+        assert by_name["c_time"] == pa.duration("us")
+        assert by_name["c_text"] == pa.string()
+        assert by_name["c_blob"] == pa.binary()
+        assert by_name["c_bin"] == pa.binary()
+        assert by_name["c_json"] == pa.string()
+
+    def test_values_survive_the_declared_types(self, alltypes_conn) -> None:
+        cur = alltypes_conn.cursor()
+        cur.execute("SELECT c_bit, c_set, c_ubig, c_dec FROM alltypes WHERE c_int = 4")
+        table = cur.fetch_arrow_table()
+        cur.close()
+        row = {name: table.column(name)[0].as_py() for name in table.column_names}
+        assert row["c_bit"] == 170
+        # A set has no order left by the time the connector hands it over, so
+        # the rendering sorts rather than inventing one.
+        assert row["c_set"] == "a,b"
+        assert row["c_ubig"] == 18446744073709551615
+        assert row["c_dec"] == Decimal("2.55")

--- a/tests/integration/test_ob_mysql_driver.py
+++ b/tests/integration/test_ob_mysql_driver.py
@@ -317,7 +317,7 @@ class TestArrowSchemaComesFromMetadata:
         # before ``description`` is built, so an empty result has nothing to
         # read it from. Pinned here so the exception stays the only one.
         assert set(drifted) == {"c_dec"}, f"columns drifted with the rows: {drifted}"
-        assert drifted["c_dec"] == ("decimal128(38, 2)", "decimal128(38, 0)")
+        assert drifted["c_dec"] == ("decimal256(76, 2)", "decimal256(76, 0)")
 
     def test_all_null_column_keeps_the_type_of_a_populated_one(self, alltypes_conn) -> None:
         cur = alltypes_conn.cursor()
@@ -344,6 +344,31 @@ class TestArrowSchemaComesFromMetadata:
         assert by_name["c_blob"] == pa.binary()
         assert by_name["c_bin"] == pa.binary()
         assert by_name["c_json"] == pa.string()
+
+    def test_a_wide_decimal_reports_one_width_for_every_filter(self, alltypes_conn) -> None:
+        """Two filters over one DECIMAL(65, 2) column must agree on the type.
+
+        Measuring the precision from the values and narrowing to decimal128
+        when they fit made the width a property of the rows, so the same
+        column answered decimal128 below 10^36 and decimal256 above it.
+        """
+        cur = alltypes_conn.cursor()
+        cur.execute("DROP TABLE IF EXISTS wide_decimal")
+        cur.execute("CREATE TABLE wide_decimal (d DECIMAL(65,2))")
+        cur.execute("INSERT INTO wide_decimal VALUES (1.50), (%s)" % ("9" * 40 + ".99"))
+        cur.close()
+
+        small = _schema_of(alltypes_conn, "SELECT d FROM wide_decimal WHERE d < 2")
+        large = _schema_of(alltypes_conn, "SELECT d FROM wide_decimal WHERE d > 2")
+        both = _schema_of(alltypes_conn, "SELECT d FROM wide_decimal")
+        assert small == large == both
+        assert small.field("d").type == pa.decimal256(76, 2)
+
+        cur = alltypes_conn.cursor()
+        cur.execute("SELECT d FROM wide_decimal WHERE d > 2")
+        table = cur.fetch_arrow_table()
+        cur.close()
+        assert table.column(0)[0].as_py() == Decimal("9" * 40 + ".99")
 
     def test_values_survive_the_declared_types(self, alltypes_conn) -> None:
         cur = alltypes_conn.cursor()


### PR DESCRIPTION
## What

`ob-mysql` is the only driver with no native Arrow result format, so it assembles the table itself. It did that by handing PyArrow the row values and letting it infer. The Arrow type now comes from `cursor.description` instead.

Follow-up to #392, found by `scripts/probe_types.py`.

## Why

Inference made a column's type a property of whichever rows came back:

| Case | Before | After |
|---|---|---|
| `DECIMAL(18,2)`, page of 2dp values | `decimal128(3, 2)` | `decimal256(76, 2)` |
| same column, page of 4dp values | `decimal128(10, 9)` | `decimal256(76, 4)` |
| `DECIMAL(65,2)`, rows below 10^36 | `decimal128(38, 2)` | `decimal256(76, 2)` |
| same column, rows above 10^36 | `decimal256(76, 2)` | `decimal256(76, 2)` |
| empty result | every column `string` | the column's own type |
| all-NULL column | `null` | the column's own type |
| `INT` holding 42 | `int64` | `int32` |
| `BIGINT UNSIGNED` | `int64`, cannot hold the range | `uint64` |

Consumers that carry a schema across calls cannot work with a type that moves: Flight advertises a schema in `FlightInfo` before the data is read, and the result cache stores a column-schema sidecar.

Entry 1 of `description` is the field type and entry 7 the flag bits, which together fix the Arrow type before a value is read. `BLOB` and `VARCHAR` separate on `charsetnr` (63 is the binary collation). `TIME` maps to `duration` rather than `time64`, because MySQL returns a `timedelta` of up to 838 hours rather than a clock reading.

## The decimal width

The one thing `description` will not give up. MySQL sends a column length and a scale in the column-definition packet, but `MySQLProtocol.parse_column` unpacks both into throwaway locals:

```python
(charset, _, column_type, flags, _) = struct.unpack("<xHIBHBxx", packet)
```

so `precision` and `scale` come back `None`. Measured on both the pure-Python and the C-extension paths (`use_pure=False`), which report the same.

The scale survives in the values. The connector builds each `Decimal` from MySQL's decimal text, which carries the column's own scale, so `DECIMAL(18, 2)` yields `Decimal('10.00')` rather than `Decimal('10')` and `DECIMAL(38, 9)` yields `Decimal('2.500000000')`. Taking the widest scale in the column recovers the declared scale for any result holding at least one non-null value.

The precision is not measured at all. Choosing the narrower `decimal128` when the values happened to fit made the width a property of the rows: a real `DECIMAL(65, 2)` reported `decimal128(38, 2)` below 10^36 and `decimal256(76, 2)` above it, so two filters over one column disagreed. It is now fixed at the `decimal256` limit, which no MySQL DECIMAL can overflow: DECIMAL tops out at 65 digits with a scale of at most 30, and for any scale `s` the available `76 - s` integer digits exceed the `65 - s` MySQL can supply. The cost is 32 bytes a value rather than 16 on every decimal column.

Residual limitation, documented in the module: an empty or all-NULL decimal column has no scale to read and falls back to 0, reporting `decimal256(76, 0)` where a populated one reports `decimal256(76, 2)`. No value can be misrepresented by it, since in both cases there is no value; what it costs is a schema a consumer cannot compare across an empty and a non-empty result. A consumer needing one stable schema has to take it from the model, which is what the Flight surface already does.

## Test plan

- New `drivers/ob-mysql/tests/test_arrow_types.py`, 12 tests covering each row of the table above plus the value round-trips
- `uv run pytest` green: 4708 passed, 1006 skipped, 1 xfailed; `drivers/ob-mysql/tests` 59 passed
- Verified end to end against a live MySQL 8 through `db_executor.execute_sql(dialect="mysql")`, which is the path that exercises the driver: exact decimals, `uint64` preserved at 18446744073709551615, binary base64'd, and an empty result keeping its column types
- `ruff check` and `mypy` clean on the new module. The 6 pre-existing ANN401 and mypy findings elsewhere in `ob-mysql` are unchanged from main
- Note: `tests/integration/drift/vendor_exec` drives `pymysql`, not `ob_mysql`, so it does not exercise this path
