### PR TITLE
docs(types): the matrix measures drivers, and Postgres decimals are not lossy

### DIFF
--- a/docs/api/endpoints.md
+++ b/docs/api/endpoints.md
@@ -169,7 +169,7 @@ Every `warnings` list in this API uses the same shape so agents can branch on st
 }
 ```
 
-Initial warning code taxonomy: `GRAIN_OVERRIDE_INCOMPATIBLE`, `FILTER_CONTEXT_OVERRIDE_INCOMPATIBLE`, `POP_CONSTRAINT_VIOLATED`, `CUMULATIVE_CONSTRAINT_VIOLATED`, `FAN_TRAP_RISK`, `ORPHAN_DATA_OBJECT`, `SHARED_TABLE_CONTRACT_DISAGREEMENT`, `LARGE_RESULT_SET`, `CACHE_TTL_FLOOR_HIT`, `INCOMPATIBLE_COMBINATION`, `SQL_VALIDATION`, `MERGE_WARNING`. Codes are extended over time, never repurposed.
+Initial warning code taxonomy: `GRAIN_OVERRIDE_INCOMPATIBLE`, `FILTER_CONTEXT_OVERRIDE_INCOMPATIBLE`, `POP_CONSTRAINT_VIOLATED`, `CUMULATIVE_CONSTRAINT_VIOLATED`, `FAN_TRAP_RISK`, `ORPHAN_DATA_OBJECT`, `SHARED_TABLE_CONTRACT_DISAGREEMENT`, `LARGE_RESULT_SET`, `CACHE_TTL_FLOOR_HIT`, `INCOMPATIBLE_COMBINATION`, `SQL_VALIDATION`, `MERGE_WARNING`, `DECLARED_TYPE_NOT_APPLIED`. Codes are extended over time, never repurposed.
 
 **Error (403):** Single-model mode: model upload is disabled.
 
@@ -552,6 +552,45 @@ If the query has no explicit `limit`, a default of 10,000 rows is enforced.
  "explain": { "..." : "..." }
 }
 ```
+
+#### Column types follow the model, not the engine
+
+A result is reconciled against the type the model declares before it is
+returned, so a column's type is a property of the model rather than of
+whichever engine is behind it. The same query answers the same way on every
+surface - REST, pgwire and Flight - and on a cache hit as on a miss.
+
+It matters where an engine cannot express a declared type at all:
+
+| Engine | Driver returns | You receive |
+|---|---|---|
+| MySQL (no boolean type) | `int64` `1` | `true` — and `BOOL` on pgwire |
+| Dremio | `date64[ms]` | `date32[day]` |
+
+This is an allowlist of exactly those cases, not a general cast. A `resultType`
+names a *family*, so an engine answering **more** precisely than the
+declaration - a `decimal(38, 2)` behind a measure declared `float` - is left
+alone rather than narrowed. See
+[Arrow type fidelity](../reference/type-fidelity.md) for the per-engine
+measurements.
+
+**When it is refused.** A declared boolean holding something other than `0`,
+`1` or `NULL` is not cast: Arrow maps every nonzero to `true`, and asserting
+that a column holding `7` is `true` invents content the model never claimed.
+The column keeps the engine's type, `columns[].type` **reports that type**
+rather than the declared one, and the declaration comes back as a warning:
+
+```json
+{
+ "code": "DECLARED_TYPE_NOT_APPLIED",
+ "severity": "warning",
+ "message": "Column 'Tier' was not reconciled to its declared type: declared boolean but the column holds values other than 0 and 1; left as int64",
+ "context": { "column": "Tier", "reason": "declared boolean but the column holds values other than 0 and 1" }
+}
+```
+
+So `columns[].type` always describes the cells beside it, and `warnings` tells
+you where the model wanted otherwise.
 
 **Query parameters** (apply to both the session and shortcut form):
 

--- a/docs/reference/type-fidelity.md
+++ b/docs/reference/type-fidelity.md
@@ -5,7 +5,7 @@ semantic layer's promise is that a measure declared `decimal(18, 2)` arrives as
 an exact fixed-point number; whether it does is a property of the driver and its
 cast rendering, not of the SQL.
 
