### PR TITLE
fix(drivers): every driver package is mypy-clean

### DIFF
--- a/drivers/ob-bigquery/pyproject.toml
+++ b/drivers/ob-bigquery/pyproject.toml
@@ -42,6 +42,11 @@ python_version = "3.12"
 strict = true
 files = ["src/ob_bigquery"]
 
+# Untyped upstream - neither ships a py.typed marker.
+[[tool.mypy.overrides]]
+module = ["pyarrow.*"]
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]

--- a/drivers/ob-bigquery/src/ob_bigquery/__init__.py
+++ b/drivers/ob-bigquery/src/ob_bigquery/__init__.py
@@ -70,7 +70,11 @@ def connect(
     if credentials_file is not None and credentials is None:
         from google.oauth2 import service_account
 
-        credentials = service_account.Credentials.from_service_account_file(credentials_file)
+        # google-auth annotates the class but not this constructor, so a
+        # typed caller has to say it knows.
+        credentials = service_account.Credentials.from_service_account_file(  # type: ignore[no-untyped-call]
+            credentials_file
+        )
 
     client_kwargs: dict[str, Any] = {}
     if project is not None:

--- a/drivers/ob-clickhouse/pyproject.toml
+++ b/drivers/ob-clickhouse/pyproject.toml
@@ -46,6 +46,11 @@ python_version = "3.12"
 strict = true
 files = ["src/ob_clickhouse"]
 
+# Untyped upstream - neither ships a py.typed marker.
+[[tool.mypy.overrides]]
+module = ["pyarrow.*"]
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]

--- a/drivers/ob-databricks/src/ob_databricks/cursor.py
+++ b/drivers/ob-databricks/src/ob_databricks/cursor.py
@@ -53,7 +53,14 @@ class Cursor:
 
     @property
     def rowcount(self) -> int:
-        return self._native.rowcount
+        """Rows the last statement produced, or -1 where the driver says nothing.
+
+        ``self._native`` is untyped, so the value arrives as ``Any``; PEP 249
+        promises an ``int`` and -1 is what it reserves for "unknown", which is
+        what a connector answering ``None`` means.
+        """
+        count = self._native.rowcount
+        return int(count) if isinstance(count, int) else -1
 
     def _check_open(self) -> None:
         if self._closed:

--- a/drivers/ob-dremio/pyproject.toml
+++ b/drivers/ob-dremio/pyproject.toml
@@ -45,6 +45,11 @@ python_version = "3.12"
 strict = true
 files = ["src/ob_dremio"]
 
+# Untyped upstream - neither ships a py.typed marker.
+[[tool.mypy.overrides]]
+module = ["pyarrow.*"]
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]

--- a/drivers/ob-dremio/src/ob_dremio/connection.py
+++ b/drivers/ob-dremio/src/ob_dremio/connection.py
@@ -12,7 +12,7 @@ from ob_dremio.cursor import Cursor
 from ob_dremio.exceptions import ProgrammingError
 
 if TYPE_CHECKING:
-    import pyarrow.flight  # type: ignore[import-untyped]
+    import pyarrow.flight
 
 
 class Connection:

--- a/drivers/ob-driver-core/pyproject.toml
+++ b/drivers/ob-driver-core/pyproject.toml
@@ -19,6 +19,8 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+    # The package parses YAML, so checking its own types needs the stubs.
+    "types-PyYAML>=6.0",
     "pytest>=8.0",
     "mypy>=1.10",
     "ruff>=0.4",

--- a/drivers/ob-driver-core/src/ob_driver_core/detection.py
+++ b/drivers/ob-driver-core/src/ob_driver_core/detection.py
@@ -33,4 +33,7 @@ def is_obml(query: str) -> bool:
 
 def parse_obml(query: str) -> dict[str, Any]:
     """Parse an OBML YAML string into a dict. Call only after :func:`is_obml`."""
-    return yaml.safe_load(query.strip())  # type: ignore[return-value]
+    parsed: Any = yaml.safe_load(query.strip())
+    if not isinstance(parsed, dict):
+        raise ValueError("OBML must parse to a mapping")
+    return parsed

