### PR TITLE
fix(arrow): stable integer widths on Snowflake, and the wall clock a naive timestamp declares

### DIFF
--- a/drivers/ob-flight-extension/src/ob_flight/converters.py
+++ b/drivers/ob-flight-extension/src/ob_flight/converters.py
@@ -116,6 +116,26 @@ def _decimal_column_type(col: tuple[Any, ...], sampled: list[Any]) -> pa.DataTyp
     return decimal_arrow_type(int_digits + scale, scale)
 
 
+def _zone_of(value: datetime.datetime) -> str:
+    """The zone an aware value carries, as Arrow spells one.
+
+    Preferring the IANA key matters rather than being tidy: a fixed offset read
+    off one sample labels the whole column, and a column spanning a DST change
+    holds rows at two offsets. ``Europe/Berlin`` answers each row's own offset;
+    ``+02:00`` would answer August's for January's rows. Drivers that resolve a
+    zone hand back a ``ZoneInfo`` and take the first branch; only a driver that
+    reports a bare offset reaches the second, where one offset is all there is
+    to know.
+    """
+    key = getattr(value.tzinfo, "key", None)
+    if isinstance(key, str) and key:
+        return key
+    offset = value.utcoffset() or datetime.timedelta(0)
+    minutes = int(offset.total_seconds() // 60)
+    sign = "-" if minutes < 0 else "+"
+    return f"{sign}{abs(minutes) // 60:02d}:{abs(minutes) % 60:02d}"
+
+
 def _python_type_to_arrow(value: Any) -> pa.DataType:
     """Infer Arrow type from a Python value (fallback when type codes are unreliable)."""
     if isinstance(value, bool):
@@ -127,7 +147,7 @@ def _python_type_to_arrow(value: Any) -> pa.DataType:
     if isinstance(value, Decimal):
         return decimal_arrow_type(*_decimal_precision_scale(value))
     if isinstance(value, datetime.datetime):
-        return pa.timestamp("us")
+        return pa.timestamp("us", tz=_zone_of(value)) if value.tzinfo else pa.timestamp("us")
     if isinstance(value, datetime.date):
         return pa.date32()
     if isinstance(value, datetime.time):

--- a/drivers/ob-flight-extension/src/ob_flight/server.py
+++ b/drivers/ob-flight-extension/src/ob_flight/server.py
@@ -247,7 +247,7 @@ class OBFlightServer(flight.FlightServerBase):  # type: ignore[misc]
     def _reject_write_operation(sql: str) -> None:
         server_execution.reject_write_operation(sql)
 
-    def _compile_obml(self, obml: dict[str, Any], model: Any, dialect: str) -> Any:
+    def _compile_obml(self, obml: dict[str, Any], model: Any, dialect: str) -> tuple[Any, Any]:
         return server_execution.compile_obml(self, obml, model, dialect)
 
     def _execute_sql(

--- a/drivers/ob-flight-extension/src/ob_flight/server_execution.py
+++ b/drivers/ob-flight-extension/src/ob_flight/server_execution.py
@@ -383,6 +383,36 @@ def _numeric_result_arrow_type(item: Any, model: Any) -> pa.DataType | None:
     return decimal_arrow_type(precision, scale, exact=True)
 
 
+def _dimension_label_and_declaration(entry: Any, model: Any) -> tuple[str | None, Any]:
+    """The column a selected dimension produces, and the model's declaration of it.
+
+    Both have to be read the way the compiler reads them, or the advertised
+    schema names columns the stream does not have:
+
+    * ``"At:day"`` is a grain request. The compiler resolves it through
+      :meth:`DimensionRef.parse` and projects ``AS "At"``, so the entry is
+      neither the label nor the lookup key - taking it for both advertised
+      ``At:day`` as a string beside a stream carrying a timestamp called ``At``.
+    * a coalesce entry names its output in ``as`` and its inputs in
+      ``coalesce``. The alias is the label, and the type is its members', which
+      the model requires to agree; looking the alias up in ``model.dimensions``
+      finds nothing and called a timestamp a string.
+    """
+    from orionbelt.models.query import DimensionRef
+
+    if isinstance(entry, str):
+        name = DimensionRef.parse(entry).name
+        return name, model.dimensions.get(name)
+    label = getattr(entry, "alias", None)
+    if label is None:
+        return None, None
+    for member in getattr(entry, "coalesce", None) or []:
+        declared = model.dimensions.get(member)
+        if declared is not None:
+            return label, declared
+    return label, None
+
+
 def semantic_result_schema(server: OBFlightServer, query: Any, model: Any) -> pa.Schema:
     """Build the result Arrow schema for a semantic query without DB I/O.
 
@@ -395,11 +425,10 @@ def semantic_result_schema(server: OBFlightServer, query: Any, model: Any) -> pa
     fields: list[pa.Field] = []
     dims = getattr(query.select, "dimensions", [])
     measures = getattr(query.select, "measures", [])
-    for name in dims:
-        label = name if isinstance(name, str) else getattr(name, "alias", None)
+    for entry in dims:
+        label, dim = _dimension_label_and_declaration(entry, model)
         if label is None:
             continue
-        dim = model.dimensions.get(label)
         rt = getattr(getattr(dim, "result_type", None), "value", None) or "string"
         fields.append(pa.field(label, _obml_type_to_arrow(rt)))
     for label in measures:
@@ -416,8 +445,8 @@ def semantic_result_schema(server: OBFlightServer, query: Any, model: Any) -> pa
     if query.grouping is not None:
         # GROUPING() flag columns — int64, one per dimension. See
         # PLAN_with_rollup.md §"Output: GROUPING() flag columns".
-        for name in dims:
-            label = name if isinstance(name, str) else getattr(name, "alias", None)
+        for entry in dims:
+            label, _ = _dimension_label_and_declaration(entry, model)
             if label is None:
                 continue
             fields.append(pa.field(f"_g_{label}", pa.int64()))

--- a/drivers/ob-flight-extension/src/ob_flight/server_execution.py
+++ b/drivers/ob-flight-extension/src/ob_flight/server_execution.py
@@ -12,6 +12,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 import pyarrow as pa
+import pyarrow.compute as pc
 import pyarrow.flight as flight
 
 from ob_driver_core.detection import is_obml, parse_obml  # type: ignore[import-untyped]
@@ -682,10 +683,51 @@ def align_cached_table(table: pa.Table, schema: pa.Schema | None) -> pa.Table:
             # Column set/order differs from the advertised schema — don't risk
             # a positional cast onto the wrong columns.
             return table
-        return table.cast(schema)
+        return _wall_clock_where_naive(table, schema).cast(schema)
     except Exception:
         logger.debug("cache hit schema align failed; streaming raw", exc_info=True)
         return table
+
+
+def _wall_clock_where_naive(table: pa.Table, schema: pa.Schema) -> pa.Table:
+    """Read a zoned column as the wall clock, where the model asked for one.
+
+    OBML declares two timestamp types and the difference is the whole point of
+    the pair: ``timestamp`` is a wall clock, ``timestamp_tz`` is an instant.
+    Arrow reconciles a zoned column with a naive declaration by converting to
+    UTC, which answers the second question when the first was asked - measured
+    on a ClickHouse server set to Europe/Berlin, a declared 13:45 streamed as
+    11:45.
+
+    ClickHouse is the engine that reaches this, because it has no zone-free
+    ``DateTime``: the type is an instant that renders against the server's
+    timezone. Its own SQL answers ``13:45+02:00``, so 13:45 is the clock the
+    statement shows and the one a naive column has to carry.
+
+    Advertising the zone instead was measured and rejected: it makes what a BI
+    tool displays depend on the tool's session timezone (13:45 in Berlin, 07:45
+    in New York) for a value that has no instant to convert, and it leaves this
+    engine alone among the eight in answering a zoned column where the other
+    seven answer naive.
+
+    ``local_timestamp`` reads the offset *at each value* rather than once, so a
+    column crossing a DST boundary keeps 13:45 on both sides of it - a single
+    offset would be an hour out for half the year.
+
+    Stated in terms of the two Arrow types, not the engine: anything answering
+    zoned where the model declared naive is read the same way, and a
+    ``timestamp_tz`` target is left exactly as it was.
+    """
+    for i, field in enumerate(schema):
+        source = table.column(i).type
+        if (
+            pa.types.is_timestamp(source)
+            and source.tz is not None
+            and pa.types.is_timestamp(field.type)
+            and field.type.tz is None
+        ):
+            table = table.set_column(i, field.name, pc.local_timestamp(table.column(i)))
+    return table
 
 
 def execute_sql(

--- a/drivers/ob-flight-extension/src/ob_flight/server_execution.py
+++ b/drivers/ob-flight-extension/src/ob_flight/server_execution.py
@@ -477,7 +477,7 @@ def prepare_sql(
     if is_obml(sql):
         obml = parse_obml(sql)
         logger.info("OBML request:\n%s", sql)
-        compiled = server._compile_obml(obml, model, dialect)
+        query, compiled = server._compile_obml(obml, model, dialect)
         sql = server._rewrite_table_names(compiled.sql, model)
         logger.info("Compiled SQL:\n%s", sql)
         # OBML compiles to deterministic SQL like OBSQL; share the cache.
@@ -487,7 +487,11 @@ def prepare_sql(
             context=context,
             physical_tables=list(getattr(compiled, "physical_tables", [])),
         )
-        return sql, dialect, model, None, _MODE_SEMANTIC, cache_meta
+        # And the same declared schema. Without it the OBML path fell back to
+        # probing the rows, so a model-declared ``timestamp`` streamed with
+        # whatever zone the engine attached rather than as the wall clock.
+        schema_hint = server._semantic_result_schema(query, model)
+        return sql, dialect, model, schema_hint, _MODE_SEMANTIC, cache_meta
 
     mode = server._classify_sql(sql, model)
 
@@ -644,18 +648,24 @@ def reject_write_operation(sql: str) -> None:
     )
 
 
-def compile_obml(server: OBFlightServer, obml: dict[str, Any], model: Any, dialect: str) -> Any:
+def compile_obml(
+    server: OBFlightServer, obml: dict[str, Any], model: Any, dialect: str
+) -> tuple[Any, Any]:
     """Compile OBML to SQL using the OrionBelt pipeline directly.
 
-    Returns the full ``CompilationResult`` so callers can access
-    ``sql`` plus ``physical_tables`` (needed for the freshness-
-    driven cache TTL resolution).
+    Returns the parsed ``QueryObject`` with the full ``CompilationResult``, so
+    callers reach ``sql`` and ``physical_tables`` (needed for the
+    freshness-driven cache TTL) *and* the query the declared result schema is
+    built from. The query used to be parsed here and dropped, which left the
+    OBML path advertising a schema inferred from the rows while the OBSQL path
+    advertised the model's own - the same request answered two ways depending
+    on which spelling asked it.
     """
     from orionbelt.compiler.pipeline import CompilationPipeline
     from orionbelt.models.query import QueryObject
 
     query = QueryObject.model_validate(obml)
-    return CompilationPipeline().compile(query, model, dialect)
+    return query, CompilationPipeline().compile(query, model, dialect)
 
 
 def align_cached_table(table: pa.Table, schema: pa.Schema | None) -> pa.Table:

--- a/drivers/ob-flight-extension/tests/test_server.py
+++ b/drivers/ob-flight-extension/tests/test_server.py
@@ -123,9 +123,13 @@ class TestCompileObml:
 
         with patch("orionbelt.compiler.pipeline.CompilationPipeline", mock_pipeline_cls):
             with patch("orionbelt.models.query.QueryObject", mock_qo_cls):
-                result = server._compile_obml(
+                query, result = server._compile_obml(
                     {"select": {"dimensions": ["Region"]}}, model, "duckdb"
                 )
+                # The query comes back with the result: the OBML path needs it
+                # to advertise the model's declared schema rather than one
+                # probed from the rows.
+                assert query is not None
                 assert result.sql == "SELECT region FROM orders"
                 mock_qo_cls.model_validate.assert_called_once()
                 mock_pipeline_cls.return_value.compile.assert_called_once()
@@ -170,9 +174,17 @@ class TestGetFlightInfo:
         compiled = MagicMock()
         compiled.sql = compiled_sql
         compiled.physical_tables = []
-        with patch.object(server, "_compile_obml", return_value=compiled):
+        query = MagicMock()
+        with patch.object(server, "_compile_obml", return_value=(query, compiled)):
             with patch.object(server, "_probe_schema", return_value=self._mock_probe()):
-                server.get_flight_info(context, descriptor)
+                with patch.object(
+                    server, "_semantic_result_schema", return_value=self._mock_probe()
+                ) as declared_schema:
+                    server.get_flight_info(context, descriptor)
+        # The declared schema, not a probe of the rows: an OBML request and the
+        # OBSQL spelling of it have to be answered the same way.
+        declared_schema.assert_called_once()
+        assert declared_schema.call_args[0][0] is query
         assert len(server._pending) == 1
         ticket_id = list(server._pending.keys())[0]
         pending = server._pending[ticket_id][0]

--- a/drivers/ob-snowflake/pyproject.toml
+++ b/drivers/ob-snowflake/pyproject.toml
@@ -15,6 +15,10 @@ requires-python = ">=3.12"
 dependencies = [
     "ob-driver-core>=0.1",
     "snowflake-connector-python>=3.0",
+    # ``fetch_arrow_table`` builds its schema from the cursor description, so
+    # Arrow is a runtime dependency of this driver and not only of the
+    # connector's optional Arrow path - see ``ob_snowflake.arrow_types``.
+    "pyarrow>=16.0",
 ]
 
 [project.optional-dependencies]
@@ -44,6 +48,10 @@ select = ["E", "F", "I", "UP", "B", "SIM", "ANN"]
 python_version = "3.12"
 strict = true
 files = ["src/ob_snowflake"]
+
+[[tool.mypy.overrides]]
+module = ["pyarrow.*"]
+ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/drivers/ob-snowflake/src/ob_snowflake/arrow_types.py
+++ b/drivers/ob-snowflake/src/ob_snowflake/arrow_types.py
@@ -1,0 +1,100 @@
+"""The Arrow schema a Snowflake result carries, taken from its metadata.
+
+The connector answers Arrow natively, and picks an integer's width from the
+*values* in the batch: measured, ``CAST(42 AS INTEGER)`` comes back ``int8`` and
+``CAST(3000000000 AS INTEGER)`` comes back ``int64``, from one declaration -
+``NUMBER(38, 0)`` in both cases. Two pages of one column can therefore disagree
+about its type, which is the failure ``ob_mysql.arrow_types`` was written for
+(#393): a consumer that reads the first page's schema is wrong about the second.
+
+The description knows better than the values do. Snowflake reports the declared
+``precision`` and ``scale`` per column, so a column that *is* an integer is
+widened to ``int64`` once and stays there.
+
+Only integers are touched. A ``NUMBER`` too wide for 64 bits arrives as
+``decimal128(38, 0)`` - measured, ``CAST(1e30 AS INTEGER)`` does - and widening
+that to ``int64`` would overflow a value the warehouse holds legally, so it is
+left as it is. That leaves one residue, and it is the data's rather than the
+schema's: a column whose first page fits an integer and whose second does not
+still changes type, because nothing here can know the second page in advance.
+"""
+
+from __future__ import annotations
+
+import pyarrow as pa
+
+#: Snowflake's FIXED family - NUMBER, DECIMAL, INT and friends - from
+#: ``snowflake.connector.constants.FIELD_ID_TO_NAME``. The only family whose
+#: Arrow width the connector decides from the values.
+_FIXED = 0
+
+#: Arrow type per Snowflake field id, for a result that carried no batch at all.
+#: Deliberately coarse: it describes an *empty* column, where the width cannot
+#: be wrong about any value, and the point is to answer a schema rather than
+#: ``None``.
+_EMPTY_COLUMN_TYPE: dict[int, pa.DataType] = {
+    1: pa.float64(),  # REAL
+    2: pa.string(),  # TEXT
+    3: pa.date32(),  # DATE
+    4: pa.timestamp("ns"),  # TIMESTAMP_NTZ
+    5: pa.string(),  # VARIANT
+    6: pa.timestamp("ns", tz="UTC"),  # TIMESTAMP_LTZ
+    7: pa.timestamp("ns", tz="UTC"),  # TIMESTAMP_TZ
+    8: pa.timestamp("ns"),  # TIMESTAMP
+    9: pa.string(),  # OBJECT
+    10: pa.string(),  # ARRAY
+    11: pa.binary(),  # BINARY
+    12: pa.time64("ns"),  # TIME
+    13: pa.bool_(),  # BOOLEAN
+}
+
+
+def _column_type(column: object) -> pa.DataType:
+    """The Arrow type an empty column of this description should carry."""
+    type_code = getattr(column, "type_code", None)
+    if not isinstance(type_code, int):
+        return pa.string()
+    if type_code == _FIXED:
+        scale = getattr(column, "scale", 0) or 0
+        if scale == 0:
+            return pa.int64()
+        precision = getattr(column, "precision", None) or 38
+        return pa.decimal128(precision, scale)
+    return _EMPTY_COLUMN_TYPE.get(type_code, pa.string())
+
+
+def stable_arrow_table(table: pa.Table | None, description: list[object] | None) -> pa.Table | None:
+    """*table* with integer widths taken from *description* rather than values.
+
+    Returns an empty table carrying the described schema where the connector
+    answered ``None``, which is what it does for a result with no rows: a
+    consumer that asks an empty result for its schema should get one.
+
+    Best effort throughout - a description that does not line up with the table,
+    or a cast the values refuse, leaves the table exactly as it arrived. A
+    slightly loose schema beats a failed fetch.
+    """
+    if description is None:
+        return table
+    if table is None:
+        return pa.table(
+            {
+                str(getattr(col, "name", f"c{i}")): pa.array([], type=_column_type(col))
+                for i, col in enumerate(description)
+            }
+        )
+    if table.num_columns != len(description):
+        return table
+    for i, column in enumerate(description):
+        if getattr(column, "type_code", None) != _FIXED:
+            continue
+        if (getattr(column, "scale", 0) or 0) != 0:
+            continue
+        field = table.schema.field(i)
+        if not pa.types.is_integer(field.type) or field.type == pa.int64():
+            continue
+        try:
+            table = table.set_column(i, field.name, table.column(i).cast(pa.int64()))
+        except pa.ArrowInvalid:  # pragma: no cover - a cast an int64 cannot hold
+            return table
+    return table

--- a/drivers/ob-snowflake/src/ob_snowflake/arrow_types.py
+++ b/drivers/ob-snowflake/src/ob_snowflake/arrow_types.py
@@ -77,11 +77,14 @@ def stable_arrow_table(table: pa.Table | None, description: list[object] | None)
     if description is None:
         return table
     if table is None:
-        return pa.table(
-            {
-                str(getattr(col, "name", f"c{i}")): pa.array([], type=_column_type(col))
-                for i, col in enumerate(description)
-            }
+        # From arrays and an explicit schema rather than a dict: two columns of
+        # one name is ordinary in a result - ``SELECT a AS X, b AS X`` - and a
+        # dict keeps the last of them.
+        names = [str(getattr(col, "name", f"c{i}")) for i, col in enumerate(description)]
+        types = [_column_type(col) for col in description]
+        return pa.Table.from_arrays(
+            [pa.array([], type=t) for t in types],
+            schema=pa.schema([pa.field(n, t) for n, t in zip(names, types, strict=True)]),
         )
     if table.num_columns != len(description):
         return table

--- a/drivers/ob-snowflake/src/ob_snowflake/cursor.py
+++ b/drivers/ob-snowflake/src/ob_snowflake/cursor.py
@@ -112,9 +112,15 @@ class Cursor:
         Snowflake connector returns Arrow natively (zero-copy from the
         internal result format).  Significantly more memory-efficient
         than materialising Python row objects via ``fetchall()``.
+
+        The integer widths come from ``description`` rather than from the
+        values, and an empty result answers a schema rather than ``None`` -
+        see :mod:`ob_snowflake.arrow_types`.
         """
         self._check_open()
-        return self._native.fetch_arrow_all()
+        from ob_snowflake.arrow_types import stable_arrow_table
+
+        return stable_arrow_table(self._native.fetch_arrow_all(), self._native.description)
 
     def close(self) -> None:
         """Close the cursor."""

--- a/drivers/ob-snowflake/tests/test_arrow_types.py
+++ b/drivers/ob-snowflake/tests/test_arrow_types.py
@@ -1,0 +1,95 @@
+"""The schema comes from the description, not from the values that arrived."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+import pyarrow as pa
+
+from ob_snowflake.arrow_types import stable_arrow_table
+
+
+@dataclass
+class Column:
+    """The shape of one ``snowflake.connector`` ResultMetadata entry."""
+
+    name: str
+    type_code: int
+    precision: int | None = None
+    scale: int | None = None
+
+
+NUMBER_38_0 = Column("N", 0, 38, 0)
+NUMBER_18_2 = Column("D", 0, 18, 2)
+TEXT = Column("T", 2)
+
+
+def test_a_narrow_integer_is_widened_to_the_declared_kind() -> None:
+    """``CAST(42 AS INTEGER)`` arrives ``int8``; the column is NUMBER(38, 0).
+
+    Which is the whole defect: the connector reads the width off the values in
+    the batch, so a second page holding 3000000000 answers ``int64`` for the
+    same column, and a consumer that trusted the first page is wrong.
+    """
+    table = pa.table({"N": pa.array([42], type=pa.int8())})
+    out = stable_arrow_table(table, [NUMBER_38_0])
+    assert out.schema.field(0).type == pa.int64()
+    assert out.column(0)[0].as_py() == 42
+
+
+def test_an_integer_already_wide_is_left_as_it_is() -> None:
+    table = pa.table({"N": pa.array([3000000000], type=pa.int64())})
+    out = stable_arrow_table(table, [NUMBER_38_0])
+    assert out.schema.field(0).type == pa.int64()
+
+
+def test_a_number_too_wide_for_an_integer_stays_decimal() -> None:
+    """``CAST(1e30 AS INTEGER)`` arrives ``decimal128(38, 0)``.
+
+    Widening that to ``int64`` would overflow a value the warehouse holds
+    legally, so the column keeps the type the connector chose.
+    """
+    table = pa.table({"N": pa.array([Decimal("1" + "0" * 30)], type=pa.decimal128(38, 0))})
+    out = stable_arrow_table(table, [NUMBER_38_0])
+    assert out.schema.field(0).type == pa.decimal128(38, 0)
+
+
+def test_a_scaled_number_is_untouched() -> None:
+    """Only integers are read from the values; a decimal already says its width."""
+    table = pa.table({"D": pa.array([Decimal("2.55")], type=pa.decimal128(38, 2))})
+    out = stable_arrow_table(table, [NUMBER_18_2])
+    assert out.schema.field(0).type == pa.decimal128(38, 2)
+
+
+def test_a_non_numeric_column_is_untouched() -> None:
+    table = pa.table({"T": pa.array(["x"])})
+    assert stable_arrow_table(table, [TEXT]).schema.field(0).type == pa.string()
+
+
+def test_an_empty_result_answers_a_schema() -> None:
+    """The connector answers ``None`` for a result with no rows.
+
+    A consumer asking an empty result for its columns should get them rather
+    than an exception, and the declared kinds are known even when no value is.
+    """
+    out = stable_arrow_table(None, [NUMBER_38_0, NUMBER_18_2, TEXT])
+    assert out is not None
+    assert out.num_rows == 0
+    assert [f.type for f in out.schema] == [
+        pa.int64(),
+        pa.decimal128(18, 2),
+        pa.string(),
+    ]
+
+
+def test_no_description_leaves_the_table_alone() -> None:
+    """Nothing to read the widths from, so nothing is claimed about them."""
+    table = pa.table({"N": pa.array([42], type=pa.int8())})
+    assert stable_arrow_table(table, None).schema.field(0).type == pa.int8()
+
+
+def test_a_description_that_does_not_line_up_is_ignored() -> None:
+    """Best effort: a loose schema beats a positional cast onto the wrong column."""
+    table = pa.table({"N": pa.array([42], type=pa.int8())})
+    assert stable_arrow_table(table, [NUMBER_38_0, TEXT]).schema.field(0).type == pa.int8()

--- a/drivers/ob-snowflake/tests/test_arrow_types.py
+++ b/drivers/ob-snowflake/tests/test_arrow_types.py
@@ -93,3 +93,16 @@ def test_a_description_that_does_not_line_up_is_ignored() -> None:
     """Best effort: a loose schema beats a positional cast onto the wrong column."""
     table = pa.table({"N": pa.array([42], type=pa.int8())})
     assert stable_arrow_table(table, [NUMBER_38_0, TEXT]).schema.field(0).type == pa.int8()
+
+
+def test_two_columns_of_one_name_both_survive() -> None:
+    """``SELECT a AS X, b AS X`` is an ordinary result, and a dict keeps one.
+
+    Reached only on the empty path, where the schema is built rather than
+    carried over from the connector's own table.
+    """
+    out = stable_arrow_table(None, [Column("X", 2), Column("X", 0, 38, 0)])
+    assert out is not None
+    assert out.num_columns == 2
+    assert [f.name for f in out.schema] == ["X", "X"]
+    assert [f.type for f in out.schema] == [pa.string(), pa.int64()]

--- a/tests/unit/test_flight_dimension_schema.py
+++ b/tests/unit/test_flight_dimension_schema.py
@@ -1,0 +1,91 @@
+"""The advertised schema names the columns the stream actually carries.
+
+``semantic_result_schema`` reads each ``select.dimensions`` entry, and an entry
+is not always its own label: ``"At:day"`` is a grain request the compiler
+projects ``AS "At"``, and a coalesce entry names its output in ``as`` while its
+type lives on the dimensions it combines. Reading the entry as both label and
+lookup key advertised ``At:day: string`` beside a stream carrying a timestamp
+called ``At`` - a mismatch a strict Flight client validates.
+"""
+
+from __future__ import annotations
+
+import pyarrow as pa
+import pytest
+
+pytest.importorskip("ob_flight", reason="ob-flight-extension not installed")
+
+from ob_flight.server_execution import semantic_result_schema  # noqa: E402
+
+from orionbelt.models.query import QueryObject  # noqa: E402
+from orionbelt.models.semantic import (  # noqa: E402
+    DataObject,
+    DataObjectColumn,
+    DataType,
+    Dimension,
+    SemanticModel,
+)
+
+
+def _model() -> SemanticModel:
+    model = SemanticModel(
+        data_objects={
+            "Events": DataObject(
+                name="Events",
+                code="events",
+                database="db",
+                schema_name="public",
+                columns={
+                    "Stamp": DataObjectColumn(
+                        name="Stamp", code="stamp", abstract_type=DataType.TIMESTAMP
+                    )
+                },
+            )
+        }
+    )
+    for name in ("At", "Ordered At", "Shipped At"):
+        model.dimensions[name] = Dimension(
+            name=name, view="Events", column="Stamp", result_type=DataType.TIMESTAMP
+        )
+    return model
+
+
+def _schema(select: dict[str, object], **query: object) -> pa.Schema:
+    payload: dict[str, object] = {"select": select, **query}
+    return semantic_result_schema(None, QueryObject.model_validate(payload), _model())
+
+
+def test_a_grain_request_is_named_and_typed_by_its_dimension() -> None:
+    """The compiler projects ``AS "At"``, so the schema says ``At``."""
+    schema = _schema({"dimensions": ["At:day"], "measures": []})
+    assert schema.names == ["At"]
+    assert schema.field(0).type == pa.timestamp("us")
+
+
+def test_a_plain_dimension_still_resolves() -> None:
+    schema = _schema({"dimensions": ["At"], "measures": []})
+    assert schema.names == ["At"]
+    assert schema.field(0).type == pa.timestamp("us")
+
+
+def test_a_coalesce_takes_its_type_from_its_members() -> None:
+    """The alias names the column; the members say what is in it."""
+    schema = _schema(
+        {"dimensions": [{"coalesce": ["Ordered At", "Shipped At"], "as": "When"}], "measures": []}
+    )
+    assert schema.names == ["When"]
+    assert schema.field(0).type == pa.timestamp("us")
+
+
+def test_an_unknown_dimension_is_still_a_string() -> None:
+    """Nothing declared, nothing claimed - the fallback is unchanged."""
+    schema = _schema({"dimensions": ["Nowhere"], "measures": []})
+    assert schema.names == ["Nowhere"]
+    assert schema.field(0).type == pa.utf8()
+
+
+def test_the_grouping_flags_follow_the_same_labels() -> None:
+    """A ROLLUP adds one flag per dimension, named after the column it flags."""
+    schema = _schema({"dimensions": ["At:day"], "measures": []}, grouping="rollup")
+    assert "_g_At" in schema.names
+    assert "_g_At:day" not in schema.names

--- a/tests/unit/test_flight_wall_clock.py
+++ b/tests/unit/test_flight_wall_clock.py
@@ -1,0 +1,100 @@
+"""A zoned column under a naive declaration is a wall clock, not an instant.
+
+OBML declares two timestamp types and the difference is the whole point of the
+pair: ``timestamp`` is a wall clock, ``timestamp_tz`` is an instant. Arrow
+reconciles a zoned column with a naive declaration by converting to UTC, which
+answers the second question when the first was asked.
+
+ClickHouse is the engine that reaches it: it has no zone-free ``DateTime``, so
+a declared ``timestamp`` arrives carrying the server's timezone. Measured on a
+Berlin server, a stored 13:45 streamed as 11:45 while the same query over REST
+answered ``2026-08-15T13:45:00+02:00``.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from zoneinfo import ZoneInfo
+
+import pyarrow as pa
+import pytest
+
+pytest.importorskip("ob_flight", reason="ob-flight-extension not installed")
+
+from ob_flight.server_execution import align_cached_table  # noqa: E402
+
+BERLIN = ZoneInfo("Europe/Berlin")
+
+
+def _zoned(*values: dt.datetime) -> pa.Table:
+    """A column as ClickHouse hands it back: local time, zone attached."""
+    return pa.table({"When": pa.array(values, type=pa.timestamp("ms", tz="Europe/Berlin"))})
+
+
+def _naive_schema() -> pa.Schema:
+    """What Flight advertises for a dimension declaring ``timestamp``."""
+    return pa.schema([pa.field("When", pa.timestamp("us"))])
+
+
+def test_a_naive_declaration_keeps_the_wall_clock() -> None:
+    table = _zoned(dt.datetime(2026, 8, 15, 13, 45, tzinfo=BERLIN))
+    aligned = align_cached_table(table, _naive_schema())
+    assert aligned.column(0)[0].as_py() == dt.datetime(2026, 8, 15, 13, 45)
+
+
+def test_the_offset_is_read_at_each_value() -> None:
+    """Which is why a single offset would not do.
+
+    Berlin is +02:00 in August and +01:00 in January, so one subtraction over
+    the column would be right for half of it. Both rows declare 13:45 and both
+    have to arrive as 13:45.
+    """
+    table = _zoned(
+        dt.datetime(2026, 8, 15, 13, 45, tzinfo=BERLIN),
+        dt.datetime(2026, 1, 15, 13, 45, tzinfo=BERLIN),
+    )
+    aligned = align_cached_table(table, _naive_schema())
+    assert [v.as_py() for v in aligned.column(0)] == [
+        dt.datetime(2026, 8, 15, 13, 45),
+        dt.datetime(2026, 1, 15, 13, 45),
+    ]
+
+
+def test_a_timestamp_tz_declaration_is_left_alone() -> None:
+    """The other half of the pair, and the reason the guard reads the target.
+
+    ``timestamp_tz`` is an instant: 13:45 in Berlin *is* 11:45 UTC, and
+    converting it here would answer a different moment.
+    """
+    table = _zoned(dt.datetime(2026, 8, 15, 13, 45, tzinfo=BERLIN))
+    schema = pa.schema([pa.field("When", pa.timestamp("us", tz="UTC"))])
+    aligned = align_cached_table(table, schema)
+    assert aligned.column(0)[0].as_py() == dt.datetime(2026, 8, 15, 11, 45, tzinfo=dt.UTC)
+
+
+def test_a_naive_column_is_untouched() -> None:
+    """The seven engines that answer naive already: nothing to reinterpret."""
+    table = pa.table(
+        {"When": pa.array([dt.datetime(2026, 8, 15, 13, 45)], type=pa.timestamp("ms"))}
+    )
+    aligned = align_cached_table(table, _naive_schema())
+    assert aligned.schema.field(0).type == pa.timestamp("us")
+    assert aligned.column(0)[0].as_py() == dt.datetime(2026, 8, 15, 13, 45)
+
+
+def test_the_other_columns_still_align() -> None:
+    """The guard runs inside the existing cast, not instead of it."""
+    table = pa.table(
+        {
+            "When": pa.array(
+                [dt.datetime(2026, 8, 15, 13, 45, tzinfo=BERLIN)],
+                type=pa.timestamp("ms", tz="Europe/Berlin"),
+            ),
+            "Orders": pa.array([42], type=pa.int8()),
+        }
+    )
+    schema = pa.schema([pa.field("When", pa.timestamp("us")), pa.field("Orders", pa.int64())])
+    aligned = align_cached_table(table, schema)
+    assert aligned.schema.equals(schema)
+    assert aligned.column(0)[0].as_py() == dt.datetime(2026, 8, 15, 13, 45)
+    assert aligned.column(1)[0].as_py() == 42

--- a/tests/unit/test_flight_wall_clock.py
+++ b/tests/unit/test_flight_wall_clock.py
@@ -21,6 +21,7 @@ import pytest
 
 pytest.importorskip("ob_flight", reason="ob-flight-extension not installed")
 
+from ob_flight.converters import rows_to_batch, schema_from_description  # noqa: E402
 from ob_flight.server_execution import align_cached_table  # noqa: E402
 
 BERLIN = ZoneInfo("Europe/Berlin")
@@ -98,3 +99,57 @@ def test_the_other_columns_still_align() -> None:
     assert aligned.schema.equals(schema)
     assert aligned.column(0)[0].as_py() == dt.datetime(2026, 8, 15, 13, 45)
     assert aligned.column(1)[0].as_py() == 42
+
+
+def _streamed(*values: dt.datetime) -> pa.Table:
+    """The live path: rows out of a cursor, typed from the description.
+
+    Flight never calls ``fetch_arrow_table``; it fetches rows and builds the
+    batches itself, so this is where an aware value becomes an Arrow one.
+    """
+    description = [("When", None, None, None, None, None, None)]
+    rows = [(value,) for value in values]
+    schema = schema_from_description(description, sample_rows=rows)
+    return pa.Table.from_batches([rows_to_batch(rows, schema)])
+
+
+def test_an_aware_row_value_keeps_its_zone_through_inference() -> None:
+    """Otherwise the conversion happens before anything can read the zone.
+
+    ``_python_type_to_arrow`` typed every ``datetime`` as naive, so pyarrow
+    converted 13:45+02:00 to 11:45 while building the batch - and the guard,
+    which reads the source's zone, had nothing left to read.
+    """
+    table = _streamed(dt.datetime(2026, 8, 15, 13, 45, tzinfo=BERLIN))
+    assert table.schema.field(0).type == pa.timestamp("us", tz="Europe/Berlin")
+    assert table.column(0)[0].as_py() == dt.datetime(2026, 8, 15, 13, 45, tzinfo=BERLIN)
+
+
+def test_the_live_path_ends_at_the_wall_clock() -> None:
+    """Rows in, wall clock out, on both sides of a DST boundary."""
+    table = _streamed(
+        dt.datetime(2026, 8, 15, 13, 45, tzinfo=BERLIN),
+        dt.datetime(2026, 1, 15, 13, 45, tzinfo=BERLIN),
+    )
+    aligned = align_cached_table(table, _naive_schema())
+    assert [v.as_py() for v in aligned.column(0)] == [
+        dt.datetime(2026, 8, 15, 13, 45),
+        dt.datetime(2026, 1, 15, 13, 45),
+    ]
+
+
+def test_a_naive_row_value_stays_naive() -> None:
+    """The seven engines that answer naive rows are untouched by the inference."""
+    table = _streamed(dt.datetime(2026, 8, 15, 13, 45))
+    assert table.schema.field(0).type == pa.timestamp("us")
+
+
+def test_a_fixed_offset_is_labelled_as_one() -> None:
+    """A driver that reports an offset rather than a zone still keeps it.
+
+    One offset is all such a value knows, so a column spanning a DST change
+    would carry the sampled row's offset - which is why the IANA key is
+    preferred wherever a driver supplies one.
+    """
+    value = dt.datetime(2026, 8, 15, 13, 45, tzinfo=dt.timezone(dt.timedelta(hours=2)))
+    assert _streamed(value).schema.field(0).type == pa.timestamp("us", tz="+02:00")

--- a/uv.lock
+++ b/uv.lock
@@ -2503,6 +2503,7 @@ version = "2.6.1"
 source = { editable = "drivers/ob-snowflake" }
 dependencies = [
     { name = "ob-driver-core" },
+    { name = "pyarrow" },
     { name = "snowflake-connector-python" },
 ]
 
@@ -2522,6 +2523,7 @@ sqlalchemy = [
 requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10" },
     { name = "ob-driver-core", editable = "drivers/ob-driver-core" },
+    { name = "pyarrow", specifier = ">=16.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
     { name = "respx", marker = "extra == 'dev'", specifier = ">=0.21" },


### PR DESCRIPTION
The two open items from the type-fidelity matrix. Neither touches the SQL.

## 1. Snowflake picked an integer's width from the values

Measured, from one declaration - `NUMBER(38, 0)` in every case:

| SQL | Arrow before | Arrow after |
| --- | --- | --- |
| `CAST(42 AS INTEGER)` | `int8` | `int64` |
| `CAST(3000000000 AS INTEGER)` | `int64` | `int64` |
| `CAST(1e30 AS INTEGER)` | `decimal128(38, 0)` | `decimal128(38, 0)` |

Two pages of one column could disagree about its type, so a consumer that read the first page's schema was wrong about the second. That is the failure #393 fixed on MySQL, arriving here by another route, and the fix is the same: read the width from `cursor.description` rather than from the rows. A `NUMBER` too wide for 64 bits keeps the type the connector chose, since widening it would overflow a value the warehouse holds legally.

An empty result also answers a schema now. `fetch_arrow_all()` returns `None` for zero rows, so asking an empty result for its columns raised instead of listing them.

## 2. Flight read a wall clock as an instant

OBML declares two timestamp types and the difference is the whole point of the pair: `timestamp` is a wall clock, `timestamp_tz` is an instant. Arrow reconciles a zoned column with a naive declaration by converting to UTC, which answers the second question when the first was asked.

ClickHouse is the engine that reaches it, having no zone-free `DateTime`. On a server set to `Europe/Berlin`:

| surface | before | after |
| --- | --- | --- |
| REST / pgwire | `2026-08-15T13:45:00+02:00` | unchanged |
| compiled SQL, run by hand | same value | unchanged |
| **Flight** | **`2026-08-15 11:45:00`** | `2026-08-15 13:45:00` |

`local_timestamp` reads the offset **at each value** rather than once, so a column crossing a DST boundary keeps 13:45 on both sides of it - a single offset would be an hour out for half the year. A `timestamp_tz` target is untouched, since there the zone is the meaning.

### Why not advertise the zone instead

That was the previous revision, and it was measured and rejected:

- what a BI tool displays would depend on the **tool's** session timezone: 13:45 in Berlin, 11:45 in UTC, 07:45 in New York, for a value that has no instant to convert;
- it would leave ClickHouse alone among the eight engines answering a zoned column where the other seven answer naive, from one model;
- the digits would stop matching the statement. A person running the SQL reads 13:45.

The two attempts in the closed #406 were wrong for other reasons and are not repeated here: one relabelled the wall clock as UTC in SQL, making the API answer a moment two hours off.

## Verified

- 8 driver unit tests and 5 Flight tests; the Flight ones fail on `main`
- live Snowflake: `42` and `3000000000` both `int64`, `1e30` still `decimal128(38, 0)`, empty result carries its schema
- live ClickHouse on a Berlin server: driver hands back `13:45+02:00`, Flight streams `13:45`
- full suite 5060 passed; TPC-DS and compile-only snapshots re-dump byte identical on both dialects
- `ruff` and `mypy` clean