### PR TITLE
fix(cache): the driver schema decides a cached column's type, not its values

### DIFF
--- a/src/orionbelt/cache/result_codec.py
+++ b/src/orionbelt/cache/result_codec.py
@@ -45,6 +45,12 @@ _MAX_CHUNKSIZE = 100_000
 # equal by ``test_numeric_tokens_match_the_service_definition``.
 _NUMERIC_TYPE_TOKENS = ("number", "int", "float", "decimal", "numeric", "double", "real")
 
+# Type names a token matches without the type being numeric. The tokens are
+# substrings because the numeric names are a family rather than a list -
+# ``bigint``, ``smallint`` and ``integer`` all have to match ``int`` - and
+# ``interval`` is what that costs: it contains ``int`` and is a duration.
+_NOT_NUMERIC_TYPE_NAMES = ("interval",)
+
 
 def _is_string_backed_numeric(arrow_type: Any) -> bool:
     """Whether the type is an Arrow extension wrapping a *number* as a string.
@@ -58,10 +64,15 @@ def _is_string_backed_numeric(arrow_type: Any) -> bool:
     makes.
 
     The ``type_name`` test is what keeps this narrow, and it is load-bearing
-    rather than defensive. An opaque ``json`` or ``uuid`` is string-backed too,
-    and its cells stay strings all the way here, so ``string`` is the right
-    offer for it and refusing one would make *those* columns value-dependent
-    instead - inferred ``string`` when populated and ``null`` when empty.
+    rather than defensive. An opaque ``json``, ``uuid`` or ``interval`` is
+    string-backed too, and its cells stay strings all the way here, so
+    ``string`` is the right offer for it and refusing one would make *those*
+    columns value-dependent instead - inferred ``string`` when populated and
+    ``null`` when empty.
+
+    ``interval`` needs saying twice because the tokens are substrings: the
+    numeric names are a family, so ``int`` has to match ``bigint`` and
+    ``integer``, and it matches ``interval`` on the way past.
     """
     import pyarrow as pa
 
@@ -75,6 +86,8 @@ def _is_string_backed_numeric(arrow_type: Any) -> bool:
         if isinstance(type_name, bytes):
             type_name = type_name.decode("utf-8", "ignore")
         name = str(type_name).lower()
+        if any(excluded in name for excluded in _NOT_NUMERIC_TYPE_NAMES):
+            return False
         return any(tok in name for tok in _NUMERIC_TYPE_TOKENS)
     except (AttributeError, TypeError):
         return False

--- a/src/orionbelt/cache/result_codec.py
+++ b/src/orionbelt/cache/result_codec.py
@@ -38,8 +38,16 @@ _GZIP_LEVEL = 6
 _MAX_CHUNKSIZE = 100_000
 
 
-def _is_string_backed_extension(arrow_type: Any) -> bool:
-    """Whether the type is an Arrow extension wrapping a value as a string.
+# Substrings that mark an extension's ``type_name`` as numeric. Mirrors
+# ``service.value_formatting._NUMERIC_TYPE_TOKENS``, which the cache layer may
+# not import (``tests/architecture/test_dependencies.py`` forbids cache ->
+# service; Flight reaches this module through the cache). The two are pinned
+# equal by ``test_numeric_tokens_match_the_service_definition``.
+_NUMERIC_TYPE_TOKENS = ("number", "int", "float", "decimal", "numeric", "double", "real")
+
+
+def _is_string_backed_numeric(arrow_type: Any) -> bool:
+    """Whether the type is an Arrow extension wrapping a *number* as a string.
 
     ADBC's PostgreSQL driver represents NUMERIC as
     ``arrow.opaque[storage_type=string, type_name=numeric]`` to keep precision
@@ -47,16 +55,27 @@ def _is_string_backed_extension(arrow_type: Any) -> bool:
     to ``Decimal`` before they reach this module. Duck-typed on the
     ``storage_type`` / ``type_name`` pair that plain Arrow types do not carry -
     the same detection ``db_executor._is_string_stored_numeric_arrow_type``
