### PR TITLE
fix: .env resolved from the working directory, and one Arrow-to-hint mapping

### DIFF
--- a/drivers/ob-flight-extension/src/ob_flight/server_execution.py
+++ b/drivers/ob-flight-extension/src/ob_flight/server_execution.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Any
 import pyarrow as pa
 import pyarrow.compute as pc
 from ob_driver_core.detection import is_obml, parse_obml
+from orionbelt.service.db_executor import arrow_type_to_hint
 from pyarrow import flight
 
 from ob_flight.converters import rows_to_batch, schema_from_description
@@ -24,34 +25,23 @@ if TYPE_CHECKING:
 logger = logging.getLogger("ob_flight.server")
 
 
-def _arrow_to_obsl_type_hint(arrow_type: pa.DataType) -> str:
-    """Map an Arrow DataType to the OBSL ``ColumnMetadata.type`` vocabulary
-    (``string`` / ``number`` / ``datetime`` / ``boolean`` / ``binary``). Used
-    when Flight writes to the shared result cache so readers on the other
-    surfaces decode column types correctly instead of falling back to
-    ``string``.
-    """
-    # Before the numeric test, which Arrow's ``is_integer`` does not exclude a
-    # bool from on every version, and because ``string`` is the fallback here:
-    # a boolean landing there is indistinguishable from an unrecognised type.
-    # A sidecar written ``string`` makes pgwire advertise a declared boolean as
-    # TEXT (OID 25) on a Flight-warmed entry, whatever the reader reconciles
-    # the data itself to.
-    if pa.types.is_boolean(arrow_type):
-        return "boolean"
-    if pa.types.is_integer(arrow_type) or pa.types.is_floating(arrow_type):
-        return "number"
-    if pa.types.is_decimal(arrow_type):
-        return "number"
-    if (
-        pa.types.is_date(arrow_type)
-        or pa.types.is_timestamp(arrow_type)
-        or pa.types.is_time(arrow_type)
-    ):
-        return "datetime"
-    if pa.types.is_binary(arrow_type) or pa.types.is_large_binary(arrow_type):
-        return "binary"
-    return "string"
+#: Arrow type -> the OBSL ``ColumnMetadata.type`` vocabulary, used when Flight
+#: writes the *shared* result cache sidecar so readers on the other surfaces
+#: decode column types instead of falling back to ``string``.
+#:
+#: Flight kept its own copy of this until now, and that is how the boolean case
+#: shipped: two of the three copies were corrected and this one was missed, so a
+#: Flight-warmed entry still made pgwire advertise a declared boolean as TEXT.
+#: The core mapping is a superset - it additionally recovers ADBC's opaque types
+#: from the vendor name they carry, and places intervals and durations - so
+#: adopting it also fixes what the sidecar said for those:
+#:
+#:     interval        string -> datetime
+#:     duration        string -> datetime
+#:     opaque numeric  string -> number
+#:
+#: each of which was the mapping's "unrecognised" bucket rather than a claim.
+_arrow_to_obsl_type_hint = arrow_type_to_hint
 
 
 # Query modes for the Flight SQL surface. See PLAN_flight_natural_sql.md §3.2.

--- a/drivers/ob-flight-extension/tests/test_converters.py
+++ b/drivers/ob-flight-extension/tests/test_converters.py
@@ -275,28 +275,40 @@ class TestSidecarTypeHints:
         assert _arrow_to_obsl_type_hint(pa.binary()) == "binary"
         assert _arrow_to_obsl_type_hint(pa.utf8()) == "string"
 