-Measured **2026-09-04** with `scripts/probe_types.py`, against all eight engines
+Measured **2026-09-06** with `scripts/probe_types.py`, against all eight engines
 live. Each case is rendered through the engine's own `cast_to_obml_type`, so
 this is what OBSL emits rather than a hand-spelled approximation.
 
@@ -22,16 +22,17 @@ uv run python scripts/probe_types.py --json all   # regenerate the data below
 | `WIDENED` | Still fixed-point, at a wider precision or scale. An engine widening a `SUM` is doing the right thing; a widened *cast* is the engine's own decimal rules, recorded rather than judged. |
 | `FAMILY` | Right family, different width - an `int64` where the model said `integer`. |
 | `ZONED` | A `timestamp` came back carrying a timezone. OBML's `timestamp` is a wall clock. |
-| `LOSSY` | The fixed-point type became a float or a string. |
+| `TEXT` | A number carried as a string with every digit intact - ADBC does this for Postgres NUMERIC, whose precision Arrow's decimal cannot hold. `db_executor` parses the cells back to `Decimal`, so nothing is lost. |
+| `LOSSY` | The fixed-point type became a float, or a string that does not carry the digits. This is the one that costs data. |
 
 ## The matrix
 
 | Declared | DuckDB | Postgres | MySQL | ClickHouse | Snowflake | BigQuery | Databricks | Dremio |
 |---|---|---|---|---|---|---|---|---|
-| `decimal(18,2)` | EXACT | LOSSY | WIDENED | EXACT | WIDENED | WIDENED | EXACT | EXACT |
-| `decimal(38,9)` | EXACT | LOSSY | WIDENED | EXACT | EXACT | EXACT | EXACT | EXACT |
-| `decimal(19,2) big` | EXACT | LOSSY | WIDENED | EXACT | WIDENED | WIDENED | EXACT | EXACT |
-| `SUM decimal(18,2)` | WIDENED | LOSSY | WIDENED | WIDENED | WIDENED | WIDENED | WIDENED | WIDENED |
+| `decimal(18,2)` | EXACT | TEXT | WIDENED | EXACT | WIDENED | WIDENED | EXACT | EXACT |
+| `decimal(38,9)` | EXACT | TEXT | WIDENED | EXACT | EXACT | EXACT | EXACT | EXACT |
+| `decimal(19,2) big` | EXACT | TEXT | WIDENED | EXACT | WIDENED | WIDENED | EXACT | EXACT |
+| `SUM decimal(18,2)` | WIDENED | TEXT | WIDENED | WIDENED | WIDENED | WIDENED | WIDENED | WIDENED |
 | `integer` | EXACT | EXACT | FAMILY | EXACT | FAMILY | FAMILY | EXACT | EXACT |
 | `bigint` | EXACT | EXACT | EXACT | EXACT | EXACT | EXACT | EXACT | EXACT |
 | `double` | EXACT | EXACT | EXACT | EXACT | EXACT | EXACT | EXACT | EXACT |
@@ -62,14 +63,19 @@ Every row above is a measurement of a **driver**. That is not the same as what
 a caller receives, because OBSL reconciles a result against the type the model
 *declared* before anyone sees it. Four rows read alarming and are not.
 
-**Postgres `LOSSY string` on every decimal is correct**, and is the clearest
-reason this table is not the whole story. ADBC represents `NUMERIC` as
+**Postgres `TEXT` on every decimal costs nothing.** ADBC represents `NUMERIC` as
 `arrow.opaque[storage_type=string, type_name=numeric]` because Postgres NUMERIC
 is arbitrary precision with NaN and Infinity, Arrow's `decimal128` caps at 38
 digits and needs the scale up front, and typmod is `-1` for a computed
-expression. Preserving the exact digits as text is the faithful choice, and
+expression. Preserving the exact digits as text is the faithful choice - it is
+what lets a NUMERIC wider than Arrow's 38 digits survive at all - and
 `db_executor` parses those cells back to `Decimal` before any caller sees them.
