### PR TITLE
fix(validator): a measure expression has to parse, like a column's does

### DIFF
--- a/docs/guide/model-format.md
+++ b/docs/guide/model-format.md
@@ -594,7 +594,7 @@ measures:
 | `columns` | list | No | List of column references (`dataObject`+`column`) for simple single-column measures |
 | `resultType` | enum | Yes | Data type of the result. Emitted as a CAST around the aggregate, so the measure carries its declared precision and type |
 | `aggregation` | enum | Yes | `sum`, `count`, `count_distinct`, `avg`, `min`, `max`, `any_value`, `median`, `mode`, `listagg`; statistical: `stddev`, `stddev_pop`, `variance`, `var_pop`, `corr`, `covar_pop`, `covar_samp`, `regr_slope`, `regr_intercept` — see [Aggregation Types](#aggregation-types) for dialect coverage |
-| `expression` | string | No | Expression with `{[DataObject].[Column]}` placeholders |
+| `expression` | string | No | Expression with `{[DataObject].[Column]}` placeholders. It has to parse: a body the expression parser does not accept is refused at load with `INVALID_MEASURE_EXPRESSION`, the way a computed column's is with `INVALID_COLUMN_EXPRESSION` |
 | `distinct` | bool | No | Apply DISTINCT to aggregation |
 | `total` | bool | No | Grand total shorthand (equivalent to `grain: { mode: FIXED }`) |
 | `anchor` | string | No | [Data object whose grain a cross-fact expression is evaluated at](compilation.md#cross-fact-measure-expressions). Only meaningful when the expression reads facts no join path reaches together |

--- a/src/orionbelt/models/expressions.py
+++ b/src/orionbelt/models/expressions.py
@@ -324,3 +324,37 @@ def find_malformed_measure_refs(expression: str) -> list[tuple[str, str]]:
         for match in pattern.finditer(remainder):
             found.append((shape.format(*match.groups()), reason))
     return found
+
+
+#: What a botched reference stands for while an expression is judged on its own
+#: syntax: a bare literal, which the parser takes anywhere a column reference
+#: goes. Never compiled - only ever parsed, to answer whether the rest reads.
+_NEUTRAL_FACTOR = "0"
+
+_REFERENCE_SHAPES = re.compile(
+    "|".join(
+        [
+            f"(?P<valid>{VALID_MEASURE_REF.pattern})",
+            *(pattern.pattern for pattern, _, _ in _MALFORMED_MEASURE_REFS),
+        ]
+    )
+)
+
+
+def expression_without_malformed_refs(expression: str) -> str:
+    """*expression* with every botched reference replaced by a plain factor.
+
+    What a reference is meant to be, grammatically, is one factor - so a body
+    whose brackets are wrong can still be asked whether the rest of it reads.
+    Without this, a measure had to be skipped whole once its reference check
+    fired, and an unrelated syntax error in the same body stayed hidden until
+    the author fixed the brackets and reloaded.
+
+    Well-formed references are left as they are, so what the parser complains
+    about still names the author's own columns.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        return match.group(0) if match.group("valid") is not None else _NEUTRAL_FACTOR
+
+    return _REFERENCE_SHAPES.sub(_replace, expression)

--- a/src/orionbelt/models/expressions.py
+++ b/src/orionbelt/models/expressions.py
@@ -244,3 +244,83 @@ def find_qualified_refs(expression: str) -> list[tuple[str, str]]:
             continue
         refs.extend((obj.strip(), col.strip()) for obj, col in QUALIFIED_COLUMN_REF.findall(text))
     return refs
+
+
+VALID_MEASURE_REF = re.compile(r"\{\[[^\]{}\[]+\]\.\[[^\]{}\[]+\]\}")
+"""A well-formed ``{[Data Object].[Column]}`` reference, brackets and all.
+
+Stricter than :data:`QUALIFIED_COLUMN_REF`, which is what the tokenizer reads:
+this one refuses a nested brace or bracket, so stripping every match leaves a
+remainder in which a botched reference still shows its shape.
+"""
+
+#: ``(pattern, shape, what is wrong)`` for each way a measure reference is
+#: misspelled. ``shape`` renders the offending text back the way the author
+#: typed it, from the pattern's groups.
+_MALFORMED_MEASURE_REFS: tuple[tuple[re.Pattern[str], str, str], ...] = (
+    (
+        re.compile(r"\{\[([^\]{}\[]+)\]\[([^\]{}\[]+)\]\}"),
+        "{{[{0}][{1}]}}",
+        "missing '.' separator",
+    ),
+    (
+        re.compile(r"\{\[([^\]{}\[]+\.[^\]{}\[]+)\]\}"),
+        "{{[{0}]}}",
+        "use '{[Obj].[Col]}' syntax",
+    ),
+    (
+        re.compile(r"\{([A-Za-z][^\[{}\]]*\.[A-Za-z][^\[{}\]]*)\}"),
+        "{{{0}}}",
+        "missing '[' and ']', use '{[Obj].[Col]}' syntax",
+    ),
+    (
+        re.compile(r"\{\[([^\]{}\[]+)\]\.\[([^\]{}\[]+)\](?!\})"),
+        "{{[{0}].[{1}]",
+        "missing closing '}'",
+    ),
+    (
+        re.compile(r"(?<!\{)\[([^\]{}\[]+)\]\.\[([^\]{}\[]+)\]\}"),
+        "[{0}].[{1}]}}",
+        "missing opening '{'",
+    ),
+    (
+        re.compile(r"\{\[([^\]{}\[]+)\]\.\[([^\]{}\[]*)\}(?!\])"),
+        "{{[{0}].[{1}}}",
+        "missing closing ']' on column",
+    ),
+    (
+        re.compile(r"\{\[([^\]{}\[]*)\.?\[([^\]{}\[]+)\]\}"),
+        "{{[{0}.[{1}]}}",
+        "missing closing ']' on data object",
+    ),
+    (
+        re.compile(r"\{([^\[{}\]]+)\]\.\[([^\]{}\[]+)\]\}"),
+        "{{{0}].[{1}]}}",
+        "missing opening '[' on data object",
+    ),
+    (
+        re.compile(r"\{\[([^\]{}\[]+)\]\.([^\[{}\]]+)\]\}"),
+        "{{[{0}].{1}]}}",
+        "missing opening '[' on column",
+    ),
+)
+
+
+def find_malformed_measure_refs(expression: str) -> list[tuple[str, str]]:
+    """The botched ``{[Data Object].[Column]}`` references *expression* carries.
+
+    Each pair is the offending text as the author typed it and what is wrong
+    with it. Well-formed references are stripped first, so only the attempts
+    are scanned.
+
+    Read by the two places that have to agree on what a malformed reference is:
+    the resolver reports each one, and the measure-expression parse check stays
+    quiet on a body that carries any - a reference the scanner cannot read does
+    not parse either, and naming the bracket is the useful half of that pair.
+    """
+    remainder = VALID_MEASURE_REF.sub("", expression)
+    found: list[tuple[str, str]] = []
+    for pattern, shape, reason in _MALFORMED_MEASURE_REFS:
+        for match in pattern.finditer(remainder):
+            found.append((shape.format(*match.groups()), reason))
+    return found

--- a/src/orionbelt/parser/resolver.py
+++ b/src/orionbelt/parser/resolver.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel
 from pydantic import ValidationError as PydanticValidationError
 
 from orionbelt.models.errors import SemanticError, ValidationResult
-from orionbelt.models.expressions import find_qualified_refs
+from orionbelt.models.expressions import find_malformed_measure_refs, find_qualified_refs
 from orionbelt.models.semantic import (
     CustomExtension,
     DataColumnRef,
@@ -1334,76 +1334,20 @@ class ReferenceResolver:
                     )
                 )
 
-        # Strip valid refs, scan remainder for malformed attempts.
-        remainder = re.sub(r"\{\[[^\]{}\[]+\]\.\[[^\]{}\[]+\]\}", "", expression)
-        path = f"measures.{measure_name}.expression"
-
-        def _merr(msg: str) -> None:
+        # Strip valid refs, scan remainder for malformed attempts. The scan
+        # itself lives in ``models.expressions``: the measure-expression parse
+        # check consults it too, so that a botched bracket is reported once,
+        # by the check that names the bracket.
+        for ref, reason in find_malformed_measure_refs(expression):
             errors.append(
-                SemanticError(code="MALFORMED_EXPRESSION_REF", message=msg, path=path, span=span)
-            )
-
-        # {[Obj][Col]} — missing dot separator
-        for o, c in re.findall(r"\{\[([^\]{}\[]+)\]\[([^\]{}\[]+)\]\}", remainder):
-            _merr(
-                f"Measure '{measure_name}' has malformed reference"
-                f" '{{[{o}][{c}]}}' — missing '.' separator"
-            )
-
-        # {[Obj.Col]} — dot inside single bracket pair
-        for bad in re.findall(r"\{\[([^\]{}\[]+\.[^\]{}\[]+)\]\}", remainder):
-            _merr(
-                f"Measure '{measure_name}' has malformed reference"
-                f" '{{[{bad}]}}' — use '{{[Obj].[Col]}}' syntax"
-            )
-
-        # {Obj.Col} — missing all inner brackets
-        for bad in re.findall(r"\{([A-Za-z][^\[{}\]]*\.[A-Za-z][^\[{}\]]*)\}", remainder):
-            _merr(
-                f"Measure '{measure_name}' has malformed reference"
-                f" '{{{bad}}}' — missing '[' and ']', use '{{[Obj].[Col]}}' syntax"
-            )
-
-        # {[Obj].[Col] — missing closing }
-        for o, c in re.findall(r"\{\[([^\]{}\[]+)\]\.\[([^\]{}\[]+)\](?!\})", remainder):
-            _merr(
-                f"Measure '{measure_name}' has malformed reference"
-                f" '{{[{o}].[{c}]' — missing closing '}}'"
-            )
-
-        # [Obj].[Col]} — missing opening {
-        for o, c in re.findall(r"(?<!\{)\[([^\]{}\[]+)\]\.\[([^\]{}\[]+)\]\}", remainder):
-            _merr(
-                f"Measure '{measure_name}' has malformed reference"
-                f" '[{o}].[{c}]}}' — missing opening '{{'"
-            )
-
-        # {[Obj].[Col} — missing ] on column
-        for o, c in re.findall(r"\{\[([^\]{}\[]+)\]\.\[([^\]{}\[]*)\}(?!\])", remainder):
-            _merr(
-                f"Measure '{measure_name}' has malformed reference"
-                f" '{{[{o}].[{c}}}' — missing closing ']' on column"
-            )
-
-        # {[Obj.[Col]} — missing ] on data object
-        for o, c in re.findall(r"\{\[([^\]{}\[]*)\.?\[([^\]{}\[]+)\]\}", remainder):
-            _merr(
-                f"Measure '{measure_name}' has malformed reference"
-                f" '{{[{o}.[{c}]}}' — missing closing ']' on data object"
-            )
-
-        # {Obj].[Col]} — missing [ on data object
-        for o, c in re.findall(r"\{([^\[{}\]]+)\]\.\[([^\]{}\[]+)\]\}", remainder):
-            _merr(
-                f"Measure '{measure_name}' has malformed reference"
-                f" '{{{o}].[{c}]}}' — missing opening '[' on data object"
-            )
-
-        # {[Obj].Col]} — missing [ on column
-        for o, c in re.findall(r"\{\[([^\]{}\[]+)\]\.([^\[{}\]]+)\]\}", remainder):
-            _merr(
-                f"Measure '{measure_name}' has malformed reference"
-                f" '{{[{o}].{c}]}}' — missing opening '[' on column"
+                SemanticError(
+                    code="MALFORMED_EXPRESSION_REF",
+                    message=(
+                        f"Measure '{measure_name}' has malformed reference '{ref}' — {reason}"
+                    ),
+                    path=f"measures.{measure_name}.expression",
+                    span=span,
+                )
             )
 
     def _validate_metric_expression_refs(

--- a/src/orionbelt/parser/validator.py
+++ b/src/orionbelt/parser/validator.py
@@ -10,8 +10,8 @@ import networkx as nx
 from orionbelt.models.errors import SemanticError
 from orionbelt.models.expressions import (
     QUALIFIED_COLUMN_REF,
+    expression_without_malformed_refs,
     find_function_calls,
-    find_malformed_measure_refs,
     find_placeholders,
     find_qualified_refs,
 )
@@ -1262,13 +1262,19 @@ class SemanticValidator:
         computed-column check gives: a validator that parsed the body its own
         way could answer differently from the code that has to build it.
 
-        Which is also why *refused_columns* is needed: the tokenizer inlines a
-        computed column's body in place, so a measure reading a column already
-        refused would fail to parse for a fault that is not the measure's, and
-        one bad column would multiply into an error per measure that reads it.
-        Parsed against :meth:`_model_without` instead, where those columns stand
-        for themselves, so what is left to fail is the measure's own syntax and
-        an author sees both faults in one pass rather than one per reload.
+        Two faults belonging to another check are neutralized rather than
+        skipped, so that what is left to fail is the measure's own syntax:
+
+        * a reference the scanner cannot read, which
+          :func:`expression_without_malformed_refs` stands in a factor for;
+        * a computed column the parser already refused - the tokenizer inlines
+          such a body in place, so one bad column would otherwise multiply into
+          an error per measure that reads it. *refused_columns* names them and
+          :meth:`_model_without` lets them stand for themselves.
+
+        Skipping the measure whole was the first shape of both, and it hid an
+        unrelated syntax error in the same body until the author fixed the
+        other fault and reloaded. An author sees both in one pass instead.
         """
         from orionbelt.compiler.expr_parser import (
             parse_expression,
@@ -1280,13 +1286,13 @@ class SemanticValidator:
         for name, measure in model.measures.items():
             if not measure.expression:
                 continue
-            if find_malformed_measure_refs(measure.expression):
-                # Reported once, by the check that names the bracket: a
-                # reference the scanner cannot read does not parse either, and
-                # "missing ']' on column" is the useful half of that pair.
-                continue
+            # A botched reference is reported once, by the check that names
+            # the bracket - "missing ']' on column" is the useful half of that
+            # pair - so it stands for a plain factor here and the rest of the
+            # body is still judged on its own syntax.
+            body = expression_without_malformed_refs(measure.expression)
             try:
-                parse_expression(tokenize_measure_expression(measure.expression, probe))
+                parse_expression(tokenize_measure_expression(body, probe))
             except RecursionError:
                 continue
             except Exception as exc:  # noqa: BLE001 - any parse failure, reported as one

--- a/src/orionbelt/parser/validator.py
+++ b/src/orionbelt/parser/validator.py
@@ -106,6 +106,7 @@ class SemanticValidator:
                 model, {e.path for e in reference_errors if e.path}
             )
         )
+        errors.extend(self._check_measure_expressions(model))
         errors.extend(self._check_expression_functions(model))
         errors.extend(self._check_query_timezone_coverage(model))
         errors.extend(self._check_reference_name_collisions(model))
@@ -1192,6 +1193,50 @@ class SemanticValidator:
                             context={"dataObject": obj_name, "column": col_name},
                         )
                     )