-    def test_it_agrees_with_the_executor_s_mapping(self) -> None:
-        """There are two copies of this. Fixing one and missing the other is
-        exactly how the boolean case shipped, so pin that they agree on every
-        type either is asked about.
+    def test_it_is_the_executor_s_mapping(self) -> None:
+        """Not merely equal - the same object.
+
+        Flight kept its own copy, and that is how the boolean case shipped:
+        two of the three copies were corrected and this one was missed. An
+        equality test would still pass the day someone re-forks it; identity
+        will not.
         """
-        import pyarrow as pa
-        from orionbelt.service.db_executor import _arrow_type_to_hint
+        from orionbelt.service.db_executor import arrow_type_to_hint
 
         from ob_flight.server_execution import _arrow_to_obsl_type_hint
 
-        for arrow_type in (
-            pa.bool_(),
-            pa.int64(),
-            pa.int32(),
-            pa.float64(),
-            pa.decimal128(18, 2),
-            pa.date32(),
-            pa.timestamp("us"),
-            pa.time64("us"),
-            pa.binary(),
-            pa.utf8(),
-        ):
-            assert _arrow_to_obsl_type_hint(arrow_type) == _arrow_type_to_hint(arrow_type), (
-                f"the two mappings disagree on {arrow_type}"
-            )
+        assert _arrow_to_obsl_type_hint is arrow_type_to_hint
+
+    def test_the_types_the_old_copy_could_not_place(self) -> None:
+        """Adopting the core mapping also fixed what the sidecar said for
+        these. Each was landing in the ``string`` bucket, which is that
+        mapping's answer for "unrecognised" rather than a claim about the
+        column.
+        """
+        import pyarrow as pa
+
+        from ob_flight.server_execution import _arrow_to_obsl_type_hint
+
+        assert _arrow_to_obsl_type_hint(pa.month_day_nano_interval()) == "datetime"
+        assert _arrow_to_obsl_type_hint(pa.duration("s")) == "datetime"
+        assert _arrow_to_obsl_type_hint(pa.opaque(pa.string(), "numeric", "PostgreSQL")) == "number"
+
+    def test_an_unrecognised_opaque_type_still_says_string(self) -> None:
+        """The bucket is still the fallback for what it cannot place."""
+        import pyarrow as pa
+
+        from ob_flight.server_execution import _arrow_to_obsl_type_hint
+
+        assert (
+            _arrow_to_obsl_type_hint(pa.opaque(pa.string(), "tsvector", "PostgreSQL")) == "string"
+        )

--- a/src/orionbelt/api/app.py
+++ b/src/orionbelt/api/app.py
@@ -774,19 +774,23 @@ def main() -> None:
     # Load .env into os.environ so all env vars (DB credentials, POSTGRES_SCHEMA,
     # etc.) are visible to os.getenv() — not just to pydantic Settings.
     #
-    # Resolved from the working directory, which is how pydantic-settings
-    # resolves ``env_file=".env"`` (see ``settings.Settings``). Bare
-    # ``load_dotenv()`` searches upward from *this file* instead, so a source
-    # checkout's own .env was loaded whatever directory the server started in -
-    # and the two resolutions then disagreed with each other. Measured: started
-    # from a directory whose .env said ``API_SERVER_PORT=8020`` with no
-    # ``MODEL_FILES``, ``Settings()`` read exactly that while the process came
-    # up on the repo's 9003 against the repo's database. ``find_dotenv``
-    # answers "" when there is none, and ``load_dotenv("")`` is a no-op, so a
-    # deployment with no file on disk keeps using real environment variables.
-    from dotenv import find_dotenv, load_dotenv
+    # Exactly ``./.env``, which is what pydantic-settings reads for
+    # ``env_file=".env"`` (see ``settings.Settings``). Both of the obvious
+    # alternatives search, and searching is the whole problem: bare
+    # ``load_dotenv()`` walks up from *this file*, so a source checkout's .env
+    # was loaded whatever directory the server started in;
+    # ``find_dotenv(usecwd=True)`` walks up from the working directory, so a
+    # subdirectory with no .env of its own still inherits a parent's - and
+    # ``Settings`` inherits neither. Either way the two disagree, and the
+    # disagreement injects a *different deployment's* database credentials and
+    # ``MODEL_FILES`` into ``os.environ`` while ``Settings`` reads the intended
+    # ones. A missing file makes this a no-op, so a deployment configured
+    # purely by environment variables is unaffected.
+    from pathlib import Path
 
-    load_dotenv(find_dotenv(usecwd=True), override=False)
+    from dotenv import load_dotenv
+
+    load_dotenv(Path.cwd() / ".env", override=False)
 
     settings = Settings()
 

--- a/src/orionbelt/api/app.py
+++ b/src/orionbelt/api/app.py
@@ -773,9 +773,20 @@ def main() -> None:
     """Run the REST API server using settings from environment / .env file."""
     # Load .env into os.environ so all env vars (DB credentials, POSTGRES_SCHEMA,
     # etc.) are visible to os.getenv() — not just to pydantic Settings.
-    from dotenv import load_dotenv
+    #
+    # Resolved from the working directory, which is how pydantic-settings
+    # resolves ``env_file=".env"`` (see ``settings.Settings``). Bare
+    # ``load_dotenv()`` searches upward from *this file* instead, so a source
+    # checkout's own .env was loaded whatever directory the server started in -
+    # and the two resolutions then disagreed with each other. Measured: started
+    # from a directory whose .env said ``API_SERVER_PORT=8020`` with no
+    # ``MODEL_FILES``, ``Settings()`` read exactly that while the process came
+    # up on the repo's 9003 against the repo's database. ``find_dotenv``
+    # answers "" when there is none, and ``load_dotenv("")`` is a no-op, so a
+    # deployment with no file on disk keeps using real environment variables.
+    from dotenv import find_dotenv, load_dotenv
 
-    load_dotenv(override=False)
+    load_dotenv(find_dotenv(usecwd=True), override=False)
 
     settings = Settings()
 

--- a/src/orionbelt/service/db_executor.py
+++ b/src/orionbelt/service/db_executor.py
@@ -319,7 +319,7 @@ def coarse_hint_from_type_name(name: str) -> str:
     return "string"
 
 
-def _arrow_type_to_hint(arrow_type: Any) -> str:
+def arrow_type_to_hint(arrow_type: Any) -> str:
     """Map a PyArrow type to a simple type hint string.
 
     ADBC's PostgreSQL driver wraps types Arrow can't represent natively
