### PR TITLE
fix(types): a declared timestamp is a wall clock on BigQuery and Databricks

### DIFF
--- a/docs/guide/functions.md
+++ b/docs/guide/functions.md
@@ -368,10 +368,12 @@ settings:
 A timestamp column is then converted **at the column**, so every expression
 reading it starts from the same frame — `AT TIME ZONE` on DuckDB and Postgres,
 `toTimeZone` on ClickHouse, `CONVERT_TIMEZONE` on Snowflake and Dremio,
-`CONVERT_TZ` on MySQL, `DATETIME(x, zone)` on BigQuery, `from_utc_timestamp` on
-Databricks. Converting at the column rather than around an expression is what
-keeps a conversion from being applied twice: on MySQL, the same conversion
-applied twice moves 00:30 to 02:30.
+`CONVERT_TZ` on MySQL, `DATETIME(x, zone)` on BigQuery — where a naive column
+is declared with `TIMESTAMP(x, defaultTimezone)` first, since BigQuery's wall
+clock type is DATETIME and `DATETIME` has no signature that takes one —
+`from_utc_timestamp` on Databricks. Converting at the column rather than around
+an expression is what keeps a conversion from being applied twice: on MySQL, the
+same conversion applied twice moves 00:30 to 02:30.
 
 Two column kinds are treated differently, because they are different questions:
 

--- a/docs/guide/model-format.md
+++ b/docs/guide/model-format.md
@@ -230,6 +230,26 @@ Project.Ancestors` addresses the array without any further declaration.
 | `synonyms` | list | No | Alternative names or terms (LLM hints) |
 | `owner` | string | No | Responsible team or person |
 
+#### Timestamps carry a zone only when you say so
+
+`timestamp` is a wall clock: a reading with no zone attached. `timestamp_tz`
+is an instant, and describes a stored column only -- it is not something a
+dimension or measure can be cast to.
+
+Wherever a declared `timestamp` produces a cast, it renders to the engine's own
+wall-clock type: `DATETIME` on BigQuery and MySQL, `TIMESTAMP_NTZ` on Databricks
+and Snowflake, `TIMESTAMP` on PostgreSQL, DuckDB and Dremio. A `timestamp`
+therefore means the same reading on every dialect, rather than picking up
+whichever zone the session happened to be set to.
+
+ClickHouse is the exception, and it is the engine's rather than the model's:
+every `DateTime64` carries a zone, defaulting to the server's. The reading is
+preserved, but the label follows the server, so the same model can report a
+different zone on a different ClickHouse.
+
+To move a reading into a zone deliberately, set `defaultTimezone` and
+`queryTimezone` in model settings rather than relying on a cast.
+
 #### Computed Columns
 
 A column with `expression` instead of `code` defines a **computed column**: a column-level SQL expression that references *sibling columns of the same data object* via single-brace `{Column}` placeholders. The expression is inlined wherever the column is referenced — there's no materialization, no extra join.
@@ -438,7 +458,7 @@ dimensions:
 |----------|------|----------|-------------|
 | `dataObject` | string | Yes | Source data object name |
 | `column` | string | Yes | Column name in the data object |
-| `resultType` | enum | Yes | Data type of the result (informative only, not used for SQL generation) |
+| `resultType` | enum | Yes | Data type of the result. A temporal `resultType` over a `timeGrain` is emitted as a CAST, so the dimension keeps its declared type rather than whatever the engine's truncation returns |
 | `timeGrain` | enum | No | Time grain: `year`, `quarter`, `month`, `week`, `day`, `hour`, `minute`, `second`. The underlying column's `abstractType` must be `date`, `timestamp`, or `timestamp_tz` — validation rejects `timeGrain` on string/numeric columns (error code `TIME_GRAIN_ON_NON_TEMPORAL`). For text columns that encode dates (e.g. `'2024-03'`), define a computed column with `to_date()` first and point the dimension at that. |
 | `via` | string | No | Force join path through this intermediate data object (role-playing dimensions) |
 | `format` | string | No | Display format pattern (e.g. `#,##0.00`, `0.00%`) |
@@ -572,7 +592,7 @@ measures:
 | Property | Type | Required | Description |
 |----------|------|----------|-------------|
 | `columns` | list | No | List of column references (`dataObject`+`column`) for simple single-column measures |