-The driver is lossy here; **OBSL is not**.
+Measured: `12345678901234567.89::numeric(19,2)` comes back
+`Decimal('12345678901234567.89')`.
+
+This row read `LOSSY` until 2026-09-06, which contradicted this page's own
+definition of the verdict: nothing became a float, and the string carries every
+digit. It has its own verdict now.
 
 **ClickHouse `ZONED` on `timestamp` is intrinsic.** ClickHouse has no naive
 `DateTime` - the type is an instant rendered against the server timezone. Every

--- a/docs/reference/type-fidelity.md
+++ b/docs/reference/type-fidelity.md
@@ -56,7 +56,11 @@ uv run python scripts/probe_types.py --json all   # regenerate the data below
 | `date` | `date32[day]` | `date32[day]` | `date32[day]` | `date32[day]` | `date32[day]` | `date32[day]` | `date32[day]` | `date64[ms]` |
 | `timestamp` | `timestamp[us]` | `timestamp[us]` | `timestamp[us]` | `timestamp[ms, tz=Europe/Berlin]` | `timestamp[ns]` | `timestamp[us]` | `timestamp[us]` | `timestamp[ms]` |
 
-## Reading the two rows that look alarming
+## What the table measures, and what OBSL delivers
+
+Every row above is a measurement of a **driver**. That is not the same as what
+a caller receives, because OBSL reconciles a result against the type the model
+*declared* before anyone sees it. Four rows read alarming and are not.
 
 **Postgres `LOSSY string` on every decimal is correct**, and is the clearest
 reason this table is not the whole story. ADBC represents `NUMERIC` as
@@ -72,23 +76,61 @@ The driver is lossy here; **OBSL is not**.
 OBSL surface reconciles it against the declared wall clock; see the Flight
 alignment in `ob_flight/server_execution.py`.
 
-## Open gaps
+**MySQL `LOSSY` on `boolean` and Dremio `FAMILY` on `date` are reconciled.**
+MySQL has no boolean type, so a declared one arrives as `int64` `1`; Dremio
+returns `date64[ms]` where the other seven give `date32[day]`. Both are still
+true of the drivers, and neither reaches a caller: `service/result_schema.py`
+casts them to the declared type on every surface.
 
-| Engine | Gap |
-|---|---|
-| MySQL | `boolean` is **lossy**: MySQL has no boolean type, so a declared one arrives as `int64` `1`. |
-| Dremio | `date` returns `date64[ms]` where the other seven give `date32[day]`. |
+```
+MySQL, a dimension declared boolean
+  driver returns      int64      1, 0
+  REST returns        boolean    true, false
+  pgwire advertises   OID 16     t, f
+```
+
+Reconciliation is an allowlist of exactly those two cases, not a general cast.
+A `resultType` names a *family*, so an engine answering more precisely than the
+declaration - a `decimal(38, 2)` behind a measure declared `float` - is not
+drift and is left alone. Timestamps are excluded too: ClickHouse's zoned-for-
+naive case needs the wall clock preserved value by value rather than converted.
+
+## When reconciliation is refused
+
+A declared boolean holding something other than `0`, `1` or `NULL` is not cast:
+Arrow maps every nonzero to `true`, and asserting that a column holding `7` is
+`true` invents content the model never claimed. The column keeps the engine's
+type, the response *reports* that type rather than the declared one, and the
+declaration is carried as a warning:
+
+```json
+{
+  "code": "DECLARED_TYPE_NOT_APPLIED",
+  "message": "Column 'Tier' was not reconciled to its declared type: declared boolean
+              but the column holds values other than 0 and 1; left as int64"
+}
+```
+
+So `type` always describes the bytes beside it, and `warnings` tells you where
+the model wanted otherwise.
 
 ## What CI asserts
 
