### PR TITLE
fix(clickhouse): a declared timestamp is a wall clock, and the SQL says so

### DIFF
--- a/drivers/ob-flight-extension/src/ob_flight/server_execution.py
+++ b/drivers/ob-flight-extension/src/ob_flight/server_execution.py
@@ -12,6 +12,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 import pyarrow as pa
+import pyarrow.compute as pc
 import pyarrow.flight as flight
 
 from ob_driver_core.detection import is_obml, parse_obml  # type: ignore[import-untyped]
@@ -682,10 +683,44 @@ def align_cached_table(table: pa.Table, schema: pa.Schema | None) -> pa.Table:
             # Column set/order differs from the advertised schema — don't risk
             # a positional cast onto the wrong columns.
             return table
-        return table.cast(schema)
+        return _wall_clock_where_naive(table, schema).cast(schema)
     except Exception:
         logger.debug("cache hit schema align failed; streaming raw", exc_info=True)
         return table
+
+
+def _wall_clock_where_naive(table: pa.Table, schema: pa.Schema) -> pa.Table:
+    """Read a zoned column as the wall clock, where the model asked for one.
+
+    Arrow casts a zoned timestamp to a naive one by converting to UTC, which is
+    the right answer for an instant and the wrong one for a wall clock. OBML
+    declares both and the difference is the whole point of the pair:
+    ``timestamp`` is a wall clock, ``timestamp_tz`` is an instant. So a column
+    arriving zoned under a *naive* declaration is reinterpreted here first, and
+    a ``timestamp_tz`` target is left exactly as it was.
+
+    ClickHouse is the engine that reaches this: it has no zone-free DateTime, so
+    a ``DateTime64(3)`` resolves against the server's timezone and arrives as
+    ``timestamp[ms, tz=Europe/Berlin]``. Measured on a Berlin server, a declared
+    13:45 streamed as 11:45 - the cast doing exactly what it promises to an
+    instant. ``local_timestamp`` reads the offset *at each value* rather than
+    once, so the same column crossing a DST boundary keeps 13:45 on both sides
+    of it, which a fixed offset could not.
+
+    The guard is not ClickHouse-specific on purpose: it is stated in terms of
+    the two Arrow types, so any engine that answers zoned where the model
+    declared naive is read the same way.
+    """
+    for i, field in enumerate(schema):
+        source = table.column(i).type
+        if (
+            pa.types.is_timestamp(source)
+            and source.tz is not None
+            and pa.types.is_timestamp(field.type)
+            and field.type.tz is None
+        ):
+            table = table.set_column(i, field.name, pc.local_timestamp(table.column(i)))
+    return table
 
 
 def execute_sql(

--- a/src/orionbelt/dialect/clickhouse.py
+++ b/src/orionbelt/dialect/clickhouse.py
@@ -180,6 +180,10 @@ _NUMERIC_ABSTRACT_TYPES: frozenset[str] = frozenset({"int", "float"})
 #: rather than ``CAST`` because ``CAST`` saturates on overflow (#356).
 _INT_TYPE_RE = re.compile(r"^\s*U?Int(?:8|16|32|64|128|256)\s*$", re.IGNORECASE)
 
+#: A naive-timestamp cast target, which this dialect renders as a UTC-labelled
+#: ``DateTime64``. ``timestamp_tz`` is not one: there the zone is the meaning.
+_NAIVE_TIMESTAMP_RE = re.compile(r"DateTime64\(\s*3\s*,\s*'UTC'\s*\)", re.IGNORECASE)
+
 #: A decimal cast target's width. Case-insensitive, and both spellings the
 #: engine takes: ``Decimal(P, S)`` names its own precision, while the fixed
 #: ``Decimal32/64/128/256(S)`` carry theirs in the name.
@@ -221,7 +225,13 @@ class ClickHouseDialect(Dialect):
         "integer": "Int32",
         "double": "Float64",
         "date": "Date",
-        "timestamp": "DateTime64(3)",
+        # Pinned to UTC, and read through :meth:`_wall_clock_timestamp` on the
+        # way in. A bare ``DateTime64(3)`` resolves against whatever timezone
+        # the *server* is configured with, so the same model on two deployments
+        # rendered one stored instant as two different wall clocks - and OBML's
+        # ``timestamp`` is a wall clock. The zone here is a label the conversion
+        # has already made true.
+        "timestamp": "DateTime64(3, 'UTC')",
         "time": "String",
         "string": "String",
         "boolean": "Bool",
@@ -463,6 +473,8 @@ class ClickHouseDialect(Dialect):
         # pre-round needs the target's own scale, and no other branch below
         # claims a decimal.
         is_null_literal = isinstance(inner, Literal) and inner.value is None
+        if not is_null_literal and _NAIVE_TIMESTAMP_RE.search(resolved_type):
+            inner_sql = self._wall_clock_timestamp(inner_sql)
         width = None if is_null_literal else _decimal_width(resolved_type)
         if width is not None and source_exact:
             # No float can reach this cast, so the text route has nothing to
@@ -686,6 +698,31 @@ class ClickHouseDialect(Dialect):
             f"ifNull(CAST({rounded} AS Nullable(Decimal256({scale}))), "
             f"{to_decimal}(toString({inner_sql}), {scale}))"
         )
