### PR TITLE
fix(arrow): load pyarrow at startup so results carry the driver schema

### DIFF
--- a/src/orionbelt/api/app.py
+++ b/src/orionbelt/api/app.py
@@ -56,6 +56,7 @@ from orionbelt.api.routers import (
 from orionbelt.api.routers import settings as settings_router
 from orionbelt.api.schemas import HealthResponse
 from orionbelt.cache.factory import build_cache
+from orionbelt.service import db_executor
 from orionbelt.service.session_manager import SessionManager
 from orionbelt.settings import Settings
 
@@ -272,18 +273,30 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
         unknown_default_ttl_seconds=settings.cache_unknown_freshness_default_ttl,
         heartbeat_auth_token=settings.heartbeat_auth_token,
     )
-    if cache.backend_name == "file":
-        # Pay every lazy-import tax at startup so the first user-visible
-        # cache hit doesn't include ~100ms of cold imports + first-call
-        # codec setup. Top-level ``pyarrow`` alone is ~60MB of native
-        # code; ``pyarrow.ipc`` is the Arrow stream reader/writer that
-        # ``result_codec`` actually uses. DuckDB lazy-imports ``pytz``
-        # on the first TIMESTAMPTZ bind. We exercise all three with a
-        # full encode → decode round-trip on a one-row payload.
-        try:
-            import pyarrow  # noqa: F401
-            import pyarrow.ipc  # noqa: F401
+    # Load pyarrow before serving, whatever the cache backend. The executor's
+    # Arrow fetch paths refuse to run unless it is already imported, so this is
+    # what decides whether a result carries the driver's schema — and that
+    # schema is what types a cached or ``format=arrow`` column from the
+    # declaration rather than from the values one result happened to contain
+    # (#410). It used to sit inside the ``backend_name == "file"`` branch
+    # below, so on the default ``cache_backend=noop`` it never ran and every
+    # column fell back to inference. Startup is also the only safe moment:
+    # importing it inside a live uvicorn loop on macOS drags in gRPC
+    # initialisation mid-request, which is why the executor guards rather than
+    # imports.
+    if not db_executor.ensure_arrow():
+        logger.warning(
+            "pyarrow is not installed — result columns will be typed by "
+            "inference rather than from the driver schema"
+        )
 
+    if cache.backend_name == "file":
+        # Pay the remaining lazy-import taxes at startup so the first
+        # user-visible cache hit doesn't include first-call codec setup.
+        # DuckDB lazy-imports ``pytz`` on the first TIMESTAMPTZ bind. We
+        # exercise these with a full encode → decode round-trip on a one-row
+        # payload.
+        try:
             from orionbelt.cache import result_codec
 
             # Run the encode → decode round-trip on the default threadpool so