@@ -376,6 +376,12 @@ def _arrow_type_to_hint(arrow_type: Any) -> str:
         return coarse_hint_from_type_name(type_name)
     return "string"
 
+
+#: The historical private name. Kept because this module and its tests use it
+#: throughout, and renaming every call site would bury the one-line change
+#: that matters: the mapping is now shared with the Flight driver, which had
+#: its own copy.
+_arrow_type_to_hint = arrow_type_to_hint
 
 # ---------------------------------------------------------------------------
 # Timezone resolution

--- a/tests/unit/test_env_resolution.py
+++ b/tests/unit/test_env_resolution.py
@@ -1,0 +1,83 @@
+"""``.env`` resolution must agree between the two things that read it.
+
+``Settings`` declares ``env_file=".env"``, which pydantic-settings resolves
+from the working directory. ``api.app.main`` separately calls ``load_dotenv``
+so that plain ``os.getenv`` callers (driver credentials, POSTGRES_SCHEMA) see
+the same values - and a bare ``load_dotenv()`` searches upward from *its own
+source file* instead. In a source checkout the two therefore disagreed: the
+server, started anywhere, loaded the repo's .env into ``os.environ`` while
+``Settings`` read whatever was beside the working directory.
+
+Measured before the fix: started from a directory whose .env said
+``API_SERVER_PORT=8020`` with no ``MODEL_FILES``, ``Settings()`` resolved 8020
+and the process came up on the repo's 9003, against the repo's database.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+APP = pathlib.Path(__file__).resolve().parents[2] / "src" / "orionbelt" / "api" / "app.py"
+
+
+def _load_dotenv_call() -> ast.Call:
+    tree = ast.parse(APP.read_text())
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "load_dotenv"
+        ):
+            return node
+    raise AssertionError("app.py no longer calls load_dotenv")
+
+
+class TestDotenvIsResolvedFromTheWorkingDirectory:
+    def test_it_does_not_search_upward_from_the_package(self) -> None:
+        """A bare call resolves relative to app.py, not the caller's cwd."""
+        call = _load_dotenv_call()
+        assert call.args, (
+            "load_dotenv() with no path searches upward from app.py, so a source "
+            "checkout's .env wins over the working directory's"
+        )
+
+    def test_the_path_comes_from_find_dotenv_with_usecwd(self) -> None:
+        call = _load_dotenv_call()
+        path_arg = call.args[0]
+        assert isinstance(path_arg, ast.Call)
+        assert isinstance(path_arg.func, ast.Name)
+        assert path_arg.func.id == "find_dotenv"
+        assert any(
+            kw.arg == "usecwd" and getattr(kw.value, "value", None) is True
+            for kw in path_arg.keywords
+        ), "find_dotenv must be told to start from the working directory"
+
+    def test_real_environment_variables_still_win(self) -> None:
+        """``override=False`` is what lets a container pass config without a file."""
+        call = _load_dotenv_call()
+        assert any(
+            kw.arg == "override" and getattr(kw.value, "value", None) is False
+            for kw in call.keywords
+        )
+
+    def test_a_missing_file_is_a_no_op(self) -> None:
+        """``find_dotenv`` answers "" when there is none, and load_dotenv("")
+        must not raise - a deployment configured purely by environment has no
+        file on disk."""
+        import tempfile
+
+        from dotenv import find_dotenv, load_dotenv
+
+        cwd = pathlib.Path.cwd()
+        try:
+            with tempfile.TemporaryDirectory() as empty:
+                import os
+
+                os.chdir(empty)
+                assert find_dotenv(usecwd=True) == ""
+                assert load_dotenv("") is False
+        finally:
+            import os
+
+            os.chdir(cwd)

