### PR TITLE
chore(probe): measure all eight engines, BigQuery's aggregate included

### DIFF
--- a/scripts/probe_types.py
+++ b/scripts/probe_types.py
@@ -23,6 +23,33 @@ Usage::
     uv run python scripts/probe_types.py postgres snowflake
     uv run python scripts/probe_types.py all             # every reachable engine
 
+All eight engines can be measured on a laptop. Six read their credentials from
+``.env``; the two that do not have containers, and a matrix missing them is an
+incomplete matrix rather than a fact about the world - MySQL is the only engine
+that loses ``boolean``, and nobody saw that while it sat out.
+
+MySQL, on the image the tests pin::
+
+    docker run -d --name probe-mysql -p 13306:3306 \
+      -e MYSQL_ROOT_PASSWORD=probe -e MYSQL_DATABASE=probe mysql:8.0
+    # ready in ~30s: docker exec probe-mysql mysqladmin ping -uroot -pprobe
+    MYSQL_HOST=127.0.0.1 MYSQL_PORT=13306 MYSQL_DATABASE=probe \
+    MYSQL_USER=root MYSQL_PASSWORD=probe \
+    uv run python scripts/probe_types.py mysql
+
+Dremio, from the demo stack in ``demo/dremio``. ``run-demo.sh`` builds images and
+promotes datasets; a probe needs neither, only the engine and its admin user::
+
+    docker compose -f demo/dremio/docker-compose.yml up -d dremio   # ~20s
+    curl -s -X PUT http://localhost:19047/apiv2/bootstrap/firstuser \
+      -H 'Content-Type: application/json' -H 'Authorization: _dremionull' \
+      -d '{"userName":"obsl_admin","firstName":"OBSL","lastName":"Demo",
+           "email":"obsl@example.invalid","createdAt":1756800000000,
+           "password":"obsl_admin_pw_123!"}'
+    DREMIO_HOST=localhost DREMIO_PORT=32010 DREMIO_USERNAME=obsl_admin \
+    DREMIO_PASSWORD='obsl_admin_pw_123!' \
+    uv run python scripts/probe_types.py dremio
+
 Each row prints a verdict, the Arrow type and the round-tripped value:
 
 * ``EXACT``   -- the declared type came back unchanged.
@@ -75,12 +102,16 @@ EXPECTED: dict[str, pa.DataType] = {
 }
 
 #: Engines whose ``SELECT`` needs a FROM clause for a bare scalar expression.
+#: Engines that will not select from nothing. BigQuery takes a bare constant but
+#: refuses to aggregate one - "Aggregate function SUM not allowed in SELECT
+#: without FROM clause" - and the aggregate cases are the ones worth measuring,
+#: since an aggregate is where an engine decides a result precision. So it gets
+#: a row source rather than losing those cases: skipping them printed nothing at
+#: all, which reads as a missing row rather than a case that was never run.
 FROM_SUFFIX: dict[str, str] = {
     "dremio": " FROM (VALUES (1))",
+    "bigquery": " FROM (SELECT 1)",
 }
-
-#: Engines that reject an aggregate over a constant with no FROM clause.
-NO_BARE_AGGREGATE = frozenset({"bigquery"})
 
 ENGINES = (
     "duckdb",
@@ -155,8 +186,6 @@ def render(engine: str) -> list[tuple[str, str, str]]:
     dialect = DialectRegistry.get(engine)
     out: list[tuple[str, str, str]] = []
     for label, literal, obml_type, aggregate in CASES:
-        if aggregate and engine in NO_BARE_AGGREGATE:
-            continue
         expr: Any = dialect.cast_to_obml_type(RawSQL(sql=literal), parse_data_type(obml_type))
         if aggregate:
             expr = FunctionCall(name="SUM", args=[expr])


### PR DESCRIPTION
`scripts/probe_types.py` measured six engines and shrugged at two. Both were one container away, and the gaps they hid are real.

## Two engines were sitting out

Neither MySQL nor Dremio has credentials in `.env`, so the drivers fell back to `localhost:3306` and to nothing, and both read as unreachable. The recipes now live in the module docstring rather than in whoever ran it last.

MySQL runs on the image the tests already pin. Dremio comes from the demo stack in `demo/dremio`, and a probe needs only its engine and an admin user - not the full `run-demo.sh`, which builds images and promotes datasets.

What they were hiding:

| Engine | Finding |
| --- | --- |
| MySQL | **no boolean type, so a declared `boolean` arrives as `int64` 1** - the only LOSSY boolean of the eight |
| MySQL | every decimal widens to `decimal256(76, s)`, values exact; `integer` comes back `int64` |
| Dremio | otherwise clean, but `date` is `date64[ms]` where the other seven give `date32[day]` |

## BigQuery's aggregate was skipped, not measured

`NO_BARE_AGGREGATE` existed for a real reason - BigQuery answers `400 Aggregate function SUM not allowed in SELECT without FROM clause` - but the probe already solves that for Dremio with `FROM_SUFFIX`, so BigQuery gets `FROM (SELECT 1)` and the set goes away.

The aggregate cases are the ones most worth measuring, since an aggregate is where an engine decides a result precision. And a skipped case printed nothing at all, so a reader could not tell it from a missing row. BigQuery's SUM now reports `decimal128(38, 9)`, the same widening its other decimal cases show.

## Verified

Ran the probe on `bigquery` (all 11 cases, SUM included), `duckdb`, `mysql` and `dremio` from the containers above. `ruff check` and `ruff format` clean.