### PR TITLE
fix(mysql): a time grain is a point in time, not a string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,12 @@ htmlcov/
 # written per browser session. The console logs were already caught by
 # *.log above, which left only the .yml page dumps showing as untracked.
 .playwright-mcp/
+# Playwright writes screenshots to the working directory when the tool is
+# given a bare filename, which is the repo root. Twice now one has been
+# swept into a commit by ``git add -A``.
+*.playwright.png
+gradio*-production.png
+ui-gradio*.png
 /cache/
 /usage/
 security/

--- a/src/orionbelt/dialect/base.py
+++ b/src/orionbelt/dialect/base.py
@@ -375,8 +375,17 @@ class Dialect(ABC):
         — "Parameterized types are not allowed in CAST expressions") can
         override to wrap the cast with a ROUND to honour the user-specified
         scale.
+
+        An expression already cast to the same type is returned as it is. The
+        two casts a grained dimension can attract - the one the grain applies to
+        keep its own type, and the one the declared ``resultType`` applies on
+        top - agree whenever the model declares what the grain already
+        produces, and ``CAST(CAST(x AS DATE) AS DATE)`` says it twice.
         """
-        return Cast(expr=expr, type_name=self.render_obml_type(obml_type))
+        rendered = self.render_obml_type(obml_type)
+        if isinstance(expr, Cast) and expr.type_name == rendered:
+            return expr
+        return Cast(expr=expr, type_name=rendered)
 
     # Widest decimal every supported engine accepts, and the integer digits kept
     # free for a running total. A sum is as many digits as its rows make it, so

--- a/src/orionbelt/dialect/mysql.py
+++ b/src/orionbelt/dialect/mysql.py
@@ -270,9 +270,25 @@ class MySQLDialect(Dialect):
             )
 
         fmt = grain_format_map.get(grain) or "%Y-%m-%d"
-        return FunctionCall(
-            name="DATE_FORMAT",
-            args=[column, Literal.string(fmt)],
+        formatted = FunctionCall(name="DATE_FORMAT", args=[column, Literal.string(fmt)])
+        # DATE_FORMAT answers a string, so without this the grain handed back
+        # text where all seven other dialects hand back a date or a timestamp:
+        # the same model, the same dimension, a different type per engine. It
+        # also made ``resultType: string`` on a grained dimension look like a
+        # deliberate label rather than a description of this defect.
+        #
+        # The same cast, for the same reason, is already applied by this
+        # dialect's portable date-truncation ("cast back so the result compares
+        # and sorts as a date rather than lexically"); the dimension grain was
+        # the path that missed it. Quarter and week never needed it: they are
+        # rendered with date arithmetic rather than a format string.
+        return Cast(
+            expr=formatted,
+            type_name=(
+                "DATETIME"
+                if grain in (TimeGrain.HOUR, TimeGrain.MINUTE, TimeGrain.SECOND)
+                else "DATE"
+            ),
         )
 
     def render_cast(self, expr: Expr, target_type: str) -> Expr:
@@ -340,7 +356,10 @@ class MySQLDialect(Dialect):
         This puts MySQL where BigQuery already sits, which returns the true
         value for the same query because its ``NUMERIC`` is (38, 9).
         """
-        return Cast(expr=expr, type_name=self.render_obml_type(self._widened(obml_type)))
+        rendered = self.render_obml_type(self._widened(obml_type))
+        if isinstance(expr, Cast) and expr.type_name == rendered:
+            return expr
+        return Cast(expr=expr, type_name=rendered)
 
     @staticmethod
     def _widened(obml_type: OBMLType) -> OBMLType:

--- a/src/orionbelt/dialect/mysql.py
+++ b/src/orionbelt/dialect/mysql.py
@@ -670,13 +670,24 @@ class MySQLDialect(Dialect):
         return f"DATE_ADD({date_sql}, INTERVAL {count} {unit.upper()})"
 
     def _render_date_trunc_sql(self, column_sql: str, grain: str) -> str:
+        """The string-level truncation, cast for the same reason as the others.
+
+        ``DATE_FORMAT`` answers a string, and this helper feeds the
+        period-over-period spine, whose recursive CTE takes ``spine_date``'s
+        type from its anchor row. Text there made the PoP time dimension a
+        ``VARCHAR`` while the same dimension, in the same model, came back as a
+        ``DATE`` when no PoP metric was in the query. Measured on MySQL 8 over
+        the emitted spine: ``varchar(10)`` before, ``date`` after, same values.
+
+        Quarter, week and day need nothing: they are date arithmetic already.
+        """
         grain_map = {
-            "year": f"DATE_FORMAT({column_sql}, '%Y-01-01')",
+            "year": f"CAST(DATE_FORMAT({column_sql}, '%Y-01-01') AS DATE)",
             "quarter": (
                 f"DATE_ADD(MAKEDATE(YEAR({column_sql}), 1), "
                 f"INTERVAL (QUARTER({column_sql}) - 1) * 3 MONTH)"
             ),
-            "month": f"DATE_FORMAT({column_sql}, '%Y-%m-01')",
+            "month": f"CAST(DATE_FORMAT({column_sql}, '%Y-%m-01') AS DATE)",
             "week": f"DATE_SUB({column_sql}, INTERVAL WEEKDAY({column_sql}) DAY)",
             "day": f"DATE({column_sql})",
         }