--- a/tests/unit/test_env_resolution.py
+++ b/tests/unit/test_env_resolution.py
@@ -1,16 +1,23 @@
 """``.env`` resolution must agree between the two things that read it.
 
-``Settings`` declares ``env_file=".env"``, which pydantic-settings resolves
-from the working directory. ``api.app.main`` separately calls ``load_dotenv``
-so that plain ``os.getenv`` callers (driver credentials, POSTGRES_SCHEMA) see
-the same values - and a bare ``load_dotenv()`` searches upward from *its own
-source file* instead. In a source checkout the two therefore disagreed: the
-server, started anywhere, loaded the repo's .env into ``os.environ`` while
-``Settings`` read whatever was beside the working directory.
+``Settings`` declares ``env_file=".env"``, which pydantic-settings reads as
+exactly ``./.env`` - no search. ``api.app.main`` separately calls
+``load_dotenv`` so that plain ``os.getenv`` callers (driver credentials,
+POSTGRES_SCHEMA) see the same values, and every searching form of that call
+disagrees with it:
 
-Measured before the fix: started from a directory whose .env said
-``API_SERVER_PORT=8020`` with no ``MODEL_FILES``, ``Settings()`` resolved 8020
-and the process came up on the repo's 9003, against the repo's database.
+* bare ``load_dotenv()`` walks up from *its own source file*, so a source
+  checkout's .env was loaded whatever directory the server started in.
+  Measured: started from a directory whose .env said ``API_SERVER_PORT=8020``
+  with no ``MODEL_FILES``, ``Settings()`` resolved 8020 while the process came
+  up on the repo's 9003, against the repo's database.
+* ``find_dotenv(usecwd=True)`` walks up from the working directory, so a
+  subdirectory with no .env of its own inherits a parent's while ``Settings``
+  inherits nothing. Measured: parent .env ``API_SERVER_PORT=8123``, child with
+  none - ``Settings()`` alone said 8000, and 8123 after the load.
+
+Either way the disagreement injects a different deployment's credentials and
+``MODEL_FILES`` into ``os.environ`` while ``Settings`` reads the intended ones.
 """
 
 from __future__ import annotations
@@ -34,24 +41,20 @@ def _load_dotenv_call() -> ast.Call:
 
 
 class TestDotenvIsResolvedFromTheWorkingDirectory:
-    def test_it_does_not_search_upward_from_the_package(self) -> None:
-        """A bare call resolves relative to app.py, not the caller's cwd."""
+    def test_it_does_not_search(self) -> None:
+        """Neither upward from this file nor upward from the cwd."""
         call = _load_dotenv_call()
-        assert call.args, (
-            "load_dotenv() with no path searches upward from app.py, so a source "
-            "checkout's .env wins over the working directory's"
+        assert call.args, "load_dotenv() with no path walks up from app.py"
+        source = ast.unparse(call.args[0])
+        assert "find_dotenv" not in source, (
+            "find_dotenv searches upward; pydantic-settings reads only ./.env, "
+            "so a subdirectory would inherit a parent's file while Settings does not"
         )
 
-    def test_the_path_comes_from_find_dotenv_with_usecwd(self) -> None:
+    def test_the_path_is_exactly_the_working_directory_s_env(self) -> None:
         call = _load_dotenv_call()
-        path_arg = call.args[0]
-        assert isinstance(path_arg, ast.Call)
-        assert isinstance(path_arg.func, ast.Name)
-        assert path_arg.func.id == "find_dotenv"
-        assert any(
-            kw.arg == "usecwd" and getattr(kw.value, "value", None) is True
-            for kw in path_arg.keywords
-        ), "find_dotenv must be told to start from the working directory"
+        source = ast.unparse(call.args[0])
+        assert "Path.cwd()" in source and "'.env'" in source, source
 
     def test_real_environment_variables_still_win(self) -> None:
         """``override=False`` is what lets a container pass config without a file."""
@@ -61,23 +64,58 @@ class TestDotenvIsResolvedFromTheWorkingDirectory:
             for kw in call.keywords
         )
 