+
+    def _wall_clock_timestamp(self, inner_sql: str) -> str:
+        """Read *inner_sql* as the wall clock it shows, labelled UTC.
+
+        OBML has two timestamp types and the difference is the whole point of
+        the pair: ``timestamp`` is a wall clock, ``timestamp_tz`` is an instant.
+        ClickHouse has no wall clock. Its ``DateTime`` is an instant that
+        *renders* against the server's timezone, so a declared ``timestamp``
+        came back as ``timestamp[ms, tz=Europe/Berlin]`` on one deployment and
+        as UTC on another, from the same stored data.
+
+        Converting through the value's own text is what fixes it, for the reason
+        the decimal round converts through text too: ``toString`` renders the
+        wall clock the engine shows, and reading that back as UTC keeps the
+        digits while making the zone a label rather than a property of the
+        server. Measured, 13:45 stays 13:45 in August and in January, where
+        casting to ``DateTime64(3, 'UTC')`` instead answers 11:45 and 12:45 -
+        that cast preserves the instant, which is the *other* type's promise.
+
+        In the SQL rather than in the result, because the compiled statement is
+        the single point of truth: someone who runs it themselves has to get
+        what OBSL would have returned. Measured on 20M rows grouped by the
+        column, 2.14s to 2.59s.
+        """
+        return f"toDateTime64(toString({inner_sql}), 3, 'UTC')"
 
     def _coerce_text_argument(self, expr: Expr) -> Expr:
         """Read a ``FixedString`` by value rather than by storage.

--- a/tests/integration/test_clickhouse_execution.py
+++ b/tests/integration/test_clickhouse_execution.py
@@ -505,3 +505,53 @@ def test_an_exact_operand_rounds_without_the_text_route(ch_setup) -> None:
     rows = _fetch_clickhouse(ch_setup, f"SELECT {shortcut} AS a, {long_way} AS b FROM exact_sum")
     assert rows[0]["a"] == rows[0]["b"], rows[0]
     ch_setup.command("DROP TABLE exact_sum")
+
+
+@pytest.mark.parametrize("session_zone", ["Europe/Berlin", "America/New_York", "UTC"])
+def test_a_declared_timestamp_is_the_same_wall_clock_on_any_server(
+    ch_setup, session_zone: str
+) -> None:
+    """The server's timezone must not decide what a declared timestamp says.
+
+    ClickHouse's DateTime is an instant that renders against the server's own
+    zone, so before this the same stored value answered 13:45 on a Berlin
+    deployment and 07:45 on a New York one. The conversion reads the wall clock
+    as text and labels it UTC, which is a label the reading has made true.
+
+    ``session_timezone`` stands in for the server setting, so the case is
+    reachable from a container that runs UTC.
+    """
+    from orionbelt.ast.nodes import RawSQL
+    from orionbelt.dialect.registry import DialectRegistry
+    from orionbelt.models.types import parse_data_type
+
+    dialect = DialectRegistry.get("clickhouse")
+    stored = RawSQL(sql="CAST('2026-08-15 13:45:00' AS DateTime64(3))")
+    sql = dialect.compile_expr(dialect.cast_to_obml_type(stored, parse_data_type("timestamp")))
+    # Read back in UTC, which is what makes the assertion say anything: a
+    # plain toString renders in the session zone, so the old rendering and this
+    # one would print the same text for different instants.
+    rows = _fetch_clickhouse(
+        ch_setup,
+        f"SELECT toString(toTimeZone({sql}, 'UTC')) AS v "
+        f"SETTINGS session_timezone = '{session_zone}'",
+    )
+    assert rows[0]["v"] == "2026-08-15 13:45:00.000"
+
+
+def test_the_wall_clock_survives_a_dst_boundary(ch_setup) -> None:
+    """The offset differs by season, so nothing here may apply one."""
+    from orionbelt.ast.nodes import RawSQL
+    from orionbelt.dialect.registry import DialectRegistry
+    from orionbelt.models.types import parse_data_type
+
+    dialect = DialectRegistry.get("clickhouse")
+    for stamp in ("2026-08-15 13:45:00", "2026-01-15 13:45:00"):
+        stored = RawSQL(sql=f"CAST('{stamp}' AS DateTime64(3))")
+        sql = dialect.compile_expr(dialect.cast_to_obml_type(stored, parse_data_type("timestamp")))
+        rows = _fetch_clickhouse(
+            ch_setup,
+            f"SELECT toString(toTimeZone({sql}, 'UTC')) AS v "
+            f"SETTINGS session_timezone = 'Europe/Berlin'",
+        )
+        assert rows[0]["v"] == f"{stamp}.000", stamp

--- a/tests/unit/test_clickhouse_wall_clock.py
+++ b/tests/unit/test_clickhouse_wall_clock.py
@@ -1,0 +1,68 @@
+"""A declared ``timestamp`` is a wall clock, and this engine has none.
+
+ClickHouse's ``DateTime`` is an instant that renders against the server's
+timezone, so the same stored data answered ``timestamp[ms, tz=Europe/Berlin]``
+on one deployment and UTC on another. OBML's two timestamp types are a wall
+clock and an instant, and the first has to survive the trip.
+
+The conversion is in the SQL rather than in the result, because the compiled
+statement is what a person can take away and run themselves.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from orionbelt.ast.nodes import Cast, ColumnRef, Literal
+from orionbelt.dialect.clickhouse import ClickHouseDialect
+from orionbelt.models.types import parse_data_type
+
+
+@pytest.fixture
+def dialect() -> ClickHouseDialect:
+    return ClickHouseDialect()
+
+
+def test_the_cast_reads_the_value_as_text(dialect: ClickHouseDialect) -> None:
+    """``toString`` renders the wall clock the engine shows; UTC labels it.
+
+    Casting to ``DateTime64(3, 'UTC')`` directly would preserve the *instant*
+    instead - measured, 13:45 on a Berlin server answers 11:45 that way, which
+    is what ``timestamp_tz`` promises and this type does not.
+    """
+    cast = dialect.cast_to_obml_type(ColumnRef(name="Stamp"), parse_data_type("timestamp"))
+    assert dialect.compile_expr(cast) == (
+        "CAST(toDateTime64(toString(\"Stamp\"), 3, 'UTC') AS Nullable(DateTime64(3, 'UTC')))"
+    )
+
+
+def test_the_declared_type_carries_the_zone(dialect: ClickHouseDialect) -> None:
+    """A bare ``DateTime64(3)`` would resolve against the server's timezone."""
+    assert dialect.render_obml_type(parse_data_type("timestamp")) == "DateTime64(3, 'UTC')"
+
+
+def test_a_null_pad_is_left_alone(dialect: ClickHouseDialect) -> None:
+    """Every CFL union leg carries one, and ``toString(NULL)`` types as binary.
+
+    The same exemption the decimal pre-round takes, for the same reason: there
+    is no wall clock in a NULL to preserve.
+    """
+    cast = dialect.cast_to_obml_type(Literal.null(), parse_data_type("timestamp"))
+    assert dialect.compile_expr(cast) == "CAST(NULL AS Nullable(DateTime64(3, 'UTC')))"
+
+
+def test_a_date_target_is_untouched(dialect: ClickHouseDialect) -> None:
+    """The rewrite is scoped to the type that has a wall clock to lose."""
+    cast = dialect.cast_to_obml_type(ColumnRef(name="Day"), parse_data_type("date"))
+    assert dialect.compile_expr(cast) == 'CAST("Day" AS Nullable(Date))'
+
+
+def test_a_concrete_datetime_target_is_untouched(dialect: ClickHouseDialect) -> None:
+    """A hand-built cast to the engine's own type says what it says.
+
+    The rewrite belongs to OBML's ``timestamp``, which this dialect renders with
+    the UTC label; a ``Cast`` naming ``DateTime64(3)`` is asking for the
+    server's rendering and gets it.
+    """
+    sql = dialect.compile_expr(Cast(expr=ColumnRef(name="Stamp"), type_name="DateTime64(3)"))
+    assert sql == 'CAST("Stamp" AS Nullable(DateTime64(3)))'