--- a/src/orionbelt/dialect/mysql.py
+++ b/src/orionbelt/dialect/mysql.py
@@ -243,18 +243,14 @@ class MySQLDialect(Dialect):
         return f"`{escaped}`"
 
     def _render_time_grain(self, column: Expr, grain: TimeGrain) -> Expr:
-        """MySQL time grain truncation via DATE_FORMAT or DATE_ADD+MAKEDATE for quarters."""
-        grain_format_map: dict[TimeGrain, str | None] = {
-            TimeGrain.SECOND: "%Y-%m-%d %H:%i:%s",
-            TimeGrain.MINUTE: "%Y-%m-%d %H:%i:00",
-            TimeGrain.HOUR: "%Y-%m-%d %H:00:00",
-            TimeGrain.DAY: "%Y-%m-%d",
-            TimeGrain.WEEK: "%Y-%u",
-            TimeGrain.MONTH: "%Y-%m-01",
-            TimeGrain.QUARTER: None,  # handled below
-            TimeGrain.YEAR: "%Y-01-01",
-        }
+        """MySQL time grain truncation via DATE_FORMAT or DATE_ADD+MAKEDATE for quarters.
 
+        The format strings live in one table, ``_DATE_FORMAT_BY_UNIT``, which
+        the catalog's ``date_trunc`` and the string-level helper read too: three
+        copies of the same truncation drifted twice, once on the cast and once
+        on the sub-day grains. A week never arrives here - the base class floors
+        it through the model's calendar first.
+        """
         if grain == TimeGrain.QUARTER:
             from orionbelt.ast.nodes import RawSQL
 
@@ -269,7 +265,7 @@ class MySQLDialect(Dialect):
                 )
             )
 
-        fmt = grain_format_map.get(grain) or "%Y-%m-%d"
+        fmt = self._DATE_FORMAT_BY_UNIT.get(grain.value, "%Y-%m-%d")
         formatted = FunctionCall(name="DATE_FORMAT", args=[column, Literal.string(fmt)])
         # DATE_FORMAT answers a string, so without this the grain handed back
         # text where all seven other dialects hand back a date or a timestamp:
@@ -282,14 +278,7 @@ class MySQLDialect(Dialect):
         # and sorts as a date rather than lexically"); the dimension grain was
         # the path that missed it. Quarter and week never needed it: they are
         # rendered with date arithmetic rather than a format string.
-        return Cast(
-            expr=formatted,
-            type_name=(
-                "DATETIME"
-                if grain in (TimeGrain.HOUR, TimeGrain.MINUTE, TimeGrain.SECOND)
-                else "DATE"
-            ),
-        )
+        return Cast(expr=formatted, type_name=self._truncated_type(grain.value))
 
     def render_cast(self, expr: Expr, target_type: str) -> Expr:
         return Cast(expr=expr, type_name=target_type)
@@ -552,13 +541,26 @@ class MySQLDialect(Dialect):
             )
         if unit == "week":
             return f"DATE(DATE_SUB({rendered}, INTERVAL WEEKDAY({rendered}) DAY))"
