### PR TITLE
feat(validate): check a model against the datasource on request

### DIFF
--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -283,6 +283,82 @@ Validate OBML YAML within a session context. Does not store the model.
 }
 ```
 
+#### Checking the model against the datasource
+
+Validation is offline by default: the model is checked against itself and the
+OBML schema, and no connection is opened. That leaves one thing unchecked — the
+physical binding. A data object's `database` / `schema` / `code`, and each
+column's `code`, are opaque strings to the validator, so a model can be valid in
+every structural sense and still name a table that was dropped or a column that
+was renamed. The first thing to say so is the warehouse, at query time.
+
+`?online=true` closes that gap:
+
+| Query param | Default | Meaning |
+|---|---|---|
+| `online` | `false` | Probe the datasource for every data object's table and declared columns |
+| `dialect` | `DB_VENDOR` | Which configured datasource to probe |
+
+`dialect` here selects a *connection to open*, which is why it falls back to
+`DB_VENDOR` rather than to the model's `settings.defaultDialect` — a model
+declaring `defaultDialect: snowflake` on a DuckDB deployment would otherwise be
+probed by opening a Snowflake connection that does not exist.
+
+Each data object costs one round trip: a `SELECT <declared columns> FROM <table>
+LIMIT 0`, quoted exactly as a compiled query would quote it. That plans without
+scanning, and proves the columns are addressable through the same connection and
+the same spelling real queries use — which also settles identifier case without
+OBSL having to know which engines fold it. Only when that projection fails does
+a second `SELECT * ... LIMIT 0` run, to tell a missing table from a missing
+column and to name which one.
+
+Findings are errors like any other, so `valid` goes to `false`:
+
+```json
+{
+ "valid": false,
+ "errors": [
+ {
+ "code": "DATASOURCE_COLUMN_MISSING",
+ "message": "Column 'order_id' does not exist on main.orders (data object 'Orders').",
+ "path": "dataObjects.Orders.columns.Order ID.code",
+ "hint": "Correct the column's 'code', or drop the column from the model."
+ },
+ {
+ "code": "DATASOURCE_TYPE_MISMATCH",
+ "message": "Column 'amount' on data object 'Orders' is declared 'float' but the datasource returns a string column.",
+ "path": "dataObjects.Orders.columns.Amount.abstractType"
+ }
+ ],
+ "warnings": []
+}
+```
+
+| Code | Meaning |
+|---|---|
+| `DATASOURCE_TABLE_MISSING` | The table a data object maps to could not be read. Carries the driver's own error. |
+| `DATASOURCE_COLUMN_MISSING` | A declared `code` names no column on an existing table. |
+| `DATASOURCE_COLUMN_CASE` | The column exists under a different letter case, and this engine rejected the model's spelling. The hint carries the real one. |
+| `DATASOURCE_TYPE_MISMATCH` | The column's type is not in the family its `abstractType` declares. |
+| `DATASOURCE_UNAVAILABLE` | The check could not run at all — no driver, no credentials, no connection. Reported once, not per data object. |
+| `DATASOURCE_UNSUPPORTED_DIALECT` | `dialect` names an engine OBSL has no dialect for. |
+| `DATASOURCE_PROBE_FAILED` | The table and columns are all there but the read was still refused (a column-level grant, most likely). Carries the driver's error. |
+
+Since the flag is opt-in, it fails closed: asking for a check that cannot run
+returns `DATASOURCE_UNAVAILABLE` and `valid: false` rather than a green light.
+
+Two things are deliberately out of scope. Type comparison is by *family* —
+number, datetime, string, boolean, binary — so a `float` backed by `DECIMAL(38,9)`
+or a `timestamp` backed by `DATE` is not drift; only a `float` backed by text
+is. And a column that comes back null-typed, which a zero-row fetch is exactly
+where you find, is skipped rather than reported. Data objects sourced through
+`nestedIn` are not probed: their rows come from unnesting a parent's array
+column, so their columns belong to that array's element type rather than to any
+table of their own.
+
+The same options are on `POST /v1/validate` (stateless) and on the CLI as
+`obsl validate --online`.
+
 ---
 
 ## Session Query Compilation & Execution

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -53,7 +53,7 @@ For `compile` and `execute` you supply the query one of two ways (exactly one):
 | Command | Options |
 | --- | --- |
 | _common (where remote-capable)_ | `-f, --format {table,json,csv,tsv}` · `-s, --server URL` (env `OBSL_SERVER`) · `--api-key KEY` (env `OBSL_API_KEY`) |
-| `validate` | `-f/--format` · `-s/--server` · `--api-key` |
+| `validate` | `--online` · `-d/--dialect NAME` (with `--online`; defaults to `DB_VENDOR`) · `-f/--format` · `-s/--server` · `--api-key` |
 | `compile` | `-q/--query PATH` · `--sql TEXT` · `-d/--dialect NAME` · `--explain` · `--pretty/--no-pretty` (default pretty) · `-f/--format` · `-s/--server` · `--api-key` |
 | `execute` | `-q/--query PATH` · `--sql TEXT` · `-d/--dialect NAME` · `--limit N` (default 1000; see note) · `-f/--format` · `-s/--server` · `--api-key` |
 | `describe` | `-f/--format` |
@@ -85,6 +85,52 @@ obsl validate model.yaml -f json   # machine-readable result
 - run: |
     for m in models/*.yaml; do obsl validate "$m" || exit 1; done
 ```