--- a/tests/unit/test_data_types.py
+++ b/tests/unit/test_data_types.py
@@ -215,12 +215,14 @@ class TestDialectRendering:
         ("dialect_name", "expected"),
         [
             ("bigquery", "DATETIME"),
-            # ClickHouse is the exception and cannot be fixed by naming a type:
-            # every DateTime64 carries a zone, defaulting to the server's. The
-            # wall clock is preserved, only the label is the server's; pinning
-            # one instead shifts the value, because relabelling a stored
-            # DateTime moves it (measured: 13:45 Berlin becomes 11:45 UTC).
-            ("clickhouse", "DateTime64(3)"),
+            # ClickHouse has no naive type - every DateTime64 carries a zone,
+            # defaulting to the server's - so naming one is not enough on its
+            # own: relabelling a stored DateTime moves it (measured, 13:45
+            # Berlin becomes 11:45 UTC). The label is honest here because
+            # ``_wall_clock_timestamp`` converts through the value's own text
+            # first, so what is labelled UTC is the wall clock the engine
+            # showed. Both halves are the fix; neither works alone.
+            ("clickhouse", "DateTime64(3, 'UTC')"),
             ("databricks", "TIMESTAMP_NTZ"),
             ("dremio", "TIMESTAMP"),
             ("duckdb", "TIMESTAMP"),


### PR DESCRIPTION
OBML has two timestamp types and the difference is the whole point of the pair: `timestamp` is a wall clock, `timestamp_tz` is an instant. ClickHouse has no wall clock - its `DateTime` is an instant that renders against the server's timezone - so one stored value answered `timestamp[ms, tz=Europe/Berlin]` on one deployment and UTC on another. Downstream that is not cosmetic: converting a zoned value to UTC, which is what an Arrow cast to a naive type does, moved 13:45 to 11:45.

## The fix, in the SQL

```sql
CAST(toDateTime64(toString(x), 3, 'UTC') AS Nullable(DateTime64(3, 'UTC')))
```

`toString` renders the wall clock the engine shows, and reading it back as UTC keeps the digits, so the zone becomes a label the reading has made true rather than a property of the server.

Measured under three server settings, one answer:

| `session_timezone` | before | after |
| --- | --- | --- |
| `Europe/Berlin` | 11:45 UTC | 13:45 UTC |
| `America/New_York` | 17:45 UTC | 13:45 UTC |
| `UTC` | 13:45 UTC | 13:45 UTC |

And across a DST boundary, where a single offset would be an hour out for half the year: 13:45 in August and 13:45 in January.

**Naming the type alone would not do it.** Casting a stored `DateTime` to `DateTime64(3, 'UTC')` preserves the *instant* and moves the clock - that is `timestamp_tz`'s promise, not this one. The conversion and the label are both needed; this PR updates the #395 rendering test, whose comment warned against the pin alone and was right about it.

## Why not in the result layer

An earlier revision of this PR fixed it in Flight's schema alignment with `pc.local_timestamp`. That works, and it is the wrong place: the compiled statement is the single point of truth, and someone who takes the SQL from `/query/sql` and runs it themselves has to get what OBSL would have returned. No layer after execution repairs this now.

Measured cost, 20M rows grouped by the column: 2.14s to 2.59s.

A NULL pad keeps the plain cast, the same exemption the decimal pre-round takes, since `toString(NULL)` types as binary and every CFL union leg carries one.

## Tests

- 5 unit tests on the rendering (`tests/unit/test_clickhouse_wall_clock.py`), 3 of which fail on `main`
- 4 live ClickHouse tests: the three `session_timezone` settings above and the DST pair, 3 of which fail on `main`
- the #395 type-rendering test updated, with the reasoning that keeps a future reader from reverting it
- full suite green; TPC-DS and compile-only snapshots re-dump byte identical (the corpus has no declared timestamp cast)