-        pattern = self._DATE_FORMAT_BY_UNIT[unit]
-        formatted = f"DATE_FORMAT({rendered}, '{pattern}')"
-        # DATE_FORMAT returns a string; cast back so the result compares and
-        # sorts as a date rather than lexically.
-        return (
-            f"CAST({formatted} AS {'DATETIME' if unit in ('hour', 'minute', 'second') else 'DATE'})"
-        )
+        return self._format_truncation(rendered, unit)
+
+    @staticmethod
+    def _truncated_type(unit: str) -> str:
+        """What a truncation to *unit* is cast back to.
+
+        An hour and finer keep a time of day, so they are a DATETIME; a day and
+        coarser have none left to keep.
+        """
+        return "DATETIME" if unit in ("hour", "minute", "second") else "DATE"
+
+    def _format_truncation(self, rendered: str, unit: str) -> str:
+        """Truncate to *unit* with a format string, cast back to its own type.
+
+        DATE_FORMAT returns a string; the cast makes the result compare and sort
+        as a point in time rather than lexically, and it is what keeps an hourly
+        bucket an hour rather than the midnight a DATE would round it to.
+        """
+        formatted = f"DATE_FORMAT({rendered}, '{self._DATE_FORMAT_BY_UNIT[unit]}')"
+        return f"CAST({formatted} AS {self._truncated_type(unit)})"
 
     def _render_week_start_sunday(self, value: Expr) -> str:
         """MySQL: ``DAYOFWEEK`` numbers Sunday as 1, so the offset is one less.
@@ -670,28 +672,34 @@ class MySQLDialect(Dialect):
         return f"DATE_ADD({date_sql}, INTERVAL {count} {unit.upper()})"
 
     def _render_date_trunc_sql(self, column_sql: str, grain: str) -> str:
-        """The string-level truncation, cast for the same reason as the others.
+        """The same truncation as the dimension grain, over SQL text.
 
-        ``DATE_FORMAT`` answers a string, and this helper feeds the
-        period-over-period spine, whose recursive CTE takes ``spine_date``'s
-        type from its anchor row. Text there made the PoP time dimension a
-        ``VARCHAR`` while the same dimension, in the same model, came back as a
-        ``DATE`` when no PoP metric was in the query. Measured on MySQL 8 over
-        the emitted spine: ``varchar(10)`` before, ``date`` after, same values.
+        This one feeds the period-over-period spine, and it answered a bare
+        ``DATE_FORMAT`` where the grain answered a cast one. Both halves of that
+        mattered. MySQL's recursive CTE takes ``spine_date``'s type from its
+        anchor row, which is the MIN of these buckets, so text there made the
+        PoP time dimension a ``VARCHAR`` - measured on MySQL 8 over the emitted
+        spine, ``varchar(10)`` before and ``date`` after, same values. And an
+        unlisted grain fell through to ``DATE(...)``, which rounded an hourly
+        bucket to midnight: an hourly PoP compared one bucket a day against a
+        spine stepping by the hour, so every other row found no rows to join.
 
-        Quarter, week and day need nothing: they are date arithmetic already.
+        Quarter, week and day stay as they are: they are date arithmetic
+        already, and a day has no time of day to lose.
         """
         grain_map = {
-            "year": f"CAST(DATE_FORMAT({column_sql}, '%Y-01-01') AS DATE)",
             "quarter": (
                 f"DATE_ADD(MAKEDATE(YEAR({column_sql}), 1), "
                 f"INTERVAL (QUARTER({column_sql}) - 1) * 3 MONTH)"
             ),
-            "month": f"CAST(DATE_FORMAT({column_sql}, '%Y-%m-01') AS DATE)",
             "week": f"DATE_SUB({column_sql}, INTERVAL WEEKDAY({column_sql}) DAY)",
             "day": f"DATE({column_sql})",
         }