+
+### Checking against the datasource
+
+Validation is offline by default: the model is checked against itself and the
+OBML schema, and no connection is opened. The physical binding is what that
+leaves out — a data object's `code` and each column's `code` are opaque strings
+to the validator, so a model stays valid after the table behind it is dropped or
+a column is renamed, and the warehouse is the first thing to say otherwise.
+
+`--online` adds a probe of every data object: one `SELECT <declared columns>
+FROM <table> LIMIT 0`, quoted the way a compiled query would quote it, which
+plans without scanning and proves the columns are readable under the spelling
+the model uses.
+
+```bash
+obsl validate model.yaml --online
+# error: model is invalid:
+# error:   [DATASOURCE_COLUMN_MISSING] Column 'order_id' does not exist on main.orders
+#          (data object 'Orders'). (dataObjects.Orders.columns.Order ID.code)
+# error:   [DATASOURCE_TYPE_MISMATCH] Column 'amount' on data object 'Orders' is declared
+#          'float' but the datasource returns a string column.
+# error:   [DATASOURCE_TABLE_MISSING] Data object 'Shipments' maps to main.shipments,
+#          which the datasource could not read: Catalog Error: Table with name
+#          shipments does not exist!
+```
+
+Findings are errors like any other, so the command exits `1` — which is what
+makes it useful as a post-deploy check, run against the warehouse the model will
+actually query:
+
+```yaml
+- run: obsl validate models/sales.yaml --online
+  env:
+    DB_VENDOR: postgres
+    POSTGRES_HOST: ${{ secrets.PG_HOST }}
+```
+
+`-d/--dialect` picks which configured datasource to probe. Note that it defaults
+to `DB_VENDOR` rather than to the model's `defaultDialect`, unlike the `--dialect`
+on `compile` and `execute`: here it selects a *connection to open*, and the model's
+declared dialect says what SQL to generate, not what server is reachable.
+
+Because the flag is opt-in it fails closed — if the connection is missing you get
+`DATASOURCE_UNAVAILABLE` and a non-zero exit, not a pass. See
+[the endpoint reference](../api/endpoints.md#checking-the-model-against-the-datasource)
+for the full list of codes and what the probe deliberately does not check.
 
 ## Compile
 

--- a/src/orionbelt/api/routers/sessions.py
+++ b/src/orionbelt/api/routers/sessions.py
@@ -110,6 +110,7 @@ __all__ = [
     "router",
     # re-exported helpers (imported by other modules from this namespace)
     "_resolve_dialect",
+    "_probe_dialect",
     "_run_with_cache",
     "_build_execute_response",
     "_build_explain_response",
@@ -444,13 +445,40 @@ async def remove_model(
 # -- validation & query -----------------------------------------------------
 
 
+def _probe_dialect(online: bool, dialect: str | None) -> str | None:
+    """The dialect the datasource probe should use, or ``None`` when offline.
+
+    Deliberately *not* the chain :func:`_resolve_dialect` walks. That one picks
+    the SQL to generate, where the model's ``defaultDialect`` is the best
+    answer; this one picks a *connection to open*, and the only connection a
+    deployment is configured for is ``DB_VENDOR``. A model that declares
+    ``defaultDialect: snowflake`` on a DuckDB deployment would otherwise be
+    probed by opening a Snowflake connection that does not exist, and every
+    data object would come back unavailable.
+    """
+    if not online:
+        return None
+    from orionbelt.api.deps import get_db_vendor
+
+    return dialect or get_db_vendor()
+
+
 @router.post("/{session_id}/validate", response_model=ValidateResponse)
 async def validate_model(
     session_id: str,
     body: ValidateRequest,
+    online: bool = False,
+    dialect: str | None = None,
     mgr: SessionManager = Depends(get_session_manager),  # noqa: B008
 ) -> ValidateResponse:
-    """Validate an OBML model within a session context."""
+    """Validate an OBML model within a session context.
+
+    With ``online=true`` the model is additionally checked against the
+    configured datasource: each data object is probed for its table and its
+    declared columns, and drift is reported as an error. ``dialect`` selects
+    the engine to probe, defaulting to the model's ``settings.defaultDialect``
+    then ``DB_VENDOR``.
+    """
     if not body.model_yaml and not body.model_json:
         raise HTTPException(status_code=422, detail="Provide either model_yaml or model_json")
     store = _get_store(session_id, mgr)
@@ -459,6 +487,7 @@ async def validate_model(
         raw_dict=cast("dict[str, object] | None", body.model_json),
         extends_yaml=body.extends,
         inherits_model_id=body.inherits,
+        datasource_dialect=_probe_dialect(online, dialect),
     )
     return ValidateResponse(
         valid=summary.valid,

--- a/src/orionbelt/api/routers/sessions.py
+++ b/src/orionbelt/api/routers/sessions.py
@@ -476,8 +476,10 @@ async def validate_model(
     With ``online=true`` the model is additionally checked against the
     configured datasource: each data object is probed for its table and its
     declared columns, and drift is reported as an error. ``dialect`` selects
-    the engine to probe, defaulting to the model's ``settings.defaultDialect``
-    then ``DB_VENDOR``.
+    the datasource to probe and defaults to ``DB_VENDOR`` — it names a
+    connection to open, not SQL to generate, so unlike the ``dialect`` on the
+    query endpoints it does not fall back to the model's
+    ``settings.defaultDialect``.
     """
     if not body.model_yaml and not body.model_json:
         raise HTTPException(status_code=422, detail="Provide either model_yaml or model_json")

--- a/src/orionbelt/api/routers/shortcuts.py
+++ b/src/orionbelt/api/routers/shortcuts.py
@@ -413,11 +413,23 @@ async def shortcut_sparql(
 @router.post("/validate", response_model=ValidateResponse, tags=["validation"])
 async def shortcut_validate(
     body: ValidateRequest,
+    online: bool = False,
+    dialect: str | None = None,
 ) -> ValidateResponse:
-    """Validate an OBML model (stateless — no session required)."""
+    """Validate an OBML model (stateless — no session required).
+
+    With ``online=true`` the model is additionally checked against the
+    configured datasource: each data object is probed for its table and its
+    declared columns, and drift is reported as an error. ``dialect`` selects
+    the engine to probe, defaulting to ``DB_VENDOR``.
+    """
+    from orionbelt.api.routers.sessions import _probe_dialect
+
     store = ModelStore()
     raw = cast("dict[str, object] | None", body.model_json)
-    summary = store.validate(body.model_yaml, raw_dict=raw)
+    summary = store.validate(
+        body.model_yaml, raw_dict=raw, datasource_dialect=_probe_dialect(online, dialect)
+    )
     return ValidateResponse(
         valid=summary.valid,
         errors=[error_info_to_detail(e) for e in summary.errors],

--- a/src/orionbelt/api/routers/shortcuts.py
+++ b/src/orionbelt/api/routers/shortcuts.py
@@ -421,7 +421,10 @@ async def shortcut_validate(
     With ``online=true`` the model is additionally checked against the
     configured datasource: each data object is probed for its table and its
     declared columns, and drift is reported as an error. ``dialect`` selects
-    the engine to probe, defaulting to ``DB_VENDOR``.
+    the datasource to probe and defaults to ``DB_VENDOR`` — it names a
+    connection to open, not SQL to generate, so unlike the ``dialect`` on the
+    query endpoints it does not fall back to the model's
+    ``settings.defaultDialect``.
     """
     from orionbelt.api.routers.sessions import _probe_dialect
 

--- a/src/orionbelt/cli/_local.py
+++ b/src/orionbelt/cli/_local.py
@@ -85,9 +85,18 @@ def _compile(
         raise CliError(str(exc)) from None
 
 
-def validate(model_yaml: str) -> ValidationSummary:
-    """Validate an OBML model without storing it."""
-    return ModelStore().validate(model_yaml)
+def validate(
+    model_yaml: str, *, online: bool = False, dialect: str | None = None
+) -> ValidationSummary:
+    """Validate an OBML model without storing it.
+
+    ``online`` additionally probes the configured datasource for every data
+    object's table and declared columns. The dialect selects the *connection*
+    to open, so it falls back to ``DB_VENDOR`` rather than to the model's
+    ``defaultDialect`` — see ``api.routers.sessions._probe_dialect``.
+    """
+    probe_dialect = (dialect or os.getenv("DB_VENDOR") or "duckdb") if online else None
+    return ModelStore().validate(model_yaml, datasource_dialect=probe_dialect)
 
 
 def _load(model_yaml: str) -> tuple[ModelStore, str, SemanticModel]:

--- a/src/orionbelt/cli/_remote.py
+++ b/src/orionbelt/cli/_remote.py
@@ -70,8 +70,16 @@ class RemoteClient:
 
     # -- operations ---------------------------------------------------------
 
-    def validate(self, model_yaml: str) -> dict[str, Any]:
-        return cast("dict[str, Any]", self._post("/validate", {"model_yaml": model_yaml}))
+    def validate(
+        self, model_yaml: str, *, online: bool = False, dialect: str | None = None
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {"online": "true"} if online else {}
+        if online and dialect:
+            params["dialect"] = dialect
+        return cast(
+            "dict[str, Any]",
+            self._post("/validate", {"model_yaml": model_yaml}, params=params or None),
+        )
 
     def _query_body(self, query: QueryObject) -> dict[str, Any]:
         return query.model_dump(by_alias=True, mode="json", exclude_none=True)

--- a/src/orionbelt/cli/main.py
+++ b/src/orionbelt/cli/main.py
@@ -154,21 +154,55 @@ def _remote_input_schema_warnings(data: dict[str, Any], label: str) -> list[str]
 # --------------------------------------------------------------------------
 
 
+OnlineOpt = Annotated[
+    bool,
+    typer.Option(
+        "--online",
+        help=(
+            "Also check the model against the datasource: probe every data object "
+            "for its table, declared columns and column types."
+        ),
+    ),
+]
+#: Separate from ``DialectOpt`` because it selects a different thing. That one
+#: picks the SQL to generate and falls back to the model's ``defaultDialect``;
+#: this one picks the connection the probe opens, and the only connection a
+#: deployment has is ``DB_VENDOR``.
+ProbeDialectOpt = Annotated[
+    str | None,
+    typer.Option(
+        "--dialect",
+        "-d",
+        help="Datasource to probe with --online (defaults to DB_VENDOR).",
+    ),
+]
+
+
 @app.command()
 def validate(
     model: ModelArg,
     fmt: FormatOpt = OutputFormat.table,
+    online: OnlineOpt = False,
+    dialect: ProbeDialectOpt = None,
     server: ServerOpt = None,
     api_key: ApiKeyOpt = None,
 ) -> None:
-    """Validate an OBML model. Exits non-zero when the model is invalid."""
+    """Validate an OBML model. Exits non-zero when the model is invalid.
+
+    Offline by default: the model is checked against itself and the OBML
+    schema, and no connection is opened. ``--online`` adds a datasource probe
+    whose findings are errors like any other, so a dropped table or a renamed
+    column fails the command.
+    """
     model_yaml = _io.read_text(model)
     if server:
         from orionbelt.cli._local import CliError
         from orionbelt.cli._remote import RemoteClient
 
         try:
-            data = RemoteClient(server, api_key).validate(model_yaml)
+            data = RemoteClient(server, api_key).validate(
+                model_yaml, online=online, dialect=dialect
+            )
         except CliError as exc:
             raise _fail(str(exc)) from None
         valid = bool(data.get("valid"))
@@ -177,7 +211,7 @@ def validate(
     else:
         from orionbelt.cli import _local
 
-        summary = _local.validate(model_yaml)
+        summary = _local.validate(model_yaml, online=online, dialect=dialect)
         valid = summary.valid
         errors = [dataclasses.asdict(e) for e in summary.errors]
         warnings = [dataclasses.asdict(w) for w in summary.warnings]

--- a/src/orionbelt/service/datasource_probe.py
+++ b/src/orionbelt/service/datasource_probe.py
@@ -278,8 +278,12 @@ def _type_findings(
                 ),
                 path=f"dataObjects.{obj_name}.columns.{col.name}.abstractType",
                 hint=(
-                    f"Change abstractType to one of the '{declared}' family that matches "
-                    f"the column, or cast it in the source view."
+                    # Names the family that came back, not the declared one. The
+                    # declared family is what the model already says, so offering
+                    # it as the correction reads as "change float to a number
+                    # type" - advice to make no change at all.
+                    f"Either change abstractType to a '{actual}' type, or cast "
+                    f"'{col.code}' to {col.abstract_type} in the source view."
                 ),
                 context={
                     "dataObject": obj_name,

--- a/src/orionbelt/service/datasource_probe.py
+++ b/src/orionbelt/service/datasource_probe.py
@@ -74,15 +74,35 @@ _DECLARED_FAMILY: dict[DataType, str] = {
 }
 
 
-def _arrow_family(arrow_type: Any) -> str | None:
-    """Family for a PyArrow type, or ``None`` when it should not be compared.
+#: Opaque vendor type names that are positively text, as opposed to names
+#: ``coarse_hint_from_type_name`` merely fails to place. It answers ``"string"``
+#: for both, so without this list a Postgres ``uuid`` or ``xml`` column stays
+#: undecidable and a ``float`` declared over it passes. Every entry is a type
+#: whose values *are* text; a name not here (``tsvector``, a vendor type nobody
+#: has seen) still refutes nothing.
+_OPAQUE_STRING_NAMES = frozenset(
+    {
+        "uuid",
+        "xml",
+        "json",
+        "jsonb",
+        "inet",
+        "cidr",
+        "macaddr",
+        "macaddr8",
+        "citext",
+        "name",
+        "bpchar",
+        "character",
+        "character varying",
+        "varchar",
+        "text",
+    }
+)
 
-    ``None`` is the answer for a null-typed column and for anything this does
-    not recognise: a nested or extension type carries no claim the model made,
-    and guessing at one would report a mismatch that is really an omission
-    here. A ``LIMIT 0`` fetch is where null-typed columns turn up, so that
-    branch is load-bearing rather than defensive.
-    """
+
+def _structural_family(arrow_type: Any) -> str | None:
+    """Family from PyArrow's own type predicates, or ``None`` if none match."""
     import pyarrow as pa
 
     try:
@@ -114,35 +134,57 @@ def _arrow_family(arrow_type: Any) -> str | None:
         if pa.types.is_binary(arrow_type) or pa.types.is_large_binary(arrow_type):
             return _BINARY
     except (AttributeError, TypeError):
-        # ADBC hands back OpaqueType subclasses that do not implement the full
+        # ADBC hands back extension subclasses that do not implement the full
         # DataType protocol, and the ``pa.types.is_*`` helpers raise on them
-        # rather than returning False. Fall through to the name-based route.
-        pass
-    return _opaque_family(arrow_type)
+        # rather than returning False.
+        return None
+    return None
 
 
-def _opaque_family(arrow_type: Any) -> str | None:
-    """Family for a type PyArrow cannot represent natively, by its vendor name.
+def _arrow_family(arrow_type: Any) -> str | None:
+    """Family for a PyArrow type, or ``None`` when it should not be compared.
 
-    ADBC's Postgres driver wraps ``NUMERIC``, ``MONEY`` and friends in an
-    ``OpaqueType`` whose storage is a string. Every ``pa.types.is_*`` helper
-    answers False for it, so the structural route above classifies a Postgres
-    ``NUMERIC`` column as nothing at all and a measure declared over it is
-    never type-checked - the one place the check is most worth having.
+    ``None`` is the answer for a null-typed column and for anything neither
+    route below places: an unplaced type carries no claim the model made, and
+    guessing would report a mismatch that is really an omission here. A
+    ``LIMIT 0`` fetch is where null-typed columns turn up, so that branch is
+    load-bearing rather than defensive.
 
-    ``db_executor`` already recovers these from the ``type_name`` the wrapper
-    carries; this reuses that mapping rather than growing a second copy of it.
-    The result is coarse, so it goes through :func:`_hint_family` for the same
-    reason the PEP 249 path does: ``coarse_hint_from_type_name`` answers
-    ``"string"`` both for a real text type and for everything it does not
-    recognise, and that cannot be allowed to refute a declaration.
+    Two routes, because a driver has two ways of handing back a type PyArrow
+    has no native spelling for, and they need opposite treatment:
+
+    ``arrow.opaque``
+        ADBC's escape hatch for a vendor type it cannot convert - Postgres
+        ``NUMERIC``, ``MONEY``, ``uuid``, ``tsvector``. Its storage is a
+        *carrier*, almost always a string, and says nothing about the value:
+        classifying ``NUMERIC`` by its storage would call it text. Only the
+        vendor ``type_name`` means anything, so that is what is read.
+
+    A canonical extension (``arrow.json``, ...)
+        The opposite. Its storage *is* the representation - Postgres ``json``
+        and ``jsonb`` both arrive as ``arrow.json`` over string storage - so
+        the storage type is exactly the right thing to classify, and it keeps
+        working for canonical extensions that do not exist yet.
     """
-    from orionbelt.service.db_executor import coarse_hint_from_type_name
+    family = _structural_family(arrow_type)
+    if family is not None:
+        return family
 
     type_name = getattr(arrow_type, "type_name", None)
-    if not isinstance(type_name, str):
-        return None
-    return _hint_family(coarse_hint_from_type_name(type_name))
+    if isinstance(type_name, str):
+        if type_name.lower() in _OPAQUE_STRING_NAMES:
+            return _STRING
+        from orionbelt.service.db_executor import coarse_hint_from_type_name
+
+        # Coarse, so it goes through ``_hint_family`` for the reason the PEP 249
+        # path does: ``"string"`` is that mapping's unknown bucket as well as
+        # its answer for text, and an unknown must not refute a declaration.
+        return _hint_family(coarse_hint_from_type_name(type_name))
+
+    storage = getattr(arrow_type, "storage_type", None)
+    if storage is not None:
+        return _structural_family(storage)
+    return None
 
 
 def _hint_family(type_hint: str) -> str | None:

--- a/src/orionbelt/service/datasource_probe.py
+++ b/src/orionbelt/service/datasource_probe.py
@@ -1,0 +1,452 @@
+"""Probe the configured datasource for the tables and columns a model declares.
+
+Validation is otherwise entirely offline. :mod:`orionbelt.parser.validator`
+resolves a model against *itself* - every reference it checks names something
+declared in the same document - and the physical binding is the one part it
+cannot reach: a data object's ``database`` / ``schema`` / ``code``, and each
+column's ``code``, are opaque strings on the way to codegen. So a model can be
+valid in every structural sense and still name a table that was dropped or a
+column that was renamed, and the first thing to say so is the warehouse, at
+query time, to whoever ran the query rather than to whoever wrote the model.
+
+This module closes that gap on request. Two things make the shape of the probe:
+
+*   It asks for the declared columns **by name, quoted exactly as codegen
+    quotes them** - ``SELECT "amount", "order_date" FROM "sales" LIMIT 0`` -
+    rather than reading ``information_schema``. That proves the columns are
+    addressable *through the same connection and the same spelling the
+    compiled query will use*, which a catalog read does not, and it settles
+    identifier case without this module having to carry a table of which
+    engines fold it: the engine answers.
+*   ``LIMIT 0`` means the round trip costs a plan and no scan, and the result
+    still carries a full schema, so column types come back from the same
+    request that proves the columns exist.
+
+Only when that fails does a second ``SELECT *`` run, to tell a missing table
+from a missing column and to name which column. The happy path is one round
+trip per data object.
+
+Findings use the same :class:`SemanticError` shape as the offline validator,
+so a caller that already renders validation errors renders these unchanged.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+from typing import TYPE_CHECKING, Any
+
+from orionbelt.dialect.registry import DialectRegistry, UnsupportedDialectError
+from orionbelt.models.errors import SemanticError
+from orionbelt.models.semantic import DataType
+
+if TYPE_CHECKING:
+    from orionbelt.models.semantic import DataObject, DataObjectColumn, SemanticModel
+
+logger = logging.getLogger(__name__)
+
+#: How the probe describes a type it is willing to compare. Deliberately coarse:
+#: the question is whether a column still holds the *kind* of value the model
+#: says it does, not whether ``int32`` widened to ``int64``. A narrower
+#: comparison would fire on every engine that stores an OBML ``int`` as
+#: ``NUMBER(38,0)`` or a ``timestamp`` as ``TIMESTAMP_NTZ``, which is noise
+#: rather than drift.
+_NUMBER = "number"
+_DATETIME = "datetime"
+_STRING = "string"
+_BOOLEAN = "boolean"
+_BINARY = "binary"
+
+#: Declared OBML type -> the family a physical column must belong to. ``json``
+#: sits with ``string`` because most engines have no JSON type and the ones
+#: that do accept a text column in the same position.
+_DECLARED_FAMILY: dict[DataType, str] = {
+    DataType.STRING: _STRING,
+    DataType.JSON: _STRING,
+    DataType.INT: _NUMBER,
+    DataType.FLOAT: _NUMBER,
+    DataType.DATE: _DATETIME,
+    DataType.TIME: _DATETIME,
+    DataType.TIME_TZ: _DATETIME,
+    DataType.TIMESTAMP: _DATETIME,
+    DataType.TIMESTAMP_TZ: _DATETIME,
+    DataType.BOOLEAN: _BOOLEAN,
+}
+
+
+def _arrow_family(arrow_type: Any) -> str | None:
+    """Family for a PyArrow type, or ``None`` when it should not be compared.
+
+    ``None`` is the answer for a null-typed column and for anything this does
+    not recognise: a nested or extension type carries no claim the model made,
+    and guessing at one would report a mismatch that is really an omission
+    here. A ``LIMIT 0`` fetch is where null-typed columns turn up, so that
+    branch is load-bearing rather than defensive.
+    """
+    import pyarrow as pa
+
+    try:
+        if pa.types.is_null(arrow_type):
+            return None
+        if pa.types.is_boolean(arrow_type):
+            return _BOOLEAN
+        if (
+            pa.types.is_integer(arrow_type)
+            or pa.types.is_floating(arrow_type)
+            or pa.types.is_decimal(arrow_type)
+        ):
+            return _NUMBER
+        if (
+            pa.types.is_timestamp(arrow_type)
+            or pa.types.is_date(arrow_type)
+            or pa.types.is_time(arrow_type)
+        ):
+            return _DATETIME
+        if pa.types.is_string(arrow_type) or pa.types.is_large_string(arrow_type):
+            return _STRING
+        if pa.types.is_binary(arrow_type) or pa.types.is_large_binary(arrow_type):
+            return _BINARY
+    except (AttributeError, TypeError):
+        # Mirrors ``db_executor._arrow_type_to_hint``: ADBC hands back
+        # OpaqueType subclasses that do not implement the full DataType
+        # protocol, and the ``pa.types.is_*`` helpers raise on them rather
+        # than returning False.
+        return None
+    return None
+
+
+def _hint_family(type_hint: str) -> str | None:
+    """Family for the coarse PEP 249 hint, or ``None`` when undecidable.
+
+    ``db_executor`` buckets a driver type code into one of four strings, and
+    ``"string"`` is both a real answer and the fallback for every type code it
+    does not recognise - a BOOLEAN column lands there, and so does anything
+    exotic. It therefore refutes nothing, and reading it as a claim would
+    report a mismatch on a correct model whenever the Arrow path happened to
+    be unavailable. The other three buckets are positive classifications.
+    """
+    if type_hint in (_NUMBER, _DATETIME, _BINARY):
+        return type_hint
+    return None
+
+
+def _families(result: Any) -> list[str | None]:
+    """Family per result column, in the order the driver returned them.
+
+    Prefers the Arrow schema, which distinguishes a boolean from a string;
+    the coarse PEP 249 hint cannot. Seven of the eight drivers are
+    Arrow-native, so the fallback is the exception.
+    """
+    schema = result.arrow_schema
+    if schema is not None:
+        try:
+            return [_arrow_family(field.type) for field in schema]
+        except ImportError:  # pragma: no cover - a schema implies pyarrow
+            pass
+    return [_hint_family(col.type_hint) for col in result.columns]
+
+
+def _physical_columns(obj: DataObject) -> list[DataObjectColumn]:
+    """The columns of *obj* that name a physical column.
+
+    A computed column defines itself with an inline ``expression`` and its
+    ``code`` is ignored at codegen, so asking the warehouse for it would
+    report every computed column as missing.
+    """
+    return [col for col in obj.columns.values() if col.code and not col.is_computed]
+
+
+def _qualified_name(obj: DataObject) -> str:
+    """Unquoted ``database.schema.code``, for a message a human reads."""
+    parts = [p for p in (obj.database, obj.schema_name, obj.code) if p]
+    return ".".join(parts) if parts else obj.code
+
+
+def _select_columns(dialect: Any, obj: DataObject, columns: list[DataObjectColumn]) -> str:
+    """``SELECT <declared columns> FROM <table> LIMIT 0`` for *obj*.
+
+    The column list is quoted through the dialect, which is what makes a pass
+    meaningful: it is the spelling a compiled query will use, so the engine is
+    answering the question the model actually asks of it.
+    """
+    projection = ", ".join(dialect.quote_identifier(col.code) for col in columns)
+    table = dialect.format_table_ref(obj.database, obj.schema_name, obj.code)
+    return f"SELECT {projection} FROM {table} LIMIT 0"
+
+
+def _select_star(dialect: Any, obj: DataObject) -> str:
+    """``SELECT * FROM <table> LIMIT 0`` for *obj*."""
+    table = dialect.format_table_ref(obj.database, obj.schema_name, obj.code)
+    return f"SELECT * FROM {table} LIMIT 0"
+
+
+def _type_findings(
+    obj_name: str,
+    columns: list[DataObjectColumn],
+    families: list[str | None],
+) -> list[SemanticError]:
+    """Compare each declared ``abstractType`` against the type that came back.
+
+    Matched by position: the projection was built from *columns* in this order,
+    so column *i* of the result is column *i* of the model. Matching by name
+    instead would have to survive engines that fold the output label, and there
+    is nothing to gain from it.
+    """
+    findings: list[SemanticError] = []
+    for col, actual in zip(columns, families, strict=False):
+        declared = _DECLARED_FAMILY.get(col.abstract_type)
+        if declared is None or actual is None or declared == actual:
+            continue
+        findings.append(
+            SemanticError(
+                code="DATASOURCE_TYPE_MISMATCH",
+                message=(
+                    f"Column '{col.code}' on data object '{obj_name}' is declared "
+                    f"'{col.abstract_type}' but the datasource returns a {actual} column."
+                ),
+                path=f"dataObjects.{obj_name}.columns.{col.name}.abstractType",
+                hint=(
+                    f"Change abstractType to one of the '{declared}' family that matches "
+                    f"the column, or cast it in the source view."
+                ),
+                context={
+                    "dataObject": obj_name,
+                    "column": col.name,
+                    "code": col.code,
+                    "declaredType": str(col.abstract_type),
+                    "actualFamily": actual,
+                },
+            )
+        )
+    return findings
+
+
+def _column_findings(
+    obj_name: str,
+    obj: DataObject,
+    columns: list[DataObjectColumn],
+    present: list[str],
+    families: list[str | None],
+    projection_error: str,
+) -> list[SemanticError]:
+    """Explain why the projection failed, given the columns ``SELECT *`` found.
+
+    ``present`` and *families* come from the star probe, so they describe the
+    table as it really is. A declared column absent from it is missing; one
+    that matches only when case is ignored is the more interesting answer,
+    because the projection just proved the engine will not accept the spelling
+    the model uses.
+    """
+    findings: list[SemanticError] = []
+    by_name = dict(zip(present, families, strict=False))
+    folded = {name.casefold(): name for name in present}
+    surviving: list[DataObjectColumn] = []
+    surviving_families: list[str | None] = []
+
+    for col in columns:
+        if col.code in by_name:
+            surviving.append(col)
+            surviving_families.append(by_name[col.code])
+            continue
+        actual_name = folded.get(col.code.casefold())
+        if actual_name is None:
+            findings.append(
+                SemanticError(
+                    code="DATASOURCE_COLUMN_MISSING",
+                    message=(
+                        f"Column '{col.code}' does not exist on {_qualified_name(obj)} "
+                        f"(data object '{obj_name}')."
+                    ),
+                    path=f"dataObjects.{obj_name}.columns.{col.name}.code",
+                    hint="Correct the column's 'code', or drop the column from the model.",
+                    context={"dataObject": obj_name, "column": col.name, "code": col.code},
+                )
+            )
+            continue
+        findings.append(
+            SemanticError(
+                code="DATASOURCE_COLUMN_CASE",
+                message=(
+                    f"Column '{col.code}' on {_qualified_name(obj)} is spelled "
+                    f"'{actual_name}' in the datasource, and this engine rejected "
+                    f"the model's spelling."
+                ),
+                path=f"dataObjects.{obj_name}.columns.{col.name}.code",
+                hint=f"Set the column's 'code' to '{actual_name}'.",
+                context={
+                    "dataObject": obj_name,
+                    "column": col.name,
+                    "code": col.code,
+                    "actualCode": actual_name,
+                },
+            )
+        )
+        surviving.append(col)
+        surviving_families.append(by_name[actual_name])
+
+    if not findings:
+        # The table is readable and every declared column is there under the
+        # exact spelling the model uses, yet the projection was rejected. The
+        # cause is something this function cannot name - a column-level
+        # permission, a type the engine will not project, a driver quirk - so
+        # the driver's own words are the useful thing to return.
+        findings.append(
+            SemanticError(
+                code="DATASOURCE_PROBE_FAILED",
+                message=(
+                    f"Reading the declared columns of data object '{obj_name}' failed, "
+                    f"though {_qualified_name(obj)} exists and every column was found: "
+                    f"{projection_error}"
+                ),
+                path=f"dataObjects.{obj_name}",
+                context={"dataObject": obj_name, "error": projection_error},
+            )
+        )
+        return findings
+
+    return findings + _type_findings(obj_name, surviving, surviving_families)
+
+
+def _probe_object(
+    dialect: Any, dialect_name: str, obj_name: str, obj: DataObject
+) -> list[SemanticError]:
+    """Probe one data object. Raises ``ExecutionUnavailableError`` to the caller."""
+    from orionbelt.service.db_executor import ExecutionError, execute_sql
+
+    columns = _physical_columns(obj)
+
+    if not columns:
+        # Nothing to project, so the table's own existence is the whole
+        # question - a data object whose columns are all computed still has
+        # to come FROM somewhere.
+        try:
+            execute_sql(_select_star(dialect, obj), dialect=dialect_name)
+        except ExecutionError as exc:
+            return [_table_missing(obj_name, obj, str(exc))]
+        return []
+
+    try:
+        result = execute_sql(_select_columns(dialect, obj, columns), dialect=dialect_name)
+    except ExecutionError as exc:
+        projection_error = str(exc)
+    else:
+        return _type_findings(obj_name, columns, _families(result))
+
+    # The projection failed. A second probe separates a missing table from a
+    # missing column, and returns the column list needed to say which.
+    try:
+        star = execute_sql(_select_star(dialect, obj), dialect=dialect_name)
+    except ExecutionError as exc:
+        return [_table_missing(obj_name, obj, str(exc))]
+
+    return _column_findings(
+        obj_name,
+        obj,
+        columns,
+        [col.name for col in star.columns],
+        _families(star),
+        projection_error,
+    )
+
+
+def _table_missing(obj_name: str, obj: DataObject, error: str) -> SemanticError:
+    """The table a data object maps to could not be read."""
+    return SemanticError(
+        code="DATASOURCE_TABLE_MISSING",
+        message=(
+            f"Data object '{obj_name}' maps to {_qualified_name(obj)}, which the "
+            f"datasource could not read: {error}"
+        ),
+        path=f"dataObjects.{obj_name}.code",
+        hint="Correct the data object's 'database', 'schema' and 'code', or create the table.",
+        context={
+            "dataObject": obj_name,
+            "table": _qualified_name(obj),
+            "error": error,
+        },
+    )
+
+
+def _ensure_arrow() -> None:
+    """Import pyarrow, when installed, before any probe runs.
+
+    ``db_executor`` takes a driver's Arrow path only when pyarrow is *already*
+    in ``sys.modules``: it will not pull a heavy dependency in behind a query's
+    back. That is the right default for executing a query, where the coarse
+    PEP 249 hint carries enough type information for the response. It is the
+    wrong one here, because that coarse bucket folds BOOLEAN and every type
+    code the driver does not recognise into ``"string"`` — which
+    :func:`_hint_family` correctly refuses to treat as a claim, so the type
+    check quietly stops running. Which types a probe can compare would then
+    depend on whether something else in the process happened to import pyarrow
+    first, and the same model would validate differently under the API and the
+    CLI. Importing it up front is what makes the comparison deterministic.
+    """
+    with contextlib.suppress(ImportError):
+        import pyarrow  # noqa: F401
+
+
+def probe_datasource(model: SemanticModel, *, dialect: str) -> list[SemanticError]:
+    """Check every data object in *model* against the configured datasource.
+
+    Returns one finding per problem, in data object declaration order, or an
+    empty list when the model matches the warehouse. The caller decides what a
+    finding means; nothing here raises for a mismatch.
+
+    Objects sourced by ``nestedIn`` are skipped: their rows come from unnesting
+    an array on another object, so their columns belong to that array's element
+    type rather than to any table of their own, and projecting the declared
+    codes against the fallback ``code`` table would report drift that is not
+    there.
+    """
+    from orionbelt.service.db_executor import ExecutionUnavailableError
+
+    _ensure_arrow()
+    try:
+        impl = DialectRegistry.get(dialect)
+    except UnsupportedDialectError:
+        return [
+            SemanticError(
+                code="DATASOURCE_UNSUPPORTED_DIALECT",
+                message=f"Cannot probe the datasource: unsupported dialect '{dialect}'.",
+                hint="Pass a supported dialect, or set the model's settings.defaultDialect.",
+                context={"dialect": dialect},
+            )
+        ]
+
+    findings: list[SemanticError] = []
+    for obj_name, obj in model.data_objects.items():
+        if obj.nested_in is not None:
+            continue
+        try:
+            findings.extend(_probe_object(impl, dialect, obj_name, obj))
+        except ExecutionUnavailableError as exc:
+            # No connection, no driver, or no credentials. Every remaining
+            # object would fail the same way, so stop rather than repeat it
+            # once per data object, and say plainly that the check did not run.
+            findings.append(
+                SemanticError(
+                    code="DATASOURCE_UNAVAILABLE",
+                    message=f"The datasource check could not run: {exc}",
+                    hint=(
+                        "Configure the vendor connection (DB_VENDOR and its credentials), "
+                        "or validate without the datasource check."
+                    ),
+                    context={"dialect": dialect, "error": str(exc)},
+                )
+            )
+            break
+        except Exception as exc:  # noqa: BLE001 - a probe must not fail validation
+            # Anything else - a dialect that refuses to render the reference,
+            # a driver raising outside its documented contract. Report it
+            # against the object rather than losing the rest of the model.
+            logger.warning("Datasource probe failed for '%s': %s", obj_name, exc)
+            findings.append(
+                SemanticError(
+                    code="DATASOURCE_PROBE_FAILED",
+                    message=f"Probing data object '{obj_name}' failed: {exc}",
+                    path=f"dataObjects.{obj_name}",
+                    context={"dataObject": obj_name, "error": str(exc)},
+                )
+            )
+    return findings

--- a/src/orionbelt/service/datasource_probe.py
+++ b/src/orionbelt/service/datasource_probe.py
@@ -100,6 +100,13 @@ def _arrow_family(arrow_type: Any) -> str | None:
             pa.types.is_timestamp(arrow_type)
             or pa.types.is_date(arrow_type)
             or pa.types.is_time(arrow_type)
+            # An interval is not a point in time, but "datetime" is the bucket
+            # this codebase puts it in, and ADBC's Postgres driver hands a real
+            # ``INTERVAL`` back as ``month_day_nano_interval`` rather than
+            # wrapping it. Without these two the column is unclassified and a
+            # ``timestamp`` declared over it is never checked.
+            or pa.types.is_interval(arrow_type)
+            or pa.types.is_duration(arrow_type)
         ):
             return _DATETIME
         if pa.types.is_string(arrow_type) or pa.types.is_large_string(arrow_type):
@@ -107,12 +114,35 @@ def _arrow_family(arrow_type: Any) -> str | None:
         if pa.types.is_binary(arrow_type) or pa.types.is_large_binary(arrow_type):
             return _BINARY
     except (AttributeError, TypeError):
-        # Mirrors ``db_executor._arrow_type_to_hint``: ADBC hands back
-        # OpaqueType subclasses that do not implement the full DataType
-        # protocol, and the ``pa.types.is_*`` helpers raise on them rather
-        # than returning False.
+        # ADBC hands back OpaqueType subclasses that do not implement the full
+        # DataType protocol, and the ``pa.types.is_*`` helpers raise on them
+        # rather than returning False. Fall through to the name-based route.
+        pass
+    return _opaque_family(arrow_type)
+
+
+def _opaque_family(arrow_type: Any) -> str | None:
+    """Family for a type PyArrow cannot represent natively, by its vendor name.
+
+    ADBC's Postgres driver wraps ``NUMERIC``, ``MONEY`` and friends in an
+    ``OpaqueType`` whose storage is a string. Every ``pa.types.is_*`` helper
+    answers False for it, so the structural route above classifies a Postgres
+    ``NUMERIC`` column as nothing at all and a measure declared over it is
+    never type-checked - the one place the check is most worth having.
+
+    ``db_executor`` already recovers these from the ``type_name`` the wrapper
+    carries; this reuses that mapping rather than growing a second copy of it.
+    The result is coarse, so it goes through :func:`_hint_family` for the same
+    reason the PEP 249 path does: ``coarse_hint_from_type_name`` answers
+    ``"string"`` both for a real text type and for everything it does not
+    recognise, and that cannot be allowed to refute a declaration.
+    """
+    from orionbelt.service.db_executor import coarse_hint_from_type_name
+
+    type_name = getattr(arrow_type, "type_name", None)
+    if not isinstance(type_name, str):
         return None
-    return None
+    return _hint_family(coarse_hint_from_type_name(type_name))
 
 
 def _hint_family(type_hint: str) -> str | None:

--- a/src/orionbelt/service/model_store.py
+++ b/src/orionbelt/service/model_store.py
@@ -939,6 +939,7 @@ class ModelStore:
         raw_dict: dict[str, object] | None = None,
         extends_yaml: list[str] | None = None,
         inherits_model_id: str | None = None,
+        datasource_dialect: str | None = None,
     ) -> ValidationSummary:
         """Validate a model without storing it.  Accepts YAML string or raw dict.
 
@@ -946,6 +947,13 @@ class ModelStore:
         ``/validate`` endpoints match what the schema-guarded load/query
         endpoints enforce — a model that fails the schema is reported invalid
         here rather than being silently coerced.
+
+        ``datasource_dialect`` turns on the online check: every data object is
+        probed against the configured warehouse for that dialect and any drift
+        — a dropped table, a renamed column, a column whose type no longer
+        matches ``abstractType`` — is reported as an error alongside the
+        offline ones. Left as ``None``, validation stays entirely offline and
+        opens no connection.
         """
         _model, raw, errors, warnings = self._parse_and_validate(
             yaml_str,
@@ -960,11 +968,35 @@ class ModelStore:
         fatal = {"YAML_SAFETY_ERROR", "YAML_PARSE_ERROR"}
         if not any(e.code in fatal for e in errors):
             errors = self._schema_errors(raw) + errors
+        if datasource_dialect:
+            errors = errors + self._datasource_errors(_model, datasource_dialect)
         return ValidationSummary(
             valid=len(errors) == 0,
             errors=errors,
             warnings=warnings,
         )
+
+    @staticmethod
+    def _datasource_errors(model: SemanticModel, dialect: str) -> list[ErrorInfo]:
+        """Online findings for *model*, as ``ErrorInfo``.
+
+        Imported here rather than at module scope so that the offline path —
+        which is every caller that does not ask for the check — never pulls in
+        the executor and its driver stack.
+        """
+        from orionbelt.service.datasource_probe import probe_datasource
+
+        return [
+            ErrorInfo(
+                code=f.code,
+                message=f.message,
+                path=f.path,
+                severity=f.severity,
+                hint=f.hint,
+                context=f.context,
+            )
+            for f in probe_datasource(model, dialect=dialect)
+        ]
 
     @staticmethod
     def _schema_errors(raw: dict[str, object]) -> list[ErrorInfo]:

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -611,6 +611,58 @@ class TestSessionModelFlow:
         assert response.status_code == 200
         assert response.json()["valid"] is True
 
+    async def test_validate_is_offline_by_default(
+        self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The sample model names WAREHOUSE.PUBLIC tables that exist nowhere,
+        so a probe that ran would fail it."""
+
+        def explode(*args: object, **kwargs: object) -> object:
+            raise AssertionError("validate must not touch the datasource by default")
+
+        monkeypatch.setattr("orionbelt.service.db_executor.execute_sql", explode)
+        sid = (await client.post("/v1/sessions")).json()["session_id"]
+        response = await client.post(
+            f"/v1/sessions/{sid}/validate", json={"model_yaml": SAMPLE_MODEL_YAML}
+        )
+        assert response.json()["valid"] is True
+
+    async def test_validate_online_reports_datasource_drift(
+        self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from orionbelt.service.db_executor import ExecutionError
+
+        def missing(*args: object, **kwargs: object) -> object:
+            raise ExecutionError("relation does not exist")
+
+        monkeypatch.setattr("orionbelt.service.db_executor.execute_sql", missing)
+        sid = (await client.post("/v1/sessions")).json()["session_id"]
+        response = await client.post(
+            f"/v1/sessions/{sid}/validate?online=true&dialect=duckdb",
+            json={"model_yaml": SAMPLE_MODEL_YAML},
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["valid"] is False
+        assert {e["code"] for e in body["errors"]} == {"DATASOURCE_TABLE_MISSING"}
+
+    async def test_shortcut_validate_online(
+        self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from orionbelt.service.db_executor import ExecutionUnavailableError
+
+        def unavailable(*args: object, **kwargs: object) -> object:
+            raise ExecutionUnavailableError("no credentials configured")
+
+        monkeypatch.setattr("orionbelt.service.db_executor.execute_sql", unavailable)
+        response = await client.post(
+            "/v1/validate?online=true&dialect=duckdb", json={"model_yaml": SAMPLE_MODEL_YAML}
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["valid"] is False
+        assert [e["code"] for e in body["errors"]] == ["DATASOURCE_UNAVAILABLE"]
+
     async def test_compile_query_in_session(self, client: AsyncClient) -> None:
         sid = (await client.post("/v1/sessions")).json()["session_id"]
         load = await client.post(

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -421,10 +421,58 @@ def test_execute_remote_sql_limit_warns(monkeypatch, query_file):
 def test_validate_remote(monkeypatch, model_file):
     from orionbelt.cli import _remote
 
-    def fake_validate(self, model_yaml):
+    def fake_validate(self, model_yaml, *, online=False, dialect=None):
         return {"valid": True, "errors": [], "warnings": []}
 
     monkeypatch.setattr(_remote.RemoteClient, "validate", fake_validate)
     result = runner.invoke(app, ["validate", model_file, "-s", "http://example", "-f", "json"])
     assert result.exit_code == 0
     assert json.loads(result.stdout)["valid"] is True
+
+
+def test_validate_remote_forwards_online_flags(monkeypatch, model_file):
+    from orionbelt.cli import _remote
+
+    seen = {}
+
+    def fake_validate(self, model_yaml, *, online=False, dialect=None):
+        seen["online"] = online
+        seen["dialect"] = dialect
+        return {"valid": True, "errors": [], "warnings": []}
+
+    monkeypatch.setattr(_remote.RemoteClient, "validate", fake_validate)
+    result = runner.invoke(
+        app,
+        ["validate", model_file, "-s", "http://example", "-f", "json", "--online", "-d", "duckdb"],
+    )
+    assert result.exit_code == 0
+    assert seen == {"online": True, "dialect": "duckdb"}
+
+
+def test_validate_online_query_params(monkeypatch):
+    """``online`` and ``dialect`` travel as query params, not in the body."""
+    from orionbelt.cli._remote import RemoteClient
+
+    seen = {}
+
+    def fake_request(self, method, path, *, json=None, params=None):
+        seen["params"] = params
+        return {"valid": True, "errors": [], "warnings": []}
+
+    monkeypatch.setattr(RemoteClient, "_request", fake_request)
+    RemoteClient("http://example", None).validate("version: 1.0", online=True, dialect="postgres")
+    assert seen["params"] == {"online": "true", "dialect": "postgres"}
+
+
+def test_validate_offline_sends_no_params(monkeypatch):
+    from orionbelt.cli._remote import RemoteClient
+
+    seen = {}
+
+    def fake_request(self, method, path, *, json=None, params=None):
+        seen["params"] = params
+        return {"valid": True, "errors": [], "warnings": []}
+
+    monkeypatch.setattr(RemoteClient, "_request", fake_request)
+    RemoteClient("http://example", None).validate("version: 1.0")
+    assert seen["params"] is None

--- a/tests/unit/test_datasource_probe.py
+++ b/tests/unit/test_datasource_probe.py
@@ -1,0 +1,507 @@
+"""Tests for the online datasource probe (``service/datasource_probe.py``).
+
+The probe's whole job is to turn what a warehouse says into findings, so the
+tests drive it through a stub executor that records the SQL it was asked to run
+and answers with a chosen schema or a chosen failure. That covers the branch
+that matters most - the two-probe fallback that separates a missing table from
+a missing column - without needing eight live warehouses, and pins the SQL
+shape, which is the part a dialect change could quietly alter.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from orionbelt.parser.resolver import ReferenceResolver
+from orionbelt.service.datasource_probe import probe_datasource
+from orionbelt.service.db_executor import ExecutionError, ExecutionUnavailableError
+
+MODEL_YAML = """\
+version: 1.0
+
+dataObjects:
+  Orders:
+    code: orders
+    database: ""
+    schema: main
+    columns:
+      Order ID:
+        code: order_id
+        abstractType: string
+      Amount:
+        code: amount
+        abstractType: float
+        numClass: additive
+      Ordered At:
+        code: ordered_at
+        abstractType: timestamp
+      Net:
+        expression: "{Amount} * 0.8"
+        abstractType: float
+
+dimensions:
+  Order Ref:
+    dataObject: Orders
+    column: Order ID
+    resultType: string
+
+measures:
+  Total Amount:
+    aggregation: sum
+    columns:
+      - dataObject: Orders
+        column: Amount
+    resultType: float
+"""
+
+
+class FakeColumn:
+    """Stands in for ``db_executor.ColumnMeta``."""
+
+    def __init__(self, name: str, type_hint: str = "string") -> None:
+        self.name = name
+        self.type_hint = type_hint
+
+
+class FakeResult:
+    """Stands in for ``db_executor.ExecutionResult``.
+
+    ``arrow_schema`` is built from real PyArrow fields so the family mapping is
+    exercised against the types a driver actually hands back, rather than
+    against a second reimplementation of it.
+    """
+
+    def __init__(self, fields: list[tuple[str, Any]]) -> None:
+        import pyarrow as pa
+
+        self.arrow_schema = pa.schema([pa.field(name, typ) for name, typ in fields])
+        self.columns = [FakeColumn(name) for name, _ in fields]
+
+
+class FakeExecutor:
+    """Answers each probe from a table of SQL-substring -> outcome."""
+
+    def __init__(self, outcomes: list[Any]) -> None:
+        self.outcomes = list(outcomes)
+        self.sql: list[str] = []
+
+    def __call__(self, sql: str, *, dialect: str) -> Any:
+        self.sql.append(sql)
+        outcome = self.outcomes.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+
+@pytest.fixture
+def model() -> Any:
+    """The probe model, resolved."""
+
+    from orionbelt.parser.loader import TrackedLoader
+
+    raw, source_map = TrackedLoader().load_string(MODEL_YAML)
+    resolved, result = ReferenceResolver().resolve(raw, source_map)
+    assert result.valid, result.errors
+    return resolved
+
+
+@pytest.fixture
+def stub(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Install a fake ``execute_sql`` and hand back the installer."""
+
+    def install(*outcomes: Any) -> FakeExecutor:
+        executor = FakeExecutor(list(outcomes))
+        monkeypatch.setattr("orionbelt.service.db_executor.execute_sql", executor, raising=True)
+        return executor
+
+    return install
+
+
+def _matching_schema() -> FakeResult:
+    import pyarrow as pa
+
+    return FakeResult(
+        [
+            ("order_id", pa.string()),
+            ("amount", pa.float64()),
+            ("ordered_at", pa.timestamp("us")),
+        ]
+    )
+
+
+class TestHappyPath:
+    def test_matching_model_reports_nothing(self, model: Any, stub: Any) -> None:
+        stub(_matching_schema())
+        assert probe_datasource(model, dialect="duckdb") == []
+
+    def test_one_round_trip_when_everything_matches(self, model: Any, stub: Any) -> None:
+        """The star probe is the fallback, so a clean model must not pay for it."""
+        executor = stub(_matching_schema())
+        probe_datasource(model, dialect="duckdb")
+        assert len(executor.sql) == 1
+
+    def test_projection_names_declared_columns_quoted(self, model: Any, stub: Any) -> None:
+        executor = stub(_matching_schema())
+        probe_datasource(model, dialect="duckdb")
+        assert executor.sql[0] == (
+            'SELECT "order_id", "amount", "ordered_at" FROM "main"."orders" LIMIT 0'
+        )
+
+    def test_computed_column_is_not_projected(self, model: Any, stub: Any) -> None:
+        """``Net`` has an expression, so its ``code`` is not a physical column."""
+        executor = stub(_matching_schema())
+        probe_datasource(model, dialect="duckdb")
+        assert "net" not in executor.sql[0]
+
+    def test_probe_scans_nothing(self, model: Any, stub: Any) -> None:
+        executor = stub(_matching_schema())
+        probe_datasource(model, dialect="duckdb")
+        assert executor.sql[0].endswith("LIMIT 0")
+
+
+class TestMissingTable:
+    def test_both_probes_failing_reports_the_table(self, model: Any, stub: Any) -> None:
+        stub(
+            ExecutionError("relation orders does not exist"),
+            ExecutionError("relation orders does not exist"),
+        )
+        findings = probe_datasource(model, dialect="duckdb")
+        assert [f.code for f in findings] == ["DATASOURCE_TABLE_MISSING"]
+
+    def test_message_carries_the_driver_error(self, model: Any, stub: Any) -> None:
+        stub(ExecutionError("boom"), ExecutionError("relation orders does not exist"))
+        (finding,) = probe_datasource(model, dialect="duckdb")
+        assert "relation orders does not exist" in finding.message
+
+    def test_path_points_at_the_code(self, model: Any, stub: Any) -> None:
+        stub(ExecutionError("boom"), ExecutionError("boom"))
+        (finding,) = probe_datasource(model, dialect="duckdb")
+        assert finding.path == "dataObjects.Orders.code"
+
+
+class TestMissingColumn:
+    def test_star_probe_names_the_missing_column(self, model: Any, stub: Any) -> None:
+        import pyarrow as pa
+
+        stub(
+            ExecutionError('column "amount" does not exist'),
+            FakeResult([("order_id", pa.string()), ("ordered_at", pa.timestamp("us"))]),
+        )
+        findings = probe_datasource(model, dialect="duckdb")
+        assert [f.code for f in findings] == ["DATASOURCE_COLUMN_MISSING"]
+        assert findings[0].context is not None
+        assert findings[0].context["code"] == "amount"
+
+    def test_second_probe_is_the_star(self, model: Any, stub: Any) -> None:
+        import pyarrow as pa
+
+        executor = stub(
+            ExecutionError("nope"),
+            FakeResult([("order_id", pa.string()), ("ordered_at", pa.timestamp("us"))]),
+        )
+        probe_datasource(model, dialect="duckdb")
+        assert executor.sql[1] == 'SELECT * FROM "main"."orders" LIMIT 0'
+
+
+class TestColumnCase:
+    def test_case_only_difference_is_reported_as_case(self, model: Any, stub: Any) -> None:
+        """The projection was rejected, so this engine does care about case."""
+        import pyarrow as pa
+
+        stub(
+            ExecutionError('column "amount" does not exist'),
+            FakeResult(
+                [
+                    ("order_id", pa.string()),
+                    ("AMOUNT", pa.float64()),
+                    ("ordered_at", pa.timestamp("us")),
+                ]
+            ),
+        )
+        findings = probe_datasource(model, dialect="postgres")
+        assert [f.code for f in findings] == ["DATASOURCE_COLUMN_CASE"]
+
+    def test_case_finding_hints_the_real_spelling(self, model: Any, stub: Any) -> None:
+        import pyarrow as pa
+
+        stub(
+            ExecutionError("nope"),
+            FakeResult(
+                [
+                    ("order_id", pa.string()),
+                    ("AMOUNT", pa.float64()),
+                    ("ordered_at", pa.timestamp("us")),
+                ]
+            ),
+        )
+        (finding,) = probe_datasource(model, dialect="postgres")
+        assert finding.hint is not None
+        assert "AMOUNT" in finding.hint
+
+    def test_case_insensitive_engine_reports_nothing(self, model: Any, stub: Any) -> None:
+        """DuckDB accepts the projection, so the probe never asks about case.
+
+        This is the reason the probe projects the declared names rather than
+        diffing a catalog listing: on an engine that folds case, a spelling
+        difference is not drift, and a diff would report one.
+        """
+        import pyarrow as pa
+
+        stub(
+            FakeResult(
+                [
+                    ("order_id", pa.string()),
+                    ("AMOUNT", pa.float64()),
+                    ("ordered_at", pa.timestamp("us")),
+                ]
+            )
+        )
+        assert probe_datasource(model, dialect="duckdb") == []
+
+
+class TestTypeMismatch:
+    def test_declared_float_backed_by_text(self, model: Any, stub: Any) -> None:
+        import pyarrow as pa
+
+        stub(
+            FakeResult(
+                [
+                    ("order_id", pa.string()),
+                    ("amount", pa.string()),
+                    ("ordered_at", pa.timestamp("us")),
+                ]
+            )
+        )
+        findings = probe_datasource(model, dialect="duckdb")
+        assert [f.code for f in findings] == ["DATASOURCE_TYPE_MISMATCH"]
+        assert findings[0].path == "dataObjects.Orders.columns.Amount.abstractType"
+
+    def test_declared_timestamp_backed_by_text(self, model: Any, stub: Any) -> None:
+        import pyarrow as pa
+
+        stub(
+            FakeResult(
+                [
+                    ("order_id", pa.string()),
+                    ("amount", pa.float64()),
+                    ("ordered_at", pa.string()),
+                ]
+            )
+        )
+        (finding,) = probe_datasource(model, dialect="duckdb")
+        assert finding.context is not None
+        assert finding.context["declaredType"] == "timestamp"
+        assert finding.context["actualFamily"] == "string"
+
+    @pytest.mark.parametrize("arrow_type", ["int64", "float32", "decimal"])
+    def test_any_numeric_satisfies_float(self, model: Any, stub: Any, arrow_type: str) -> None:
+        """The comparison is by family: a widened int is not drift."""
+        import pyarrow as pa
+
+        actual = {
+            "int64": pa.int64(),
+            "float32": pa.float32(),
+            "decimal": pa.decimal128(38, 9),
+        }[arrow_type]
+        stub(
+            FakeResult(
+                [("order_id", pa.string()), ("amount", actual), ("ordered_at", pa.timestamp("us"))]
+            )
+        )
+        assert probe_datasource(model, dialect="duckdb") == []
+
+    def test_date_satisfies_declared_timestamp(self, model: Any, stub: Any) -> None:
+        import pyarrow as pa
+
+        stub(
+            FakeResult(
+                [
+                    ("order_id", pa.string()),
+                    ("amount", pa.float64()),
+                    ("ordered_at", pa.date32()),
+                ]
+            )
+        )
+        assert probe_datasource(model, dialect="duckdb") == []
+
+    def test_null_typed_column_is_not_compared(self, model: Any, stub: Any) -> None:
+        """A ``LIMIT 0`` fetch is exactly where a null-typed column turns up.
+
+        It carries no type to disagree with, so comparing it would report every
+        column of a driver that degrades an empty result as a mismatch.
+        """
+        import pyarrow as pa
+
+        stub(
+            FakeResult(
+                [("order_id", pa.string()), ("amount", pa.null()), ("ordered_at", pa.null())]
+            )
+        )
+        assert probe_datasource(model, dialect="duckdb") == []
+
+    def test_coarse_string_hint_never_refutes(self, model: Any, stub: Any) -> None:
+        """Without an Arrow schema, ``"string"`` is also the unknown bucket.
+
+        ``db_executor`` falls back to it for every PEP 249 type code it does
+        not recognise, so treating it as a claim would fail a correct model.
+        """
+
+        class NoArrowResult:
+            arrow_schema = None
+            columns = [
+                FakeColumn("order_id", "string"),
+                FakeColumn("amount", "string"),
+                FakeColumn("ordered_at", "string"),
+            ]
+
+        stub(NoArrowResult())
+        assert probe_datasource(model, dialect="duckdb") == []
+
+    def test_coarse_number_hint_does_refute(self, model: Any, stub: Any) -> None:
+        """The other three buckets are positive classifications and are used."""
+
+        class NoArrowResult:
+            arrow_schema = None
+            columns = [
+                FakeColumn("order_id", "number"),
+                FakeColumn("amount", "number"),
+                FakeColumn("ordered_at", "datetime"),
+            ]
+
+        stub(NoArrowResult())
+        findings = probe_datasource(model, dialect="duckdb")
+        assert [f.code for f in findings] == ["DATASOURCE_TYPE_MISMATCH"]
+        assert findings[0].context is not None
+        assert findings[0].context["column"] == "Order ID"
+
+
+class TestUnavailable:
+    def test_missing_connection_reports_once(self, model: Any, stub: Any) -> None:
+        stub(ExecutionUnavailableError("no credentials for postgres"))
+        findings = probe_datasource(model, dialect="postgres")
+        assert [f.code for f in findings] == ["DATASOURCE_UNAVAILABLE"]
+
+    def test_unavailable_stops_further_probes(self, model: Any, stub: Any) -> None:
+        """Every remaining object would fail identically."""
+        executor = stub(ExecutionUnavailableError("no credentials"))
+        probe_datasource(model, dialect="postgres")
+        assert len(executor.sql) == 1
+
+    def test_unsupported_dialect_opens_no_connection(self, model: Any, stub: Any) -> None:
+        executor = stub()
+        findings = probe_datasource(model, dialect="oracle")
+        assert [f.code for f in findings] == ["DATASOURCE_UNSUPPORTED_DIALECT"]
+        assert executor.sql == []
+
+
+NESTED_MODEL_YAML = """\
+version: 1.0
+
+dataObjects:
+  Orders:
+    code: orders
+    database: ""
+    schema: main
+    columns:
+      Order ID:
+        code: order_id
+        abstractType: string
+      Lines:
+        code: lines
+        abstractType: json
+
+  Order Lines:
+    code: lines
+    database: ""
+    schema: main
+    nestedIn:
+      dataObject: Orders
+      column: Lines
+    columns:
+      Sku:
+        code: sku
+        abstractType: string
+
+dimensions:
+  Order Ref:
+    dataObject: Orders
+    column: Order ID
+    resultType: string
+"""
+
+
+class TestSkippedObjects:
+    def test_nested_object_is_not_probed(self, stub: Any) -> None:
+        """Its rows come from unnesting the parent's array column, so its
+        columns belong to that array's element type rather than to a table.
+        Projecting the declared codes against the fallback ``code`` table would
+        report drift that is not there.
+        """
+        import pyarrow as pa
+
+        from orionbelt.parser.loader import TrackedLoader
+
+        raw, source_map = TrackedLoader().load_string(NESTED_MODEL_YAML)
+        model, result = ReferenceResolver().resolve(raw, source_map)
+        assert result.valid, result.errors
+
+        executor = stub(FakeResult([("order_id", pa.string()), ("lines", pa.string())]))
+        assert probe_datasource(model, dialect="duckdb") == []
+        assert len(executor.sql) == 1
+        assert "orders" in executor.sql[0]
+
+
+class TestProbeFailed:
+    def test_projection_failing_for_no_visible_reason(self, model: Any, stub: Any) -> None:
+        """Table readable, every column present and correctly spelled, yet the
+        projection was rejected - a column-level grant, most likely. The probe
+        cannot name the cause, so it returns the driver's words.
+        """
+
+        stub(ExecutionError("permission denied for column amount"), _matching_schema())
+        findings = probe_datasource(model, dialect="postgres")
+        assert [f.code for f in findings] == ["DATASOURCE_PROBE_FAILED"]
+        assert "permission denied for column amount" in findings[0].message
+
+    def test_unexpected_driver_error_does_not_lose_the_model(self, model: Any, stub: Any) -> None:
+        stub(RuntimeError("driver exploded"))
+        findings = probe_datasource(model, dialect="duckdb")
+        assert [f.code for f in findings] == ["DATASOURCE_PROBE_FAILED"]
+
+
+class TestValidateIntegration:
+    """``ModelStore.validate`` is where a finding becomes an error."""
+
+    def test_offline_by_default_opens_no_connection(self, monkeypatch: Any) -> None:
+        from orionbelt.service.model_store import ModelStore
+
+        def explode(*args: Any, **kwargs: Any) -> Any:
+            raise AssertionError("validate must not touch the datasource by default")
+
+        monkeypatch.setattr("orionbelt.service.db_executor.execute_sql", explode)
+        assert ModelStore().validate(MODEL_YAML).valid is True
+
+    def test_online_finding_makes_the_model_invalid(self, stub: Any) -> None:
+        from orionbelt.service.model_store import ModelStore
+
+        stub(ExecutionError("nope"), ExecutionError("relation orders does not exist"))
+        summary = ModelStore().validate(MODEL_YAML, datasource_dialect="duckdb")
+        assert summary.valid is False
+        assert [e.code for e in summary.errors] == ["DATASOURCE_TABLE_MISSING"]
+
+    def test_online_clean_model_stays_valid(self, stub: Any) -> None:
+        from orionbelt.service.model_store import ModelStore
+
+        stub(_matching_schema())
+        assert ModelStore().validate(MODEL_YAML, datasource_dialect="duckdb").valid is True
+
+    def test_offline_errors_still_come_first(self, stub: Any) -> None:
+        """A model that does not parse is not worth a round trip's diagnosis."""
+        from orionbelt.service.model_store import ModelStore
+
+        executor = stub()
+        summary = ModelStore().validate("key: [unclosed", datasource_dialect="duckdb")
+        assert summary.valid is False
+        assert executor.sql == []

--- a/tests/unit/test_datasource_probe.py
+++ b/tests/unit/test_datasource_probe.py
@@ -690,3 +690,45 @@ class TestStringFamilyExtensionTypes:
             )
         )
         assert probe_datasource(resolved, dialect="postgres") == []
+
+
+class TestTypeMismatchHint:
+    """The hint has to name the family that came back, not the declared one.
+
+    Naming the declared family reads as "change float to a number type" -
+    advice to make no change at all - which is what it did before.
+    """
+
+    def test_hint_names_the_actual_family_not_the_declared_one(self, model: Any, stub: Any) -> None:
+        import pyarrow as pa
+
+        stub(
+            FakeResult(
+                [
+                    ("order_id", pa.string()),
+                    ("amount", pa.string()),
+                    ("ordered_at", pa.timestamp("us")),
+                ]
+            )
+        )
+        (finding,) = probe_datasource(model, dialect="duckdb")
+        assert finding.hint is not None
+        assert "change abstractType to a 'string' type" in finding.hint
+        assert "'number'" not in finding.hint
+
+    def test_hint_offers_the_cast_back_to_the_declared_type(self, model: Any, stub: Any) -> None:
+        """The other half of the choice: fix the model, or fix the source."""
+        import pyarrow as pa
+
+        stub(
+            FakeResult(
+                [
+                    ("order_id", pa.string()),
+                    ("amount", pa.string()),
+                    ("ordered_at", pa.timestamp("us")),
+                ]
+            )
+        )
+        (finding,) = probe_datasource(model, dialect="duckdb")
+        assert finding.hint is not None
+        assert "cast 'amount' to float" in finding.hint

--- a/tests/unit/test_datasource_probe.py
+++ b/tests/unit/test_datasource_probe.py
@@ -585,3 +585,108 @@ class TestOpaqueAndIntervalTypes:
             )
         )
         assert probe_datasource(model, dialect="postgres") == []
+
+
+class TestStringFamilyExtensionTypes:
+    """A driver has two ways to hand back a type PyArrow cannot spell natively,
+    and they need opposite treatment. Verified against a live Postgres:
+    ``json``/``jsonb`` arrive as the canonical ``arrow.json`` extension over
+    string storage, while ``uuid``/``xml``/``inet`` arrive as ``arrow.opaque``
+    with only a vendor name to go on.
+    """
+
+    def test_canonical_json_extension_is_a_string(self) -> None:
+        """Postgres json and jsonb both arrive this way."""
+        import pyarrow as pa
+
+        assert datasource_probe._arrow_family(pa.json_(pa.string())) == "string"
+
+    @pytest.mark.parametrize("name", ["uuid", "xml", "inet", "json", "text", "varchar"])
+    def test_named_opaque_text_types_are_strings(self, name: str) -> None:
+        import pyarrow as pa
+
+        opaque = pa.opaque(pa.string(), type_name=name, vendor_name="PostgreSQL")
+        assert datasource_probe._arrow_family(opaque) == "string"
+
+    def test_opaque_name_matching_is_case_insensitive(self) -> None:
+        import pyarrow as pa
+
+        opaque = pa.opaque(pa.string(), type_name="UUID", vendor_name="PostgreSQL")
+        assert datasource_probe._arrow_family(opaque) == "string"
+
+    def test_unknown_opaque_name_stays_undecidable(self) -> None:
+        """``tsvector`` is text-ish, but the mapping cannot *say* so, and its
+        storage is a carrier rather than a claim. Silence beats a guess."""
+        import pyarrow as pa
+
+        opaque = pa.opaque(pa.string(), type_name="tsvector", vendor_name="PostgreSQL")
+        assert datasource_probe._arrow_family(opaque) is None
+
+    def test_opaque_numeric_is_not_read_as_its_string_storage(self) -> None:
+        """The reason opaque storage is never consulted: ADBC carries NUMERIC
+        over string storage, so a storage-based answer would call money text.
+        """
+        import pyarrow as pa
+
+        opaque = pa.opaque(pa.string(), type_name="numeric", vendor_name="PostgreSQL")
+        assert opaque.storage_type == pa.string()
+        assert datasource_probe._arrow_family(opaque) == "number"
+
+    def test_declared_float_over_a_json_column_is_reported(self, model: Any, stub: Any) -> None:
+        """End to end: OBML maps json to the string family, so a float declared
+        over a Postgres JSON column is drift and must not pass."""
+        import pyarrow as pa
+
+        stub(
+            FakeResult(
+                [
+                    ("order_id", pa.string()),
+                    ("amount", pa.json_(pa.string())),
+                    ("ordered_at", pa.timestamp("us")),
+                ]
+            )
+        )
+        findings = probe_datasource(model, dialect="postgres")
+        assert [f.code for f in findings] == ["DATASOURCE_TYPE_MISMATCH"]
+        assert findings[0].context is not None
+        assert findings[0].context["actualFamily"] == "string"
+
+    def test_declared_float_over_an_opaque_uuid_is_reported(self, model: Any, stub: Any) -> None:
+        import pyarrow as pa
+
+        stub(
+            FakeResult(
+                [
+                    ("order_id", pa.string()),
+                    ("amount", pa.opaque(pa.string(), "uuid", "PostgreSQL")),
+                    ("ordered_at", pa.timestamp("us")),
+                ]
+            )
+        )
+        findings = probe_datasource(model, dialect="postgres")
+        assert [f.code for f in findings] == ["DATASOURCE_TYPE_MISMATCH"]
+
+    def test_declared_json_over_a_json_column_is_clean(self, stub: Any) -> None:
+        """OBML ``json`` sits in the string family, so this must not fire."""
+        import pyarrow as pa
+
+        from orionbelt.parser.loader import TrackedLoader
+
+        yaml = MODEL_YAML.replace(
+            "      Amount:\n        code: amount\n        abstractType: float",
+            "      Amount:\n        code: amount\n        abstractType: json",
+        ).replace("aggregation: sum", "aggregation: count")
+        raw, source_map = TrackedLoader().load_string(yaml)
+        resolved, result = ReferenceResolver().resolve(raw, source_map)
+        assert result.valid, result.errors
+
+        stub(
+            FakeResult(
+                [
+                    ("order_id", pa.string()),
+                    ("amount", pa.json_(pa.string())),
+                    ("ordered_at", pa.timestamp("us")),
+                ]
+            )
+        )
+        assert probe_datasource(resolved, dialect="postgres") == []

--- a/tests/unit/test_datasource_probe.py
+++ b/tests/unit/test_datasource_probe.py
@@ -15,6 +15,7 @@ from typing import Any
 import pytest
 
 from orionbelt.parser.resolver import ReferenceResolver
+from orionbelt.service import datasource_probe
 from orionbelt.service.datasource_probe import probe_datasource
 from orionbelt.service.db_executor import ExecutionError, ExecutionUnavailableError
 
@@ -505,3 +506,82 @@ class TestValidateIntegration:
         summary = ModelStore().validate("key: [unclosed", datasource_dialect="duckdb")
         assert summary.valid is False
         assert executor.sql == []
+
+
+class TestOpaqueAndIntervalTypes:
+    """Types PyArrow cannot represent natively still have to be classified.
+
+    ADBC's Postgres driver wraps NUMERIC and MONEY in an ``OpaqueType`` whose
+    storage is a string, and every ``pa.types.is_*`` helper answers False for
+    it. Structural classification alone therefore skips exactly the columns a
+    measure is most likely to be declared over. Verified against a live
+    Postgres: `numeric` arrives opaque, `interval` arrives as a native
+    `month_day_nano_interval`, and before this both were unclassified.
+    """
+
+    def test_opaque_numeric_is_a_number(self) -> None:
+        import pyarrow as pa
+
+        opaque = pa.opaque(pa.string(), type_name="numeric", vendor_name="PostgreSQL")
+        assert datasource_probe._arrow_family(opaque) == "number"
+
+    def test_opaque_money_is_a_number(self) -> None:
+        import pyarrow as pa
+
+        opaque = pa.opaque(pa.string(), type_name="money", vendor_name="PostgreSQL")
+        assert datasource_probe._arrow_family(opaque) == "number"
+
+    def test_opaque_interval_is_datetime(self) -> None:
+        import pyarrow as pa
+
+        opaque = pa.opaque(pa.string(), type_name="interval", vendor_name="PostgreSQL")
+        assert datasource_probe._arrow_family(opaque) == "datetime"
+
+    def test_native_interval_is_datetime(self) -> None:
+        """Not opaque at all - ADBC returns a real Arrow interval."""
+        import pyarrow as pa
+
+        assert datasource_probe._arrow_family(pa.month_day_nano_interval()) == "datetime"
+        assert datasource_probe._arrow_family(pa.duration("s")) == "datetime"
+
+    def test_unrecognised_opaque_name_refutes_nothing(self) -> None:
+        """``coarse_hint_from_type_name`` answers "string" for a real text type
+        and for everything it does not recognise alike, so it must not be
+        allowed to contradict a declaration."""
+        import pyarrow as pa
+
+        opaque = pa.opaque(pa.string(), type_name="tsvector", vendor_name="PostgreSQL")
+        assert datasource_probe._arrow_family(opaque) is None
+
+    def test_declared_string_over_postgres_numeric_is_reported(self, model: Any, stub: Any) -> None:
+        """The finding this fixes, end to end: `Order ID` is declared string."""
+        import pyarrow as pa
+
+        stub(
+            FakeResult(
+                [
+                    ("order_id", pa.opaque(pa.string(), "numeric", "PostgreSQL")),
+                    ("amount", pa.float64()),
+                    ("ordered_at", pa.timestamp("us")),
+                ]
+            )
+        )
+        findings = probe_datasource(model, dialect="postgres")
+        assert [f.code for f in findings] == ["DATASOURCE_TYPE_MISMATCH"]
+        assert findings[0].context is not None
+        assert findings[0].context["actualFamily"] == "number"
+
+    def test_declared_float_over_postgres_numeric_is_clean(self, model: Any, stub: Any) -> None:
+        """The other half: a NUMERIC behind a `float` must not now false-fire."""
+        import pyarrow as pa
+
+        stub(
+            FakeResult(
+                [
+                    ("order_id", pa.string()),
+                    ("amount", pa.opaque(pa.string(), "numeric", "PostgreSQL")),
+                    ("ordered_at", pa.timestamp("us")),
+                ]
+            )
+        )
+        assert probe_datasource(model, dialect="postgres") == []


### PR DESCRIPTION
## What

Validation was entirely offline. `parser/validator.py` resolves a model against itself, and the physical binding is the one part it cannot reach: a data object's `database` / `schema` / `code`, and each column's `code`, are opaque strings on the way to codegen. So a model stayed valid after the table behind it was dropped or a column was renamed, and the first thing to say otherwise was the warehouse, at query time, to whoever ran the query rather than to whoever wrote the model.

This adds an opt-in datasource check:

| Surface | How |
|---|---|
| `POST /v1/sessions/{id}/validate` | `?online=true[&dialect=]` |
| `POST /v1/validate` (stateless) | `?online=true[&dialect=]` |
| CLI | `obsl validate model.yaml --online [-d duckdb]` |

Findings are errors like any other, so `valid` goes to false and the CLI exits 1, which is what makes it usable as a post-deploy check.

## How the probe is shaped

It asks for the declared columns **by name, quoted exactly as codegen quotes them**, rather than reading `information_schema`:

```sql
SELECT "order_id", "amount" FROM "main"."orders" LIMIT 0
```

That proves the columns are addressable through the same connection and the same spelling a compiled query will use, which a catalog read does not. It also settles identifier case without this module carrying a table of which engines fold it: the engine answers. Verified both ways, the same case-only difference is a finding on Postgres and correctly silent on DuckDB.

`LIMIT 0` plans without scanning while still returning a full schema, so column types arrive in the same request that proves the columns exist. Only when the projection fails does a second `SELECT *` run, to tell a missing table from a missing column and to name which one. The happy path is one round trip per data object.

## Findings

| Code | Meaning |
|---|---|
| `DATASOURCE_TABLE_MISSING` | The table could not be read. Carries the driver's own error. |
| `DATASOURCE_COLUMN_MISSING` | A declared `code` names no column on an existing table. |
| `DATASOURCE_COLUMN_CASE` | The column exists under a different case and this engine rejected the model's spelling. The hint carries the real one. |
| `DATASOURCE_TYPE_MISMATCH` | The column's type is not in the family its `abstractType` declares. |
| `DATASOURCE_UNAVAILABLE` | The check could not run at all. Reported once, not per data object. |
| `DATASOURCE_UNSUPPORTED_DIALECT` | `dialect` names an engine with no OBSL dialect. |
| `DATASOURCE_PROBE_FAILED` | Table and columns are all there but the read was refused, most likely a column-level grant. |

## Type comparison

By family (number, datetime, string, boolean, binary), so a `float` backed by `DECIMAL(38,9)` is not drift and a `float` backed by text is. It reads the Arrow schema, and `_ensure_arrow` imports pyarrow first because `db_executor` takes a driver's Arrow path only when pyarrow is already in `sys.modules`. Without that the coarse PEP 249 hint applies, which folds BOOLEAN and every unrecognised type code into `"string"`, and the check would silently stop running, differently under the API and the CLI. A null-typed column, which is exactly what a zero-row fetch produces on some drivers, is skipped rather than reported.

## Notes

- The probe dialect falls back to `DB_VENDOR`, **not** to the model's `defaultDialect` as `_resolve_dialect` does. That one picks the SQL to generate; this one picks a connection to open, and a model declaring `defaultDialect: snowflake` on a DuckDB deployment would otherwise be probed by opening a Snowflake connection that does not exist.
- Offline stays the default and opens no connection. `ModelStore.validate` imports the probe only when asked, and a test asserts the default path never reaches the executor.
- Because the flag is opt-in it fails closed: asking for a check that cannot run returns `DATASOURCE_UNAVAILABLE` and `valid: false`, not a green light.
- Data objects sourced through `nestedIn` are not probed. Their rows come from unnesting a parent's array column, so their columns belong to that array's element type rather than to any table of their own.
- No OBML change, so no schema / contract manifest / ontology / OSI propagation.

## Verification

Live against **DuckDB** and **Postgres** for every finding: missing table, missing column, case difference, type mismatch, and a clean pass. On a DuckDB built with deliberate drift:

```
error:   [DATASOURCE_COLUMN_MISSING] Column 'order_id' does not exist on main.orders
error:   [DATASOURCE_TYPE_MISMATCH] Column 'amount' on data object 'Orders' is declared
         'float' but the datasource returns a string column.
error:   [DATASOURCE_TABLE_MISSING] Data object 'Shipments' maps to main.shipments, which
         the datasource could not read: Catalog Error: Table with name shipments does not exist!
```

Full suite: 4940 passed, 1046 skipped. `ruff check`, `ruff format`, `mypy src/` and `mkdocs build --strict` all clean. 32 new probe tests plus API and CLI coverage.

Docs: `docs/api/endpoints.md` (codes, semantics, what is deliberately not checked) and `docs/guide/cli.md` (`--online`, CI example).