-    def test_a_missing_file_is_a_no_op(self) -> None:
-        """``find_dotenv`` answers "" when there is none, and load_dotenv("")
-        must not raise - a deployment configured purely by environment has no
-        file on disk."""
+    def test_a_parent_env_is_not_inherited(self) -> None:
+        """The behavioural half: a child with no .env must see nothing."""
+        import os
         import tempfile
 
-        from dotenv import find_dotenv, load_dotenv
+        from dotenv import load_dotenv
+
+        from orionbelt.settings import Settings
 
         cwd = pathlib.Path.cwd()
-        try:
-            with tempfile.TemporaryDirectory() as empty:
-                import os
+        with tempfile.TemporaryDirectory() as parent:
+            (pathlib.Path(parent) / ".env").write_text("API_SERVER_PORT=8123\n")
+            child = pathlib.Path(parent) / "child"
+            child.mkdir()
+            try:
+                os.chdir(child)
+                load_dotenv(pathlib.Path.cwd() / ".env", override=False)
+                assert Settings().api_server_port != 8123
+            finally:
+                os.chdir(cwd)
+                os.environ.pop("API_SERVER_PORT", None)
 
+    def test_the_working_directory_s_own_env_is_read(self) -> None:
+        import os
+        import tempfile
+
+        from dotenv import load_dotenv
+
+        from orionbelt.settings import Settings
+
+        cwd = pathlib.Path.cwd()
+        with tempfile.TemporaryDirectory() as here:
+            (pathlib.Path(here) / ".env").write_text("API_SERVER_PORT=8321\n")
+            try:
+                os.chdir(here)
+                load_dotenv(pathlib.Path.cwd() / ".env", override=False)
+                assert Settings().api_server_port == 8321
+            finally:
+                os.chdir(cwd)
+                os.environ.pop("API_SERVER_PORT", None)
+
+    def test_a_missing_file_is_a_no_op(self) -> None:
+        """A deployment configured purely by environment has no file on disk."""
+        import os
+        import tempfile
+
+        from dotenv import load_dotenv
+
+        cwd = pathlib.Path.cwd()
+        with tempfile.TemporaryDirectory() as empty:
+            try:
                 os.chdir(empty)
-                assert find_dotenv(usecwd=True) == ""
-                assert load_dotenv("") is False
-        finally:
-            import os
-
-            os.chdir(cwd)
+                assert load_dotenv(pathlib.Path.cwd() / ".env") is False
+            finally:
+                os.chdir(cwd)

--- a/tests/unit/test_env_resolution.py
+++ b/tests/unit/test_env_resolution.py
@@ -25,6 +25,8 @@ from __future__ import annotations
 import ast
 import pathlib
 
+import pytest
+
 APP = pathlib.Path(__file__).resolve().parents[2] / "src" / "orionbelt" / "api" / "app.py"
 
 
@@ -64,58 +66,49 @@ class TestDotenvIsResolvedFromTheWorkingDirectory:
             for kw in call.keywords
         )
 