-        return grain_map.get(grain, f"DATE({column_sql})")
+        if grain in grain_map:
+            return grain_map[grain]
+        if grain in self._DATE_FORMAT_BY_UNIT:
+            return self._format_truncation(column_sql, grain)
+        return f"DATE({column_sql})"
 
     def render_date_spine_cte_sql(
         self, min_date: str, max_date: str, grain: str, offset: int, offset_grain: str

--- a/tests/integration/drift/compile_only/mysql/13_sales_yoy_growth.sql
+++ b/tests/integration/drift/compile_only/mysql/13_sales_yoy_growth.sql
@@ -2,7 +2,7 @@ WITH `date_range` AS (
 SELECT MIN(`__ob_pop_src`.`__ob_bucket`) AS min_date,
        MAX(`__ob_pop_src`.`__ob_bucket`) AS max_date
   FROM (
-    SELECT DATE_FORMAT(`Sales`.`salesdate`, '%Y-%m-01') AS `__ob_bucket`
+    SELECT CAST(DATE_FORMAT(`Sales`.`salesdate`, '%Y-%m-01') AS DATE) AS `__ob_bucket`
       FROM `orionbelt_1`.`sales` AS `Sales`
   ) AS `__ob_pop_src`
 ),
@@ -25,7 +25,7 @@ SELECT `date_spine`.spine_date AS `Sales Month`,
        CAST(SUM(`__ob_pop_src`.`Sales__salesamount`) AS DECIMAL(38, 2)) AS `Total Sales`
   FROM `date_spine`
   LEFT JOIN (
-    SELECT DATE_FORMAT(`Sales`.`salesdate`, '%Y-%m-01') AS `__ob_bucket`,
+    SELECT CAST(DATE_FORMAT(`Sales`.`salesdate`, '%Y-%m-01') AS DATE) AS `__ob_bucket`,
            `Sales`.`salesamount` AS `Sales__salesamount`
       FROM `orionbelt_1`.`sales` AS `Sales`
   ) AS `__ob_pop_src`

--- a/tests/integration/test_mysql_execution.py
+++ b/tests/integration/test_mysql_execution.py
@@ -206,3 +206,114 @@ def test_a_period_over_period_month_comes_back_as_a_date(mysql_setup, vendor_mod
     assert rows, "the PoP query returned no rows"
     month = rows[0]["Sales Month"]
     assert isinstance(month, datetime.date), f"the month came back as {type(month).__name__}"
+
+
+_HOURLY_MODEL_YAML = """\
+version: 1.0
+dataObjects:
+  Events:
+    code: pop_events
+    schema: {schema}
+    columns:
+      Event ID: {{code: id, abstractType: string}}
+      Occurred At: {{code: occurred_at, abstractType: timestamp}}
+      Amount: {{code: amount, abstractType: float, numClass: additive}}
+dimensions:
+  Occurred Hour:
+    dataObject: Events
+    column: Occurred At
+    resultType: timestamp
+    timeGrain: hour
+measures:
+  Revenue:
+    columns: [{{dataObject: Events, column: Amount}}]
+    resultType: float
+    aggregation: sum
+metrics:
+  Revenue HoH Diff:
+    type: period_over_period
+    expression: '{{[Revenue]}}'
+    periodOverPeriod:
+      timeDimension: Occurred Hour
+      grain: hour
+      offset: -1
+      offsetGrain: hour
+      comparison: difference
+"""
+
+
+@pytest.fixture(scope="module")
+def hourly_events(mysql_setup):
+    """Four rows across three hours of one day, and the model that reads them."""
+    from orionbelt.parser.loader import TrackedLoader
+    from orionbelt.parser.resolver import ReferenceResolver
+
+    conn, schema = mysql_setup
+    cur = conn.cursor()
+    cur.execute("DROP TABLE IF EXISTS pop_events")
+    cur.execute(
+        "CREATE TABLE pop_events (id VARCHAR(8), occurred_at DATETIME, amount DECIMAL(10, 2))"
+    )
+    cur.execute(
+        "INSERT INTO pop_events VALUES ('a', '2024-03-15 09:15:00', 10.0),"
+        " ('b', '2024-03-15 09:40:00', 5.0), ('c', '2024-03-15 10:20:00', 20.0),"
+        " ('d', '2024-03-15 11:05:00', 7.0)"
+    )
+    cur.close()
+    raw, source_map = TrackedLoader().load_string(_HOURLY_MODEL_YAML.format(schema=schema))
+    model, result = ReferenceResolver().resolve(raw, source_map)
+    assert result.valid, result.errors
+    return model
+
+
+def test_an_hourly_period_over_period_compares_hours(mysql_setup, hourly_events) -> None:
+    """``grain: hour`` buckets by the hour, rather than summing the whole day.
+
+    ``PeriodOverPeriod.grain`` is the whole ``TimeGrain`` enum, and the spine's
+    bucket comes from the string-level truncation, which had no entry for the
+    sub-day grains and fell through to ``DATE(...)``. The three hours collapsed
+    into one row of 42.00 under a date, with nothing to compare it to, and no
+    error anywhere: the wrong answer here is a plausible-looking one.
+    """
+    import datetime
+
+    from orionbelt.models.query import QueryObject, QuerySelect
+
+    conn, _schema = mysql_setup
+    query = QueryObject(
+        select=QuerySelect(dimensions=["Occurred Hour"], measures=["Revenue", "Revenue HoH Diff"])
+    )
+    rows = _fetch_mysql(conn, compile_for(query, hourly_events, "mysql"))
+    assert [(r["Occurred Hour"], float(r["Revenue"]), r["Revenue HoH Diff"]) for r in rows] == [
+        (datetime.datetime(2024, 3, 15, 9, 0), 15.0, None),
+        (datetime.datetime(2024, 3, 15, 10, 0), 20.0, 5.0),
+        (datetime.datetime(2024, 3, 15, 11, 0), 7.0, -13.0),
+    ]
+
+
+@pytest.mark.parametrize(
+    "grain", ["year", "quarter", "month", "week", "day", "hour", "minute", "second"]
+)
+def test_both_truncation_paths_answer_the_same_value(mysql_setup, hourly_events, grain) -> None:
+    """The dimension grain and the spine's bucket are the same truncation.
+
+    They are rendered by two helpers -- one over the AST for a dimension, one
+    over SQL text for the period-over-period spine -- and they have drifted
+    twice: once on the cast that DATE_FORMAT's text needs, once on the sub-day
+    grains. Compared by value rather than by spelling, so a difference in how
+    either is written cannot hide one in what it answers.
+    """
+    from orionbelt.ast.nodes import RawSQL
+    from orionbelt.dialect.registry import DialectRegistry
+    from orionbelt.models.semantic import TimeGrain
+
+    conn, _schema = mysql_setup
+    dialect = DialectRegistry.get("mysql")
+    column = "`occurred_at`"
+    grained = dialect.compile_expr(dialect.render_time_grain(RawSQL(sql=column), TimeGrain(grain)))
+    bucketed = dialect.render_date_trunc_sql(column, grain)
+    rows = _fetch_mysql(
+        conn, f"SELECT {grained} AS grained, {bucketed} AS bucketed FROM pop_events ORDER BY id"
+    )
+    for row in rows:
+        assert row["grained"] == row["bucketed"], f"{grain}: {grained} vs {bucketed}"

--- a/tests/integration/test_mysql_execution.py
+++ b/tests/integration/test_mysql_execution.py
@@ -182,3 +182,27 @@ def test_commerce_case(mysql_setup, vendor_model, truth_results, case: CommerceC
     sql = compile_for(case.query, vendor_model, "mysql")
     actual = _fetch_mysql(conn, sql)
     compare_rows(actual, truth_results[case.name], case=case.name)
+
+
+def test_a_period_over_period_month_comes_back_as_a_date(mysql_setup, vendor_model) -> None:
+    """The PoP time dimension is a date here too, not a formatted string.
+
+    The spine's bucket goes through the string-level truncation rather than the
+    dimension grain, and MySQL's recursive CTE takes ``spine_date``'s type from
+    its anchor row: a ``DATE_FORMAT`` bucket made it ``varchar(10)``, so the
+    same ``Sales Month`` came back as a date without a PoP metric in the query
+    and as text with one. Executed, because the string sorts and reads the same
+    and only the type gives it away.
+    """
+    import datetime
+
+    from orionbelt.models.query import QueryObject, QuerySelect
+
+    conn, _schema = mysql_setup
+    query = QueryObject(
+        select=QuerySelect(dimensions=["Sales Month"], measures=["Sales YoY Growth"])
+    )
+    rows = _fetch_mysql(conn, compile_for(query, vendor_model, "mysql"))
+    assert rows, "the PoP query returned no rows"
+    month = rows[0]["Sales Month"]
+    assert isinstance(month, datetime.date), f"the month came back as {type(month).__name__}"

--- a/tests/unit/test_dialects.py
+++ b/tests/unit/test_dialects.py
@@ -670,16 +670,23 @@ class TestMySQLDialect:
         assert "`c`" in sql
 
     def test_time_grain_day(self, dialect: MySQLDialect) -> None:
-        result = dialect.render_time_grain(col("dt"), TimeGrain.DAY)
-        assert isinstance(result, FunctionCall)
-        assert result.name == "DATE_FORMAT"
+        """DATE_FORMAT answers a string, so the grain casts it back to a DATE.
+
+        Every other dialect's grain returns a date or a timestamp; without the
+        cast this one returned text, which is the same dimension arriving as a
+        different type depending on the engine underneath it.
+        """
+        sql = dialect.compile_expr(dialect.render_time_grain(col("dt"), TimeGrain.DAY))
+        assert sql == "CAST(DATE_FORMAT(`dt`, '%Y-%m-%d') AS DATE)"
 
     def test_time_grain_month(self, dialect: MySQLDialect) -> None:
-        result = dialect.render_time_grain(col("dt"), TimeGrain.MONTH)
-        assert isinstance(result, FunctionCall)
-        assert result.name == "DATE_FORMAT"
-        sql = dialect.compile_expr(result)
-        assert "%Y-%m-01" in sql
+        sql = dialect.compile_expr(dialect.render_time_grain(col("dt"), TimeGrain.MONTH))
+        assert sql == "CAST(DATE_FORMAT(`dt`, '%Y-%m-01') AS DATE)"
+
+    def test_a_sub_day_grain_keeps_its_time(self, dialect: MySQLDialect) -> None:
+        """An hour grain casts to DATETIME, not DATE, or the hour is lost."""
+        sql = dialect.compile_expr(dialect.render_time_grain(col("dt"), TimeGrain.HOUR))
+        assert sql == "CAST(DATE_FORMAT(`dt`, '%Y-%m-%d %H:00:00') AS DATETIME)"
 
     def test_time_grain_quarter(self, dialect: MySQLDialect) -> None:
         from orionbelt.ast.nodes import RawSQL
@@ -690,10 +697,8 @@ class TestMySQLDialect:
         assert "QUARTER" in result.sql
 
     def test_time_grain_year(self, dialect: MySQLDialect) -> None:
-        result = dialect.render_time_grain(col("dt"), TimeGrain.YEAR)
-        assert isinstance(result, FunctionCall)
-        sql = dialect.compile_expr(result)
-        assert "%Y-01-01" in sql
+        sql = dialect.compile_expr(dialect.render_time_grain(col("dt"), TimeGrain.YEAR))
+        assert sql == "CAST(DATE_FORMAT(`dt`, '%Y-01-01') AS DATE)"
 
     def test_time_grain_week(self, dialect: MySQLDialect) -> None:
         """Breaking: a weekly bucket is the week's start date, not a ``%Y-%u``

--- a/tests/unit/test_dimension_declared_type.py
+++ b/tests/unit/test_dimension_declared_type.py
@@ -155,15 +155,22 @@ def test_a_timestamp_dimension_keeps_its_time(model: SemanticModel) -> None:
 
 
 def test_a_string_dimension_over_a_grain_is_not_cast(model: SemanticModel) -> None:
-    """A grain declared ``string`` is asking for a label, and a label it stays.
+    """A grained dimension is temporal on every dialect, whatever it declares.
 
-    MySQL renders a month grain as ``DATE_FORMAT``, a string by construction, so
-    a model that wants the label declares ``resultType: string``. Casting that
-    to ``CHAR`` would add a cast that says nothing.
+    This test used to assert the opposite, and the reason is worth keeping:
+    MySQL's grain was a bare ``DATE_FORMAT``, a string by construction, so a
+    model that wanted the month back as a label declared ``resultType: string``
+    to describe what MySQL happened to return. That made a defect look like a
+    feature. The grain now casts back to a DATE, so the declaration describes
+    nothing MySQL does, and no dialect answers a grain with text.
+
+    A time bucket is a point in time. Handing one back as a string loses the
+    type, and with it the ordering, the range filters and the client's ability
+    to read it as a date at all.
     """
     sql = _sql(model, "Month Label", "mysql")
-    assert "DATE_FORMAT(`Event`.`occurred`, '%Y-%m-01') AS `Month Label`" in sql
-    assert "CAST(DATE_FORMAT" not in sql
+    assert "CAST(DATE_FORMAT(`Event`.`occurred`, '%Y-%m-01') AS DATE)" in sql
+    assert "AS CHAR" not in sql
 
 
 def test_an_ungrained_dimension_is_unchanged(model: SemanticModel) -> None:
@@ -259,3 +266,19 @@ def test_dimensions_exclude_returns_the_missing_month_combinations() -> None:
         (datetime.date(2024, 1, 1), "Books"),
         (datetime.date(2024, 2, 1), "Toys"),
     ]
+
+
+def test_no_dialect_answers_a_grain_with_text(model: SemanticModel) -> None:
+    """The invariant behind the fix: a time bucket is never a string.
+
+    MySQL was the only dialect that broke it, and only on the six grains it
+    renders with a format string -- quarter and week were already date
+    arithmetic, so one dialect disagreed with itself as well as with the
+    other seven.
+    """
+    for dialect in ("duckdb", "postgres", "mysql", "clickhouse", "bigquery", "snowflake"):
+        sql = _sql(model, "Occurred Month", dialect)
+        projection = sql.split("FROM")[0]
+        assert "DATE_FORMAT" not in projection or "CAST(DATE_FORMAT" in projection, (
+            f"{dialect} projects a grain as text: {projection}"
+        )

--- a/tests/unit/test_mysql_cast_width.py
+++ b/tests/unit/test_mysql_cast_width.py
@@ -146,7 +146,12 @@ class TestWhatDoesNotMove:
         assert "CAST(COUNT(`S`.`qty`) AS SIGNED)" in _sql("Sale Count", "mysql")
 
     def test_a_pass_through_measure_still_has_no_cast(self) -> None:
-        assert "CAST(" not in _sql("Biggest", "mysql")
+        # Scoped to the measure. The statement carries one cast that is not the
+        # measure's: MySQL's grain is a DATE_FORMAT, and it is cast back to a
+        # DATE so the dimension keeps the type every other dialect gives it.
+        sql = _sql("Biggest", "mysql")
+        assert "MAX(`S`.`amt`) AS `Biggest`" in sql
+        assert "CAST(MAX(" not in sql
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_pop.py
+++ b/tests/unit/test_pop.py
@@ -614,6 +614,26 @@ class TestPoPMultiDialect:
         assert "DATE_RANGE" in sql
         assert "POP_COMPARE" in sql
 
+    def test_the_mysql_bucket_carries_the_same_type_as_the_grain(self) -> None:
+        """The PoP bucket and the dimension grain are the same truncation.
+
+        The grain a dimension renders with is typed, but the spine's bucket is
+        rendered by the string-level helper, which was still bare text: the
+        same model answered ``Order Date`` as a date without a PoP metric and
+        as a string with one.
+        """
+        model = _load_model()
+        query = QueryObject(
+            select=QuerySelect(
+                dimensions=["Order Date"],
+                measures=["Revenue", "Revenue YoY Growth"],
+            ),
+        )
+        sql = CompilationPipeline().compile(query, model, "mysql").sql
+        assert "DATE_FORMAT" in sql, "the format-string path is not exercised"
+        for before in sql.split("DATE_FORMAT")[:-1]:
+            assert before.endswith("CAST("), f"a bucket is projected as text: ...{before[-60:]}"
+
     def test_pop_with_multiple_dimensions(self) -> None:
         """PoP with non-time dimensions should include them in the self-join."""
         model = _load_model()

--- a/tests/unit/test_pop_dialects.py
+++ b/tests/unit/test_pop_dialects.py
@@ -176,3 +176,18 @@ def test_quarter_week_spine_executes_on_duckdb(grain: str) -> None:
     )
     rows = duckdb.sql(f"WITH date_spine AS ({body}) SELECT * FROM date_spine").fetchall()
     assert rows, f"empty {grain} spine"
+
+
+@pytest.mark.parametrize("grain", DATE_GRAINS)
+def test_the_spine_bucket_is_never_text_on_mysql(grain: str) -> None:
+    """The bucket the spine is built from is a date, not a formatted string.
+
+    MySQL's ``DATE_FORMAT`` answers text, and the spine's recursive CTE takes
+    ``spine_date``'s type from its anchor row -- the MIN of these buckets. Text
+    there made the PoP time dimension come back as a ``VARCHAR`` while the same
+    dimension, in the same model, came back as a ``DATE`` when no PoP metric was
+    in the query. Measured on MySQL 8 over the emitted spine: ``varchar(10)``
+    before the cast, ``date`` after, same values.
+    """
+    sql = DialectRegistry.get("mysql").render_date_trunc_sql("`Sales`.`salesdate`", grain)
+    assert "DATE_FORMAT" not in sql or sql.startswith("CAST(DATE_FORMAT"), sql

--- a/tests/unit/test_pop_dialects.py
+++ b/tests/unit/test_pop_dialects.py
@@ -178,7 +178,12 @@ def test_quarter_week_spine_executes_on_duckdb(grain: str) -> None:
     assert rows, f"empty {grain} spine"
 
 
-@pytest.mark.parametrize("grain", DATE_GRAINS)
+#: Every grain a ``periodOverPeriod`` may name: ``PeriodOverPeriod.grain`` is the
+#: whole ``TimeGrain`` enum, so the spine's bucket has to render all eight.
+ALL_GRAINS = [*DATE_GRAINS, "hour", "minute", "second"]
+
+
+@pytest.mark.parametrize("grain", ALL_GRAINS)
 def test_the_spine_bucket_is_never_text_on_mysql(grain: str) -> None:
     """The bucket the spine is built from is a date, not a formatted string.
 
@@ -191,3 +196,18 @@ def test_the_spine_bucket_is_never_text_on_mysql(grain: str) -> None:
     """
     sql = DialectRegistry.get("mysql").render_date_trunc_sql("`Sales`.`salesdate`", grain)
     assert "DATE_FORMAT" not in sql or sql.startswith("CAST(DATE_FORMAT"), sql
+
+
+@pytest.mark.parametrize("grain", ["hour", "minute", "second"])
+def test_a_sub_day_spine_bucket_keeps_its_time_on_mysql(grain: str) -> None:
+    """A grain finer than a day is a DATETIME, not the midnight a DATE rounds to.
+
+    These grains were not in the helper's table at all and fell through to
+    ``DATE(...)``, so an hourly PoP bucketed a whole day into one row while the
+    spine stepped by the hour. Executed on MySQL 8 over four rows across three
+    hours: one row of 42.00 under a date before, three hourly rows with the
+    hour-over-hour differences after.
+    """
+    sql = DialectRegistry.get("mysql").render_date_trunc_sql("`Events`.`occurred_at`", grain)
+    assert sql.endswith(" AS DATETIME)"), sql
+    assert "%H" in sql, sql


### PR DESCRIPTION
## What

MySQL was the only dialect whose time grain answered **text**. Six of its eight grains rendered as a bare `DATE_FORMAT`, so the same dimension in the same model came back as a string here and as a date or timestamp on the other seven.

| Grain | Before | After |
|---|---|---|
| year, month, day | `DATE_FORMAT(...)` → **string** | `CAST(... AS DATE)` |
| hour, minute, second | `DATE_FORMAT(...)` → **string** | `CAST(... AS DATETIME)` |
| quarter, week | already date arithmetic | unchanged |

The dialect disagreed with itself as well as with the others: quarter and week were already temporal.

## Why this is the root cause of the `resultType: string` question

The same cast, for the same reason, is **already applied by this dialect's own portable date-truncation**, which explains itself in a comment:

> `# DATE_FORMAT returns a string; cast back so the result compares and sorts as a date rather than lexically.`

The dimension grain was the one path that missed it. That is what made `resultType: string` on a grained dimension look like a deliberate label rather than a description of the defect — a model declared `string` because MySQL happened to return one.

It is not a label anyone chose. A time bucket is a point in time; handing one back as text loses the type, and with it the ordering, the range filters and the client's ability to read it as a date at all.

## Emitted SQL is unchanged for every model in the corpus

A grain now carries its own cast, and a declared temporal `resultType` used to add a second one saying the same thing, which produced `CAST(CAST(DATE_FORMAT(...) AS DATE) AS DATE)`. So `cast_to_obml_type` now returns an expression already cast to the target rather than wrapping it again.

**The compile-only snapshots come out byte-identical.** Only the case the declared-type cast did not cover changes, which is exactly the case that was broken.

## Verified on MySQL 8

| Dimension | Declares | Now returns |
|---|---|---|
| `Occurred Month` | `date`, month grain | date `2024-03-01` |
| `Month Label` | **`string`**, month grain | date `2024-03-01` |
| `Stamp Hour` | `timestamp`, hour grain | `2024-03-15T10:00:00`, hour intact |

## Test plan

- `uv run pytest` green: 4718 passed, 1011 skipped, 1 xfailed
- New `test_no_dialect_answers_a_grain_with_text` pins the invariant across six dialects
- New `test_a_sub_day_grain_keeps_its_time` pins DATETIME rather than DATE for hour, so the fix cannot itself drop the time
- `test_a_string_dimension_over_a_grain_is_not_cast` rewritten: it previously asserted the defect, and its docstring now records why
- `test_a_pass_through_measure_still_has_no_cast` narrowed — it asserted "no `CAST(` anywhere in the statement" as a proxy for "the measure has no cast", which the dimension's legitimate cast now trips
- `ruff check`, `mypy src/` clean

## Still open, not in this PR

A declared `resultType` **coarser than the grain** silently collapses buckets and changes the numbers. `timeGrain: hour` with `resultType: date` validates cleanly and then compiles to `CAST(DATE_TRUNC('hour', ...) AS DATE)`, which is in the `GROUP BY` too:

```
before #374 (no cast):  09:00 -> 1.0,  10:00 -> 1.0,  11:00 -> 1.0
on main today:          2024-03-15 -> 3.0
```

Three hourly buckets become one daily total, with no error. That wants rejecting at model load, and it is a separate change from this one.

## Review follow-up: period-over-period went through the other truncation

Review caught that the dimension grain was not the only path. The spine's bucket is rendered by the string-level `render_date_trunc_sql`, which still answered a bare `DATE_FORMAT` for year and month, so a PoP query kept the behaviour this PR set out to remove.

It is not only a label. MySQL's recursive CTE takes `spine_date`'s type from its anchor row, which is the `MIN` of those buckets, so text there propagates to the projected time dimension. Executed on MySQL 8 over the emitted spine, same query, same values:

| Bucket | `Sales Month` comes back as |
|---|---|
| `DATE_FORMAT(...)` | `varchar(10)` |
| `CAST(DATE_FORMAT(...) AS DATE)` | `date` |

So the same `Sales Month` was a date without a PoP metric in the query and a string with one. The cast is the one this dialect's other two truncation paths already apply, so all three agree now. Quarter, week and day are date arithmetic and needed nothing.

- `test_a_period_over_period_month_comes_back_as_a_date`, executed against the MySQL container, verified to fail on the previous rendering
- `test_the_mysql_bucket_carries_the_same_type_as_the_grain` pins the compiled PoP SQL, `test_the_spine_bucket_is_never_text_on_mysql` pins the helper per grain
- One compile-only snapshot changes, `mysql/13_sales_yoy_growth.sql`, and it is the bucket
- `uv run pytest` 4724 passed, `-m docker` 522 passed, `ruff check` and `mypy src/` clean


## Review follow-up 2: the sub-day grains were not in the table at all

`PeriodOverPeriod.grain` is the whole `TimeGrain` enum, and the string-level helper listed only the date grains, so an hour fell through to `DATE(...)`. Executed on MySQL 8, four rows across three hours of one day, `grain: hour`:

| | Rows |
|---|---|
| Before | `2024-03-15` -> 42.00, nothing to compare it to |
| After | `09:00` -> 15.00, `10:00` -> 20.00 (+5.00), `11:00` -> 7.00 (-13.00) |

One row where there are three, a day's total where an hour's was asked for, and no error anywhere.

Three copies of this dialect's truncation have now drifted twice, on the cast and on the sub-day grains, so the format strings live in one table and the cast rule in one place. **The emitted SQL is unchanged for every query in the corpus:** no snapshot moves.

- `test_an_hourly_period_over_period_compares_hours`, executed, pins the three rows and the differences
- `test_both_truncation_paths_answer_the_same_value` runs the dimension grain and the spine's bucket over the same rows for all eight grains and compares by value, so a difference in how either is written cannot hide one in what it answers. Both verified to fail on the previous rendering
- `uv run pytest` 4730 passed, `-m docker` 531 passed, `ruff check` and `mypy src/` clean

### Sub-day PoP on the other seven dialects, which this PR does not fix

MySQL's spine is grain-agnostic (a recursive `DATE_ADD`), so the truncation was the only thing standing between it and a correct hourly PoP. The others build a **date** spine, and no truncation fix reaches that:

| Dialect | `grain: hour` spine |
|---|---|
| Postgres, DuckDB, Snowflake | `spine_date` is cast `::date`, so the hours collapse silently |
| BigQuery | measured: `400 GENERATE_DATE_ARRAY does not support the HOUR date part` |
| Databricks | `ValueError: Unsupported unit 'hour' for Databricks` at compile |
| ClickHouse, Dremio | not measured |

That is a spine change plus a decision about whether a sub-day `periodOverPeriod` is supported at all, which wants either a timestamp spine or a validation error naming the grain. Separate change, not this one.