--- a/drivers/ob-duckdb/src/ob_duckdb/type_codes.py
+++ b/drivers/ob-duckdb/src/ob_duckdb/type_codes.py
@@ -6,11 +6,18 @@ The DUCKDB_TYPE_MAP maps these to PEP 249 type objects.
 
 from __future__ import annotations
 
-from ob_driver_core.type_codes import BINARY, DATETIME, NUMBER, ROWID, STRING
+from ob_driver_core.type_codes import (
+    BINARY,
+    DATETIME,
+    NUMBER,
+    ROWID,
+    STRING,
+    DBAPITypeObject,
+)
 
 __all__ = ["STRING", "BINARY", "NUMBER", "DATETIME", "ROWID", "DUCKDB_TYPE_MAP"]
 
-DUCKDB_TYPE_MAP: dict[str, object] = {
+DUCKDB_TYPE_MAP: dict[str, DBAPITypeObject] = {
     # String types
     "VARCHAR": STRING,
     "TEXT": STRING,

--- a/drivers/ob-flight-extension/src/ob_flight/converters.py
+++ b/drivers/ob-flight-extension/src/ob_flight/converters.py
@@ -7,7 +7,7 @@ from decimal import Decimal
 from typing import Any
 
 import pyarrow as pa
-from ob_driver_core.type_codes import (  # type: ignore[import-untyped]
+from ob_driver_core.type_codes import (
     BINARY,
     DATETIME,
     NUMBER,

--- a/drivers/ob-flight-extension/src/ob_flight/server_execution.py
+++ b/drivers/ob-flight-extension/src/ob_flight/server_execution.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any
 import pyarrow as pa
 import pyarrow.flight as flight
 
-from ob_driver_core.detection import is_obml, parse_obml  # type: ignore[import-untyped]
+from ob_driver_core.detection import is_obml, parse_obml
 
 from ob_flight.converters import rows_to_batch, schema_from_description
 

--- a/drivers/ob-mysql/pyproject.toml
+++ b/drivers/ob-mysql/pyproject.toml
@@ -46,6 +46,11 @@ python_version = "3.12"
 strict = true
 files = ["src/ob_mysql"]
 
+# Untyped upstream - neither ships a py.typed marker.
+[[tool.mypy.overrides]]
+module = ["pyarrow.*"]
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]

--- a/drivers/ob-mysql/src/ob_mysql/__init__.py
+++ b/drivers/ob-mysql/src/ob_mysql/__init__.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 from typing import Any
 
-import mysql.connector  # type: ignore[import-untyped]
+import mysql.connector
 
 from ob_mysql.connection import Connection
 from ob_mysql.exceptions import (

--- a/drivers/ob-postgres/pyproject.toml
+++ b/drivers/ob-postgres/pyproject.toml
@@ -46,6 +46,11 @@ python_version = "3.12"
 strict = true
 files = ["src/ob_postgres"]
 
+# Untyped upstream - neither ships a py.typed marker.
+[[tool.mypy.overrides]]
+module = ["pyarrow.*", "adbc_driver_postgresql.*"]
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]

--- a/drivers/ob-postgres/src/ob_postgres/cursor.py
+++ b/drivers/ob-postgres/src/ob_postgres/cursor.py
@@ -63,7 +63,14 @@ class Cursor:
 
     @property
     def rowcount(self) -> int:
-        return self._native.rowcount
+        """Rows the last statement produced, or -1 where the driver says nothing.
+
+        ``self._native`` is untyped, so the value arrives as ``Any``; PEP 249
+        promises an ``int`` and -1 is what it reserves for "unknown", which is
+        what a connector answering ``None`` means.
+        """
+        count = self._native.rowcount
+        return int(count) if isinstance(count, int) else -1
 
     def _check_open(self) -> None:
         if self._closed:

--- a/drivers/ob-snowflake/src/ob_snowflake/cursor.py
+++ b/drivers/ob-snowflake/src/ob_snowflake/cursor.py
@@ -48,7 +48,14 @@ class Cursor:
 
     @property
     def rowcount(self) -> int:
-        return self._native.rowcount
+        """Rows the last statement produced, or -1 where the driver says nothing.
+
+        ``self._native`` is untyped, so the value arrives as ``Any``; PEP 249
+        promises an ``int`` and -1 is what it reserves for "unknown", which is
+        what a connector answering ``None`` means.
+        """
+        count = self._native.rowcount
+        return int(count) if isinstance(count, int) else -1
 
     def _check_open(self) -> None:
         if self._closed:

--- a/src/orionbelt/service/db_executor.py
+++ b/src/orionbelt/service/db_executor.py
@@ -126,7 +126,7 @@ class ExecutionResult:
 def _map_type_code(type_code: Any) -> str:
     """Map a PEP 249 type code to a simple string type hint."""
     try:
-        from ob_driver_core.type_codes import (  # type: ignore[import-untyped]
+        from ob_driver_core.type_codes import (
             BINARY,
             DATETIME,
             NUMBER,

--- a/uv.lock
+++ b/uv.lock
@@ -2312,6 +2312,7 @@ dev = [
     { name = "pytest" },
     { name = "respx" },
     { name = "ruff" },
+    { name = "types-pyyaml" },
 ]
 
 [package.metadata]
@@ -2322,6 +2323,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "respx", marker = "extra == 'dev'", specifier = ">=0.21" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4" },
+    { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
 ]
 provides-extras = ["dev"]
 


### PR DESCRIPTION
`mypy src/ob_snowflake` reported six errors. Four were not the driver's, and chasing the cause cleared the other nine packages too.

## The shared package never said it was typed

Every `from ob_driver_core...` import failed as `import-untyped`, because `ob-driver-core` ships no `py.typed`. It is not untyped - it annotates everything and passes strict mypy once its own two errors are fixed. It simply never advertised it.

- `parse_obml` raises on a body that is not a mapping instead of carrying a `type: ignore` over its return. `is_obml` already gates every call, so the raise states the contract rather than changing behaviour.
- `py.typed` added, and included in the wheel.
- `types-PyYAML` added to its dev extras: the package parses YAML, so a clean install of it alone could not check its own types. Verified in a throwaway venv holding nothing but `ob-driver-core[dev]`.

## The fifteen that remained

| kind | where | fix |
| --- | --- | --- |
| `pyarrow` / `adbc-driver-postgresql` untyped upstream | mysql, clickhouse, postgres, bigquery, dremio | one `[[tool.mypy.overrides]]` per package that imports them |
| `rowcount` returned `Any` where PEP 249 promises `int` | snowflake, postgres, databricks | answer `-1` for a driver that reports nothing, which the spec reserves for "unknown" |
| `DUCKDB_TYPE_MAP` annotated `dict[str, object]` while holding `DBAPITypeObject` | duckdb | annotate what it holds |
| `from_service_account_file` untyped in google-auth | bigquery | a targeted ignore on the one call |

Two `type: ignore` comments came out as well: `mysql-connector-python` ships type information now, and ob-dremio's `pyarrow.flight` ignore is redundant under the override. The `py.typed` marker also made three more redundant - one in `src/orionbelt/service/db_executor.py`, two in ob-flight-extension - and mypy flags an unused ignore, so those go too.

## Result

| package | before | after |
| --- | --- | --- |
| ob-driver-core | 2 | **clean** |
| ob-snowflake | 6 | **clean** |
| ob-mysql | 7 | **clean** |
| ob-clickhouse | 6 | **clean** |
| ob-duckdb | 5 | **clean** |
| ob-postgres | 9 | **clean** |
| ob-bigquery | 5 | **clean** |
| ob-databricks | 4 | **clean** |
| ob-dremio | 7 | **clean** |
| ob-flight-extension | 2 | **clean** |

## Verified

- all ten packages: `mypy src` clean
- all nine driver test suites pass, 613 tests
- main suite 5055 passed; `uv run mypy src/` clean on 151 files; `ruff check src/` clean

One thing this does not do: the driver packages are still absent from CI, so nothing keeps them clean. `ruff check` over `drivers/` reports 179 findings (46 SIM117 and 10 ANN201 in tests, 35 ANN401 on the PEP 249 `Any` boundaries, 27 I001, 22 BLE001), most auto-fixable but a few genuinely a design call. Worth its own pass, together with adding the packages to the lint job.