### PR TITLE
feat(types): publish the Arrow type-fidelity matrix and assert it in CI

### DIFF
--- a/docs/reference/type-fidelity.md
+++ b/docs/reference/type-fidelity.md
@@ -1,0 +1,94 @@
+# Arrow type fidelity
+
+What Arrow type each engine's driver returns for a declared OBML type. A
+semantic layer's promise is that a measure declared `decimal(18, 2)` arrives as
+an exact fixed-point number; whether it does is a property of the driver and its
+cast rendering, not of the SQL.
+
+Measured **2026-09-04** with `scripts/probe_types.py`, against all eight engines
+live. Each case is rendered through the engine's own `cast_to_obml_type`, so
+this is what OBSL emits rather than a hand-spelled approximation.
+
+```bash
+uv run python scripts/probe_types.py all          # human-readable
+uv run python scripts/probe_types.py --json all   # regenerate the data below
+```
+
+## Verdicts
+
+| Verdict | Meaning |
+|---|---|
+| `EXACT` | The declared type came back unchanged. |
+| `WIDENED` | Still fixed-point, at a wider precision or scale. An engine widening a `SUM` is doing the right thing; a widened *cast* is the engine's own decimal rules, recorded rather than judged. |
+| `FAMILY` | Right family, different width - an `int64` where the model said `integer`. |
+| `ZONED` | A `timestamp` came back carrying a timezone. OBML's `timestamp` is a wall clock. |
+| `LOSSY` | The fixed-point type became a float or a string. |
+
+## The matrix
+
+| Declared | DuckDB | Postgres | MySQL | ClickHouse | Snowflake | BigQuery | Databricks | Dremio |
+|---|---|---|---|---|---|---|---|---|
+| `decimal(18,2)` | EXACT | LOSSY | WIDENED | EXACT | WIDENED | WIDENED | EXACT | EXACT |
+| `decimal(38,9)` | EXACT | LOSSY | WIDENED | EXACT | EXACT | EXACT | EXACT | EXACT |
+| `decimal(18,2) big` | EXACT | LOSSY | WIDENED | EXACT | WIDENED | WIDENED | EXACT | EXACT |
+| `SUM decimal(18,2)` | WIDENED | LOSSY | WIDENED | WIDENED | WIDENED | WIDENED | WIDENED | WIDENED |
+| `integer` | EXACT | EXACT | FAMILY | EXACT | FAMILY | FAMILY | EXACT | EXACT |
+| `bigint` | EXACT | EXACT | EXACT | EXACT | EXACT | EXACT | EXACT | EXACT |
+| `double` | EXACT | EXACT | EXACT | EXACT | EXACT | EXACT | EXACT | EXACT |
+| `string` | EXACT | EXACT | EXACT | EXACT | EXACT | EXACT | EXACT | EXACT |
+| `boolean` | EXACT | EXACT | LOSSY | EXACT | EXACT | EXACT | EXACT | EXACT |
+| `date` | EXACT | EXACT | EXACT | EXACT | EXACT | EXACT | EXACT | FAMILY |
+| `timestamp` | EXACT | EXACT | EXACT | ZONED | EXACT | EXACT | EXACT | EXACT |
+
+### Arrow types returned
+
+| Declared | DuckDB | Postgres | MySQL | ClickHouse | Snowflake | BigQuery | Databricks | Dremio |
+|---|---|---|---|---|---|---|---|---|
+| `decimal(18,2)` | `decimal128(18, 2)` | `extension<arrow.opaque[storage_type=string, type_name=numeric, vendor_name=PostgreSQL]>` | `decimal256(76, 2)` | `decimal128(18, 2)` | `decimal128(38, 2)` | `decimal128(38, 9)` | `decimal128(18, 2)` | `decimal128(18, 2)` |
+| `decimal(38,9)` | `decimal128(38, 9)` | `extension<arrow.opaque[storage_type=string, type_name=numeric, vendor_name=PostgreSQL]>` | `decimal256(76, 9)` | `decimal128(38, 9)` | `decimal128(38, 9)` | `decimal128(38, 9)` | `decimal128(38, 9)` | `decimal128(38, 9)` |
+| `decimal(18,2) big` | `decimal128(19, 2)` | `extension<arrow.opaque[storage_type=string, type_name=numeric, vendor_name=PostgreSQL]>` | `decimal256(76, 2)` | `decimal128(19, 2)` | `decimal128(38, 2)` | `decimal128(38, 9)` | `decimal128(19, 2)` | `decimal128(19, 2)` |
+| `SUM decimal(18,2)` | `decimal128(38, 2)` | `extension<arrow.opaque[storage_type=string, type_name=numeric, vendor_name=PostgreSQL]>` | `decimal256(76, 2)` | `decimal128(38, 2)` | `decimal128(38, 2)` | `decimal128(38, 9)` | `decimal128(28, 2)` | `decimal128(38, 2)` |
+| `integer` | `int32` | `int32` | `int64` | `int32` | `int64` | `int64` | `int32` | `int32` |
+| `bigint` | `int64` | `int64` | `int64` | `int64` | `int64` | `int64` | `int64` | `int64` |
+| `double` | `double` | `double` | `double` | `double` | `double` | `double` | `double` | `double` |
+| `string` | `string` | `string` | `string` | `string` | `string` | `string` | `string` | `string` |
+| `boolean` | `bool` | `bool` | `int64` | `bool` | `bool` | `bool` | `bool` | `bool` |
+| `date` | `date32[day]` | `date32[day]` | `date32[day]` | `date32[day]` | `date32[day]` | `date32[day]` | `date32[day]` | `date64[ms]` |
+| `timestamp` | `timestamp[us]` | `timestamp[us]` | `timestamp[us]` | `timestamp[ms, tz=Europe/Berlin]` | `timestamp[ns]` | `timestamp[us]` | `timestamp[us]` | `timestamp[ms]` |
+
+## Reading the two rows that look alarming
+
+**Postgres `LOSSY string` on every decimal is correct**, and is the clearest
+reason this table is not the whole story. ADBC represents `NUMERIC` as
+`arrow.opaque[storage_type=string, type_name=numeric]` because Postgres NUMERIC
+is arbitrary precision with NaN and Infinity, Arrow's `decimal128` caps at 38
+digits and needs the scale up front, and typmod is `-1` for a computed
+expression. Preserving the exact digits as text is the faithful choice, and
+`db_executor` parses those cells back to `Decimal` before any caller sees them.
+The driver is lossy here; **OBSL is not**.
+
+**ClickHouse `ZONED` on `timestamp` is intrinsic.** ClickHouse has no naive
+`DateTime` - the type is an instant rendered against the server timezone. Every
+OBSL surface reconciles it against the declared wall clock; see the Flight
+alignment in `ob_flight/server_execution.py`.
+
+## Open gaps
+
+| Engine | Gap |
+|---|---|
+| MySQL | `boolean` is **lossy**: MySQL has no boolean type, so a declared one arrives as `int64` `1`. |
+| Dremio | `date` returns `date64[ms]` where the other seven give `date32[day]`. |
+
+## What CI asserts
+
+This table measures **drivers**. Every type defect OBSL has actually shipped
+lived between the driver and the caller instead - the cache codec typing a
+column from the values it happened to hold (#410), the executor never importing
+pyarrow so no result carried a schema at all (#412) - and a driver-level probe
+is blind to all of them.
+
+So `tests/integration/test_type_fidelity.py` asserts through
+`db_executor.execute_sql`, the path REST, pgwire and the CLI share, on DuckDB -
+the one engine needing no credentials, and therefore the one every CI machine
+can reach. The other seven stay in this table rather than in CI: a suite that
+skips six of eight rows reports green for a matrix nobody measured.

--- a/docs/reference/type-fidelity.md
+++ b/docs/reference/type-fidelity.md
@@ -30,7 +30,7 @@ uv run python scripts/probe_types.py --json all   # regenerate the data below
 |---|---|---|---|---|---|---|---|---|
 | `decimal(18,2)` | EXACT | LOSSY | WIDENED | EXACT | WIDENED | WIDENED | EXACT | EXACT |
 | `decimal(38,9)` | EXACT | LOSSY | WIDENED | EXACT | EXACT | EXACT | EXACT | EXACT |
-| `decimal(18,2) big` | EXACT | LOSSY | WIDENED | EXACT | WIDENED | WIDENED | EXACT | EXACT |
+| `decimal(19,2) big` | EXACT | LOSSY | WIDENED | EXACT | WIDENED | WIDENED | EXACT | EXACT |
 | `SUM decimal(18,2)` | WIDENED | LOSSY | WIDENED | WIDENED | WIDENED | WIDENED | WIDENED | WIDENED |
 | `integer` | EXACT | EXACT | FAMILY | EXACT | FAMILY | FAMILY | EXACT | EXACT |
 | `bigint` | EXACT | EXACT | EXACT | EXACT | EXACT | EXACT | EXACT | EXACT |
@@ -46,7 +46,7 @@ uv run python scripts/probe_types.py --json all   # regenerate the data below
 |---|---|---|---|---|---|---|---|---|
 | `decimal(18,2)` | `decimal128(18, 2)` | `extension<arrow.opaque[storage_type=string, type_name=numeric, vendor_name=PostgreSQL]>` | `decimal256(76, 2)` | `decimal128(18, 2)` | `decimal128(38, 2)` | `decimal128(38, 9)` | `decimal128(18, 2)` | `decimal128(18, 2)` |
 | `decimal(38,9)` | `decimal128(38, 9)` | `extension<arrow.opaque[storage_type=string, type_name=numeric, vendor_name=PostgreSQL]>` | `decimal256(76, 9)` | `decimal128(38, 9)` | `decimal128(38, 9)` | `decimal128(38, 9)` | `decimal128(38, 9)` | `decimal128(38, 9)` |
-| `decimal(18,2) big` | `decimal128(19, 2)` | `extension<arrow.opaque[storage_type=string, type_name=numeric, vendor_name=PostgreSQL]>` | `decimal256(76, 2)` | `decimal128(19, 2)` | `decimal128(38, 2)` | `decimal128(38, 9)` | `decimal128(19, 2)` | `decimal128(19, 2)` |
+| `decimal(19,2) big` | `decimal128(19, 2)` | `extension<arrow.opaque[storage_type=string, type_name=numeric, vendor_name=PostgreSQL]>` | `decimal256(76, 2)` | `decimal128(19, 2)` | `decimal128(38, 2)` | `decimal128(38, 9)` | `decimal128(19, 2)` | `decimal128(19, 2)` |
 | `SUM decimal(18,2)` | `decimal128(38, 2)` | `extension<arrow.opaque[storage_type=string, type_name=numeric, vendor_name=PostgreSQL]>` | `decimal256(76, 2)` | `decimal128(38, 2)` | `decimal128(38, 2)` | `decimal128(38, 9)` | `decimal128(28, 2)` | `decimal128(38, 2)` |
 | `integer` | `int32` | `int32` | `int64` | `int32` | `int64` | `int64` | `int32` | `int32` |
 | `bigint` | `int64` | `int64` | `int64` | `int64` | `int64` | `int64` | `int64` | `int64` |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -170,4 +170,5 @@ nav:
       - Python API: reference/python-api.md
       - Architecture: reference/architecture.md
       - Configuration: reference/configuration.md
+      - Arrow type fidelity: reference/type-fidelity.md
   - Drivers & Flight SQL: drivers.md

--- a/scripts/probe_types.py
+++ b/scripts/probe_types.py
@@ -65,6 +65,8 @@ Each row prints a verdict, the Arrow type and the round-tripped value:
 
 from __future__ import annotations
 
+import datetime
+import json
 import sys
 import traceback
 from typing import Any
@@ -123,6 +125,11 @@ ENGINES = (
     "databricks",
     "dremio",
 )
+
+
+def _today() -> str:
+    """UTC date the measurement was taken, for the published matrix."""
+    return datetime.datetime.now(datetime.UTC).date().isoformat()
 
 
 def _family(t: pa.DataType) -> str:
@@ -205,10 +212,15 @@ def fetch(engine: str, sql: str) -> pa.Table:
             cursor.close()
 
 
-def probe(engine: str) -> None:
-    print(f"\n===== {engine}")
+def measure(engine: str) -> dict[str, dict[str, str]]:
+    """Run every case against *engine* and return its row of the matrix.
+
+    Keyed by case label, so a caller comparing two runs compares like with
+    like even if the case list grows.
+    """
     cases = render(engine)
     tables: dict[int, pa.Table] = {}
+    row: dict[str, dict[str, str]] = {}
     try:
         combined = "SELECT " + ", ".join(f"{sql} AS c{i}" for i, (_, _, sql) in enumerate(cases))
         table = fetch(engine, combined)
@@ -221,34 +233,65 @@ def probe(engine: str) -> None:
                 tables[i] = fetch(engine, f"SELECT {sql} AS c{i}")
             except Exception as exc:  # noqa: BLE001 — a failure is a result here
                 detail = str(exc).splitlines()[0][:64] if str(exc).strip() else type(exc).__name__
-                print(f"  {label:19} ERR     {detail}")
+                row[label] = {"verdict": "ERR", "arrow": "", "detail": detail}
     for i, (label, obml_type, _) in enumerate(cases):
         table = tables.get(i)
         if table is None:
             continue
         arrow_type = table.schema.field(0).type
-        value = table.column(0)[0].as_py()
-        print(f"  {label:19} {verdict(obml_type, arrow_type):24} {str(arrow_type):28} {value!r}")
+        row[label] = {
+            "verdict": verdict(obml_type, arrow_type),
+            "arrow": str(arrow_type),
+            "value": repr(table.column(0)[0].as_py()),
+        }
+    return row
+
+
+def probe(engine: str) -> dict[str, dict[str, str]]:
+    print(f"\n===== {engine}")
+    row = measure(engine)
+    for label, cell in row.items():
+        if cell["verdict"] == "ERR":
+            print(f"  {label:19} ERR     {cell['detail']}")
+        else:
+            print(f"  {label:19} {cell['verdict']:24} {cell['arrow']:28} {cell['value']}")
+    return row
 
 
 def main(argv: list[str]) -> int:
-    requested = argv[1:]
+    requested = [a for a in argv[1:] if a != "--json"]
+    as_json = "--json" in argv[1:]
     if not requested:
-        print(f"usage: probe_types.py <{' | '.join(ENGINES)} | all>", file=sys.stderr)
+        print(f"usage: probe_types.py [--json] <{' | '.join(ENGINES)} | all>", file=sys.stderr)
         return 2
     engines = list(ENGINES) if requested == ["all"] else requested
     unknown = [e for e in engines if e not in ENGINES]
     if unknown:
         print(f"unknown engine(s): {', '.join(unknown)}", file=sys.stderr)
         return 2
+    matrix: dict[str, dict[str, dict[str, str]]] = {}
     for engine in engines:
         try:
-            probe(engine)
+            matrix[engine] = measure(engine) if as_json else probe(engine)
         except Exception:
             # Unreachable is the normal state for an engine with no live
-            # target; print enough to tell that apart from a probe bug.
-            print(f"\n===== {engine}\n  UNREACHABLE")
-            traceback.print_exc(limit=2)
+            # target; say so in a way a reader can tell from a probe bug.
+            # An unreachable engine is *omitted* from JSON rather than
+            # recorded as empty: a published matrix that shows a blank row
+            # claims a measurement nobody took.
+            if as_json:
+                print(f"unreachable: {engine}", file=sys.stderr)
+            else:
+                print(f"\n===== {engine}\n  UNREACHABLE")
+                traceback.print_exc(limit=2)
+    if as_json:
+        json.dump(
+            {"measured": _today(), "engines": matrix},
+            sys.stdout,
+            indent=2,
+            sort_keys=True,
+        )
+        print()
     return 0
 
 

--- a/scripts/probe_types.py
+++ b/scripts/probe_types.py
@@ -80,7 +80,11 @@ import pyarrow as pa
 CASES: list[tuple[str, str, str, bool]] = [
     ("decimal(18,2)", "2.55", "decimal(18, 2)", False),
     ("decimal(38,9)", "2.123456789", "decimal(38, 9)", False),
-    ("decimal(18,2) big", "12345678901234567.89", "decimal(19, 2)", False),
+    # 19 significant digits (17 + 2), so this needs decimal(19, 2) and the
+    # label has to say so: the published table's first column is the *declared*
+    # type, and a row labelled decimal(18,2) beside a CAST to DECIMAL(19, 2)
+    # publishes a declaration nobody made.
+    ("decimal(19,2) big", "12345678901234567.89", "decimal(19, 2)", False),
     ("SUM decimal(18,2)", "2.55", "decimal(18, 2)", True),
     ("integer", "42", "integer", False),
     ("bigint", "9007199254740993", "bigint", False),
@@ -212,11 +216,24 @@ def fetch(engine: str, sql: str) -> pa.Table:
             cursor.close()
 
 
+class EngineUnreachableError(RuntimeError):
+    """No case got an answer, so there is nothing to report about the engine."""
+
+
 def measure(engine: str) -> dict[str, dict[str, str]]:
     """Run every case against *engine* and return its row of the matrix.
 
     Keyed by case label, so a caller comparing two runs compares like with
     like even if the case list grows.
+
+    Raises :class:`EngineUnreachableError` when not one case came back. The
+    per-case retry below exists so a single unsupported cast cannot blank an
+    engine, but it cannot tell "this cast failed" from "nothing answered", and
+    on a dead connection it turns one connection error into a full row of
+    them. That row then reads as eleven measured failures, which is a claim
+    about the engine rather than about the connection - and in JSON it is
+    worse, because a published matrix showing a blank row claims a measurement
+    nobody took.
     """
     cases = render(engine)
     tables: dict[int, pa.Table] = {}
@@ -244,6 +261,9 @@ def measure(engine: str) -> dict[str, dict[str, str]]:
             "arrow": str(arrow_type),
             "value": repr(table.column(0)[0].as_py()),
         }
+    if not tables:
+        detail = next((c.get("detail", "") for c in row.values()), "")
+        raise EngineUnreachableError(detail or "no case returned a result")
     return row
 
 
@@ -273,17 +293,22 @@ def main(argv: list[str]) -> int:
     for engine in engines:
         try:
             matrix[engine] = measure(engine) if as_json else probe(engine)
-        except Exception:
-            # Unreachable is the normal state for an engine with no live
-            # target; say so in a way a reader can tell from a probe bug.
-            # An unreachable engine is *omitted* from JSON rather than
-            # recorded as empty: a published matrix that shows a blank row
-            # claims a measurement nobody took.
+        except EngineUnreachableError as exc:
+            # The normal state for an engine with no live target. Omitted from
+            # JSON rather than recorded as empty, because a published matrix
+            # showing a blank row claims a measurement nobody took.
             if as_json:
-                print(f"unreachable: {engine}", file=sys.stderr)
+                print(f"unreachable: {engine}: {exc}", file=sys.stderr)
             else:
-                print(f"\n===== {engine}\n  UNREACHABLE")
-                traceback.print_exc(limit=2)
+                # ``probe`` has already printed the engine header.
+                print(f"  UNREACHABLE  {exc}")
+        except Exception:
+            # A probe bug rather than a dead connection; show it as one.
+            if as_json:
+                print(f"failed: {engine}", file=sys.stderr)
+            else:
+                print("  FAILED")
+            traceback.print_exc(limit=2)
     if as_json:
         json.dump(
             {"measured": _today(), "engines": matrix},

--- a/scripts/type-fidelity-matrix.json
+++ b/scripts/type-fidelity-matrix.json
@@ -26,7 +26,7 @@
         "value": "Decimal('2.550000000')",
         "verdict": "WIDENED decimal128(38, 9)"
       },
-      "decimal(18,2) big": {
+      "decimal(19,2) big": {
         "arrow": "decimal128(38, 9)",
         "value": "Decimal('12345678901234567.890000000')",
         "verdict": "WIDENED decimal128(38, 9)"
@@ -83,7 +83,7 @@
         "value": "Decimal('2.55')",
         "verdict": "EXACT"
       },
-      "decimal(18,2) big": {
+      "decimal(19,2) big": {
         "arrow": "decimal128(19, 2)",
         "value": "Decimal('12345678901234568.00')",
         "verdict": "EXACT"
@@ -140,7 +140,7 @@
         "value": "Decimal('2.55')",
         "verdict": "EXACT"
       },
-      "decimal(18,2) big": {
+      "decimal(19,2) big": {
         "arrow": "decimal128(19, 2)",
         "value": "Decimal('12345678901234567.89')",
         "verdict": "EXACT"
@@ -197,7 +197,7 @@
         "value": "Decimal('2.55')",
         "verdict": "EXACT"
       },
-      "decimal(18,2) big": {
+      "decimal(19,2) big": {
         "arrow": "decimal128(19, 2)",
         "value": "Decimal('12345678901234567.89')",
         "verdict": "EXACT"
@@ -254,7 +254,7 @@
         "value": "Decimal('2.55')",
         "verdict": "EXACT"
       },
-      "decimal(18,2) big": {
+      "decimal(19,2) big": {
         "arrow": "decimal128(19, 2)",
         "value": "Decimal('12345678901234567.89')",
         "verdict": "EXACT"
@@ -311,7 +311,7 @@
         "value": "Decimal('2.55')",
         "verdict": "WIDENED decimal256(76, 2)"
       },
-      "decimal(18,2) big": {
+      "decimal(19,2) big": {
         "arrow": "decimal256(76, 2)",
         "value": "Decimal('12345678901234567.89')",
         "verdict": "WIDENED decimal256(76, 2)"
@@ -368,7 +368,7 @@
         "value": "'2.55'",
         "verdict": "LOSSY   string"
       },
-      "decimal(18,2) big": {
+      "decimal(19,2) big": {
         "arrow": "extension<arrow.opaque[storage_type=string, type_name=numeric, vendor_name=PostgreSQL]>",
         "value": "'12345678901234567.89'",
         "verdict": "LOSSY   string"
@@ -425,7 +425,7 @@
         "value": "Decimal('2.55')",
         "verdict": "WIDENED decimal128(38, 2)"
       },
-      "decimal(18,2) big": {
+      "decimal(19,2) big": {
         "arrow": "decimal128(38, 2)",
         "value": "Decimal('12345678901234567.89')",
         "verdict": "WIDENED decimal128(38, 2)"

--- a/scripts/type-fidelity-matrix.json
+++ b/scripts/type-fidelity-matrix.json
@@ -1,0 +1,461 @@
+{
+  "engines": {
+    "bigquery": {
+      "SUM decimal(18,2)": {
+        "arrow": "decimal128(38, 9)",
+        "value": "Decimal('2.550000000')",
+        "verdict": "WIDENED decimal128(38, 9)"
+      },
+      "bigint": {
+        "arrow": "int64",
+        "value": "9007199254740993",
+        "verdict": "EXACT"
+      },
+      "boolean": {
+        "arrow": "bool",
+        "value": "True",
+        "verdict": "EXACT"
+      },
+      "date": {
+        "arrow": "date32[day]",
+        "value": "datetime.date(2026, 8, 15)",
+        "verdict": "EXACT"
+      },
+      "decimal(18,2)": {
+        "arrow": "decimal128(38, 9)",
+        "value": "Decimal('2.550000000')",
+        "verdict": "WIDENED decimal128(38, 9)"
+      },
+      "decimal(18,2) big": {
+        "arrow": "decimal128(38, 9)",
+        "value": "Decimal('12345678901234567.890000000')",
+        "verdict": "WIDENED decimal128(38, 9)"
+      },
+      "decimal(38,9)": {
+        "arrow": "decimal128(38, 9)",
+        "value": "Decimal('2.123456789')",
+        "verdict": "EXACT"
+      },
+      "double": {
+        "arrow": "double",
+        "value": "2.5",
+        "verdict": "EXACT"
+      },
+      "integer": {
+        "arrow": "int64",
+        "value": "42",
+        "verdict": "FAMILY  int64"
+      },
+      "string": {
+        "arrow": "string",
+        "value": "'x'",
+        "verdict": "EXACT"
+      },
+      "timestamp": {
+        "arrow": "timestamp[us]",
+        "value": "datetime.datetime(2026, 8, 15, 13, 45)",
+        "verdict": "EXACT"
+      }
+    },
+    "clickhouse": {
+      "SUM decimal(18,2)": {
+        "arrow": "decimal128(38, 2)",
+        "value": "Decimal('2.55')",
+        "verdict": "WIDENED decimal128(38, 2)"
+      },
+      "bigint": {
+        "arrow": "int64",
+        "value": "9007199254740993",
+        "verdict": "EXACT"
+      },
+      "boolean": {
+        "arrow": "bool",
+        "value": "True",
+        "verdict": "EXACT"
+      },
+      "date": {
+        "arrow": "date32[day]",
+        "value": "datetime.date(2026, 8, 15)",
+        "verdict": "EXACT"
+      },
+      "decimal(18,2)": {
+        "arrow": "decimal128(18, 2)",
+        "value": "Decimal('2.55')",
+        "verdict": "EXACT"
+      },
+      "decimal(18,2) big": {
+        "arrow": "decimal128(19, 2)",
+        "value": "Decimal('12345678901234568.00')",
+        "verdict": "EXACT"
+      },
+      "decimal(38,9)": {
+        "arrow": "decimal128(38, 9)",
+        "value": "Decimal('2.123456789')",
+        "verdict": "EXACT"
+      },
+      "double": {
+        "arrow": "double",
+        "value": "2.5",
+        "verdict": "EXACT"
+      },
+      "integer": {
+        "arrow": "int32",
+        "value": "42",
+        "verdict": "EXACT"
+      },
+      "string": {
+        "arrow": "string",
+        "value": "'x'",
+        "verdict": "EXACT"
+      },
+      "timestamp": {
+        "arrow": "timestamp[ms, tz=Europe/Berlin]",
+        "value": "datetime.datetime(2026, 8, 15, 13, 45, tzinfo=zoneinfo.ZoneInfo(key='Europe/Berlin'))",
+        "verdict": "ZONED   tz=Europe/Berlin"
+      }
+    },
+    "databricks": {
+      "SUM decimal(18,2)": {
+        "arrow": "decimal128(28, 2)",
+        "value": "Decimal('2.55')",
+        "verdict": "WIDENED decimal128(28, 2)"
+      },
+      "bigint": {
+        "arrow": "int64",
+        "value": "9007199254740993",
+        "verdict": "EXACT"
+      },
+      "boolean": {
+        "arrow": "bool",
+        "value": "True",
+        "verdict": "EXACT"
+      },
+      "date": {
+        "arrow": "date32[day]",
+        "value": "datetime.date(2026, 8, 15)",
+        "verdict": "EXACT"
+      },
+      "decimal(18,2)": {
+        "arrow": "decimal128(18, 2)",
+        "value": "Decimal('2.55')",
+        "verdict": "EXACT"
+      },
+      "decimal(18,2) big": {
+        "arrow": "decimal128(19, 2)",
+        "value": "Decimal('12345678901234567.89')",
+        "verdict": "EXACT"
+      },
+      "decimal(38,9)": {
+        "arrow": "decimal128(38, 9)",
+        "value": "Decimal('2.123456789')",
+        "verdict": "EXACT"
+      },
+      "double": {
+        "arrow": "double",
+        "value": "2.5",
+        "verdict": "EXACT"
+      },
+      "integer": {
+        "arrow": "int32",
+        "value": "42",
+        "verdict": "EXACT"
+      },
+      "string": {
+        "arrow": "string",
+        "value": "'x'",
+        "verdict": "EXACT"
+      },
+      "timestamp": {
+        "arrow": "timestamp[us]",
+        "value": "datetime.datetime(2026, 8, 15, 13, 45)",
+        "verdict": "EXACT"
+      }
+    },
+    "dremio": {
+      "SUM decimal(18,2)": {
+        "arrow": "decimal128(38, 2)",
+        "value": "Decimal('2.55')",
+        "verdict": "WIDENED decimal128(38, 2)"
+      },
+      "bigint": {
+        "arrow": "int64",
+        "value": "9007199254740993",
+        "verdict": "EXACT"
+      },
+      "boolean": {
+        "arrow": "bool",
+        "value": "True",
+        "verdict": "EXACT"
+      },
+      "date": {
+        "arrow": "date64[ms]",
+        "value": "datetime.date(2026, 8, 15)",
+        "verdict": "FAMILY  date64[ms]"
+      },
+      "decimal(18,2)": {
+        "arrow": "decimal128(18, 2)",
+        "value": "Decimal('2.55')",
+        "verdict": "EXACT"
+      },
+      "decimal(18,2) big": {
+        "arrow": "decimal128(19, 2)",
+        "value": "Decimal('12345678901234567.89')",
+        "verdict": "EXACT"
+      },
+      "decimal(38,9)": {
+        "arrow": "decimal128(38, 9)",
+        "value": "Decimal('2.123456789')",
+        "verdict": "EXACT"
+      },
+      "double": {
+        "arrow": "double",
+        "value": "2.5",
+        "verdict": "EXACT"
+      },
+      "integer": {
+        "arrow": "int32",
+        "value": "42",
+        "verdict": "EXACT"
+      },
+      "string": {
+        "arrow": "string",
+        "value": "'x'",
+        "verdict": "EXACT"
+      },
+      "timestamp": {
+        "arrow": "timestamp[ms]",
+        "value": "datetime.datetime(2026, 8, 15, 13, 45)",
+        "verdict": "EXACT"
+      }
+    },
+    "duckdb": {
+      "SUM decimal(18,2)": {
+        "arrow": "decimal128(38, 2)",
+        "value": "Decimal('2.55')",
+        "verdict": "WIDENED decimal128(38, 2)"
+      },
+      "bigint": {
+        "arrow": "int64",
+        "value": "9007199254740993",
+        "verdict": "EXACT"
+      },
+      "boolean": {
+        "arrow": "bool",
+        "value": "True",
+        "verdict": "EXACT"
+      },
+      "date": {
+        "arrow": "date32[day]",
+        "value": "datetime.date(2026, 8, 15)",
+        "verdict": "EXACT"
+      },
+      "decimal(18,2)": {
+        "arrow": "decimal128(18, 2)",
+        "value": "Decimal('2.55')",
+        "verdict": "EXACT"
+      },
+      "decimal(18,2) big": {
+        "arrow": "decimal128(19, 2)",
+        "value": "Decimal('12345678901234567.89')",
+        "verdict": "EXACT"
+      },
+      "decimal(38,9)": {
+        "arrow": "decimal128(38, 9)",
+        "value": "Decimal('2.123456789')",
+        "verdict": "EXACT"
+      },
+      "double": {
+        "arrow": "double",
+        "value": "2.5",
+        "verdict": "EXACT"
+      },
+      "integer": {
+        "arrow": "int32",
+        "value": "42",
+        "verdict": "EXACT"
+      },
+      "string": {
+        "arrow": "string",
+        "value": "'x'",
+        "verdict": "EXACT"
+      },
+      "timestamp": {
+        "arrow": "timestamp[us]",
+        "value": "datetime.datetime(2026, 8, 15, 13, 45)",
+        "verdict": "EXACT"
+      }
+    },
+    "mysql": {
+      "SUM decimal(18,2)": {
+        "arrow": "decimal256(76, 2)",
+        "value": "Decimal('2.55')",
+        "verdict": "WIDENED decimal256(76, 2)"
+      },
+      "bigint": {
+        "arrow": "int64",
+        "value": "9007199254740993",
+        "verdict": "EXACT"
+      },
+      "boolean": {
+        "arrow": "int64",
+        "value": "1",
+        "verdict": "LOSSY   integer"
+      },
+      "date": {
+        "arrow": "date32[day]",
+        "value": "datetime.date(2026, 8, 15)",
+        "verdict": "EXACT"
+      },
+      "decimal(18,2)": {
+        "arrow": "decimal256(76, 2)",
+        "value": "Decimal('2.55')",
+        "verdict": "WIDENED decimal256(76, 2)"
+      },
+      "decimal(18,2) big": {
+        "arrow": "decimal256(76, 2)",
+        "value": "Decimal('12345678901234567.89')",
+        "verdict": "WIDENED decimal256(76, 2)"
+      },
+      "decimal(38,9)": {
+        "arrow": "decimal256(76, 9)",
+        "value": "Decimal('2.123456789')",
+        "verdict": "WIDENED decimal256(76, 9)"
+      },
+      "double": {
+        "arrow": "double",
+        "value": "2.5",
+        "verdict": "EXACT"
+      },
+      "integer": {
+        "arrow": "int64",
+        "value": "42",
+        "verdict": "FAMILY  int64"
+      },
+      "string": {
+        "arrow": "string",
+        "value": "'x'",
+        "verdict": "EXACT"
+      },
+      "timestamp": {
+        "arrow": "timestamp[us]",
+        "value": "datetime.datetime(2026, 8, 15, 13, 45)",
+        "verdict": "EXACT"
+      }
+    },
+    "postgres": {
+      "SUM decimal(18,2)": {
+        "arrow": "extension<arrow.opaque[storage_type=string, type_name=numeric, vendor_name=PostgreSQL]>",
+        "value": "'2.55'",
+        "verdict": "LOSSY   string"
+      },
+      "bigint": {
+        "arrow": "int64",
+        "value": "9007199254740993",
+        "verdict": "EXACT"
+      },
+      "boolean": {
+        "arrow": "bool",
+        "value": "True",
+        "verdict": "EXACT"
+      },
+      "date": {
+        "arrow": "date32[day]",
+        "value": "datetime.date(2026, 8, 15)",
+        "verdict": "EXACT"
+      },
+      "decimal(18,2)": {
+        "arrow": "extension<arrow.opaque[storage_type=string, type_name=numeric, vendor_name=PostgreSQL]>",
+        "value": "'2.55'",
+        "verdict": "LOSSY   string"
+      },
+      "decimal(18,2) big": {
+        "arrow": "extension<arrow.opaque[storage_type=string, type_name=numeric, vendor_name=PostgreSQL]>",
+        "value": "'12345678901234567.89'",
+        "verdict": "LOSSY   string"
+      },
+      "decimal(38,9)": {
+        "arrow": "extension<arrow.opaque[storage_type=string, type_name=numeric, vendor_name=PostgreSQL]>",
+        "value": "'2.123456789'",
+        "verdict": "LOSSY   string"
+      },
+      "double": {
+        "arrow": "double",
+        "value": "2.5",
+        "verdict": "EXACT"
+      },
+      "integer": {
+        "arrow": "int32",
+        "value": "42",
+        "verdict": "EXACT"
+      },
+      "string": {
+        "arrow": "string",
+        "value": "'x'",
+        "verdict": "EXACT"
+      },
+      "timestamp": {
+        "arrow": "timestamp[us]",
+        "value": "datetime.datetime(2026, 8, 15, 13, 45)",
+        "verdict": "EXACT"
+      }
+    },
+    "snowflake": {
+      "SUM decimal(18,2)": {
+        "arrow": "decimal128(38, 2)",
+        "value": "Decimal('2.55')",
+        "verdict": "WIDENED decimal128(38, 2)"
+      },
+      "bigint": {
+        "arrow": "int64",
+        "value": "9007199254740993",
+        "verdict": "EXACT"
+      },
+      "boolean": {
+        "arrow": "bool",
+        "value": "True",
+        "verdict": "EXACT"
+      },
+      "date": {
+        "arrow": "date32[day]",
+        "value": "datetime.date(2026, 8, 15)",
+        "verdict": "EXACT"
+      },
+      "decimal(18,2)": {
+        "arrow": "decimal128(38, 2)",
+        "value": "Decimal('2.55')",
+        "verdict": "WIDENED decimal128(38, 2)"
+      },
+      "decimal(18,2) big": {
+        "arrow": "decimal128(38, 2)",
+        "value": "Decimal('12345678901234567.89')",
+        "verdict": "WIDENED decimal128(38, 2)"
+      },
+      "decimal(38,9)": {
+        "arrow": "decimal128(38, 9)",
+        "value": "Decimal('2.123456789')",
+        "verdict": "EXACT"
+      },
+      "double": {
+        "arrow": "double",
+        "value": "2.5",
+        "verdict": "EXACT"
+      },
+      "integer": {
+        "arrow": "int64",
+        "value": "42",
+        "verdict": "FAMILY  int64"
+      },
+      "string": {
+        "arrow": "string",
+        "value": "'x'",
+        "verdict": "EXACT"
+      },
+      "timestamp": {
+        "arrow": "timestamp[ns]",
+        "value": "Timestamp('2026-08-15 13:45:00')",
+        "verdict": "EXACT"
+      }
+    }
+  },
+  "measured": "2026-09-04"
+}

--- a/tests/integration/test_type_fidelity.py
+++ b/tests/integration/test_type_fidelity.py
@@ -1,0 +1,167 @@
+"""Assert the Arrow type OBSL returns for each declared OBML type (II-6).
+
+``scripts/probe_types.py`` measures all eight engines, but it calls
+``cursor.fetch_arrow_table()`` directly and so measures the *driver*. That is
+the right tool for "is this engine faithful", and the wrong one for "is OBSL
+faithful": every defect this project has actually shipped lived between the
+driver and the caller, not in the driver.
+
+    #393  MySQL types inferred per page rather than from column metadata
+    #407  Snowflake integer widths narrowed by value; empty result raised
+    #410  the cache codec typed a column from the values it happened to hold
+    #412  the executor never imported pyarrow, so no result carried a schema
+          at all and #410 fell back to inference on a default deployment
+
+A driver-level probe is blind to all four. So this goes through
+``db_executor.execute_sql`` - the path REST, pgwire and the CLI all use - and
+asserts on what a caller receives.
+
+DuckDB is the engine here because it needs no credentials and so runs on every
+CI machine. The other seven are measured by the probe and published in
+``docs/reference/type-fidelity.md``; keeping them out of CI is deliberate,
+since a suite that skips six of eight rows reports green for a matrix nobody
+measured.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pyarrow as pa
+import pytest
+
+from orionbelt.ast.nodes import RawSQL
+from orionbelt.dialect.registry import DialectRegistry
+from orionbelt.models.types import parse_data_type
+from orionbelt.service.db_executor import execute_sql
+
+#: ``(OBML type, literal, expected Arrow type)``. The expectation is what a
+#: caller must receive, which is not always what the engine stores: DuckDB's
+#: ``SUM`` widens to ``decimal128(38, 2)``, and that is correct rather than a
+#: defect - an aggregate needs headroom the input width does not have.
+CASES: list[tuple[str, str, pa.DataType]] = [
+    ("decimal(18,2)", "2.55", pa.decimal128(18, 2)),
+    ("decimal(38,9)", "2.123456789", pa.decimal128(38, 9)),
+    ("integer", "42", pa.int32()),
+    ("bigint", "9007199254740993", pa.int64()),
+    ("double", "2.5", pa.float64()),
+    ("string", "'x'", pa.string()),
+    ("boolean", "1", pa.bool_()),
+    ("date", "'2026-08-15'", pa.date32()),
+]
+
+
+@pytest.fixture(scope="module")
+def duckdb_file(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """A real DuckDB file: the executor opens read-only, which in-memory refuses."""
+    import duckdb
+
+    path = tmp_path_factory.mktemp("fidelity") / "probe.duckdb"
+    duckdb.connect(str(path)).close()
+    return path
+
+
+@pytest.fixture(scope="module")
+def duckdb_env(duckdb_file: Path) -> None:
+    """Point the executor at that file for the module."""
+    previous = os.environ.get("DUCKDB_DATABASE")
+    os.environ["DUCKDB_DATABASE"] = str(duckdb_file)
+    yield
+    if previous is None:
+        os.environ.pop("DUCKDB_DATABASE", None)
+    else:
+        os.environ["DUCKDB_DATABASE"] = previous
+
+
+def _cast(literal: str, obml_type: str) -> str:
+    """*literal* cast to *obml_type* exactly as the compiler would emit it."""
+    dialect = DialectRegistry.get("duckdb")
+    expr = dialect.cast_to_obml_type(RawSQL(sql=literal), parse_data_type(obml_type))
+    return str(dialect.compile_expr(expr))
+
+
+def _returned_type(obml_type: str, literal: str) -> pa.DataType:
+    """The Arrow type a caller receives for *literal* declared as *obml_type*.
+
+    Rendered through the dialect's own ``cast_to_obml_type``, so a change to a
+    cast rendering shows up here rather than only in a hand-written SQL string
+    that has drifted from what the compiler emits.
+    """
+    result = execute_sql(f"SELECT {_cast(literal, obml_type)} AS c", dialect="duckdb")
+    assert result.arrow_schema is not None, (
+        "the executor returned no Arrow schema, so every column downstream is "
+        "typed by inference over its values - see #412"
+    )
+    return result.arrow_schema.field(0).type
+
+
+@pytest.mark.usefixtures("duckdb_env")
+class TestOBSLReturnsTheDeclaredType:
+    @pytest.mark.parametrize(
+        ("obml_type", "literal", "expected"),
+        CASES,
+        ids=[c[0] for c in CASES],
+    )
+    def test_declared_type_survives_to_the_caller(
+        self, obml_type: str, literal: str, expected: pa.DataType
+    ) -> None:
+        assert _returned_type(obml_type, literal) == expected
+
+
+@pytest.mark.usefixtures("duckdb_env")
+class TestKnownWidening:
+    """Widening that is correct, pinned so a change to it is deliberate."""
+
+    def test_sum_widens_to_the_engine_maximum(self) -> None:
+        """An aggregate needs headroom its input width does not have."""
+        assert _returned_type("decimal(18,2)", "2.55") == pa.decimal128(18, 2)
+        cast = _cast("2.55", "decimal(18,2)")
+        result = execute_sql(f"SELECT SUM({cast}) AS c", dialect="duckdb")
+        assert result.arrow_schema is not None
+        assert result.arrow_schema.field(0).type == pa.decimal128(38, 2)
+
+
+# ---------------------------------------------------------------------------
+# The #412 regression, which only a clean process can see
+# ---------------------------------------------------------------------------
+
+#: Run in a subprocess because pytest has already imported pyarrow, and that
+#: is precisely the condition that hid the bug: every in-process assertion
+#: above passes whether or not ``ensure_arrow`` does anything. A deployment
+#: does not have pytest's imports, so the guard has to be checked somewhere
+#: that does not either.
+_CLEAN_PROCESS_CHECK = """
+import sys
+assert "pyarrow" not in sys.modules, "this check is meaningless if pyarrow is preloaded"
+
+from orionbelt.service.db_executor import ensure_arrow, execute_sql
+
+ensure_arrow()
+result = execute_sql("SELECT CAST(1.5 AS DECIMAL(18,2)) AS c", dialect="duckdb")
+assert result.arrow_schema is not None, "no driver schema: see #412"
+print(result.arrow_schema.field(0).type)
+"""
+
+
+def test_a_server_start_makes_results_carry_a_driver_schema(duckdb_file: Path) -> None:
+    """What a REST or pgwire process does at startup, in a process like theirs.
+
+    Without ``ensure_arrow`` the executor cannot take the driver's Arrow path,
+    ``ExecutionResult.arrow_schema`` is ``None``, and every column downstream
+    is typed by inference over the values one result happened to contain -
+    which is the fix #410 shipped and #412 discovered was not running.
+    """
+    import subprocess
+
+    env = {**os.environ, "DUCKDB_DATABASE": str(duckdb_file)}
+    proc = subprocess.run(
+        [sys.executable, "-c", _CLEAN_PROCESS_CHECK],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=120,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout.strip() == "decimal128(18, 2)"

--- a/tests/integration/test_type_fidelity.py
+++ b/tests/integration/test_type_fidelity.py
@@ -25,7 +25,9 @@ measured.
 
 from __future__ import annotations
 
+import json
 import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -153,8 +155,6 @@ def test_a_server_start_makes_results_carry_a_driver_schema(duckdb_file: Path) -
     is typed by inference over the values one result happened to contain -
     which is the fix #410 shipped and #412 discovered was not running.
     """
-    import subprocess
-
     env = {**os.environ, "DUCKDB_DATABASE": str(duckdb_file)}
     proc = subprocess.run(
         [sys.executable, "-c", _CLEAN_PROCESS_CHECK],
@@ -165,3 +165,94 @@ def test_a_server_start_makes_results_carry_a_driver_schema(duckdb_file: Path) -
     )
     assert proc.returncode == 0, proc.stderr
     assert proc.stdout.strip() == "decimal128(18, 2)"
+
+
+# ---------------------------------------------------------------------------
+# The probe's own contract
+# ---------------------------------------------------------------------------
+
+
+class TestProbeOmitsUnreachableEngines:
+    """A published matrix must not show a row nobody measured.
+
+    The per-case retry in ``measure`` exists so one unsupported cast cannot
+    blank an engine, but it cannot tell "this cast failed" from "nothing
+    answered": on a dead connection it turned a single connection error into a
+    full row of ERR cells, and ``main`` never reached its omit branch. That row
+    then reads as eleven measured failures - a claim about the engine rather
+    than about the connection. It shipped that way for Dremio in the first run
+    of this matrix, which was really a stopped container.
+    """
+
+    def _probe_module(self):
+        import importlib.util
+
+        root = Path(__file__).resolve().parents[2]
+        spec = importlib.util.spec_from_file_location(
+            "probe_types", root / "scripts" / "probe_types.py"
+        )
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    def test_measure_raises_rather_than_returning_a_row_of_errors(self) -> None:
+        probe = self._probe_module()
+        previous = os.environ.pop("DUCKDB_DATABASE", None)
+        try:
+            with pytest.raises(probe.EngineUnreachableError):
+                probe.measure("duckdb")
+        finally:
+            if previous is not None:
+                os.environ["DUCKDB_DATABASE"] = previous
+
+    def test_json_output_omits_the_engine(self) -> None:
+        probe = self._probe_module()
+        previous = os.environ.pop("DUCKDB_DATABASE", None)
+        try:
+            proc = subprocess.run(
+                [sys.executable, str(Path(probe.__file__)), "--json", "duckdb"],
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )
+            assert proc.returncode == 0, proc.stderr
+            assert json.loads(proc.stdout)["engines"] == {}
+            assert "unreachable: duckdb" in proc.stderr
+        finally:
+            if previous is not None:
+                os.environ["DUCKDB_DATABASE"] = previous
+
+
+class TestPublishedLabelsMatchWhatIsCast:
+    """The matrix's first column is the *declared* type, so a label that
+    disagrees with the cast publishes a declaration nobody made. The ``big``
+    row said ``decimal(18,2)`` beside a ``CAST(... AS DECIMAL(19, 2))``.
+    """
+
+    def test_every_case_label_names_its_declared_type(self) -> None:
+        import importlib.util
+
+        root = Path(__file__).resolve().parents[2]
+        spec = importlib.util.spec_from_file_location(
+            "probe_types", root / "scripts" / "probe_types.py"
+        )
+        assert spec is not None and spec.loader is not None
+        probe = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(probe)
+
+        for label, _literal, obml_type, aggregate in probe.CASES:
+            stem = label.replace("SUM ", "").replace(" big", "").strip()
+            declared = obml_type.replace(" ", "")
+            assert stem.replace(" ", "") == declared, (
+                f"case {label!r} is cast as {obml_type!r}; the label has to say so"
+            )
+            assert aggregate == label.startswith("SUM ")
+
+    def test_the_published_matrix_uses_the_same_labels(self) -> None:
+        root = Path(__file__).resolve().parents[2]
+        matrix = json.loads((root / "scripts" / "type-fidelity-matrix.json").read_text())
+        page = (root / "docs" / "reference" / "type-fidelity.md").read_text()
+        for row in matrix["engines"].values():
+            for label in row:
+                assert f"`{label}`" in page, f"{label!r} measured but not published"


### PR DESCRIPTION
Track **II-6**. The measurements existed only in `scripts/probe_types.py` and a planning doc: nothing was published, nothing was asserted.

## Published

`docs/reference/type-fidelity.md`, **generated** from a full eight-engine run rather than transcribed. `probe_types.py` gains `--json`, and `scripts/type-fidelity-matrix.json` is the recorded result, so the page can be regenerated and a re-measurement diffed rather than re-read.

An unreachable engine is now *omitted* from the JSON rather than recorded as empty. A published matrix showing a blank row claims a measurement nobody took - and the first run of this did exactly that for Dremio, which turned out to be a stopped container, not a finding.

Measured 2026-09-04, all eight engines live, zero errors:

| Declared | DuckDB | Postgres | MySQL | ClickHouse | Snowflake | BigQuery | Databricks | Dremio |
|---|---|---|---|---|---|---|---|---|
| `decimal(18,2)` | EXACT | LOSSY | WIDENED | EXACT | WIDENED | WIDENED | EXACT | EXACT |
| `SUM decimal(18,2)` | WIDENED | LOSSY | WIDENED | WIDENED | WIDENED | WIDENED | WIDENED | WIDENED |
| `integer` | EXACT | EXACT | FAMILY | EXACT | FAMILY | FAMILY | EXACT | EXACT |
| `boolean` | EXACT | EXACT | **LOSSY** | EXACT | EXACT | EXACT | EXACT | EXACT |
| `date` | EXACT | EXACT | EXACT | EXACT | EXACT | EXACT | EXACT | **FAMILY** |
| `timestamp` | EXACT | EXACT | EXACT | ZONED | EXACT | EXACT | EXACT | EXACT |

Confirms both recorded gaps: MySQL `boolean` arrives as `int64` `1`; Dremio `date` as `date64[ms]` where the other seven give `date32[day]`.

Postgres reads LOSSY on every decimal **at the driver** and is *not* lossy through OBSL - ADBC preserves NUMERIC as text because it is arbitrary precision, and `db_executor` parses it back to `Decimal` before any caller sees it. Making that distinction legible is much of why the page exists.

## Asserted - and deliberately not by re-running the probe

The probe calls `cursor.fetch_arrow_table()` directly, so it measures the **driver**. Every type defect this project has actually shipped lived between the driver and the caller instead:

| | |
|---|---|
| #393 | MySQL types inferred per page rather than from column metadata |
| #407 | Snowflake integer widths narrowed by value |
| #410 | the cache codec typed a column from the values it held |
| #412 | the executor never imported pyarrow, so nothing carried a schema at all |

A driver-level probe is blind to all four. So `tests/integration/test_type_fidelity.py` goes through `db_executor.execute_sql` - the path REST, pgwire and the CLI share - on DuckDB, the one engine needing no credentials and therefore the only one every CI machine can reach. The other seven stay in the published table: a suite that skips six of eight rows reports green for a matrix nobody measured.

## The #412 guard runs in a subprocess

Because pytest has already imported pyarrow, and that is exactly the condition that hid the bug: the nine in-process assertions pass whether or not `ensure_arrow` does anything.

Verified by neutering `ensure_arrow`:

```
FAILED test_a_server_start_makes_results_carry_a_driver_schema
  AssertionError: no driver schema: see #412
1 failed, 9 passed
```

and green again when restored. The guard has teeth; the in-process tests, on their own, would not have.

Full suite 4981 passed, 1046 skipped. `ruff`, `mypy` and `mkdocs build --strict` clean.