+        return errors
+
+    def _check_measure_expressions(self, model: SemanticModel) -> list[SemanticError]:
+        """A measure expression has to parse, the way a computed column's does.
+
+        A computed column whose body does not parse is refused at load
+        (``INVALID_COLUMN_EXPRESSION``); a measure carrying the same body was
+        accepted, and the failure arrived when someone selected the measure -
+        as a bare ``ValueError`` out of the tokenizer, which the query handler
+        has no branch for, so it left the route as a 500 rather than a 422
+        naming the measure. Two authors writing the same malformed expression
+        in two places got a model-load error and a server error.
+
+        Parsed through the compiler's own entry points, for the reason the
+        computed-column check gives: a validator that parsed the body its own
+        way could answer differently from the code that has to build it.
+        """
+        from orionbelt.compiler.expr_parser import (
+            parse_expression,
+            tokenize_measure_expression,
+        )
+
+        errors: list[SemanticError] = []
+        for name, measure in model.measures.items():
+            if not measure.expression:
+                continue
+            try:
+                parse_expression(tokenize_measure_expression(measure.expression, model))
+            except RecursionError:
+                continue
+            except Exception as exc:  # noqa: BLE001 - any parse failure, reported as one
+                errors.append(
+                    SemanticError(
+                        code="INVALID_MEASURE_EXPRESSION",
+                        message=f"Measure '{name}' has invalid expression: {exc}",
+                        path=f"measures.{name}.expression",
+                        hint=(
+                            "The expression parser reads a subset of SQL. A "
+                            "construct it does not accept has to be written "
+                            "another way, or moved into the source view."
+                        ),
+                        context={"measure": name},
+                    )
+                )
         return errors
 
     def _check_expression_functions(self, model: SemanticModel) -> list[SemanticError]:

--- a/src/orionbelt/parser/validator.py
+++ b/src/orionbelt/parser/validator.py
@@ -1221,6 +1221,30 @@ class SemanticValidator:
             )
         return errors
 
+    @staticmethod
+    def _model_without(
+        model: SemanticModel, refused_columns: set[tuple[str, str]]
+    ) -> SemanticModel:
+        """*model* with the body of each refused computed column dropped.
+
+        Such a column then reads as a plain column reference - the parser takes
+        one anywhere it takes an expression - which is what a body that cannot
+        be read has to stand for while another expression is being judged.
+
+        Copied rather than mutated, and only along the path to a refused
+        column: the model belongs to whoever asked for validation, and this is
+        a probe.
+        """
+        objects = dict(model.data_objects)
+        for obj_name, col_name in refused_columns:
+            obj = objects.get(obj_name)
+            if obj is None or col_name not in obj.columns:
+                continue
+            columns = dict(obj.columns)
+            columns[col_name] = columns[col_name].model_copy(update={"expression": None})
+            objects[obj_name] = obj.model_copy(update={"columns": columns})
+        return model.model_copy(update={"data_objects": objects})
+
     def _check_measure_expressions(
         self, model: SemanticModel, refused_columns: set[tuple[str, str]]
     ) -> list[SemanticError]:
@@ -1240,15 +1264,18 @@ class SemanticValidator:
 
         Which is also why *refused_columns* is needed: the tokenizer inlines a
         computed column's body in place, so a measure reading a column already
-        refused fails to parse for a fault that is not the measure's. Reported
-        once, at the column, or one bad column would multiply into an error per
-        measure that reads it.
+        refused would fail to parse for a fault that is not the measure's, and
+        one bad column would multiply into an error per measure that reads it.
+        Parsed against :meth:`_model_without` instead, where those columns stand
+        for themselves, so what is left to fail is the measure's own syntax and
+        an author sees both faults in one pass rather than one per reload.
         """
         from orionbelt.compiler.expr_parser import (
             parse_expression,
             tokenize_measure_expression,
         )
 
+        probe = self._model_without(model, refused_columns) if refused_columns else model
         errors: list[SemanticError] = []
         for name, measure in model.measures.items():
             if not measure.expression:
@@ -1258,10 +1285,8 @@ class SemanticValidator:
                 # reference the scanner cannot read does not parse either, and
                 # "missing ']' on column" is the useful half of that pair.
                 continue
-            if any(ref in refused_columns for ref in find_qualified_refs(measure.expression)):
-                continue
             try:
-                parse_expression(tokenize_measure_expression(measure.expression, model))
+                parse_expression(tokenize_measure_expression(measure.expression, probe))
             except RecursionError:
                 continue
             except Exception as exc:  # noqa: BLE001 - any parse failure, reported as one

--- a/src/orionbelt/parser/validator.py
+++ b/src/orionbelt/parser/validator.py
@@ -11,6 +11,7 @@ from orionbelt.models.errors import SemanticError
 from orionbelt.models.expressions import (
     QUALIFIED_COLUMN_REF,
     find_function_calls,
+    find_malformed_measure_refs,
     find_placeholders,
     find_qualified_refs,
 )
@@ -1218,6 +1219,11 @@ class SemanticValidator:
         errors: list[SemanticError] = []
         for name, measure in model.measures.items():
             if not measure.expression:
+                continue
+            if find_malformed_measure_refs(measure.expression):
+                # Reported once, by the check that names the bracket: a
+                # reference the scanner cannot read does not parse either, and
+                # "missing ']' on column" is the useful half of that pair.
                 continue
             try:
                 parse_expression(tokenize_measure_expression(measure.expression, model))

--- a/src/orionbelt/parser/validator.py
+++ b/src/orionbelt/parser/validator.py
@@ -102,12 +102,16 @@ class SemanticValidator:
         # "unknown column 'X'" is the useful half of that pair.
         reference_errors = self._check_computed_column_refs(model)
         errors.extend(reference_errors)
+        # Parsed once, for both checks that have to know: the column's own, and
+        # the measure check, which stays quiet on a body whose only fault is a
+        # column already reported here.
+        refused_columns = self._refused_computed_columns(model)
         errors.extend(
             self._check_computed_column_expressions(
-                model, {e.path for e in reference_errors if e.path}
+                model, refused_columns, {e.path for e in reference_errors if e.path}
             )
         )
-        errors.extend(self._check_measure_expressions(model))
+        errors.extend(self._check_measure_expressions(model, set(refused_columns)))
         errors.extend(self._check_expression_functions(model))
         errors.extend(self._check_query_timezone_coverage(model))
         errors.extend(self._check_reference_name_collisions(model))
@@ -1134,8 +1138,42 @@ class SemanticValidator:
                     metric.expression,
                 )
 
+    def _refused_computed_columns(self, model: SemanticModel) -> dict[tuple[str, str], Exception]:
+        """Every computed column whose body the expression parser refuses.
+
+        Keyed by ``(data object, column)``, carrying what the parser said, so
+        the column's own check can report it and the measure check can tell a
+        measure that merely *reads* such a column from one that is itself
+        malformed.
+
+        A cycle is left out: :meth:`_check_no_cyclic_computed_columns` names
+        both ends of it rather than wherever the recursion happened to stop.
+        """
+        # Imported here rather than at module scope: the tokenizer lives in the
+        # compiler, and the parser package does not depend on it to be imported.
+        # It is the compiler's own entry point on purpose - a check that parsed
+        # the body its own way could answer differently from the code that has
+        # to build it.
+        from orionbelt.compiler.resolution import parse_column_expression
+
+        refused: dict[tuple[str, str], Exception] = {}
+        for obj_name, obj in model.data_objects.items():
+            for col_name, column in obj.columns.items():
+                if not column.expression:
+                    continue
+                try:
+                    parse_column_expression(column, obj, model)
+                except RecursionError:
+                    continue
+                except Exception as exc:  # noqa: BLE001 - any parse failure, reported as one
+                    refused[(obj_name, col_name)] = exc
+        return refused
+
     def _check_computed_column_expressions(
-        self, model: SemanticModel, already_reported: set[str]
+        self,
+        model: SemanticModel,
+        refused: dict[tuple[str, str], Exception],
+        already_reported: set[str],
     ) -> list[SemanticError]:
         """A computed column's expression has to parse, or the column is nothing.
 