-    def test_a_parent_env_is_not_inherited(self) -> None:
-        """The behavioural half: a child with no .env must see nothing."""
-        import os
-        import tempfile
+    def test_a_parent_env_is_not_inherited(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The behavioural half: a child with no .env must see nothing.
 
+        ``monkeypatch`` for both the cwd and the variable: ``override=False``
+        means a real ``API_SERVER_PORT`` in the caller's environment wins over
+        the temp file, so without ``delenv`` this asserts nothing when one is
+        exported - and restoring by hand leaked the deletion into whatever ran
+        next, which is how these two masked each other.
+        """
         from dotenv import load_dotenv
 
         from orionbelt.settings import Settings
 
-        cwd = pathlib.Path.cwd()
-        with tempfile.TemporaryDirectory() as parent:
-            (pathlib.Path(parent) / ".env").write_text("API_SERVER_PORT=8123\n")
-            child = pathlib.Path(parent) / "child"
-            child.mkdir()
-            try:
-                os.chdir(child)
-                load_dotenv(pathlib.Path.cwd() / ".env", override=False)
-                assert Settings().api_server_port != 8123
-            finally:
-                os.chdir(cwd)
-                os.environ.pop("API_SERVER_PORT", None)
+        monkeypatch.delenv("API_SERVER_PORT", raising=False)
+        (tmp_path / ".env").write_text("API_SERVER_PORT=8123\n")
+        child = tmp_path / "child"
+        child.mkdir()
+        monkeypatch.chdir(child)
 
-    def test_the_working_directory_s_own_env_is_read(self) -> None:
-        import os
-        import tempfile
+        load_dotenv(pathlib.Path.cwd() / ".env", override=False)
+        assert Settings().api_server_port != 8123
 
+    def test_the_working_directory_s_own_env_is_read(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         from dotenv import load_dotenv
 
         from orionbelt.settings import Settings
 
-        cwd = pathlib.Path.cwd()
-        with tempfile.TemporaryDirectory() as here:
-            (pathlib.Path(here) / ".env").write_text("API_SERVER_PORT=8321\n")
-            try:
-                os.chdir(here)
-                load_dotenv(pathlib.Path.cwd() / ".env", override=False)
-                assert Settings().api_server_port == 8321
-            finally:
-                os.chdir(cwd)
-                os.environ.pop("API_SERVER_PORT", None)
+        monkeypatch.delenv("API_SERVER_PORT", raising=False)
+        (tmp_path / ".env").write_text("API_SERVER_PORT=8321\n")
+        monkeypatch.chdir(tmp_path)
 
-    def test_a_missing_file_is_a_no_op(self) -> None:
+        load_dotenv(pathlib.Path.cwd() / ".env", override=False)
+        assert Settings().api_server_port == 8321
+
+    def test_a_missing_file_is_a_no_op(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """A deployment configured purely by environment has no file on disk."""
-        import os
-        import tempfile
-
         from dotenv import load_dotenv
 
-        cwd = pathlib.Path.cwd()
-        with tempfile.TemporaryDirectory() as empty:
-            try:
-                os.chdir(empty)
-                assert load_dotenv(pathlib.Path.cwd() / ".env") is False
-            finally:
-                os.chdir(cwd)
+        monkeypatch.chdir(tmp_path)
+        assert load_dotenv(pathlib.Path.cwd() / ".env") is False


### PR DESCRIPTION
Two independent follow-ups from #414, one commit each. Neither changes that PR's subject.

## 1. `.env` is resolved from the working directory (`0b8cd154`)

Two things read `.env` and they disagreed. `Settings` declares `env_file=".env"`, which pydantic-settings resolves from the working directory. `api.app.main` separately calls `load_dotenv` so plain `os.getenv` callers - driver credentials, `POSTGRES_SCHEMA` - see the same values, and a bare `load_dotenv()` searches upward from **its own source file** instead.

In a source checkout the repo's `.env` therefore wins whatever directory the server starts in. Measured: started from a directory whose `.env` said `API_SERVER_PORT=8020` with no `MODEL_FILES`, `Settings()` resolved exactly that while the process came up on the repo's **9003**, connected to the repo's **Postgres**, and answered a query intended for DuckDB with `relation "main.accounts" does not exist`.

`find_dotenv(usecwd=True)` makes the two agree. It answers `""` when there is no file and `load_dotenv("")` is a no-op, so a deployment configured purely by environment variables is unaffected, as is any invocation from the repo root where both resolutions already pointed at the same file.

Verified by re-running the case that exposed it: the local `.env` is now honoured (8020, `dialect=duckdb`) where it previously was not.

## 2. One Arrow-to-hint mapping, not three (`aea0ee24`)

Flight kept its own copy, and that is how the boolean case shipped in #414: two of the three copies were corrected and this one was missed, so a Flight-warmed cache entry still made pgwire advertise a declared boolean as TEXT. The agreement test added then held the line; this removes what it was guarding.

The core mapping is a superset - it recovers ADBC's opaque types from the vendor name they carry, and places intervals and durations - so adopting it also corrects three sidecar cases that were landing in the `string` bucket, which is that mapping's answer for *unrecognised* rather than a claim about the column:

| | sidecar | pgwire OID |
|---|---|---|
| `interval` | `string` → `datetime` | 25 → 1114 |
| `duration` | `string` → `datetime` | 25 → 1114 |
| opaque `numeric` | `string` → `number` | 25 → 701 |

Each is a Flight-written sidecar read back by REST or pgwire, so each was a column described as text when the data was not. Measured across every Arrow type either copy could be asked about; nothing else moves, and an opaque type the mapping genuinely cannot place still says `string`.

The test is now **identity, not equality** - two functions being equal would still pass the day someone re-forks one, which is the failure this is meant to end.

## Verification

5073 passed, 1046 skipped. Flight driver suite 204 passed. `ruff` and `mypy` clean on both packages.