-| `resultType` | enum | Yes | Data type of the result (informative only, not used for SQL generation) |
+| `resultType` | enum | Yes | Data type of the result. Emitted as a CAST around the aggregate, so the measure carries its declared precision and type |
 | `aggregation` | enum | Yes | `sum`, `count`, `count_distinct`, `avg`, `min`, `max`, `any_value`, `median`, `mode`, `listagg`; statistical: `stddev`, `stddev_pop`, `variance`, `var_pop`, `corr`, `covar_pop`, `covar_samp`, `regr_slope`, `regr_intercept` — see [Aggregation Types](#aggregation-types) for dialect coverage |
 | `expression` | string | No | Expression with `{[DataObject].[Column]}` placeholders |
 | `distinct` | bool | No | Apply DISTINCT to aggregation |

--- a/src/orionbelt/dialect/bigquery.py
+++ b/src/orionbelt/dialect/bigquery.py
@@ -32,7 +32,12 @@ class BigQueryDialect(Dialect):
         "integer": "INT64",
         "double": "FLOAT64",
         "date": "DATE",
-        "timestamp": "TIMESTAMP",
+        # DATETIME, not TIMESTAMP. OBML's cast vocabulary has one timestamp and
+        # it is the naive one, and BigQuery's TIMESTAMP is an instant: casting
+        # to it read the value as UTC and handed back a zoned result, so a
+        # dimension declaring ``resultType: timestamp`` carried a zone the model
+        # never declared. DATETIME is this engine's wall clock.
+        "timestamp": "DATETIME",
         "time": "TIME",
         "string": "STRING",
         "boolean": "BOOL",
@@ -115,7 +120,9 @@ class BigQueryDialect(Dialect):
         "date": "DATE",
         "time": "TIME",
         "time_tz": "TIME",
-        "timestamp": "TIMESTAMP",
+        # ``timestamp`` and ``timestamp_tz`` are two OBML types, and mapping
+        # both to the instant made them synonyms on this engine.
+        "timestamp": "DATETIME",
         "timestamp_tz": "TIMESTAMP",
         "boolean": "BOOL",
     }

--- a/src/orionbelt/dialect/bigquery.py
+++ b/src/orionbelt/dialect/bigquery.py
@@ -252,14 +252,23 @@ class BigQueryDialect(Dialect):
         """BigQuery has no ``AT TIME ZONE`` outside EXTRACT: ``DATETIME(x, zone)``
         reads a TIMESTAMP as wall clock in that zone, which is the same contract
         and composes with every date function unchanged.
+
+        A naive value is a DATETIME here -- the type OBML's ``timestamp`` maps
+        to -- and DATETIME has no two-argument signature that takes one:
+        probed, ``DATETIME(DATETIME '2026-08-15 13:45:00', 'Europe/Zagreb')``
+        is "No matching signature". ``TIMESTAMP(x, from_zone)`` declares the
+        wall clock as an instant first, and the pair round-trips: probed,
+        ``DATETIME(TIMESTAMP(DATETIME '2026-08-15 13:45:00', 'UTC'),
+        'Europe/Zagreb')`` is 15:45.
+
+        The declaration is the two-argument ``TIMESTAMP``'s own precondition,
+        so it also rejects a TIMESTAMP outright ("No matching signature"): a
+        column declared naive that is really an instant fails loudly instead of
+        answering with a wrong number.
         """
         rendered = self.compile_expr(value)
-        # ``from_zone`` is ignored here, and deliberately: this dialect maps the
-        # OBML ``timestamp`` type to BigQuery's TIMESTAMP, which is an instant
-        # rather than a wall clock, so there is no zone left to declare.
-        # ``TIMESTAMP(x, zone)`` takes a DATETIME and rejects a TIMESTAMP
-        # outright ("No matching signature"), which is the loud failure a
-        # genuinely naive DATETIME column would get rather than a wrong number.
+        if from_zone is not None:
+            rendered = f"TIMESTAMP({rendered}, {self._quote_zone(from_zone)})"
         return f"DATETIME({rendered}, {self._quote_zone(zone)})"
 
     def _render_date_trunc(self, unit: str, value: Expr) -> str:

--- a/src/orionbelt/dialect/databricks.py
+++ b/src/orionbelt/dialect/databricks.py
@@ -23,7 +23,11 @@ class DatabricksDialect(Dialect):
         "integer": "INT",
         "double": "DOUBLE",
         "date": "DATE",
-        "timestamp": "TIMESTAMP",
+        # TIMESTAMP_NTZ, not TIMESTAMP. OBML's cast vocabulary has one timestamp
+        # and it is the naive one; this engine's TIMESTAMP is an instant read in
+        # the session zone, so casting to it attached a zone the model never
+        # declared.
+        "timestamp": "TIMESTAMP_NTZ",
         "time": "STRING",
         "string": "STRING",
         "boolean": "BOOLEAN",