@@ -1160,43 +1198,32 @@ class SemanticValidator:
         paths it claimed. Both of those fail to parse too, and neither is
         better described as a syntax error.
         """
-        # Imported here rather than at module scope: the tokenizer lives in the
-        # compiler, and the parser package does not depend on it to be imported.
-        # It is the compiler's own entry point on purpose - a check that parsed
-        # the body its own way could answer differently from the code that has
-        # to build it.
-        from orionbelt.compiler.resolution import parse_column_expression
-
         errors: list[SemanticError] = []
-        for obj_name, obj in model.data_objects.items():
-            for col_name, column in obj.columns.items():
-                path = f"dataObjects.{obj_name}.columns.{col_name}.expression"
-                if not column.expression or path in already_reported:
-                    continue
-                try:
-                    parse_column_expression(column, obj, model)
-                except RecursionError:
-                    continue
-                except Exception as exc:  # noqa: BLE001 - any parse failure, reported as one
-                    errors.append(
-                        SemanticError(
-                            code="INVALID_COLUMN_EXPRESSION",
-                            message=(
-                                f"Computed column '{col_name}' in data object "
-                                f"'{obj_name}' has invalid expression: {exc}"
-                            ),
-                            path=path,
-                            hint=(
-                                "The expression parser reads a subset of SQL. A "
-                                "construct it does not accept has to be written "
-                                "another way, or moved into the source view."
-                            ),
-                            context={"dataObject": obj_name, "column": col_name},
-                        )
-                    )
+        for (obj_name, col_name), exc in refused.items():
+            path = f"dataObjects.{obj_name}.columns.{col_name}.expression"
+            if path in already_reported:
+                continue
+            errors.append(
+                SemanticError(
+                    code="INVALID_COLUMN_EXPRESSION",
+                    message=(
+                        f"Computed column '{col_name}' in data object "
+                        f"'{obj_name}' has invalid expression: {exc}"
+                    ),
+                    path=path,
+                    hint=(
+                        "The expression parser reads a subset of SQL. A "
+                        "construct it does not accept has to be written "
+                        "another way, or moved into the source view."
+                    ),
+                    context={"dataObject": obj_name, "column": col_name},
+                )
+            )
         return errors
 
-    def _check_measure_expressions(self, model: SemanticModel) -> list[SemanticError]:
+    def _check_measure_expressions(
+        self, model: SemanticModel, refused_columns: set[tuple[str, str]]
+    ) -> list[SemanticError]:
         """A measure expression has to parse, the way a computed column's does.
 
         A computed column whose body does not parse is refused at load