-This table measures **drivers**. Every type defect OBSL has actually shipped
-lived between the driver and the caller instead - the cache codec typing a
-column from the values it happened to hold (#410), the executor never importing
-pyarrow so no result carried a schema at all (#412) - and a driver-level probe
-is blind to all of them.
+Every type defect OBSL has actually shipped lived between the driver and the
+caller, not in the driver - the cache codec typing a column from the values it
+happened to hold (#410), the executor never importing pyarrow so no result
+carried a schema at all (#412), the same reconciliation missing from one read
+path at a time (#414) - and a driver-level probe is blind to all of them.
 
 So `tests/integration/test_type_fidelity.py` asserts through
 `db_executor.execute_sql`, the path REST, pgwire and the CLI share, on DuckDB -
 the one engine needing no credentials, and therefore the one every CI machine
 can reach. The other seven stay in this table rather than in CI: a suite that
 skips six of eight rows reports green for a matrix nobody measured.
+
+Two structural guards cover what those defects had in common, both of which
+were one rule duplicated across surfaces: the Arrow-to-hint mapping is a single
+function rather than one per surface (asserted by identity, in the Flight
+driver's suite), and any code rebuilding a cached result must reconcile the
+table and hand its findings to the response
+(`tests/architecture/test_cached_hits_reconcile.py`).

--- a/scripts/probe_types.py
+++ b/scripts/probe_types.py
@@ -59,8 +59,12 @@ Each row prints a verdict, the Arrow type and the round-tripped value:
 * ``FAMILY``  -- the right family, a different width (an int8 where the model
   said integer). Value-dependent widths are worth knowing about: two pages of
   one column can disagree.
-* ``LOSSY``   -- the fixed-point type became a float or a string. This is the
-  one that silently costs money.
+* ``TEXT``    -- a number carried as a string with every digit intact. ADBC
+  does this for Postgres NUMERIC, whose precision Arrow's decimal cannot hold;
+  ``db_executor`` parses the cells back to ``Decimal``. Nothing is lost, which
+  is why it is not ``LOSSY``.
+* ``LOSSY``   -- the fixed-point type became a float, or a string that does not
+  carry the digits. This is the one that silently costs money.
 """
 
 from __future__ import annotations
@@ -158,8 +162,30 @@ def _family(t: pa.DataType) -> str:
     return str(t)
 
 
+def _is_exact_text_decimal(got: pa.DataType) -> bool:
+    """Whether *got* is a number carried as text, with its digits intact.
+
+    ADBC wraps Postgres NUMERIC in ``arrow.opaque[storage_type=string,
+    type_name=numeric]`` because the type is arbitrary precision with NaN and
+    Infinity, Arrow's ``decimal128`` caps at 38 digits and needs the scale up
+    front, and typmod is ``-1`` for a computed expression. Every digit
+    survives, and ``db_executor`` parses the cells back to ``Decimal`` before a
+    caller sees them - so this is not the float-or-string downgrade ``LOSSY``
+    is for, and calling it that contradicted this file's own definition.
+    """
+    type_name = getattr(got, "type_name", None)
+    storage = getattr(got, "storage_type", None)
+    if not isinstance(type_name, str) or storage is None:
+        return False
+    return pa.types.is_string(storage) and any(
+        token in type_name.lower() for token in ("numeric", "decimal")
+    )
+
+
 def _decimal_verdict(obml: str, got: pa.DataType) -> str:
     precision, scale = (int(x) for x in obml[obml.index("(") + 1 : -1].split(","))
+    if _is_exact_text_decimal(got):
+        return "TEXT    exact digits"
     if not pa.types.is_decimal(got):
         return f"LOSSY   {_family(got)}"
     if (got.precision, got.scale) == (precision, scale):

--- a/scripts/type-fidelity-matrix.json
+++ b/scripts/type-fidelity-matrix.json
@@ -346,7 +346,7 @@
       "SUM decimal(18,2)": {
         "arrow": "extension<arrow.opaque[storage_type=string, type_name=numeric, vendor_name=PostgreSQL]>",
         "value": "'2.55'",
-        "verdict": "LOSSY   string"
+        "verdict": "TEXT    exact digits"
       },
       "bigint": {
         "arrow": "int64",
@@ -366,17 +366,17 @@
       "decimal(18,2)": {
         "arrow": "extension<arrow.opaque[storage_type=string, type_name=numeric, vendor_name=PostgreSQL]>",
         "value": "'2.55'",
-        "verdict": "LOSSY   string"
+        "verdict": "TEXT    exact digits"
       },
       "decimal(19,2) big": {
         "arrow": "extension<arrow.opaque[storage_type=string, type_name=numeric, vendor_name=PostgreSQL]>",
         "value": "'12345678901234567.89'",
-        "verdict": "LOSSY   string"
+        "verdict": "TEXT    exact digits"
       },
       "decimal(38,9)": {
         "arrow": "extension<arrow.opaque[storage_type=string, type_name=numeric, vendor_name=PostgreSQL]>",
         "value": "'2.123456789'",
-        "verdict": "LOSSY   string"
+        "verdict": "TEXT    exact digits"
       },
       "double": {
         "arrow": "double",
@@ -457,5 +457,5 @@
       }
     }
   },
-  "measured": "2026-09-04"
+  "measured": "2026-09-06"
 }


### PR DESCRIPTION
Follow-up to #414/#415. Two commits.

## 1. The gaps list described the code two PRs ago (`3f89a7e7`)

`docs/reference/type-fidelity.md` listed MySQL `boolean` and Dremio `date64` under **Open gaps**. Both are still true of the *drivers* - which is what that page measures - and neither has reached a caller since #414.

Reframed rather than deleted, because the driver-vs-caller distinction is the page's whole point:

```
MySQL, a dimension declared boolean
  driver returns      int64      1, 0
  REST returns        boolean    true, false
  pgwire advertises   OID 16     t, f
```

It also now says what it did not before: reconciliation is an **allowlist**, not a general cast. A `resultType` names a family, so an engine answering *more* precisely than the declaration is not drift - the case that regressed a stored `decimal128(38, 2)` to `float64` while this was being built.

`docs/api/endpoints.md` gains the same under query execute, where it is user-visible: `DECLARED_TYPE_NOT_APPLIED` joins the warning taxonomy, and the refusal rule is spelled out - a declared boolean holding a `7` keeps the engine's type, `columns[].type` reports **that**, and the declaration comes back as the warning.

## 2. Postgres decimals are carried as text, not lost (`414ed6a0`)

Prompted by the obvious question: *why is Postgres still lossy?* It is not, and the verdict contradicted the page's own definition - `LOSSY` means "became a float or a string", i.e. data is gone. Nothing is gone.

ADBC wraps NUMERIC in `arrow.opaque[storage_type=string, type_name=numeric]` because the type is arbitrary precision with NaN/Infinity, Arrow's `decimal128` caps at 38 digits and needs the scale up front, and typmod is `-1` for a computed expression. Carrying the digits as text is what lets a NUMERIC wider than Arrow's 38 survive at all.

Measured: `12345678901234567.89::numeric(19,2)` → `Decimal('12345678901234567.89')`, exact.

So the probe gains a verdict. `TEXT` is a number carried as a string with its digits intact; `LOSSY` narrows to a float, or a string that does not carry them.

| Declared | DuckDB | Postgres | MySQL | ClickHouse | Snowflake | BigQuery | Databricks | Dremio |
|---|---|---|---|---|---|---|---|---|
| `decimal(18,2)` | EXACT | **TEXT** | WIDENED | EXACT | WIDENED | WIDENED | EXACT | EXACT |
| `boolean` | EXACT | EXACT | LOSSY | EXACT | EXACT | EXACT | EXACT | EXACT |
| `date` | EXACT | EXACT | EXACT | EXACT | EXACT | EXACT | EXACT | FAMILY |

Four Postgres rows move `LOSSY → TEXT`; nothing else changes. MySQL `boolean` and Dremio `date` stay as measured, because they are still what the drivers do - the page now says what OBSL does about them.

The whole matrix was **re-measured, not patched** - all eight engines live, zero errors - since a table that is part old and part new is exactly what misleads later, and the file records one measurement date.

## Verification

Every documented claim re-measured against the code rather than recalled. 5075 passed; `ruff` clean; `mkdocs build --strict` clean.