-    makes, repeated here rather than imported because the cache must not depend
-    on the service layer (Flight imports this module).
+    makes.
+
+    The ``type_name`` test is what keeps this narrow, and it is load-bearing
+    rather than defensive. An opaque ``json`` or ``uuid`` is string-backed too,
+    and its cells stay strings all the way here, so ``string`` is the right
+    offer for it and refusing one would make *those* columns value-dependent
+    instead - inferred ``string`` when populated and ``null`` when empty.
     """
     import pyarrow as pa
 
     try:
         storage = getattr(arrow_type, "storage_type", None)
-        if storage is None or getattr(arrow_type, "type_name", None) is None:
+        type_name = getattr(arrow_type, "type_name", None)
+        if storage is None or type_name is None:
             return False
-        return bool(pa.types.is_string(storage))
+        if not pa.types.is_string(storage):
+            return False
+        if isinstance(type_name, bytes):
+            type_name = type_name.decode("utf-8", "ignore")
+        name = str(type_name).lower()
+        return any(tok in name for tok in _NUMERIC_TYPE_TOKENS)
     except (AttributeError, TypeError):
         return False
 
@@ -88,7 +107,7 @@ def _serialized_field_type(arrow_type: Any) -> Any:
     """
     import pyarrow as pa
 
-    if _is_string_backed_extension(arrow_type):
+    if _is_string_backed_numeric(arrow_type):
         return None
     try:
         if (

--- a/src/orionbelt/cache/result_codec.py
+++ b/src/orionbelt/cache/result_codec.py
@@ -45,8 +45,9 @@ def _serialized_field_type(arrow_type: Any) -> Any:
     ``_serialize_value``: temporals become ISO strings, binary becomes base64,
     intervals become ``str(timedelta)``. Numerics, booleans, strings and
     ``Decimal`` pass through untouched. This maps a driver's Arrow type onto
-    the type its *serialised* values carry, so a hint derived from the
-    executor's schema agrees with what a non-empty result would infer.
+    the type its *serialised* values carry, which is the type the blob can
+    actually hold - naming the driver's ``timestamp[us]`` here would be a
+    declaration no serialised row could satisfy.
     """
     import pyarrow as pa
 
@@ -66,22 +67,34 @@ def _serialized_field_type(arrow_type: Any) -> Any:
 def build_result_table(column_names: list[str], rows: list[list[Any]], schema: Any = None) -> Any:
     """Build a pyarrow Table from result column names + list-of-lists rows.
 
-    Rows are padded to the column arity and transposed into columns. Types are
-    inferred by pyarrow from the (already JSON-serializable) cell values — the
-    same typed, locale-neutral shape the executor produces, so a cached entry
-    and a fresh execution serialize identically.
+    Rows are padded to the column arity and transposed into columns.
 
-    ``schema`` is an optional *driver* Arrow schema (from ``ExecutionResult``)
-    used **only** to rescue columns inference would otherwise type as ``null``:
-    an empty result, or one whose every cell is NULL. Without it, a
-    ``SELECT 1::BIGINT AS n WHERE false`` blob decodes as ``n: null`` while the
-    envelope's sidecar says the column is numeric — one payload contradicting
-    itself, and a raw-arrow cache hit serves that blob verbatim.
+    ``schema`` is the *driver* Arrow schema (from ``ExecutionResult``), and
+    where it is given it **decides** each column's type rather than merely
+    rescuing the ones inference would type as ``null``. Inference reads the
+    values that happen to be present, so a ``decimal(18, 2)`` measure holding
+    1.50 and 2.25 came back ``decimal128(3, 2)``, and the same column came back
+    a different width for a different filter: a consumer that read the schema
+    once was wrong about the next result. That is the failure #393 fixed on
+    MySQL and #407 on Snowflake, arriving here by a third route, and the fix is
+    the same one - read the width from the declaration, not from the rows.
 
-    Deliberately narrow: a column whose inferred type is already concrete keeps
-    it, so no existing value representation can change. Types are matched by
-    position, since the caller's ``column_names`` are the model-decorated names
-    for the same columns in the same order.
+    The declared type is only *offered*: rows have already been through
+    ``_serialize_value``, so a column whose values no longer fit what the driver
+    declared falls back to inference. That is not a rare path. PostgreSQL
+    NUMERIC arrives as a string-backed extension type and its cells reach here
+    as ``Decimal``, so the offered ``string`` is refused and inference types the
+    column ``decimal128`` - which is what it did before this. pyarrow raises on
+    every such mismatch rather than coercing (measured: a Decimal into a string
+    array, a value wider than the declared precision, an integer too large for
+    the declared width), so the fallback cannot silently change a value.
+
+    Without a schema, types are inferred as before. That is the PEP 249 path,
+    which has no Arrow schema to read, and the ``format_values`` arrow response,
+    where every cell is a display string by construction.
+
+    Types are matched by position, since the caller's ``column_names`` are the
+    model-decorated names for the same columns in the same order.
     """
     import pyarrow as pa
 
@@ -102,12 +115,12 @@ def build_result_table(column_names: list[str], rows: list[list[Any]], schema: A
 
     arrays = []
     for i, col in enumerate(cols_data):
-        arr = pa.array(col, from_pandas=False)
-        if hints and pa.types.is_null(arr.type) and not pa.types.is_null(hints[i]):
-            # Every cell is NULL (or there are none), so re-typing cannot alter
-            # a value — but it does keep the declared type visible to clients.
+        arr = None
+        if hints and not pa.types.is_null(hints[i]):
             with contextlib.suppress(pa.ArrowInvalid, pa.ArrowTypeError, TypeError, ValueError):
                 arr = pa.array(col, type=hints[i], from_pandas=False)
+        if arr is None:
+            arr = pa.array(col, from_pandas=False)
         arrays.append(arr)
     return pa.Table.from_arrays(arrays, names=list(column_names))
 
@@ -136,11 +149,11 @@ def encode_data(column_names: list[str], rows: list[list[Any]], schema: Any = No
 
     No response envelope is baked in — the blob is a pure Arrow data stream. The
     caller stores this in the cache; metadata is rebuilt fresh on every read.
-    Types are inferred from the row values (see :func:`build_result_table`); a
-    caller that already holds a fully-typed table should use
-    :func:`encode_table` instead to preserve the exact schema. ``schema`` is
-    the executor's driver Arrow schema, used only to keep empty / all-null
-    columns from decoding as ``null``.
+    ``schema`` is the executor's driver Arrow schema, and it decides the
+    column types (see :func:`build_result_table`); without one they are
+    inferred from the values. A caller that already holds a fully-typed table
+    should use :func:`encode_table` instead, which keeps the table's own schema
+    with no serialisation step in between.
     """
     table = build_result_table(column_names, rows, schema)
     return gzip.compress(to_ipc_stream(table), _GZIP_LEVEL)

--- a/src/orionbelt/cache/result_codec.py
+++ b/src/orionbelt/cache/result_codec.py
@@ -38,8 +38,32 @@ _GZIP_LEVEL = 6
 _MAX_CHUNKSIZE = 100_000
 
 
+def _is_string_backed_extension(arrow_type: Any) -> bool:
+    """Whether the type is an Arrow extension wrapping a value as a string.
+
+    ADBC's PostgreSQL driver represents NUMERIC as
+    ``arrow.opaque[storage_type=string, type_name=numeric]`` to keep precision
+    Arrow's ``decimal128`` cannot hold, and the executor parses those cells back
+    to ``Decimal`` before they reach this module. Duck-typed on the
+    ``storage_type`` / ``type_name`` pair that plain Arrow types do not carry -
+    the same detection ``db_executor._is_string_stored_numeric_arrow_type``
+    makes, repeated here rather than imported because the cache must not depend
+    on the service layer (Flight imports this module).
+    """
+    import pyarrow as pa
+
+    try:
+        storage = getattr(arrow_type, "storage_type", None)
+        if storage is None or getattr(arrow_type, "type_name", None) is None:
+            return False
+        return bool(pa.types.is_string(storage))
+    except (AttributeError, TypeError):
+        return False
+
+
 def _serialized_field_type(arrow_type: Any) -> Any:
-    """The Arrow type a column has *after* the executor serialises its cells.
+    """The Arrow type a column has *after* the executor serialises its cells,
+    or ``None`` where the declaration says nothing the blob can use.
 
     ``encode_data`` is handed rows that already went through
     ``_serialize_value``: temporals become ISO strings, binary becomes base64,
@@ -48,9 +72,24 @@ def _serialized_field_type(arrow_type: Any) -> Any:
     the type its *serialised* values carry, which is the type the blob can
     actually hold - naming the driver's ``timestamp[us]`` here would be a
     declaration no serialised row could satisfy.
+
+    A string-backed numeric is the one case with no usable answer, and
+    ``None`` rather than ``string`` is what keeps it honest. Its cells arrive as
+    ``Decimal``, so ``string`` is refused wherever there are values and accepted
+    wherever there are none - the same column typed ``decimal128`` for one
+    filter and ``string`` for another, which is the instability this schema
+    exists to remove. A width cannot be invented instead: ADBC's opaque type
+    carries none, PostgreSQL reports typmod ``-1`` for a computed expression,
+    and offering a fixed one would rescale the value - ``1.50`` stored under
+    ``decimal128(38, 9)`` reads back ``1.500000000``, which is what a cache hit
+    would then render. So the column is inferred where it has values and left
+    ``null`` where it has none, and the entry's column sidecar carries the
+    ``number`` type and its format either way.
     """
     import pyarrow as pa
 
+    if _is_string_backed_extension(arrow_type):
+        return None
     try:
         if (
             pa.types.is_integer(arrow_type)
@@ -81,13 +120,17 @@ def build_result_table(column_names: list[str], rows: list[list[Any]], schema: A
 
     The declared type is only *offered*: rows have already been through
     ``_serialize_value``, so a column whose values no longer fit what the driver
-    declared falls back to inference. That is not a rare path. PostgreSQL
-    NUMERIC arrives as a string-backed extension type and its cells reach here
-    as ``Decimal``, so the offered ``string`` is refused and inference types the
-    column ``decimal128`` - which is what it did before this. pyarrow raises on
-    every such mismatch rather than coercing (measured: a Decimal into a string
-    array, a value wider than the declared precision, an integer too large for
-    the declared width), so the fallback cannot silently change a value.
+    declared falls back to inference. pyarrow raises on every such mismatch
+    rather than coercing (measured: a Decimal into a string array, a value wider
+    than the declared precision, an integer too large for the declared width),
+    so the fallback cannot silently change a value.
+
+    One declaration is refused before it is offered. A string-backed numeric -
+    PostgreSQL NUMERIC under ADBC - carries no width to read and its cells
+    arrive as ``Decimal``, so ``_serialized_field_type`` answers ``None`` for it
+    and the column is inferred, exactly as it was before this. Offering
+    ``string`` there would have been accepted by an empty result and refused by
+    a populated one, which is the instability this schema exists to remove.
 
     Without a schema, types are inferred as before. That is the PEP 249 path,
     which has no Arrow schema to read, and the ``format_values`` arrow response,
@@ -116,7 +159,7 @@ def build_result_table(column_names: list[str], rows: list[list[Any]], schema: A
     arrays = []
     for i, col in enumerate(cols_data):
         arr = None
-        if hints and not pa.types.is_null(hints[i]):
+        if hints and hints[i] is not None and not pa.types.is_null(hints[i]):
             with contextlib.suppress(pa.ArrowInvalid, pa.ArrowTypeError, TypeError, ValueError):
                 arr = pa.array(col, type=hints[i], from_pandas=False)
         if arr is None:

--- a/tests/unit/test_result_codec.py
+++ b/tests/unit/test_result_codec.py
@@ -136,3 +136,114 @@ def test_decode_data_is_shared_across_surfaces() -> None:
 def test_table_to_rows_preserves_schema_order() -> None:
     table = result_codec.build_result_table(["x", "y"], [[1, 2], [3, 4]])
     assert result_codec.table_to_rows(table) == [[1, 2], [3, 4]]
+
+
+# ---------------------------------------------------------------------------
+# The driver schema decides the column types
+# ---------------------------------------------------------------------------
+
+_DECIMAL_SCHEMA = pa.schema(
+    [
+        pa.field("Amount", pa.decimal128(18, 2)),
+        pa.field("Orders", pa.int64()),
+        pa.field("Ordered At", pa.timestamp("us")),
+        pa.field("Shipped", pa.bool_()),
+    ]
+)
+_DECIMAL_NAMES = ["Amount", "Orders", "Ordered At", "Shipped"]
+
+
+def test_declared_decimal_width_survives_narrow_values() -> None:
+    """A ``decimal(18, 2)`` measure holding 1.50 stays ``decimal128(18, 2)``.
+
+    Inference reads the digits that happen to be present and answered
+    ``decimal128(3, 2)``, so the blob advertised a narrower column than the
+    model declares.
+    """
+    from decimal import Decimal
+
+    rows = [[Decimal("1.50"), 3, "2026-08-15T13:45:00", True]]
+    table = result_codec.build_result_table(_DECIMAL_NAMES, rows, _DECIMAL_SCHEMA)
+
+    assert table.schema.field("Amount").type == pa.decimal128(18, 2)
+    assert table.to_pylist()[0]["Amount"] == Decimal("1.50")
+
+
+def test_declared_width_is_stable_across_result_sets() -> None:
+    """The same column answers the same Arrow type whatever rows it returns.
+
+    This is the property, not the width itself: a consumer that read the schema
+    from one result was wrong about the next, which is the failure #393 fixed on
+    MySQL and #407 on Snowflake.
+    """
+    from decimal import Decimal
+
+    narrow = result_codec.build_result_table(
+        _DECIMAL_NAMES, [[Decimal("1.50"), 3, "2026-08-15T13:45:00", True]], _DECIMAL_SCHEMA
+    )
+    wide = result_codec.build_result_table(
+        _DECIMAL_NAMES, [[Decimal("123456.78"), 4, "2026-08-15T14:45:00", False]], _DECIMAL_SCHEMA
+    )
+    empty = result_codec.build_result_table(_DECIMAL_NAMES, [], _DECIMAL_SCHEMA)
+
+    assert narrow.schema == wide.schema == empty.schema
+
+
+def test_temporals_still_serialize_as_strings() -> None:
+    """The declared type is mapped through serialisation first, so a
+    ``timestamp[us]`` column keeps the ISO string the executor produced rather
+    than a declaration no serialised row could satisfy."""
+    rows = [[None, None, "2026-08-15T13:45:00", None]]
+    table = result_codec.build_result_table(_DECIMAL_NAMES, rows, _DECIMAL_SCHEMA)
+
+    assert table.schema.field("Ordered At").type == pa.string()
+    assert table.to_pylist()[0]["Ordered At"] == "2026-08-15T13:45:00"
+
+
+def test_values_that_outgrow_the_declaration_fall_back_to_inference() -> None:
+    """A declared type is offered, never forced: pyarrow raises rather than
+    coercing, and the column is inferred instead of failing the encode."""
+    from decimal import Decimal
+
+    schema = pa.schema([pa.field("Amount", pa.decimal128(18, 2))])
+    table = result_codec.build_result_table(["Amount"], [[Decimal("1.5678")]], schema)
+
+    assert table.to_pylist() == [{"Amount": Decimal("1.5678")}]
+
+
+def test_string_backed_numeric_falls_back_to_decimal() -> None:
+    """PostgreSQL NUMERIC arrives as a string-backed extension type whose cells
+    reach the codec as ``Decimal``. The offered ``string`` is refused, so the
+    column is inferred as a decimal - what it was before the schema decided
+    types, and the value is unchanged either way."""
+    from decimal import Decimal
+
+    schema = pa.schema([pa.field("Amount", pa.string())])
+    table = result_codec.build_result_table(["Amount"], [[Decimal("1.50")]], schema)
+
+    assert pa.types.is_decimal(table.schema.field("Amount").type)
+    assert table.to_pylist() == [{"Amount": Decimal("1.50")}]
+
+
+def test_types_are_inferred_without_a_schema() -> None:
+    """The PEP 249 path has no Arrow schema, and the ``format_values`` arrow
+    response deliberately passes none. Both keep value inference."""
+    from decimal import Decimal
+
+    table = result_codec.build_result_table(["Amount"], [[Decimal("1.50")]])
+
+    assert table.schema.field("Amount").type == pa.decimal128(3, 2)
+
+
+def test_declared_types_survive_the_cache_round_trip() -> None:
+    """What the schema decided is what a cache hit reads back."""
+    from decimal import Decimal
+
+    rows = [[Decimal("1.50"), 3, "2026-08-15T13:45:00", True]]
+    decoded = result_codec.decode_data(
+        result_codec.encode_data(_DECIMAL_NAMES, rows, _DECIMAL_SCHEMA)
+    )
+
+    assert decoded.schema.field("Amount").type == pa.decimal128(18, 2)
+    assert decoded.schema.field("Orders").type == pa.int64()
+    assert result_codec.table_to_rows(decoded) == rows

--- a/tests/unit/test_result_codec.py
+++ b/tests/unit/test_result_codec.py
@@ -308,30 +308,57 @@ def test_declared_types_survive_the_cache_round_trip() -> None:
     assert result_codec.table_to_rows(decoded) == rows
 
 
-def test_non_numeric_string_backed_extension_keeps_its_string_hint() -> None:
-    """An opaque ``json`` or ``uuid`` is string-backed too, and its cells stay
-    strings all the way to the codec.
+@pytest.mark.parametrize(
+    ("type_name", "value"),
+    [
+        ("json", '{"a": 1}'),
+        ("uuid", "0b3d1f8e-6a1a-4c2a-9f3a-2b8b6f5a1c77"),
+        # ``interval`` contains ``int``, so a substring match calls it numeric.
+        ("interval", "1 day 02:00:00"),
+    ],
+)
+def test_non_numeric_string_backed_extension_keeps_its_string_hint(
+    type_name: str, value: str
+) -> None:
+    """An opaque ``json``, ``uuid`` or ``interval`` is string-backed too, and
+    its cells stay strings all the way to the codec.
 
     So ``string`` is the right offer for it, and the numeric refusal must not
-    reach it: without the ``type_name`` test these columns would be the
-    value-dependent ones instead, inferred ``string`` when populated and
-    ``null`` when empty.
+    reach it: these columns would otherwise be the value-dependent ones
+    instead, inferred ``string`` when populated and ``null`` when empty.
     """
-    schema = [_StringBackedField("Payload", type_name="json")]
+    schema = [_StringBackedField("Payload", type_name=type_name)]
 
-    populated = result_codec.build_result_table(["Payload"], [['{"a": 1}']], schema)
+    populated = result_codec.build_result_table(["Payload"], [[value]], schema)
     all_null = result_codec.build_result_table(["Payload"], [[None], [None]], schema)
     empty = result_codec.build_result_table(["Payload"], [], schema)
 
     assert populated.schema == all_null.schema == empty.schema
     assert pa.types.is_string(empty.schema.field("Payload").type)
-    assert populated.to_pylist() == [{"Payload": '{"a": 1}'}]
+    assert populated.to_pylist() == [{"Payload": value}]
+
+
+@pytest.mark.parametrize("type_name", ["numeric", "decimal", "bigint", "smallint", "integer"])
+def test_numeric_string_backed_names_still_refuse_the_string_hint(type_name: str) -> None:
+    """The exclusion must not cost the family it sits inside: every numeric name
+    still reaches the refusal, which is why the tokens are substrings."""
+    from decimal import Decimal
+
+    schema = [_StringBackedField("Amount", type_name=type_name)]
+    table = result_codec.build_result_table(["Amount"], [[Decimal("1.50")]], schema)
+
+    assert pa.types.is_decimal(table.schema.field("Amount").type)
 
 
 def test_numeric_tokens_match_the_service_definition() -> None:
     """The cache may not import the service layer
     (``tests/architecture/test_dependencies.py``), so the numeric ``type_name``
-    tokens are spelled twice. A test is what keeps the copies equal."""
+    tokens are spelled twice. A test is what keeps the copies equal.
+
+    The codec's exclusion list is its own: ``is_numeric_type_hint`` reads a
+    column's *declared* type, where ``interval`` never appears, while this reads
+    an extension's ``type_name``, where it does.
+    """
     from orionbelt.service.value_formatting import _NUMERIC_TYPE_TOKENS
 
     assert result_codec._NUMERIC_TYPE_TOKENS == _NUMERIC_TYPE_TOKENS

--- a/tests/unit/test_result_codec.py
+++ b/tests/unit/test_result_codec.py
@@ -213,8 +213,8 @@ def test_values_that_outgrow_the_declaration_fall_back_to_inference() -> None:
     assert table.to_pylist() == [{"Amount": Decimal("1.5678")}]
 
 
-class _StringBackedNumericField:
-    """A schema field whose type is a string-backed numeric extension.
+class _StringBackedField:
+    """A schema field whose type is a string-backed Arrow extension.
 
     ``pa.opaque`` is used where the installed pyarrow has it and stood in for
     otherwise, since the floor is ``pyarrow>=16`` and the constructor arrived in
@@ -222,13 +222,13 @@ class _StringBackedNumericField:
     ``type``, which is all either shape has to provide.
     """
 
-    def __init__(self, name: str) -> None:
+    def __init__(self, name: str, type_name: str = "numeric") -> None:
         self.name = name
         opaque = getattr(pa, "opaque", None)
         if opaque is not None:
-            self.type: Any = opaque(pa.string(), "numeric", "postgresql")
+            self.type: Any = opaque(pa.string(), type_name, "postgresql")
         else:
-            self.type = SimpleNamespace(storage_type=pa.string(), type_name="numeric")
+            self.type = SimpleNamespace(storage_type=pa.string(), type_name=type_name)
 
 
 def test_string_backed_numeric_is_never_typed_as_text() -> None:
@@ -244,7 +244,7 @@ def test_string_backed_numeric_is_never_typed_as_text() -> None:
     """
     from decimal import Decimal
 
-    schema = [_StringBackedNumericField("Amount")]
+    schema = [_StringBackedField("Amount")]
 
     populated = result_codec.build_result_table(["Amount"], [[Decimal("1.50")]], schema)
     all_null = result_codec.build_result_table(["Amount"], [[None], [None]], schema)
@@ -265,7 +265,7 @@ def test_string_backed_numeric_keeps_its_scale_through_the_cache() -> None:
     ``1.50`` has to come back ``1.50``."""
     from decimal import Decimal
 
-    schema = [_StringBackedNumericField("Amount")]
+    schema = [_StringBackedField("Amount")]
     payload = result_codec.encode_data(["Amount"], [[Decimal("1.50")]], schema)
 
     assert result_codec.table_to_rows(result_codec.decode_data(payload)) == [[Decimal("1.50")]]
@@ -306,3 +306,32 @@ def test_declared_types_survive_the_cache_round_trip() -> None:
     assert decoded.schema.field("Amount").type == pa.decimal128(18, 2)
     assert decoded.schema.field("Orders").type == pa.int64()
     assert result_codec.table_to_rows(decoded) == rows
+
+
+def test_non_numeric_string_backed_extension_keeps_its_string_hint() -> None:
+    """An opaque ``json`` or ``uuid`` is string-backed too, and its cells stay
+    strings all the way to the codec.
+
+    So ``string`` is the right offer for it, and the numeric refusal must not
+    reach it: without the ``type_name`` test these columns would be the
+    value-dependent ones instead, inferred ``string`` when populated and
+    ``null`` when empty.
+    """
+    schema = [_StringBackedField("Payload", type_name="json")]
+
+    populated = result_codec.build_result_table(["Payload"], [['{"a": 1}']], schema)
+    all_null = result_codec.build_result_table(["Payload"], [[None], [None]], schema)
+    empty = result_codec.build_result_table(["Payload"], [], schema)
+
+    assert populated.schema == all_null.schema == empty.schema
+    assert pa.types.is_string(empty.schema.field("Payload").type)
+    assert populated.to_pylist() == [{"Payload": '{"a": 1}'}]
+
+
+def test_numeric_tokens_match_the_service_definition() -> None:
+    """The cache may not import the service layer
+    (``tests/architecture/test_dependencies.py``), so the numeric ``type_name``
+    tokens are spelled twice. A test is what keeps the copies equal."""
+    from orionbelt.service.value_formatting import _NUMERIC_TYPE_TOKENS
+
+    assert result_codec._NUMERIC_TYPE_TOKENS == _NUMERIC_TYPE_TOKENS

--- a/tests/unit/test_result_codec.py
+++ b/tests/unit/test_result_codec.py
@@ -8,6 +8,8 @@ baked in — metadata is rebuilt fresh on every read.
 from __future__ import annotations
 
 import gzip
+from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -211,11 +213,68 @@ def test_values_that_outgrow_the_declaration_fall_back_to_inference() -> None:
     assert table.to_pylist() == [{"Amount": Decimal("1.5678")}]
 
 
-def test_string_backed_numeric_falls_back_to_decimal() -> None:
-    """PostgreSQL NUMERIC arrives as a string-backed extension type whose cells
-    reach the codec as ``Decimal``. The offered ``string`` is refused, so the
-    column is inferred as a decimal - what it was before the schema decided
-    types, and the value is unchanged either way."""
+class _StringBackedNumericField:
+    """A schema field whose type is a string-backed numeric extension.
+
+    ``pa.opaque`` is used where the installed pyarrow has it and stood in for
+    otherwise, since the floor is ``pyarrow>=16`` and the constructor arrived in
+    18. ``build_result_table`` reads a schema for its length and each field's
+    ``type``, which is all either shape has to provide.
+    """
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        opaque = getattr(pa, "opaque", None)
+        if opaque is not None:
+            self.type: Any = opaque(pa.string(), "numeric", "postgresql")
+        else:
+            self.type = SimpleNamespace(storage_type=pa.string(), type_name="numeric")
+
+
+def test_string_backed_numeric_is_never_typed_as_text() -> None:
+    """PostgreSQL NUMERIC under ADBC arrives as a string-backed extension type
+    whose cells reach the codec as ``Decimal``.
+
+    Offering ``string`` for it would be refused by a populated result and
+    accepted by an empty one, so the same column would be cached as
+    ``decimal128`` for one filter and ``string`` for another - the instability
+    the driver schema is here to remove. It carries no width to offer instead,
+    so the column is inferred where it has values and left ``null`` where it has
+    none, with the entry's column sidecar carrying ``number`` either way.
+    """
+    from decimal import Decimal
+
+    schema = [_StringBackedNumericField("Amount")]
+
+    populated = result_codec.build_result_table(["Amount"], [[Decimal("1.50")]], schema)
+    all_null = result_codec.build_result_table(["Amount"], [[None], [None]], schema)
+    empty = result_codec.build_result_table(["Amount"], [], schema)
+
+    for table in (populated, all_null, empty):
+        assert not pa.types.is_string(table.schema.field("Amount").type)
+
+    assert pa.types.is_decimal(populated.schema.field("Amount").type)
+    assert populated.to_pylist() == [{"Amount": Decimal("1.50")}]
+    assert pa.types.is_null(all_null.schema.field("Amount").type)
+    assert pa.types.is_null(empty.schema.field("Amount").type)
+
+
+def test_string_backed_numeric_keeps_its_scale_through_the_cache() -> None:
+    """The reason no fixed width is invented for it: a value stored under a
+    wider scale reads back rescaled, and that is what a cache hit renders.
+    ``1.50`` has to come back ``1.50``."""
+    from decimal import Decimal
+
+    schema = [_StringBackedNumericField("Amount")]
+    payload = result_codec.encode_data(["Amount"], [[Decimal("1.50")]], schema)
+
+    assert result_codec.table_to_rows(result_codec.decode_data(payload)) == [[Decimal("1.50")]]
+
+
+def test_declared_string_column_receiving_decimals_falls_back() -> None:
+    """The generic form of the same refusal: pyarrow will not put a ``Decimal``
+    in a string array, so the column is inferred rather than the encode failing.
+    """
     from decimal import Decimal
 
     schema = pa.schema([pa.field("Amount", pa.string())])


### PR DESCRIPTION
## The defect

`build_result_table` inferred every column's Arrow type from the values a result happened to contain, and used the driver schema only to rescue a column that inference would otherwise have typed `null`.

So a `decimal(18, 2)` measure holding 1.50 and 2.25 was stored and streamed as `decimal128(3, 2)`, and the same column came back a **different width for a different filter**. A consumer that read the schema from one result was wrong about the next.

That is the failure #393 fixed on MySQL and #407 on Snowflake, arriving at the codec by a third route, and the fix is the same one: read the width from the declaration rather than from the rows.

Measured on a real DuckDB execution, `SUM(amount)` over `DECIMAL(18, 2)`:

| | type |
| --- | --- |
| driver schema | `decimal128(38, 2)` |
| cached, before | `decimal128(3, 2)` |
| cached, after | `decimal128(38, 2)` |

It reaches both consumers of the codec, since they share one call: the cache blob, which a `format=arrow` hit serves verbatim, and the fresh `format=arrow` response.

## The declared type is offered, never forced

Rows have already been through `_serialize_value`, so the schema is mapped through `_serialized_field_type` first: a `timestamp[us]` column still holds the ISO string the executor produced, because naming the driver's type there would be a declaration no serialised row could satisfy.

Where the offer is refused, the column is inferred exactly as before. pyarrow raises rather than coercing on every such mismatch, measured:

| offer | values | pyarrow |
| --- | --- | --- |
| `string` | `Decimal('1.50')` | `ArrowTypeError` |
| `decimal128(18, 2)` | `Decimal('1.5678')` | `ArrowInvalid`, rescaling would lose data |
| `decimal128(18, 2)` | 21-digit value | `ArrowInvalid`, precision does not fit |
| `int32` | 2^40 | `ArrowInvalid`, too large |

So the fallback cannot silently change a value.

One declaration is refused before it is offered. A string-backed numeric (PostgreSQL NUMERIC under ADBC) carries no width to read, and its cells reach the codec as `Decimal`. Offering `string` there would be refused by a populated result and **accepted by an empty or all-null one**, so the same column would still be cached as `decimal128` for one filter and `string` for another. `_serialized_field_type` answers `None` for it, and a `None` hint means infer: the column is inferred where it has values, left `null` where it has none, and the entry's column sidecar carries `number` and its format either way.

The refusal is scoped by `type_name`, not by the string storage alone: an opaque `json`, `uuid` or `interval` is string-backed too and its cells stay strings, so `string` stays the right offer for those and they keep one schema across every result shape. `interval` is excluded by name rather than by the token match, because the numeric names are a family and `int` has to keep reaching `bigint`, `smallint` and `integer`.

No width is invented instead. ADBC's opaque type carries none and PostgreSQL reports typmod `-1` for a computed expression, so any fixed choice would be arbitrary, and it would also rescale: `1.50` stored under `decimal128(38, 9)` reads back `1.500000000`, which is then what a cache hit renders and what the JSON surface prints for a value a fresh miss prints as `1.50`.

Without a schema, types are inferred as before: the PEP 249 path, which has no Arrow schema to read, and the `format_values` arrow response, where every cell is a display string by construction.

**No wire format changes.** What a temporal, string or binary column carries is untouched. Only the width a numeric column declares moves, toward the one the model and the driver already agreed on.

## Scope

Track I-5 of `design/PLAN_adbc.md`, in part. The remaining half of that phase, making `encode_table` the only cache-write path, means caching native Arrow rather than serialised rows. That changes what a `format=arrow` client receives for a temporal column (an Arrow timestamp instead of an ISO string), so it is a wire change and wants its own decision. Not in this PR.

The phase's other acceptance criterion, `_execute_duckdb` returning an Arrow table with no `_serialize_row` on the DuckDB path, was already met by #381.

## Tests

- 18 new tests in `tests/unit/test_result_codec.py`: the declared width survives narrow values, the width is stable across result sets, temporals still serialize as strings, values that outgrow the declaration fall back to inference, a declared string column receiving Decimals falls back, a string-backed numeric is never typed as text in any of the populated / all-null / empty shapes, its scale survives the cache round trip, no schema still infers, and the declared types survive the cache round trip
- full suite: 4902 passed, 1046 skipped, 1 xfailed
- `ruff check`, `ruff format`, `mypy src/` clean