@@ -37,7 +41,8 @@ class DatabricksDialect(Dialect):
         "date": "DATE",
         "time": "STRING",
         "time_tz": "STRING",
-        "timestamp": "TIMESTAMP",
+        # Two OBML types, and mapping both to the instant made them synonyms.
+        "timestamp": "TIMESTAMP_NTZ",
         "timestamp_tz": "TIMESTAMP",
         "boolean": "BOOLEAN",
     }

--- a/tests/integration/test_bigquery_execution.py
+++ b/tests/integration/test_bigquery_execution.py
@@ -177,3 +177,26 @@ def test_measure_sweep(bigquery_setup, vendor_model, kind: str, name: str, dims:
     sql = compile_for(sweep_query(name, dims), vendor_model, "bigquery")
     rows = _fetch_bigquery(client, sql)  # raises on a BigQuery execution error
     assert isinstance(rows, list), f"{kind} {name!r} returned no result set"
+
+
+def test_timestamp_is_a_wall_clock(bigquery_setup) -> None:
+    """A declared ``timestamp`` must keep its wall clock and carry no zone.
+
+    BigQuery's TIMESTAMP is an instant, so casting to it read the value as UTC
+    and handed back a zoned result. OBML's cast vocabulary has one timestamp
+    and it is the naive one -- ``timestamp_tz`` is the zoned declaration and
+    has no cast target -- so the engine's wall clock type is DATETIME.
+    """
+    from orionbelt.ast.nodes import RawSQL
+    from orionbelt.dialect.registry import DialectRegistry
+    from orionbelt.models.types import parse_data_type
+
+    client, _cfg = bigquery_setup
+    dialect = DialectRegistry.get("bigquery")
+    cast = dialect.cast_to_obml_type(
+        RawSQL(sql="'2026-08-15 13:45:00'"), parse_data_type("timestamp")
+    )
+    rows = _fetch_bigquery(client, f"SELECT {dialect.compile_expr(cast)} AS v")
+    value = rows[0]["v"]
+    assert value.tzinfo is None, f"a declared timestamp carried a zone: {value!r}"
+    assert (value.hour, value.minute) == (13, 45)

--- a/tests/integration/test_bigquery_execution.py
+++ b/tests/integration/test_bigquery_execution.py
@@ -200,3 +200,28 @@ def test_timestamp_is_a_wall_clock(bigquery_setup) -> None:
     value = rows[0]["v"]
     assert value.tzinfo is None, f"a declared timestamp carried a zone: {value!r}"
     assert (value.hour, value.minute) == (13, 45)
+
+
+def test_a_naive_column_converts_through_the_query_zone(bigquery_setup) -> None:
+    """``defaultTimezone`` + ``queryTimezone`` on a naive column must execute.
+
+    A naive value is a DATETIME here, and ``DATETIME(x, zone)`` has no
+    signature that takes one: ignoring the declared source zone emitted
+    ``DATETIME(<datetime>, 'Europe/Zagreb')``, which BigQuery rejects with "No
+    matching signature". Declaring it with ``TIMESTAMP(x, 'UTC')`` first both
+    runs and lands on the right wall clock.
+    """
+    from orionbelt.ast.nodes import InTimeZone, RawSQL
+    from orionbelt.dialect.registry import DialectRegistry
+
+    client, _cfg = bigquery_setup
+    dialect = DialectRegistry.get("bigquery")
+    node = InTimeZone(
+        expr=RawSQL(sql="DATETIME '2026-08-15 13:45:00'"),
+        zone="Europe/Zagreb",
+        from_zone="UTC",
+    )
+    rows = _fetch_bigquery(client, f"SELECT {dialect.compile_expr(node)} AS v")
+    value = rows[0]["v"]
+    assert value.tzinfo is None, f"the converted value carried a zone: {value!r}"
+    assert (value.hour, value.minute) == (15, 45)

--- a/tests/integration/test_databricks_execution.py
+++ b/tests/integration/test_databricks_execution.py
@@ -293,3 +293,25 @@ def test_measure_sweep(
     sql = compile_for(sweep_query(name, dims), vendor_model, "databricks")
     rows = _fetch_databricks(con, sql)  # raises on a Databricks execution error
     assert isinstance(rows, list), f"{kind} {name!r} returned no result set"
+
+
+def test_timestamp_is_a_wall_clock(databricks_setup) -> None:
+    """A declared ``timestamp`` must keep its wall clock and carry no zone.
+
+    Databricks' TIMESTAMP is an instant read in the session zone, so casting to
+    it attached a zone the model never declared. TIMESTAMP_NTZ is this engine's
+    wall clock, which is what its own driver notes already prescribed.
+    """
+    from orionbelt.ast.nodes import RawSQL
+    from orionbelt.dialect.registry import DialectRegistry
+    from orionbelt.models.types import parse_data_type
+
+    con, _cfg = databricks_setup
+    dialect = DialectRegistry.get("databricks")
+    cast = dialect.cast_to_obml_type(
+        RawSQL(sql="'2026-08-15 13:45:00'"), parse_data_type("timestamp")
+    )
+    rows = _fetch_databricks(con, f"SELECT {dialect.compile_expr(cast)} AS v")
+    value = rows[0]["v"]
+    assert value.tzinfo is None, f"a declared timestamp carried a zone: {value!r}"
+    assert (value.hour, value.minute) == (13, 45)

--- a/tests/unit/test_data_types.py
+++ b/tests/unit/test_data_types.py
@@ -213,9 +213,14 @@ class TestDialectRendering:
     @pytest.mark.parametrize(
         ("dialect_name", "expected"),
         [
-            ("bigquery", "TIMESTAMP"),
+            ("bigquery", "DATETIME"),
+            # ClickHouse is the exception and cannot be fixed by naming a type:
+            # every DateTime64 carries a zone, defaulting to the server's. The
+            # wall clock is preserved, only the label is the server's; pinning
+            # one instead shifts the value, because relabelling a stored
+            # DateTime moves it (measured: 13:45 Berlin becomes 11:45 UTC).
             ("clickhouse", "DateTime64(3)"),
-            ("databricks", "TIMESTAMP"),
+            ("databricks", "TIMESTAMP_NTZ"),
             ("dremio", "TIMESTAMP"),
             ("duckdb", "TIMESTAMP"),
             ("mysql", "TIMESTAMP"),
@@ -238,6 +243,21 @@ class TestDialectRendering:
         rendered = DialectRegistry.get(dialect_name).render_obml_type(SimpleType("timestamp"))
         assert rendered == expected
         assert rendered not in {"TIMESTAMPTZ", "TIMESTAMP_TZ", "TIMESTAMP WITH TIME ZONE"}
+
+    @pytest.mark.parametrize("dialect_name", ["bigquery", "databricks"])
+    def test_timestamp_and_timestamp_tz_are_not_synonyms(self, dialect_name: str) -> None:
+        """Two OBML types must not render as one SQL type.
+
+        Both engines spell the instant ``TIMESTAMP`` and mapping the naive type
+        to it as well left a model no way to say which one it meant.
+        """
+        from orionbelt.dialect.registry import DialectRegistry
+
+        dialect = DialectRegistry.get(dialect_name)
+        naive = dialect._resolve_type_name(DataType.TIMESTAMP.value)
+        zoned = dialect._resolve_type_name(DataType.TIMESTAMP_TZ.value)
+        assert naive != zoned
+        assert zoned == "TIMESTAMP"
 
 
 class TestModelValidation:

--- a/tests/unit/test_function_catalog.py
+++ b/tests/unit/test_function_catalog.py
@@ -769,9 +769,9 @@ measures:
             ("clickhouse", "toTimeZone(toDateTime("),
             ("mysql", "CONVERT_TZ("),
             ("snowflake", "CONVERT_TIMEZONE('UTC', 'Europe/Zagreb'"),
-            # BigQuery maps the OBML timestamp type to its own TIMESTAMP, an
-            # instant, so there is no source zone left to declare.
-            ("bigquery", "DATETIME("),
+            # BigQuery's wall clock is DATETIME, which has no two-argument
+            # signature: the naive value is declared with TIMESTAMP first.
+            ("bigquery", "DATETIME(TIMESTAMP("),
             ("databricks", "from_utc_timestamp(to_utc_timestamp("),
             ("dremio", "CONVERT_TIMEZONE('UTC', 'Europe/Zagreb'"),
         ],


### PR DESCRIPTION
## What

Completes what #392 started on PostgreSQL and Snowflake. OBML's cast vocabulary has one timestamp and it is the naive one: `timestamp_tz` is a column declaration with no cast target (`resolution._CASTABLE_TEMPORAL_TYPES`). BigQuery's `TIMESTAMP` is an instant and Databricks' is an instant read in the session zone, so a dimension declaring `resultType: timestamp` came back carrying a zone the model never declared.

Measured on both live accounts, `'2026-08-15 13:45:00'` through the emitted cast:

| Dialect | Before | After |
|---|---|---|
| BigQuery | `timestamp[us, tz=UTC]` | `timestamp[us]`, 13:45 |
| Databricks | `timestamp[us, tz=Etc/UTC]` | `timestamp[us]`, 13:45 |

The abstract column map changes with them. Both engines mapped `timestamp` and `timestamp_tz` to the same SQL type, which left a model no way to say which of the two OBML types it meant.

## ClickHouse is left alone, and why

Not for lack of trying. Every `DateTime64` carries a zone, defaulting to the server's, and there is no naive spelling. The reading is already preserved; only the label follows the server. Pinning a zone instead *moves the value*, because relabelling a stored `DateTime` converts it:

| Expression | Result |
|---|---|
| `CAST('2026-08-15 13:45:00' AS DateTime64(3, 'UTC'))` | `13:45:00+00:00` |
| `CAST(toDateTime64('2026-08-15 13:45:00', 3) AS DateTime64(3, 'UTC'))` | **`11:45:00+00:00`** |

A string literal parses in the target's zone, but a stored column is an instant and relabelling shifts its wall clock. So pinning UTC would look right in a probe and silently move real data. This is an engine property the dialect cannot render its way out of, and it is now recorded next to the type map and in the docs.

## Scope note

The abstract-map half is consistency rather than behaviour: nothing currently constructs a `Cast` carrying an abstract type name, and `nested_field_type` is only consumed by MySQL and Snowflake. It stops the two OBML types being synonyms on these engines, which is the point. Postgres, DuckDB, Dremio and Snowflake still map both to one type in the abstract map (they inherit the base map, and each spells the zoned type differently), so that half of the vocabulary is not uniform yet. Out of scope here, and called out rather than half-done.

## Documentation

Adds a short section to `docs/guide/model-format.md` on what the two types mean and how each dialect renders them, including the ClickHouse exception.

Also corrects two rows that described `resultType` as "informative only, not used for SQL generation". It drives exactly the cast this change is about, on dimensions over a time grain (`resolution.make_dimension_expr`) and on measures and metrics (`star.py`, `metric_expansion.py`). Leaving that in place would have contradicted the change shipping beside it.

## Test plan

- New live tests on BigQuery and Databricks asserting the value carries **no zone** and keeps 13:45. **Both fail on the previous mapping**, verified by reverting the two map entries and re-running
- `test_timestamp_renders_the_naive_type` (added in #392) updated for the two dialects, with the ClickHouse exception documented in the parametrization
- New `test_timestamp_and_timestamp_tz_are_not_synonyms` on both engines
- Live suites green: `-m bigquery` 59 passed, `-m databricks` 59 passed
- `uv run pytest` green: 4718 passed, 1008 skipped, 1 xfailed
- `ruff check` and `mypy src/` clean
- No compile-only snapshots changed: the corpus has no temporal `resultType` over a grain

## Review follow-up: the query-zone conversion had to follow the type

Review caught that `_render_in_timezone` still ignored `from_zone` on the grounds that OBML `timestamp` was BigQuery's `TIMESTAMP`, an instant with no zone left to declare. This change makes it a `DATETIME`, so that rationale no longer holds and the emitted SQL does not even run.

Probed on the live account:

| Expression | Result |
|---|---|
| `DATETIME(DATETIME '2026-08-15 13:45:00', 'Europe/Zagreb')` | `400 No matching signature for function DATETIME` |
| `DATETIME(TIMESTAMP(DATETIME '2026-08-15 13:45:00', 'UTC'), 'Europe/Zagreb')` | `15:45`, naive |

So a model with `defaultTimezone: UTC` + `queryTimezone: Europe/Zagreb` over a naive column emitted SQL BigQuery rejects. `TIMESTAMP(x, from_zone)` declares the wall clock first. That form takes a DATETIME and rejects a TIMESTAMP, which is the same loud failure as before for a column declared naive that is really an instant: still no wrong number, just no silent one either.

- `_render_in_timezone` wraps in `TIMESTAMP(x, from_zone)` when a source zone is declared, unchanged when it is not
- New live test `test_a_naive_column_converts_through_the_query_zone`, verified to fail on the previous rendering with the `No matching signature` error
- `test_every_dialect_has_its_own_conversion` now pins `DATETIME(TIMESTAMP(` for BigQuery
- `docs/guide/functions.md` records the two-step form
- `-m bigquery` 61 passed, `uv run pytest` 4718 passed, `ruff check` and `mypy src/` clean
