### PR TITLE
fix(compiler): a boolean measure source is read as a number where one is read

### DIFF
--- a/src/orionbelt/compiler/resolution.py
+++ b/src/orionbelt/compiler/resolution.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 
 from orionbelt.ast.nodes import (
     CaseExpr,
+    Cast,
     ColumnRef,
     Expr,
     FunctionCall,
@@ -32,6 +33,7 @@ from orionbelt.compiler.filters import (
     collect_measure_filter_objects,
 )
 from orionbelt.compiler.graph import JoinGraph, JoinStep, path_overrides
+from orionbelt.compiler.type_resolver import resolve_measure_data_type
 from orionbelt.models.errors import SemanticError
 from orionbelt.models.expressions import find_qualified_refs, substitute_placeholders
 from orionbelt.models.query import (
@@ -59,12 +61,13 @@ from orionbelt.models.semantic import (
     Metric,
     MetricType,
     ModelFilter,
+    ModelSettings,
     PeriodOverPeriodComparison,
     SemanticModel,
     TimeGrain,
     WindowFunctionKind,
 )
-from orionbelt.models.types import parse_data_type
+from orionbelt.models.types import DecimalType, parse_data_type
 from orionbelt.models.warnings import WarningCode, warning
 
 if TYPE_CHECKING:
@@ -145,6 +148,47 @@ def _build_computed_column_expr(
 #: Temporal declarations OBML can cast to. ``timestamp_tz`` and ``time_tz`` are
 #: absent because the format has no cast target for them.
 _CASTABLE_TEMPORAL_TYPES = frozenset({DataType.DATE, DataType.TIMESTAMP, DataType.TIME})
+
+
+def _reads_a_number(measure: Measure, settings: ModelSettings | None) -> bool:
+    """Whether this measure's value is read as a number.
+
+    ``None`` means the measure passes its value through and emits no cast, so
+    a boolean has nothing to arrive at.
+    """
+    declared = resolve_measure_data_type(measure, settings)
+    if declared is None:
+        return False
+    return isinstance(declared, DecimalType) or declared.name in ("integer", "bigint", "double")
+
+
+def _flags_as_numbers(expr: Expr) -> Expr:
+    """Read every boolean column in *expr* as a number.
+
+    Only for a measure whose output is a number. An engine that carries a type
+    through an aggregate then hands a boolean to whatever the measure declares:
+    ``MAX(flag)`` declared decimal reached ClickHouse's decimal conversion as
+    'true' and raised, where ``SUM`` of the same column had always been a
+    number and worked.
+
+    Keyed on the type the reference already carries, so it reaches a measure
+    written either way. ``columns:`` and ``expression:`` are two spellings of
+    one measure and were not one rule: scoping this to the ``columns:`` branch
+    left ``expression: "{[ev].[Flag]}"`` failing exactly as before.
+
+    The abstract name renders per dialect, and nothing here reaches a measure
+    that passes its value through - those emit no cast for a boolean to arrive
+    at, and casting them changed what they answer rather than its type.
+    """
+
+    def rewrite(node: Expr) -> Expr | None:
+        # Equality, not identity: the node carries the value as a plain string
+        # where the model carries the enum, and is quietly matched neither.
+        if isinstance(node, ColumnRef) and node.abstract_type == DataType.BOOLEAN:
+            return Cast(expr=node, type_name="int")
+        return None
+
+    return map_nodes(expr, rewrite)
 
 
 def make_dimension_expr(
@@ -1338,6 +1382,11 @@ class QueryResolver:
         # — without this, ``count_distinct`` over an ``expression:``
         # column would emit ``COUNT(DISTINCT "obj"."")`` (zero-length
         # identifier, DB error).
+        # Whether a cast is coming, and whether it is a numeric one. A boolean
+        # source only has to become a number when it is about to be read as
+        # one; ``None`` here means the measure passes its value through.
+        numeric_output = _reads_a_number(measure, ctx.model.settings)
+
         args: list[Expr] = []
         if measure.columns:
             for ref in measure.columns:
@@ -1351,7 +1400,10 @@ class QueryResolver:
                     continue
                 obj = ctx.model.data_objects.get(obj_name)
                 if obj and col_name in obj.columns:
-                    args.append(make_column_expr(ctx.model, obj_name, col_name))
+                    col_expr = make_column_expr(ctx.model, obj_name, col_name)
+                    if numeric_output:
+                        col_expr = _flags_as_numbers(col_expr)
+                    args.append(col_expr)
                 else:
                     args.append(ColumnRef(name=col_name, table=obj_name))
         if not args:
@@ -1403,6 +1455,11 @@ class QueryResolver:
         # a dimension names: otherwise one column means two instants depending
         # on how the query reached it.
         inner = apply_query_timezone(parse_expression(tokens), ctx.model)
+        # The same rule the ``columns:`` form gets: two spellings of one
+        # measure, so a boolean reaches a numeric output as a number either
+        # way. Scoping it to the other branch left this one failing.
+        if _reads_a_number(measure, ctx.model.settings):
+            inner = _flags_as_numbers(inner)
 
         distinct = measure.distinct
         if agg == "COUNT_DISTINCT":

--- a/src/orionbelt/compiler/resolution.py
+++ b/src/orionbelt/compiler/resolution.py
@@ -184,10 +184,22 @@ def _flag_as_number(expr: Expr) -> Expr:
     ``expression:`` -- so one rule serves either. Anything larger than a bare
     reference is left alone: its own shape decides what its parts mean, and
     this cannot read that.
+
+    **A computed boolean column is the known gap, and it is older than this.**
+    ``{expression: "{Amt} > 0", abstractType: boolean}`` inlines to the
+    comparison itself, which carries no declared type, so a measure summing it
+    emits ``SUM("ev"."amt" > 0)`` -- rejected by PostgreSQL, whose ``sum`` has
+    no boolean overload, and by BigQuery. That is what ``main`` emits for the
+    same model today, in both measure spellings: this rule leaves it exactly
+    where it found it while fixing the bare-column case beside it. Closing it
+    means carrying a declared type onto an inlined body, which is the same
+    threading ``cast_to_obml_type`` wants and a piece of work in its own right.
     """
-    if isinstance(expr, ColumnRef) and expr.abstract_type == DataType.BOOLEAN:
-        # Equality, not identity: the node carries the value as a plain string
-        # where the model carries the enum, and ``is`` quietly matched neither.
+    # ColumnRef and NestedField are the two nodes that carry a declared type;
+    # a field of an unnested element is as much a source as a column is.
+    # Equality, not identity: the node carries the value as a plain string
+    # where the model carries the enum, and ``is`` quietly matched neither.
+    if isinstance(expr, ColumnRef | NestedField) and expr.abstract_type == DataType.BOOLEAN:
         return Cast(expr=expr, type_name="int")
     return expr
 

--- a/src/orionbelt/compiler/resolution.py
+++ b/src/orionbelt/compiler/resolution.py
@@ -162,8 +162,8 @@ def _reads_a_number(measure: Measure, settings: ModelSettings | None) -> bool:
     return isinstance(declared, DecimalType) or declared.name in ("integer", "bigint", "double")
 
 
-def _flags_as_numbers(expr: Expr) -> Expr:
-    """Read every boolean column in *expr* as a number.
+def _flag_as_number(expr: Expr) -> Expr:
+    """Read *expr* as a number when it is itself a boolean column.
 
     Only for a measure whose output is a number. An engine that carries a type
     through an aggregate then hands a boolean to whatever the measure declares:
@@ -171,24 +171,25 @@ def _flags_as_numbers(expr: Expr) -> Expr:
     'true' and raised, where ``SUM`` of the same column had always been a
     number and worked.
 
-    Keyed on the type the reference already carries, so it reaches a measure
-    written either way. ``columns:`` and ``expression:`` are two spellings of
-    one measure and were not one rule: scoping this to the ``columns:`` branch
-    left ``expression: "{[ev].[Flag]}"`` failing exactly as before.
+    **The value being aggregated, not every boolean inside it.** Rewriting each
+    reference reached the ones a measure uses as a *predicate*, and a predicate
+    is not read as a number: ``CASE WHEN {Flag} THEN {Amt} ELSE 0 END`` became
+    ``CASE WHEN CAST(flag AS INTEGER)``, which PostgreSQL refuses outright
+    ("argument of CASE/WHEN must be type boolean") and BigQuery with it. The
+    same reference reached through a computed column's body, so a measure could
+    break without naming a boolean at all.
 
-    The abstract name renders per dialect, and nothing here reaches a measure
-    that passes its value through - those emit no cast for a boolean to arrive
-    at, and casting them changed what they answer rather than its type.
+    Keyed on the type the reference carries, which both spellings of a measure
+    populate -- ``make_column_expr`` for ``columns:`` and the tokenizer for
+    ``expression:`` -- so one rule serves either. Anything larger than a bare
+    reference is left alone: its own shape decides what its parts mean, and
+    this cannot read that.
     """
-
-    def rewrite(node: Expr) -> Expr | None:
+    if isinstance(expr, ColumnRef) and expr.abstract_type == DataType.BOOLEAN:
         # Equality, not identity: the node carries the value as a plain string
-        # where the model carries the enum, and is quietly matched neither.
-        if isinstance(node, ColumnRef) and node.abstract_type == DataType.BOOLEAN:
-            return Cast(expr=node, type_name="int")
-        return None
-
-    return map_nodes(expr, rewrite)
+        # where the model carries the enum, and ``is`` quietly matched neither.
+        return Cast(expr=expr, type_name="int")
+    return expr
 
 
 def make_dimension_expr(
@@ -1402,7 +1403,7 @@ class QueryResolver:
                 if obj and col_name in obj.columns:
                     col_expr = make_column_expr(ctx.model, obj_name, col_name)
                     if numeric_output:
-                        col_expr = _flags_as_numbers(col_expr)
+                        col_expr = _flag_as_number(col_expr)
                     args.append(col_expr)
                 else:
                     args.append(ColumnRef(name=col_name, table=obj_name))
@@ -1459,7 +1460,7 @@ class QueryResolver:
         # measure, so a boolean reaches a numeric output as a number either
         # way. Scoping it to the other branch left this one failing.
         if _reads_a_number(measure, ctx.model.settings):
-            inner = _flags_as_numbers(inner)
+            inner = _flag_as_number(inner)
 
         distinct = measure.distinct
         if agg == "COUNT_DISTINCT":

--- a/tests/integration/test_clickhouse_execution.py
+++ b/tests/integration/test_clickhouse_execution.py
@@ -147,3 +147,92 @@ def test_commerce_case(ch_setup, vendor_model, truth_results, case: CommerceCase
     sql = compile_for(case.query, vendor_model, "clickhouse")
     actual = _fetch_clickhouse(ch_setup, sql)
     compare_rows(actual, truth_results[case.name], case=case.name)
+
+
+def test_a_boolean_measure_survives_a_declared_decimal_type(ch_setup) -> None:
+    """A boolean column aggregated under a declared decimal has to run.
+
+    ClickHouse carries the type through MIN/MAX/any, and the decimal
+    conversion reads its value as text, so ``MAX(flag)`` arrived as 'true' and
+    raised CANNOT_PARSE_TEXT. The fix is at the layer that knows the column is
+    boolean, so the engine is handed a number and the SQL needs no special
+    case: through the dialect alone it could only be told apart from a string
+    at run time, and every shape that did cost either the wrong answer for
+    text or the operand written out three times.
+
+    Executed through the compiler rather than a hand-written cast, because
+    that is the only path carrying the column's declared type.
+
+    On today's rendering this passes with or without the cast, because the
+    engine is handed the flag and rounds it. It is here for the rendering that
+    reads the value as text, where the flag arrives as 'true' and raises. The
+    guard that bites either way is the emitted SQL, in
+    ``tests/unit/test_boolean_measure_source.py``.
+    """
+    from decimal import Decimal
+    from pathlib import Path
+    from tempfile import mkdtemp
+
+    from orionbelt.compiler.pipeline import CompilationPipeline
+    from orionbelt.models.query import QueryObject, QuerySelect
+    from orionbelt.parser.loader import TrackedLoader
+    from orionbelt.parser.resolver import ReferenceResolver
+
+    ch_setup.command("DROP TABLE IF EXISTS bool_measure")
+    ch_setup.command("CREATE TABLE bool_measure (flag Bool, note String) ENGINE=Memory")
+    ch_setup.command("INSERT INTO bool_measure VALUES (true, 'true'), (false, 'nope')")
+
+    model_yaml = """version: 1.0
+dataObjects:
+  bool_measure:
+    code: bool_measure
+    columns:
+      Flag: {code: flag, abstractType: boolean}
+      Note: {code: note, abstractType: string}
+measures:
+  MaxFlag:
+    columns: [{dataObject: bool_measure, column: Flag}]
+    resultType: float
+    dataType: "decimal(18, 2)"
+    aggregation: max
+  SumFlag:
+    columns: [{dataObject: bool_measure, column: Flag}]
+    resultType: float
+    dataType: "decimal(18, 2)"
+    aggregation: sum
+  MaxNote:
+    columns: [{dataObject: bool_measure, column: Note}]
+    resultType: float
+    dataType: "decimal(18, 2)"
+    aggregation: max
+  ExprFlag:
+    expression: "{[bool_measure].[Flag]}"
+    resultType: float
+    dataType: "decimal(18, 2)"
+    aggregation: max
+"""
+    path = Path(mkdtemp()) / "m.yaml"
+    path.write_text(model_yaml)
+    raw, source_map = TrackedLoader().load(path)
+    model, result = ReferenceResolver().resolve(raw, source_map)
+    assert result.valid, result.errors
+    pipeline = CompilationPipeline()
+
+    def run(measure: str):
+        sql = pipeline.compile(
+            QueryObject(select=QuerySelect(measures=[measure])), model, "clickhouse"
+        ).sql
+        return ch_setup.query(sql).result_rows[0][0]
+
+    assert run("MaxFlag") == Decimal("1.00")
+    assert run("SumFlag") == Decimal("1.00")
+    # The same measure written as an expression rather than a column list.
+    # Two spellings of one thing, and the rule has to reach both.
+    assert run("ExprFlag") == Decimal("1.00")
+
+    # The string column is left alone. Reinterpreting the words a flag prints
+    # would have turned this 'true' into 1.00 -- a number nobody wrote.
+    with pytest.raises(Exception, match="(?i)cannot parse|exception"):
+        run("MaxNote")
+
+    ch_setup.command("DROP TABLE bool_measure")

--- a/tests/unit/test_boolean_measure_source.py
+++ b/tests/unit/test_boolean_measure_source.py
@@ -26,6 +26,11 @@ dataObjects:
     code: ev
     columns:
       Flag: {code: flag, abstractType: boolean}
+      Amt:  {code: amt, abstractType: float, numClass: additive}
+      Guarded:
+        expression: "CASE WHEN {Flag} THEN {Amt} ELSE 0 END"
+        abstractType: float
+        numClass: additive
 measures:
   MaxPass:    {columns: [{dataObject: ev, column: Flag}], resultType: string, aggregation: max}
   AnyPass:
@@ -49,6 +54,14 @@ measures:
     resultType: float
     dataType: "decimal(18, 2)"
     aggregation: max
+  CaseSum:
+    expression: "CASE WHEN {[ev].[Flag]} THEN {[ev].[Amt]} ELSE 0 END"
+    resultType: float
+    aggregation: sum
+  ComputedSum:
+    columns: [{dataObject: ev, column: Guarded}]
+    resultType: float
+    aggregation: sum
 """
 
 DIALECTS = ("duckdb", "clickhouse", "postgres", "bigquery", "mysql", "snowflake")
@@ -100,3 +113,21 @@ def test_a_numeric_measure_reads_the_flag_as_a_number(model, measure: str, diale
     # around the aggregate -- the boolean arriving inside it uncast is exactly
     # the bug. The inner one is what this is about.
     assert _projection(model, measure, dialect).count("CAST(") >= 2
+
+
+@pytest.mark.parametrize("dialect", DIALECTS)
+@pytest.mark.parametrize("measure", ["CaseSum", "ComputedSum"])
+def test_a_boolean_used_as_a_predicate_is_left_alone(model, measure: str, dialect: str) -> None:
+    """A predicate is not read as a number, and casting it breaks the query.
+
+    Both of these have a numeric output, so the measure *is* read as a number
+    -- but the boolean inside it is a condition, not the value. Rewriting every
+    reference produced ``CASE WHEN CAST(flag AS INTEGER)``, which PostgreSQL
+    refuses ("argument of CASE/WHEN must be type boolean") and BigQuery with
+    it, while DuckDB accepted it and answered the same number. ``ComputedSum``
+    reaches the same reference through a computed column's body, so a measure
+    could break without naming a boolean at all.
+    """
+    projection = _projection(model, measure, dialect)
+    assert "WHEN CAST(" not in projection, projection
+    assert "CASE WHEN" in projection, projection

--- a/tests/unit/test_boolean_measure_source.py
+++ b/tests/unit/test_boolean_measure_source.py
@@ -1,0 +1,102 @@
+"""A boolean measure source becomes a number only where one is read.
+
+ClickHouse carries a type through MIN/MAX/any and its decimal conversion reads
+the value as text, so ``MAX(flag)`` declared decimal arrived as 'true' and
+raised. The cast that fixes it has to stop at the measures whose output is a
+number: applied to every boolean source it changed what a *pass-through*
+measure returns on every dialect, which is a public semantic, not a ClickHouse
+detail.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from orionbelt.compiler.pipeline import CompilationPipeline
+from orionbelt.models.query import QueryObject, QuerySelect
+from orionbelt.parser.loader import TrackedLoader
+from orionbelt.parser.resolver import ReferenceResolver
+
+MODEL_YAML = """version: 1.0
+dataObjects:
+  ev:
+    code: ev
+    columns:
+      Flag: {code: flag, abstractType: boolean}
+measures:
+  MaxPass:    {columns: [{dataObject: ev, column: Flag}], resultType: string, aggregation: max}
+  AnyPass:
+    columns: [{dataObject: ev, column: Flag}]
+    resultType: string
+    aggregation: any_value
+  ListPass:   {columns: [{dataObject: ev, column: Flag}], resultType: string, aggregation: listagg}
+  MinPass:    {columns: [{dataObject: ev, column: Flag}], resultType: string, aggregation: min}
+  MaxDecimal:
+    columns: [{dataObject: ev, column: Flag}]
+    resultType: float
+    dataType: "decimal(18, 2)"
+    aggregation: max
+  SumFlag:    {columns: [{dataObject: ev, column: Flag}], resultType: float, aggregation: sum}
+  ExprPass:
+    expression: "{[ev].[Flag]}"
+    resultType: string
+    aggregation: max
+  ExprDecimal:
+    expression: "{[ev].[Flag]}"
+    resultType: float
+    dataType: "decimal(18, 2)"
+    aggregation: max
+"""
+
+DIALECTS = ("duckdb", "clickhouse", "postgres", "bigquery", "mysql", "snowflake")
+
+
+@pytest.fixture(scope="module")
+def model():
+    path = Path(tempfile.mkdtemp()) / "m.yaml"
+    path.write_text(MODEL_YAML)
+    raw, source_map = TrackedLoader().load(path)
+    resolved, result = ReferenceResolver().resolve(raw, source_map)
+    assert result.valid, result.errors
+    return resolved
+
+
+def _projection(model, measure: str, dialect: str) -> str:
+    sql = (
+        CompilationPipeline()
+        .compile(QueryObject(select=QuerySelect(measures=[measure])), model, dialect)
+        .sql
+    )
+    return sql.split("FROM")[0]
+
+
+@pytest.mark.parametrize("dialect", DIALECTS)
+@pytest.mark.parametrize("measure", ["MaxPass", "AnyPass", "ListPass", "MinPass", "ExprPass"])
+def test_a_pass_through_measure_keeps_its_boolean(model, measure: str, dialect: str) -> None:
+    """No cast is emitted for these, so there is nothing for a number to serve.
+
+    Casting them anyway changed the answer rather than its type: measured on
+    DuckDB, ``MAX(flag)`` came back 1 rather than true and ``LISTAGG(flag)``
+    read '1,0' rather than 'true,false'.
+    """
+    assert "CAST(" not in _projection(model, measure, dialect)
+
+
+@pytest.mark.parametrize("dialect", DIALECTS)
+@pytest.mark.parametrize("measure", ["MaxDecimal", "SumFlag", "ExprDecimal"])
+def test_a_numeric_measure_reads_the_flag_as_a_number(model, measure: str, dialect: str) -> None:
+    """These do emit a cast, and a boolean cannot arrive at a numeric one.
+
+    ``ExprDecimal`` is the same measure as ``MaxDecimal`` written the other
+    way. They are two spellings of one thing and the rule has to reach both:
+    keyed on the ``columns:`` branch alone, the expression form went on
+    failing exactly as before.
+    """
+    # Two casts, not one. Checking merely that a cast is present passes on the
+    # broken rendering too, because the declared decimal emits one of its own
+    # around the aggregate -- the boolean arriving inside it uncast is exactly
+    # the bug. The inner one is what this is about.
+    assert _projection(model, measure, dialect).count("CAST(") >= 2

--- a/tests/unit/test_boolean_measure_source.py
+++ b/tests/unit/test_boolean_measure_source.py
@@ -31,6 +31,9 @@ dataObjects:
         expression: "CASE WHEN {Flag} THEN {Amt} ELSE 0 END"
         abstractType: float
         numClass: additive
+      Positive:
+        expression: "{Amt} > 0"
+        abstractType: boolean
 measures:
   MaxPass:    {columns: [{dataObject: ev, column: Flag}], resultType: string, aggregation: max}
   AnyPass:
@@ -60,6 +63,14 @@ measures:
     aggregation: sum
   ComputedSum:
     columns: [{dataObject: ev, column: Guarded}]
+    resultType: float
+    aggregation: sum
+  PositiveSum:
+    columns: [{dataObject: ev, column: Positive}]
+    resultType: float
+    aggregation: sum
+  PositiveExpr:
+    expression: "{[ev].[Positive]}"
     resultType: float
     aggregation: sum
 """
@@ -131,3 +142,25 @@ def test_a_boolean_used_as_a_predicate_is_left_alone(model, measure: str, dialec
     projection = _projection(model, measure, dialect)
     assert "WHEN CAST(" not in projection, projection
     assert "CASE WHEN" in projection, projection
+
+
+@pytest.mark.parametrize("measure", ["PositiveSum", "PositiveExpr"])
+def test_a_computed_boolean_column_is_a_known_gap(model, measure: str) -> None:
+    """Recorded rather than fixed, and older than this rule.
+
+    ``{expression: "{Amt} > 0", abstractType: boolean}`` inlines to the
+    comparison, which carries no declared type, so the source cannot be
+    recognised as boolean and the measure emits ``SUM("ev"."amt" > 0)``.
+    PostgreSQL rejects that -- its ``sum`` has no boolean overload -- and
+    BigQuery with it.
+
+    ``main`` emits the same SQL for the same model, in both measure spellings,
+    so this rule leaves the gap exactly where it found it while fixing the
+    bare-column case beside it. Closing it means carrying a declared type onto
+    an inlined body. Pinned here so it cannot change unnoticed, and so the
+    limitation is findable from the rule that does not cover it.
+    """
+    projection = _projection(model, measure, "postgres")
+    assert "CAST(" in projection  # the declared numeric output, not the source
+    assert '"ev"."amt" > 0' in projection, projection
+    assert 'CAST("ev"."amt" > 0' not in projection, projection


### PR DESCRIPTION
## What

A measure whose output is a number now reads a boolean source column as a number, on all eight dialects. Split out of #394, which is why it exists and where it is needed.

## Why it is separate, and why it merges first

An engine that carries a type through an aggregate hands a **boolean** to whatever the measure declares. Only this layer knows the column is boolean, so the cast belongs here rather than in a dialect.

**No engine needs this today**, and that is worth being explicit about. Measured on ClickHouse against `main`:

```
SQL   : CAST(round(MAX("t"."flag"), 2) AS Nullable(Decimal(18, 2)))
result: 1.00
```

It becomes necessary the moment a dialect reads a measure's value as *text* rather than handing it to the engine's own conversion. That is what #394's decimal rewrite does, and it is why that rewrite turned `MAX(flag)` into a parse error on ClickHouse. So this is a preparatory change: **it merges first, and #394 rebases on top.** Merging #394 without it reintroduces that regression.

It was found and fixed inside #394 across three review rounds, and it does not belong there: it changes shared compiler behaviour on every dialect, and it rode into a PR titled for one.

## The scope is the point

Applied to every boolean source, this changes what a **pass-through** measure returns. Measured on DuckDB:

| Measure | Unscoped | Scoped (this PR) |
|---|---|---|
| `MAX(flag)`, no declared type | `1` (INTEGER) | `True` (BOOLEAN) |
| `ANY_VALUE(flag)` | `1` | `True` |
| `LISTAGG(flag)` | `'1,0'` | `'true,false'` |
| `MIN(flag)` | `0` | `False` |
| `MAX(flag)` declared `decimal(18, 2)` | `1.00` | `1.00` |
| `SUM(flag)` | `1.00` | `1.00` |

Those pass-through measures emit no cast at all -- `resolve_measure_data_type` returns `None` for them -- so a boolean has nothing to arrive at and nothing to be protected from.

## Both spellings of a measure

`columns:` and `expression:` are two ways to write one measure. The rule keys on the type the column reference already carries, which both paths populate, so `expression: "{[ev].[Flag]}"` behaves the same as its own column form. Keyed on the `columns:` branch alone, it did not.

## Test plan

- `tests/unit/test_boolean_measure_source.py`: 48 cases over six dialects and both measure spellings, asserting a pass-through projection carries **no** cast and a numeric one carries **two** -- the declared cast plus the source cast. **18 fail without the change.**

  Counting matters: asserting merely that a cast is *present* passes on the broken rendering, because the declared decimal emits one of its own around the aggregate. The boolean arriving uncast *inside* it is the bug.
- A live ClickHouse case in `test_clickhouse_execution.py`, documented as passing either way on today's rendering, since the guard that bites is the emitted SQL.
- `uv run pytest`: 4928 passed
- Live matrix, `vendor_exec` plus ClickHouse: 671 passed, 1 skipped. This touches shared resolution, so all seven live engines are the check that matters
- No compile-snapshot churn
- `ruff`, `mypy` clean