@@ -1210,6 +1237,12 @@ class SemanticValidator:
         Parsed through the compiler's own entry points, for the reason the
         computed-column check gives: a validator that parsed the body its own
         way could answer differently from the code that has to build it.
+
+        Which is also why *refused_columns* is needed: the tokenizer inlines a
+        computed column's body in place, so a measure reading a column already
+        refused fails to parse for a fault that is not the measure's. Reported
+        once, at the column, or one bad column would multiply into an error per
+        measure that reads it.
         """
         from orionbelt.compiler.expr_parser import (
             parse_expression,
@@ -1224,6 +1257,8 @@ class SemanticValidator:
                 # Reported once, by the check that names the bracket: a
                 # reference the scanner cannot read does not parse either, and
                 # "missing ']' on column" is the useful half of that pair.
+                continue
+            if any(ref in refused_columns for ref in find_qualified_refs(measure.expression)):
                 continue
             try:
                 parse_expression(tokenize_measure_expression(measure.expression, model))

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -2221,3 +2221,32 @@ measures:
     def test_a_valid_expression_still_loads(self) -> None:
         errors = self._errors("ABS({[Event].[Amount]} + 1)")
         assert not any(e.code == "INVALID_MEASURE_EXPRESSION" for e in errors)
+
+    @pytest.mark.parametrize(
+        "expr",
+        [
+            "ABS({[Event].Amount]} + 1)",  # missing '[' on the column
+            "ABS({[Event][Amount]} + 1)",  # missing the '.' separator
+            "ABS({[Event].[Amount} + 1)",  # missing ']' on the column
+        ],
+    )
+    def test_a_malformed_reference_is_reported_once(self, expr: str) -> None:
+        """By the check that names the bracket, not twice.
+
+        A reference the scanner cannot read does not parse either, so both
+        checks have something to say about it. "missing opening '[' on column"
+        is the half that tells the author what to type; a second error saying
+        the same body does not parse is noise on the same line.
+        """
+        codes = [e.code for e in self._errors(expr)]
+        assert "INVALID_MEASURE_EXPRESSION" not in codes, codes
+
+    def test_the_reference_check_still_names_the_bracket(self) -> None:
+        """The half that is kept has to actually be reported."""
+        raw, source_map = TrackedLoader().load_string(
+            self.TEMPLATE.format(expr="ABS({[Event].Amount]} + 1)")
+        )
+        _model, result = ReferenceResolver().resolve(raw, source_map)
+        malformed = [e for e in result.errors if e.code == "MALFORMED_EXPRESSION_REF"]
+        assert len(malformed) == 1
+        assert "missing opening '[' on column" in malformed[0].message

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -2250,3 +2250,47 @@ measures:
         malformed = [e for e in result.errors if e.code == "MALFORMED_EXPRESSION_REF"]
         assert len(malformed) == 1
         assert "missing opening '[' on column" in malformed[0].message
+
+    COLUMN_TEMPLATE = """version: 1.0
+dataObjects:
+  Event:
+    code: ev
+    columns:
+      Amount: {code: amount, abstractType: float, numClass: additive}
+      Bad: {expression: "CAST({Amount} AS integer)", abstractType: int}
+      Chained: {expression: "{Bad} + 1", abstractType: int}
+measures:
+  Reader:
+    expression: "%s"
+    resultType: float
+    aggregation: sum
+"""
+
+    def _column_errors(self, expr: str) -> list[SemanticError]:
+        raw, source_map = TrackedLoader().load_string(self.COLUMN_TEMPLATE % expr)
+        model, _ = ReferenceResolver().resolve(raw, source_map)
+        return SemanticValidator().validate(model)
+
+    @pytest.mark.parametrize(
+        "expr",
+        [
+            "{[Event].[Bad]} + 1",  # reads the refused column itself
+            "{[Event].[Chained]} + 1",  # reads a column that reads it
+        ],
+    )
+    def test_a_measure_reading_a_refused_column_is_not_reported_again(self, expr: str) -> None:
+        """The fault is the column's, and the column already says so.
+
+        The tokenizer inlines a computed column's body in place, so a measure
+        reading a refused one fails to parse for a reason that has nothing to
+        do with the measure. One bad column would otherwise multiply into an
+        error per measure that reads it.
+        """
+        codes = [e.code for e in self._column_errors(expr)]
+        assert "INVALID_COLUMN_EXPRESSION" in codes, codes
+        assert "INVALID_MEASURE_EXPRESSION" not in codes, codes
+
+    def test_a_measure_with_its_own_fault_is_still_reported(self) -> None:
+        """The skip is for the borrowed fault only, not for any body that reads a column."""
+        codes = [e.code for e in self._column_errors("ABS({[Event].[Amount]} + 1")]
+        assert "INVALID_MEASURE_EXPRESSION" in codes, codes

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -2312,3 +2312,18 @@ measures:
         model, _ = ReferenceResolver().resolve(raw, source_map)
         SemanticValidator().validate(model)
         assert model.data_objects["Event"].columns["Bad"].expression == "CAST({Amount} AS integer)"
+
+    def test_a_malformed_reference_does_not_hide_the_rest_of_the_body(self) -> None:
+        """The bracket is one fault; a dangling operator beside it is another.
+
+        Skipping the body whole once its reference check fired meant the author
+        fixed the brackets, reloaded, and failed again on a '+' that was there
+        all along.
+        """
+        raw, source_map = TrackedLoader().load_string(
+            self.TEMPLATE.format(expr="ABS({[Event].Amount]} +)")
+        )
+        model, result = ReferenceResolver().resolve(raw, source_map)
+        assert any(e.code == "MALFORMED_EXPRESSION_REF" for e in result.errors)
+        codes = [e.code for e in SemanticValidator().validate(model)]
+        assert "INVALID_MEASURE_EXPRESSION" in codes, codes

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -2294,3 +2294,21 @@ measures:
         """The skip is for the borrowed fault only, not for any body that reads a column."""
         codes = [e.code for e in self._column_errors("ABS({[Event].[Amount]} + 1")]
         assert "INVALID_MEASURE_EXPRESSION" in codes, codes
+
+    def test_a_measure_reading_a_refused_column_keeps_its_own_syntax_error(self) -> None:
+        """Both faults in one pass, rather than one per reload.
+
+        Skipping the measure whole would hide a trailing '+' behind the
+        column's error: the author fixes the column, reloads, and the model
+        fails a second time for something that was there all along.
+        """
+        codes = [e.code for e in self._column_errors("{[Event].[Bad]} +")]
+        assert "INVALID_COLUMN_EXPRESSION" in codes, codes
+        assert "INVALID_MEASURE_EXPRESSION" in codes, codes
+
+    def test_the_probe_leaves_the_model_alone(self) -> None:
+        """Validation answers a question about the model; it does not edit one."""
+        raw, source_map = TrackedLoader().load_string(self.COLUMN_TEMPLATE % "{[Event].[Bad]} + 1")
+        model, _ = ReferenceResolver().resolve(raw, source_map)
+        SemanticValidator().validate(model)
+        assert model.data_objects["Event"].columns["Bad"].expression == "CAST({Amount} AS integer)"

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -2158,3 +2158,66 @@ measures:
     )
     def test_a_type_wide_enough_for_the_bucket_is_allowed(self, spec: str) -> None:
         assert "RESULT_TYPE_LOSES_GRAIN" not in self._errors(spec), spec
+
+
+class TestMeasureExpressionsParse:
+    """A malformed measure expression is refused at load, not at query time.
+
+    A computed column with the same body was already refused
+    (``INVALID_COLUMN_EXPRESSION``). A measure carrying it loaded, and the
+    failure arrived when someone selected the measure -- as a bare
+    ``ValueError`` out of the tokenizer, which the query handler has no branch
+    for, so it left the route as a 500 rather than a 422 naming the measure.
+    """
+
+    TEMPLATE = """version: 1.0
+dataObjects:
+  Event:
+    code: ev
+    columns:
+      Amount: {{code: amount, abstractType: float, numClass: additive}}
+measures:
+  Bad:
+    expression: "{expr}"
+    resultType: float
+    aggregation: sum
+"""
+
+    def _errors(self, expr: str) -> list[SemanticError]:
+        import tempfile
+        from pathlib import Path
+
+        path = Path(tempfile.mkdtemp()) / "m.yaml"
+        path.write_text(self.TEMPLATE.format(expr=expr))
+        raw, source_map = TrackedLoader().load(path)
+        model, _ = ReferenceResolver().resolve(raw, source_map)
+        return SemanticValidator().validate(model)
+
+    @pytest.mark.parametrize(
+        "expr",
+        [
+            "ABS({[Event].[Amount]} + 1",  # the call never closes
+            "({[Event].[Amount]} + 1",  # nor does the group
+            "{[Event].[Amount]} +",  # nothing to add to
+        ],
+    )
+    def test_an_unparseable_expression_is_refused(self, expr: str) -> None:
+        errors = self._errors(expr)
+        assert any(e.code == "INVALID_MEASURE_EXPRESSION" for e in errors), (
+            f"{expr!r} loaded; got {[e.code for e in errors]}"
+        )
+
+    def test_the_error_names_the_measure_and_its_path(self) -> None:
+        """Enough to fix the model without running the query that found it."""
+        error = next(
+            e
+            for e in self._errors("ABS({[Event].[Amount]} + 1")
+            if e.code == "INVALID_MEASURE_EXPRESSION"
+        )
+        assert error.path == "measures.Bad.expression"
+        assert "Bad" in error.message
+        assert "Missing closing" in error.message
+
+    def test_a_valid_expression_still_loads(self) -> None:
+        errors = self._errors("ABS({[Event].[Amount]} + 1)")
+        assert not any(e.code == "INVALID_MEASURE_EXPRESSION" for e in errors)


### PR DESCRIPTION
## What

A malformed **measure** expression loaded cleanly and then failed as an uncaught `ValueError` when someone selected the measure. It is now refused at model load with `INVALID_MEASURE_EXPRESSION`.

Reported against #373 (merged 2026-08-24, before v2.26.0), and **reproduced on current main** — this is shipped behaviour, not something in flight.

## The asymmetry

The same body in two places behaved two different ways:

| Where | Body | Before |
|---|---|---|
| Computed column | `ABS({...} + 1` | refused at load, `INVALID_COLUMN_EXPRESSION` |
| **Measure** | `ABS({...} + 1` | **loads with 201**, then `ValueError` out of the route |

Measured on main:

```
model load: ACCEPTED (201)
compile:    builtins.ValueError: Missing closing ')' in call to 'ABS'
```

`compile_query_or_raise` translates `ResolutionError`, `FanoutError`, `UnsupportedAggregationError`, `UnsupportedGroupingError` and `UnsupportedNestedAccessError`, but has no branch for a bare `ValueError`, so it left the route as a server error rather than a 422 naming the measure.

After: the load returns **422** with the measure and its path, and the bad expression never reaches a model.

## Why at load rather than a wrapper

The reviewer offered either. Load-time is the one that matches what the codebase already does, and it fails in the place that can name the fix. The model even has an iterator describing "the three places an author can write one" — a computed column, a measure expression, and a metric formula — and only the first was parse-checked.

Parsed through the compiler's own entry points, for the reason the computed-column check already gives in its docstring: a validator that parsed the body its own way could answer differently from the code that has to build it.

## Test plan

- New `TestMeasureExpressionsParse`: three unparseable bodies refused (unclosed call, unclosed group, dangling operator), one valid body still loads, and one asserting the error carries `measures.Bad.expression` and the measure name — enough to fix the model without running the query that found it
- Verified end to end through the API with `httpx.ASGITransport`: load goes from 201 to 422
- `uv run pytest` green: 4721 passed, 1011 skipped, 1 xfailed. No model in the corpus trips the new check
- `ruff check`, `mypy src/` clean
- Documented in `docs/guide/model-format.md` next to its sibling code

## Not changed

I did not add a blanket `except ValueError` to `compile_query_or_raise`. Closing the door at load is the fix; catching every `ValueError` at the route would also turn genuine internal faults into 422s, which is a worse trade. A model constructed in Python without going through `ModelStore.load_model` can still reach the old path, and that is not an API surface.