--- a/src/orionbelt/cli/_local.py
+++ b/src/orionbelt/cli/_local.py
@@ -25,7 +25,12 @@ from orionbelt.dialect.base import (
 from orionbelt.dialect.registry import DialectRegistry, UnsupportedDialectError
 from orionbelt.models.query import QueryObject
 from orionbelt.models.semantic import SemanticModel
-from orionbelt.service.db_executor import ExecutionResult, execute_sql, resolve_timezone
+from orionbelt.service.db_executor import (
+    ExecutionResult,
+    ensure_arrow,
+    execute_sql,
+    resolve_timezone,
+)
 from orionbelt.service.diagram import generate_mermaid_er
 from orionbelt.service.model_store import (
     ModelDescription,
@@ -171,6 +176,10 @@ def _execute_loaded(
         default_timezone=getattr(settings, "default_timezone", None) if settings else None
     )
     override = bool(getattr(settings, "override_database_timezone", False)) if settings else False
+    # See ``db_executor.ensure_arrow``: without it the executor cannot take a
+    # driver's Arrow path, and the result's columns get typed by inference over
+    # the values rather than from the driver's schema.
+    ensure_arrow()
     executed = execute_sql(compiled.sql, dialect=resolved_dialect, tz=tz, override_db_tz=override)
     return compiled, executed
 

--- a/src/orionbelt/pgwire/server.py
+++ b/src/orionbelt/pgwire/server.py
@@ -32,6 +32,7 @@ from orionbelt.pgwire.auth import (
 )
 from orionbelt.pgwire.extended import ExtendedSession
 from orionbelt.pgwire.scram import SCRAM_SHA_256, ScramError, ScramServerExchange
+from orionbelt.service import db_executor
 
 logger = logging.getLogger(__name__)
 
@@ -118,6 +119,15 @@ class PgWireServer:
         return int(sockets[0].getsockname()[1])
 
     async def start(self) -> int:
+        # Before the first connection, for the reason given on
+        # ``db_executor.ensure_arrow``: the executor's Arrow fetch only runs
+        # when pyarrow is already imported, and that is what lets a result
+        # carry the driver's schema instead of types inferred from its values.
+        if not db_executor.ensure_arrow():
+            logger.warning(
+                "pyarrow is not installed — result columns will be typed by "
+                "inference rather than from the driver schema"
+            )
         self._server = await asyncio.start_server(
             self._handle_connection, host=self.host, port=self.port
         )

--- a/src/orionbelt/service/datasource_probe.py
+++ b/src/orionbelt/service/datasource_probe.py
@@ -32,7 +32,6 @@ so a caller that already renders validation errors renders these unchanged.
 
 from __future__ import annotations
 
-import contextlib
 import logging
 from typing import TYPE_CHECKING, Any
 
@@ -443,25 +442,6 @@ def _table_missing(obj_name: str, obj: DataObject, error: str) -> SemanticError:
     )
 
 
-def _ensure_arrow() -> None:
-    """Import pyarrow, when installed, before any probe runs.
-
-    ``db_executor`` takes a driver's Arrow path only when pyarrow is *already*
-    in ``sys.modules``: it will not pull a heavy dependency in behind a query's
-    back. That is the right default for executing a query, where the coarse
-    PEP 249 hint carries enough type information for the response. It is the
-    wrong one here, because that coarse bucket folds BOOLEAN and every type
-    code the driver does not recognise into ``"string"`` — which
-    :func:`_hint_family` correctly refuses to treat as a claim, so the type
-    check quietly stops running. Which types a probe can compare would then
-    depend on whether something else in the process happened to import pyarrow
-    first, and the same model would validate differently under the API and the
-    CLI. Importing it up front is what makes the comparison deterministic.
-    """
-    with contextlib.suppress(ImportError):
-        import pyarrow  # noqa: F401
-
-
 def probe_datasource(model: SemanticModel, *, dialect: str) -> list[SemanticError]:
     """Check every data object in *model* against the configured datasource.
 
@@ -475,9 +455,9 @@ def probe_datasource(model: SemanticModel, *, dialect: str) -> list[SemanticErro
     codes against the fallback ``code`` table would report drift that is not
     there.
     """
-    from orionbelt.service.db_executor import ExecutionUnavailableError
+    from orionbelt.service.db_executor import ExecutionUnavailableError, ensure_arrow
 
-    _ensure_arrow()
+    ensure_arrow()
     try:
         impl = DialectRegistry.get(dialect)
     except UnsupportedDialectError:

--- a/src/orionbelt/service/db_executor.py
+++ b/src/orionbelt/service/db_executor.py
@@ -995,6 +995,39 @@ def _config_errors() -> tuple[type[BaseException], ...]:
     return _CONFIG_ERROR_TYPES
 
 
+def ensure_arrow() -> bool:
+    """Import pyarrow so the Arrow fetch paths are available. Idempotent.
+
+    The two ``_try_fetch_*_arrow`` helpers refuse to fetch unless pyarrow is
+    *already* in ``sys.modules``, and that guard is deliberate: importing it
+    lazily inside a running uvicorn loop on macOS triggers heavy gRPC
+    initialisation at the worst possible moment. What the guard does not do is
+    ensure the import ever happens - so whether a result carries a driver
+    schema depended on whatever else the process had touched first.
+
+    That mattered more than it looks. ``ExecutionResult.arrow_schema`` is what
+    ``cache.result_codec.build_result_table`` reads to type a column from the
+    driver's declaration instead of from the values a result happens to
+    contain (#410, and #393/#407 before it). With no schema it falls back to
+    inference, and a ``decimal(18, 2)`` column comes back ``decimal128(3, 2)``
+    for one filter and a different width for the next. The only thing importing
+    pyarrow early was a cache warm-up gated on ``cache_backend == "file"``, and
+    that setting defaults to ``noop`` - so on a default deployment the fix
+    shipped in #410 never ran.
+
+    Call this at a startup or entry boundary, never mid-request from inside a
+    server's event loop; that is the hazard the guard exists for. Returns
+    whether pyarrow is available, so a caller can log the degraded case rather
+    than wonder about it.
+    """
+    with contextlib.suppress(ImportError):
+        import pyarrow  # noqa: F401
+        import pyarrow.ipc  # noqa: F401
+
+        return True
+    return False
+
+
 def _try_fetch_arrow(cursor: Any) -> Any:
     """Try to fetch results as an Arrow Table. Returns None on failure.
 

--- a/tests/unit/test_ensure_arrow.py
+++ b/tests/unit/test_ensure_arrow.py
@@ -1,0 +1,101 @@
+"""``db_executor.ensure_arrow`` and the entry points that must call it.
+
+The executor's Arrow fetch runs only when pyarrow is already imported, and
+whether it is decided whether a result carried the driver's schema. Without
+that schema ``build_result_table`` types a column from the values one result
+happened to contain, which is the instability #410 was written to remove - so
+#410 only held where something unrelated had already imported pyarrow. The
+one thing that did was a cache warm-up gated on ``cache_backend == "file"``,
+and that setting defaults to ``noop``.
+
+These tests pin the contract rather than the import: that the helper reports
+availability, and that every surface which executes SQL calls it.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+from decimal import Decimal
+
+from orionbelt.service.db_executor import ensure_arrow
+
+SRC = pathlib.Path(__file__).resolve().parents[2] / "src" / "orionbelt"
+
+
+def _calls_ensure_arrow(relative: str) -> bool:
+    """Whether the module names ``ensure_arrow`` in a call position."""
+    tree = ast.parse((SRC / relative).read_text())
+    return any(
+        isinstance(node, ast.Call)
+        and (
+            (isinstance(node.func, ast.Name) and node.func.id == "ensure_arrow")
+            or (isinstance(node.func, ast.Attribute) and node.func.attr == "ensure_arrow")
+        )
+        for node in ast.walk(tree)
+    )
+
+
+class TestEnsureArrow:
+    def test_reports_availability(self) -> None:
+        assert ensure_arrow() is True  # pyarrow is a test dependency
+
+    def test_is_idempotent(self) -> None:
+        assert ensure_arrow() is True
+        assert ensure_arrow() is True
+
+    def test_makes_the_arrow_fetch_path_reachable(self) -> None:
+        """The guard the helper exists to satisfy."""
+        import sys
+
+        ensure_arrow()
+        assert "pyarrow" in sys.modules
+
+
+class TestEveryExecutingSurfaceCallsIt:
+    """A surface that executes SQL without this returns inferred types.
+
+    Asserted structurally because the failure is silent: nothing errors, the
+    columns simply come back typed from their values. A new surface that
+    forgets the call would otherwise ship the same regression unnoticed.
+    """
+
+    def test_rest_api_calls_it_at_startup(self) -> None:
+        assert _calls_ensure_arrow("api/app.py")
+
+    def test_pgwire_calls_it_before_accepting_connections(self) -> None:
+        assert _calls_ensure_arrow("pgwire/server.py")
+
+    def test_cli_calls_it_before_executing(self) -> None:
+        assert _calls_ensure_arrow("cli/_local.py")
+
+    def test_datasource_probe_calls_it(self) -> None:
+        assert _calls_ensure_arrow("service/datasource_probe.py")
+
+    def test_api_startup_call_is_not_gated_on_the_cache_backend(self) -> None:
+        """The regression itself: the call used to sit inside
+        ``if cache.backend_name == "file":`` and so never ran on the default
+        ``cache_backend=noop``."""
+        source = (SRC / "api" / "app.py").read_text()
+        before_cache_branch = source.split('if cache.backend_name == "file":')[0]
+        assert "ensure_arrow()" in before_cache_branch
+
+
+class TestTheTypeThisProtects:
+    """What the carried schema is worth, in the terms a user sees."""
+
+    def test_a_wide_declaration_survives_narrow_values(self) -> None:
+        import pyarrow as pa
+
+        from orionbelt.cache.result_codec import build_result_table
+
+        rows = [[Decimal("1.50")], [Decimal("2.25")]]
+        schema = pa.schema([pa.field("amount", pa.decimal128(18, 2))])
+
+        inferred = build_result_table(["amount"], rows, None)
+        carried = build_result_table(["amount"], rows, schema)
+
+        # Inference reads only the values present, so the same column comes
+        # back a different width for a different filter.
+        assert inferred.schema.field(0).type == pa.decimal128(3, 2)
+        assert carried.schema.field(0).type == pa.decimal128(18, 2)


### PR DESCRIPTION
## The problem

#410 made the driver's Arrow schema decide a column's type, instead of inference over the values one result happened to contain. **It only ran where pyarrow was already imported.**

The executor's Arrow fetch is guarded on `"pyarrow" in sys.modules` and never imports it. That guard is deliberate: importing pyarrow inside a live uvicorn loop on macOS drags in gRPC initialisation mid-request. What it does not do is ensure the import ever happens.

The only thing that did was a cache warm-up in `api/app.py`, gated on `cache.backend_name == "file"`. And `cache_backend` defaults to `noop`.

So on a default deployment `ExecutionResult.arrow_schema` was always `None`, and every column fell back to inference. Measured on DuckDB over a `DECIMAL(18, 2)` column holding `1.50` and `2.25`:

| | column type |
|---|---|
| schema unavailable (the old default) | `decimal128(3, 2)` |
| schema carried (after this) | `decimal128(18, 2)` |

The same column comes back a different width for a different filter, so a consumer that read the schema once is wrong about the next result. That is exactly what #393 (MySQL), #407 (Snowflake) and #410 (the codec) were each written to remove, reappearing through a setting that has nothing to do with types.

## The fix

`ensure_arrow()` imports pyarrow, idempotently, and reports availability so a caller can log the degraded case rather than wonder about it.

It is called at the **startup or entry boundary** of every surface that executes SQL, never mid-request from inside a running loop:

| Surface | Where |
|---|---|
| REST | `api/app.py` lifespan, unconditionally, before the cache branch |
| pgwire | `PgWireServer.start`, before accepting connections |
| CLI | `cli/_local.py`, before executing |
| datasource probe | now uses the shared helper instead of its own copy |

Flight is unaffected: `ob_flight` imports pyarrow itself.

## Tests

The failure is silent - nothing raises, columns simply come back typed from their values - so the call sites are asserted structurally, and one test pins the specific regression: that the REST call sits **before** the `if cache.backend_name == "file":` branch rather than inside it. A new surface that forgets the call fails the suite instead of shipping the bug.

Full suite 4971 passed, 1046 skipped. `ruff check`, `ruff format` and `mypy src/` clean.