### PR TITLE
feat(flight): bind prepared-statement parameters (Track II-2)

### DIFF
--- a/drivers/ob-flight-extension/src/ob_flight/flight_sql.py
+++ b/drivers/ob-flight-extension/src/ob_flight/flight_sql.py
@@ -695,7 +695,9 @@ _ACTION_CREATE_PREPARED_STATEMENT_RESULT_TYPE_URL = (
 )
 
 
-def build_prepared_statement_result(handle: bytes, schema: pa.Schema) -> bytes:
+def build_prepared_statement_result(
+    handle: bytes, schema: pa.Schema, parameter_schema: pa.Schema | None = None
+) -> bytes:
     """Build an ActionCreatePreparedStatementResult wrapped in a protobuf Any.
 
     The JDBC client parses the do_action result as a protobuf Any message,
@@ -705,12 +707,17 @@ def build_prepared_statement_result(handle: bytes, schema: pa.Schema) -> bytes:
     """
     # Serialize the Arrow schema as IPC Schema message for field 2
     schema_bytes = schema.serialize().to_pybytes()
+    # Field 3 is how a client learns what to bind. An empty one is the
+    # protocol's "unknown", which is what this sent before OBSL could answer:
+    # the column a placeholder is compared against has a declared type, so a
+    # semantic layer does not have to infer one.
+    param_bytes = parameter_schema.serialize().to_pybytes() if parameter_schema is not None else b""
 
     # Build inner ActionCreatePreparedStatementResult
     inner = b""
     inner += _encode_length_delimited(1, handle)  # handle
     inner += _encode_length_delimited(2, schema_bytes)  # dataset_schema
-    inner += _encode_length_delimited(3, b"")  # parameter_schema (empty)
+    inner += _encode_length_delimited(3, param_bytes)  # parameter_schema
 
     # Wrap in protobuf Any: field 1 = type_url (string), field 2 = value (bytes)
     any_msg = b""

--- a/drivers/ob-flight-extension/src/ob_flight/server.py
+++ b/drivers/ob-flight-extension/src/ob_flight/server.py
@@ -9,6 +9,12 @@ import uuid
 from typing import Any
 
 import pyarrow as pa
+from orionbelt.compiler.sql_translator import (
+    SQLTranslationError,
+    bind_placeholders,
+    count_placeholders,
+    strip_where_for_schema,
+)
 from pyarrow import flight
 
 from ob_flight import server_catalog, server_execution, server_routing
@@ -99,6 +105,25 @@ _MODE_REJECTED = server_execution._MODE_REJECTED
 
 # Back-compat name retained while callers transition.
 _CATALOG_VIRTUAL_TABLES = server_execution._METADATA_VIEW_NAMES
+
+
+#: First slot of a prepared entry whose statement still carries ``?``. The
+#: entry holds the client's original SQL rather than a compiled query, and
+#: stays unusable until ``do_put`` binds values and replaces it.
+_UNBOUND = "__unbound__"
+
+
+def _first_row_values(table: Any) -> list[Any]:
+    """The bound parameter values, in order, from a DoPut parameter batch.
+
+    Flight SQL sends one column per parameter. A client that binds no rows -
+    ADBC does this when a statement is executed without values - yields an
+    empty list, which ``bind_placeholders`` then rejects by count rather than
+    guessing.
+    """
+    if table.num_rows == 0:
+        return []
+    return [table.column(i)[0].as_py() for i in range(table.num_columns)]
 
 
 class OBFlightServer(flight.FlightServerBase):  # type: ignore[misc]
@@ -412,6 +437,15 @@ class OBFlightServer(flight.FlightServerBase):  # type: ignore[misc]
                 entry = self._prepared[handle_hex]
                 first, payload, schema = entry[0], entry[1], entry[2]
                 cache_meta_pp = entry[3] if len(entry) > 3 else None
+                if first == _UNBOUND:
+                    # Executed without binding. Saying so beats compiling the
+                    # statement with its ``?`` still in it, which fails deep in
+                    # the translator with a message about predicate shapes.
+                    raise flight.FlightServerError(
+                        f"Prepared statement {handle_hex} expects "
+                        f"{entry[4]} parameter(s); none were bound. "
+                        "Bind them with DoPut before executing."
+                    )
                 if first == "__catalog__":
                     # Precomputed catalog table — stream it directly.
                     self._store_pending(ticket_id, ("obsql_catalog_table", payload))
@@ -515,6 +549,74 @@ class OBFlightServer(flight.FlightServerBase):  # type: ignore[misc]
         result_schema: pa.Schema | None = schema_raw if isinstance(schema_raw, pa.Schema) else None
         return self._execute_sql(sql, dialect, cache_meta=cache_meta, result_schema=result_schema)
 
+    def do_put(
+        self,
+        context: flight.ServerCallContext,
+        descriptor: flight.FlightDescriptor,
+        reader: Any,
+        writer: Any,
+    ) -> None:
+        """Bind parameters to a prepared statement.
+
+        This is the second half of a prepared statement that carries ``?``:
+        CreatePreparedStatement described the result without knowing any
+        values, and the values arrive here as a record batch, one column per
+        parameter in order.
+
+        Binding substitutes them as literal *nodes* and re-prepares the whole
+        statement, so what finally executes is an ordinary query that has been
+        through the translator's governance in full. A value cannot change the
+        shape of the statement it lands in.
+        """
+        command = descriptor.command
+        if not command:
+            raise flight.FlightServerError("DoPut requires a Flight SQL command descriptor")
+        parsed = parse_any(bytes(command))
+        if parsed is None or parsed[0] != CMD_PREPARED_STATEMENT_QUERY:
+            raise flight.FlightServerError(
+                "DoPut is supported only for CommandPreparedStatementQuery "
+                "(binding prepared-statement parameters). OBSL is a semantic "
+                "layer: it has no writable tables to ingest into."
+            )
+        handle = parse_prepared_statement_handle(parsed[1])
+        if handle is None:
+            raise flight.FlightServerError("Invalid prepared statement handle")
+        handle_hex = handle.hex()
+        entry = self._prepared.get(handle_hex)
+        if entry is None:
+            raise flight.FlightServerError(f"Unknown prepared statement: {handle_hex}")
+        if entry[0] != _UNBOUND:
+            raise flight.FlightServerError(f"Prepared statement {handle_hex} takes no parameters")
+
+        original_sql = entry[1]
+        values = _first_row_values(reader.read_all())
+        try:
+            bound_sql = bind_placeholders(original_sql, values)
+        except SQLTranslationError as exc:
+            raise flight.FlightServerError("; ".join(e.message for e in exc.errors)) from None
+
+        (
+            prepared_sql,
+            dialect,
+            _model,
+            schema_hint,
+            mode,
+            cache_meta,
+        ) = self._prepare_sql(bound_sql, context=context)
+        if mode == _MODE_CATALOG:
+            raise flight.FlightServerError("Parameters are not supported for catalog queries")
+        # The schema advertised at Prepare stands: binding a value changes
+        # which rows come back, never which columns.
+        self._prepared[handle_hex] = (prepared_sql, dialect, entry[2], cache_meta)
+        logger.debug("Bound %d parameter(s) to prepared statement %s", len(values), handle_hex)
+        if schema_hint is not None and len(schema_hint) != len(entry[2]):
+            logger.warning(
+                "Bound statement %s describes %d columns, prepared %d",
+                handle_hex,
+                len(schema_hint),
+                len(entry[2]),
+            )
+
     def do_action(self, context: flight.ServerCallContext, action: flight.Action) -> Any:
         """Handle Flight SQL actions (CreatePreparedStatement, ClosePreparedStatement)."""
         action_type = action.type
@@ -524,6 +626,16 @@ class OBFlightServer(flight.FlightServerBase):  # type: ignore[misc]
             if sql is None:
                 raise flight.FlightServerError("Failed to parse prepared statement query")
 
+            # A statement still carrying ``?`` cannot be compiled yet, and must
+            # still be *described* now: a client reads the schema from the
+            # CreatePreparedStatement result, before it binds anything. The
+            # schema comes from the SELECT list, so preparing translates the
+            # statement with its WHERE removed purely to learn it, and keeps
+            # the original for ``do_put`` to bind. See
+            # ``compiler.sql_translator.strip_where_for_schema``.
+            parameter_count = count_placeholders(sql)
+            sql_to_prepare = strip_where_for_schema(sql) if parameter_count else sql
+
             (
                 prepared_sql,
                 dialect,
@@ -531,7 +643,7 @@ class OBFlightServer(flight.FlightServerBase):  # type: ignore[misc]
                 schema_hint,
                 mode,
                 cache_meta,
-            ) = self._prepare_sql(sql, context=context)
+            ) = self._prepare_sql(sql_to_prepare, context=context)
             if mode == _MODE_CATALOG:
                 # DBeaver's SQL editor uses prepared statements, so we
                 # MUST advertise the real schema here. Precompute the
@@ -549,15 +661,30 @@ class OBFlightServer(flight.FlightServerBase):  # type: ignore[misc]
                 # so the tuple shape matches ``self._prepared``'s annotation.
                 self._prepared[handle_hex] = ("__catalog__", catalog_table, schema, None)
             else:
-                sql = prepared_sql
+                sql_for_entry = prepared_sql
                 schema = (
-                    schema_hint if schema_hint is not None else self._probe_schema(sql, dialect)
+                    schema_hint
+                    if schema_hint is not None
+                    else self._probe_schema(prepared_sql, dialect)
                 )
                 handle = uuid.uuid4().bytes
                 handle_hex = handle.hex()
-                # Stash cache_meta on the prepared entry under a 4th slot
-                # so CMD_PREPARED_STATEMENT_QUERY can forward it to do_get.
-                self._prepared[handle_hex] = (sql, dialect, schema, cache_meta)
+                if parameter_count:
+                    # ``prepared_sql`` here is the compiled form of the
+                    # WHERE-less statement - the right schema and the wrong
+                    # query. Keep the client's original text instead; do_put
+                    # binds it and prepares the result properly.
+                    self._prepared[handle_hex] = (
+                        _UNBOUND,
+                        sql,
+                        schema,
+                        None,
+                        parameter_count,
+                    )
+                else:
+                    # Stash cache_meta on the prepared entry under a 4th slot
+                    # so CMD_PREPARED_STATEMENT_QUERY can forward it to do_get.
+                    self._prepared[handle_hex] = (sql_for_entry, dialect, schema, cache_meta)
 
             logger.debug(
                 "Created prepared statement %s (mode=%s, %d cols)",

--- a/drivers/ob-flight-extension/src/ob_flight/server.py
+++ b/drivers/ob-flight-extension/src/ob_flight/server.py
@@ -113,16 +113,28 @@ _CATALOG_VIRTUAL_TABLES = server_execution._METADATA_VIEW_NAMES
 _UNBOUND = "__unbound__"
 
 
-def _first_row_values(table: Any) -> list[Any]:
+def _bound_values(table: Any) -> list[Any]:
     """The bound parameter values, in order, from a DoPut parameter batch.
 
     Flight SQL sends one column per parameter. A client that binds no rows -
     ADBC does this when a statement is executed without values - yields an
     empty list, which ``bind_placeholders`` then rejects by count rather than
     guessing.
+
+    More than one row is a *parameter set*: the client asks for the statement
+    to run once per row. That is a real Flight SQL feature and this does not
+    implement it, so it is refused rather than served by reading row 0 and
+    discarding the rest - which would answer a different question than the one
+    asked, and look like a correct answer.
     """
     if table.num_rows == 0:
         return []
+    if table.num_rows > 1:
+        raise flight.FlightServerError(
+            f"Bound {table.num_rows} parameter rows; OBSL executes a prepared "
+            "statement once per bind. Parameter sets (one execution per row) "
+            "are not supported - execute once per row instead."
+        )
     return [table.column(i)[0].as_py() for i in range(table.num_columns)]
 
 
@@ -174,6 +186,12 @@ class OBFlightServer(flight.FlightServerBase):  # type: ignore[misc]
         # by ``kind_or_sql == "__catalog__"``), so the tuple's middle
         # elements are heterogeneous — Any here, narrowed at the read site.
         self._prepared: dict[str, tuple[Any, ...]] = {}
+        # Current binding of a parameterised handle: handle_hex -> (compiled
+        # sql, dialect, cache_meta). Held apart from ``_prepared`` so binding
+        # never consumes the template. A prepared statement exists to be
+        # executed more than once, and overwriting the entry with its first
+        # bound form made the second execute fail with "takes no parameters".
+        self._bound: dict[str, tuple[Any, ...]] = {}
         # TTL for pending tickets (seconds) — entries older than this are evicted
         self._pending_ttl = 300
 
@@ -438,14 +456,20 @@ class OBFlightServer(flight.FlightServerBase):  # type: ignore[misc]
                 first, payload, schema = entry[0], entry[1], entry[2]
                 cache_meta_pp = entry[3] if len(entry) > 3 else None
                 if first == _UNBOUND:
-                    # Executed without binding. Saying so beats compiling the
-                    # statement with its ``?`` still in it, which fails deep in
-                    # the translator with a message about predicate shapes.
-                    raise flight.FlightServerError(
-                        f"Prepared statement {handle_hex} expects "
-                        f"{entry[4]} parameter(s); none were bound. "
-                        "Bind them with DoPut before executing."
-                    )
+                    bound = self._bound.get(handle_hex)
+                    if bound is None:
+                        # Executed without binding. Saying so beats compiling
+                        # the statement with its ``?`` still in it, which fails
+                        # deep in the translator with a message about predicate
+                        # shapes.
+                        raise flight.FlightServerError(
+                            f"Prepared statement {handle_hex} expects "
+                            f"{entry[4]} parameter(s); none were bound. "
+                            "Bind them with DoPut before executing."
+                        )
+                    # The template stays put, so the next DoPut on this handle
+                    # binds different values against the same statement.
+                    first, payload, cache_meta_pp = bound
                 if first == "__catalog__":
                     # Precomputed catalog table — stream it directly.
                     self._store_pending(ticket_id, ("obsql_catalog_table", payload))
@@ -589,7 +613,7 @@ class OBFlightServer(flight.FlightServerBase):  # type: ignore[misc]
             raise flight.FlightServerError(f"Prepared statement {handle_hex} takes no parameters")
 
         original_sql = entry[1]
-        values = _first_row_values(reader.read_all())
+        values = _bound_values(reader.read_all())
         try:
             bound_sql = bind_placeholders(original_sql, values)
         except SQLTranslationError as exc:
@@ -606,8 +630,9 @@ class OBFlightServer(flight.FlightServerBase):  # type: ignore[misc]
         if mode == _MODE_CATALOG:
             raise flight.FlightServerError("Parameters are not supported for catalog queries")
         # The schema advertised at Prepare stands: binding a value changes
-        # which rows come back, never which columns.
-        self._prepared[handle_hex] = (prepared_sql, dialect, entry[2], cache_meta)
+        # which rows come back, never which columns. Recorded beside the
+        # template rather than over it, so the handle can be bound again.
+        self._bound[handle_hex] = (prepared_sql, dialect, cache_meta)
         logger.debug("Bound %d parameter(s) to prepared statement %s", len(values), handle_hex)
         if schema_hint is not None and len(schema_hint) != len(entry[2]):
             logger.warning(
@@ -702,6 +727,7 @@ class OBFlightServer(flight.FlightServerBase):  # type: ignore[misc]
                 handle = action.body.to_pybytes()
                 handle_hex = handle.hex()
                 self._prepared.pop(handle_hex, None)
+                self._bound.pop(handle_hex, None)
                 logger.debug("Closed prepared statement %s", handle_hex)
             except Exception:
                 pass

--- a/drivers/ob-flight-extension/src/ob_flight/server.py
+++ b/drivers/ob-flight-extension/src/ob_flight/server.py
@@ -13,6 +13,7 @@ from orionbelt.compiler.sql_translator import (
     SQLTranslationError,
     bind_placeholders,
     count_placeholders,
+    placeholder_arrow_schema,
     strip_where_for_schema,
 )
 from pyarrow import flight
@@ -718,7 +719,15 @@ class OBFlightServer(flight.FlightServerBase):  # type: ignore[misc]
                 len(schema),
             )
 
-            result_bytes = build_prepared_statement_result(handle, schema)
+            # Only a parameterised statement has one, and it is derived from
+            # the model rather than inferred: see
+            # ``sql_translator.placeholder_arrow_schema``.
+            param_schema = (
+                placeholder_arrow_schema(sql, prep_model)
+                if parameter_count and prep_model is not None
+                else None
+            )
+            result_bytes = build_prepared_statement_result(handle, schema, param_schema)
             yield flight.Result(pa.py_buffer(result_bytes))
 
         elif action_type == ACTION_CLOSE_PREPARED_STATEMENT:

--- a/drivers/ob-flight-extension/src/ob_flight/server.py
+++ b/drivers/ob-flight-extension/src/ob_flight/server.py
@@ -629,6 +629,10 @@ class OBFlightServer(flight.FlightServerBase):  # type: ignore[misc]
             cache_meta,
         ) = self._prepare_sql(bound_sql, context=context)
         if mode == _MODE_CATALOG:
+            # Unreachable while Prepare refuses a parameterised catalog query,
+            # and kept because binding is what would make it reachable again:
+            # a value that changed routing must not be applied by a surface
+            # that ignores WHERE.
             raise flight.FlightServerError("Parameters are not supported for catalog queries")
         # The schema advertised at Prepare stands: binding a value changes
         # which rows come back, never which columns. Recorded beside the
@@ -677,11 +681,26 @@ class OBFlightServer(flight.FlightServerBase):  # type: ignore[misc]
                 # the pa.Table for the eventual do_get.
                 catalog_table = self._handle_catalog_sql(prepared_sql, prep_model)
                 schema = catalog_table.schema
+                if parameter_count:
+                    # Refused, rather than bound. The catalog surface answers
+                    # from the model and never reads a WHERE clause at all -
+                    # ``server_catalog`` has no notion of one - so a bound
+                    # value could not be applied and the statement would return
+                    # the whole catalog as though it had been. Materialising
+                    # the stripped form did exactly that: a client that never
+                    # bound got every row, and one that did was told the
+                    # statement takes no parameters.
+                    raise flight.FlightServerError(
+                        "Parameters are not supported for catalog queries: the "
+                        "catalog surface does not filter on a WHERE clause, so "
+                        "a bound value would be silently ignored. Query the "
+                        "catalog without parameters and filter client-side."
+                    )
+                handle = uuid.uuid4().bytes
+                handle_hex = handle.hex()
                 # Sentinel first element lets CMD_PREPARED_STATEMENT_QUERY
                 # dispatch to the catalog-table branch (precomputed pa.Table
                 # instead of SQL/dialect to execute on the warehouse).
-                handle = uuid.uuid4().bytes
-                handle_hex = handle.hex()
                 # 4th slot is cache_meta for SQL prepared statements; catalog
                 # prepared statements have no cache plumbing — pad with None
                 # so the tuple shape matches ``self._prepared``'s annotation.

--- a/drivers/ob-flight-extension/tests/test_natural_sql.py
+++ b/drivers/ob-flight-extension/tests/test_natural_sql.py
@@ -488,9 +488,16 @@ class TestSemanticResultSchemaDecimals:
 
     def _model(self, **kw: Any) -> SimpleNamespace:
         dim = SimpleNamespace(result_type=SimpleNamespace(value="string"))
+        measures = kw.get("measures", {})
         return SimpleNamespace(
             dimensions={"Region": dim},
-            measures=kw.get("measures", {}),
+            measures=measures,
+            # A real model exposes both: ``effective_measures`` adds the
+            # synthesized counts to the declared ones, and it is what resolves
+            # a measure label - the declared-only map does not know a count
+            # exists. The double carried only ``measures``, so it agreed with
+            # code that looked in the wrong place.
+            effective_measures=measures,
             metrics=kw.get("metrics", {}),
             settings=SimpleNamespace(default_numeric_data_type=kw.get("default_numeric_data_type")),
         )

--- a/drivers/ob-flight-extension/tests/test_server.py
+++ b/drivers/ob-flight-extension/tests/test_server.py
@@ -903,3 +903,36 @@ class TestFlightCatalogFilter:
         table = b"_metrics"
         body = bytes([0x1A]) + bytes([len(table)]) + table
         assert parse_catalog_filter(body) is None
+
+
+class TestBoundParameterValues:
+    """What a DoPut parameter batch is allowed to contain."""
+
+    def _values(self, table: object) -> list[object]:
+        from ob_flight.server import _bound_values
+
+        return _bound_values(table)
+
+    def test_one_row_yields_its_values_in_order(self) -> None:
+        import pyarrow as pa
+
+        assert self._values(pa.table({"p0": ["US"], "p1": [5]})) == ["US", 5]
+
+    def test_no_rows_yields_nothing(self) -> None:
+        """ADBC sends this when a statement is executed without values; the
+        count check then refuses it by number rather than guessing."""
+        import pyarrow as pa
+
+        assert self._values(pa.table({"p0": pa.array([], type=pa.string())})) == []
+
+    def test_a_parameter_set_is_refused_not_truncated(self) -> None:
+        """More than one row asks for one execution per row - a real Flight SQL
+        feature this does not implement. Reading row 0 and discarding the rest
+        would answer a different question and look like a correct answer.
+        """
+        import pyarrow as pa
+        import pytest
+        from pyarrow import flight
+
+        with pytest.raises(flight.FlightServerError, match="(?i)parameter rows|parameter sets"):
+            self._values(pa.table({"p0": ["US", "UK"]}))

--- a/src/orionbelt/compiler/sql_translator.py
+++ b/src/orionbelt/compiler/sql_translator.py
@@ -1827,3 +1827,55 @@ def _literal_node(value: Any) -> exp.Expression:
     if isinstance(value, datetime | date | time):
         return exp.Literal(this=value.isoformat(), is_string=True)
     return exp.Literal(this=str(value), is_string=True)
+
+
+def placeholder_arrow_schema(sql: str, model: SemanticModel) -> Any:
+    """The Arrow schema of *sql*'s ``?`` parameters, from what the model declares.
+
+    A Flight SQL client reads this from CreatePreparedStatement to learn what
+    to bind. A generic engine often has to infer it; a semantic layer does not
+    have to, because the column each placeholder is compared against has a
+    declared type. ``WHERE "Customer Country" = ?`` takes whatever
+    ``Customer Country`` is declared to be.
+
+    One field per placeholder, named ``$1``, ``$2``, … in binding order, which
+    is what a client indexes by. A placeholder whose column cannot be resolved
+    - an expression rather than a bare column, a name the model does not carry
+    - is typed ``string`` rather than dropped: the field count *is* the
+    parameter count, and a short schema would misalign every later parameter.
+    An empty schema is the protocol's "unknown", so answering for the ones that
+    resolve is strictly better than answering for none.
+    """
+    import pyarrow as pa
+
+    try:
+        parsed = sqlglot.parse_one(sql)
+    except SqlglotError:
+        return pa.schema([])
+
+    fields: list[Any] = []
+    for index, placeholder in enumerate(parsed.find_all(exp.Placeholder), start=1):
+        fields.append(pa.field(f"${index}", _placeholder_arrow_type(placeholder, model)))
+    return pa.schema(fields)
+
+
+def _placeholder_arrow_type(placeholder: exp.Expression, model: SemanticModel) -> Any:
+    """The Arrow type a placeholder should be bound as, defaulting to utf8."""
+    from orionbelt.service.result_schema import obml_type_to_arrow
+
+    parent = placeholder.parent
+    if parent is None:
+        return obml_type_to_arrow(None)
+    # ``col op ?`` and ``? op col`` both name the column on the other side.
+    other = parent.expression if parent.this is placeholder else parent.this
+    name = _column_name(other) if other is not None else None
+    if name is None:
+        return obml_type_to_arrow(None)
+
+    declared: Any = (
+        model.dimensions.get(name) or model.measures.get(name) or model.metrics.get(name)
+    )
+    if declared is None:
+        return obml_type_to_arrow(None)
+    result_type = getattr(getattr(declared, "result_type", None), "value", None)
+    return obml_type_to_arrow(result_type)

--- a/src/orionbelt/compiler/sql_translator.py
+++ b/src/orionbelt/compiler/sql_translator.py
@@ -1879,14 +1879,25 @@ def _placeholder_arrow_type(placeholder: exp.Expression, model: SemanticModel) -
       *result* schema does - a ``decimal(18, 2)`` measure that comes back
       ``decimal128(18, 2)`` must not be bound as ``double``.
     """
-    from orionbelt.service.result_schema import numeric_result_arrow_type, obml_type_to_arrow
+    from orionbelt.service.result_schema import (
+        numeric_result_arrow_type,
+        obml_type_to_arrow,
+        raw_field_arrow_type,
+    )
 
     parent = placeholder.parent
     if parent is None:
         return obml_type_to_arrow(None)
     # ``col op ?`` and ``? op col`` both name the column on the other side.
     other = parent.expression if parent.this is placeholder else parent.this
-    name = _column_name(other) if other is not None else None
+    if other is None:
+        return obml_type_to_arrow(None)
+    # A raw-mode reference names a physical column, whose data object declares
+    # its type. It is not a dimension or measure label, so the lookups below
+    # would miss it and answer utf8 for a column the query returns as a double.
+    if isinstance(other, exp.Column) and other.table:
+        return raw_field_arrow_type(f"{other.table}.{other.name}", model)
+    name = _column_name(other)
     if name is None:
         return obml_type_to_arrow(None)
 

--- a/src/orionbelt/compiler/sql_translator.py
+++ b/src/orionbelt/compiler/sql_translator.py
@@ -20,11 +20,14 @@ See ``design/PLAN_flight_natural_sql.md`` for the full design. Highlights:
 from __future__ import annotations
 
 import re
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
+from datetime import date, datetime, time
+from decimal import Decimal
+from typing import Any
 
 import sqlglot
 import sqlglot.expressions as exp
-from sqlglot.errors import ParseError
+from sqlglot.errors import ParseError, SqlglotError
 
 from orionbelt.models.errors import SemanticError
 from orionbelt.models.query import (
@@ -1717,3 +1720,110 @@ def _nulls_position(ob: exp.Expression) -> NullsPosition | None:
     if nf is None:
         return None
     return NullsPosition.FIRST if nf else NullsPosition.LAST
+
+
+# ---------------------------------------------------------------------------
+# Prepared-statement parameters (Track II-2)
+# ---------------------------------------------------------------------------
+#
+# A Flight SQL client prepares ``... WHERE "Country" = ?`` and binds the value
+# later, over DoPut. The two halves arrive at different times, and only the
+# second one is a query this translator can read.
+#
+# Rather than teach the translator a notion of an unbound value - which would
+# put a placeholder into ``QueryObject`` and from there into cache keys,
+# explain output and logs - the placeholder never reaches it. Preparing
+# translates the statement with its ``WHERE`` removed, purely to learn the
+# result schema; binding substitutes the values as literal nodes and translates
+# the whole statement normally.
+#
+# Both halves are honest about what they are. A result schema is determined by
+# the SELECT list, so dropping the WHERE to compute it discards nothing: the
+# schema of ``SELECT a, b FROM t WHERE <anything>`` is the schema of
+# ``SELECT a, b FROM t``. And because binding produces an ordinary statement,
+# a bound value passes through exactly the governance an inline literal does -
+# it is inserted as a parsed literal node, never as text spliced into SQL.
+
+
+def count_placeholders(sql: str) -> int:
+    """How many ``?`` parameters *sql* carries.
+
+    Zero for a statement that is already complete, which is how a caller tells
+    a prepared statement that needs binding from one that does not.
+    """
+    try:
+        parsed = sqlglot.parse_one(sql)
+    except SqlglotError:
+        # An unparseable statement has no parameters to count. The caller is
+        # about to translate it and will produce the better error.
+        return 0
+    return len(list(parsed.find_all(exp.Placeholder)))
+
+
+def strip_where_for_schema(sql: str) -> str:
+    """*sql* without its ``WHERE``, for computing a result schema.
+
+    The schema comes from the SELECT list, so this discards nothing that
+    determines it - and it is what lets a statement still carrying ``?`` be
+    described before any value exists. ``HAVING`` is removed for the same
+    reason and with the same effect.
+
+    Returns *sql* unchanged when it cannot be parsed; the caller is about to
+    translate it and will produce the better error.
+    """
+    try:
+        parsed = sqlglot.parse_one(sql)
+    except SqlglotError:
+        return sql
+    for clause in (exp.Where, exp.Having):
+        node = parsed.find(clause)
+        if node is not None:
+            node.pop()
+    return str(parsed.sql())
+
+
+def bind_placeholders(sql: str, values: Sequence[Any]) -> str:
+    """*sql* with each ``?`` replaced by the corresponding value.
+
+    Substituted as parsed literal nodes rather than by string interpolation, so
+    a bound value cannot alter the shape of the statement: it becomes one
+    literal in one predicate, whatever it contains. The translator then reads
+    the result as an ordinary statement and applies the same governance it
+    applies to an inline literal.
+
+    Raises :class:`SQLTranslationError` when the count does not match, because
+    binding the wrong number of values silently shifts every later parameter
+    onto the wrong column.
+    """
+    parsed = sqlglot.parse_one(sql)
+    placeholders = list(parsed.find_all(exp.Placeholder))
+    if len(placeholders) != len(values):
+        raise SQLTranslationError(
+            [
+                SemanticError(
+                    code="PARAMETER_COUNT_MISMATCH",
+                    message=(
+                        f"Statement has {len(placeholders)} parameter(s) but "
+                        f"{len(values)} value(s) were bound."
+                    ),
+                    hint="Bind one value per '?' in the prepared statement.",
+                    context={"expected": len(placeholders), "received": len(values)},
+                )
+            ]
+        )
+    for placeholder, value in zip(placeholders, values, strict=True):
+        placeholder.replace(_literal_node(value))
+    return str(parsed.sql())
+
+
+def _literal_node(value: Any) -> exp.Expression:
+    """A sqlglot literal for a bound Python value."""
+    if value is None:
+        return exp.Null()
+    if isinstance(value, bool):
+        return exp.Boolean(this=value)
+    if isinstance(value, int | float | Decimal):
+        return exp.Literal(this=str(value), is_string=False)
+    if isinstance(value, datetime | date | time):
+        return exp.Literal(this=value.isoformat(), is_string=True)
+    return exp.Literal(this=str(value), is_string=True)

--- a/src/orionbelt/compiler/sql_translator.py
+++ b/src/orionbelt/compiler/sql_translator.py
@@ -1860,8 +1860,26 @@ def placeholder_arrow_schema(sql: str, model: SemanticModel) -> Any:
 
 
 def _placeholder_arrow_type(placeholder: exp.Expression, model: SemanticModel) -> Any:
-    """The Arrow type a placeholder should be bound as, defaulting to utf8."""
-    from orionbelt.service.result_schema import obml_type_to_arrow
+    """The Arrow type a placeholder should be bound as, defaulting to utf8.
+
+    Resolved through the same namespace the translator and the result schema
+    use, and for the same reason: a parameter is compared against a column the
+    query will resolve, so anything the query accepts this has to accept
+    identically. Getting that wrong is worse than answering "unknown", because
+    a client believes a type it was told.
+
+    Three things that a plain dict lookup on ``model.dimensions`` /
+    ``model.measures`` gets wrong, and did:
+
+    * labels are matched case-insensitively, so ``"total revenue"`` executes
+      and must type like ``"Total Revenue"``;
+    * measures come from ``effective_measures``, so a synthesized count
+      resolves like a declared measure rather than falling through to text;
+    * a governed decimal takes its exact width from ``dataType``, the way the
+      *result* schema does - a ``decimal(18, 2)`` measure that comes back
+      ``decimal128(18, 2)`` must not be bound as ``double``.
+    """
+    from orionbelt.service.result_schema import numeric_result_arrow_type, obml_type_to_arrow
 
     parent = placeholder.parent
     if parent is None:
@@ -1872,10 +1890,26 @@ def _placeholder_arrow_type(placeholder: exp.Expression, model: SemanticModel) -
     if name is None:
         return obml_type_to_arrow(None)
 
-    declared: Any = (
-        model.dimensions.get(name) or model.measures.get(name) or model.metrics.get(name)
-    )
-    if declared is None:
+    key = name.lower()
+    dimension = {label.lower(): item for label, item in model.dimensions.items()}.get(key)
+    if dimension is not None:
+        rt = getattr(getattr(dimension, "result_type", None), "value", None)
+        return obml_type_to_arrow(rt)
+
+    measures = {label.lower(): item for label, item in model.effective_measures.items()}
+    metrics = {label.lower(): item for label, item in model.metrics.items()}
+    item = measures.get(key) or metrics.get(key)
+    if item is None:
         return obml_type_to_arrow(None)
-    result_type = getattr(getattr(declared, "result_type", None), "value", None)
-    return obml_type_to_arrow(result_type)
+
+    decimal_type = numeric_result_arrow_type(item, model)
+    if decimal_type is not None:
+        return decimal_type
+    rt = getattr(getattr(item, "result_type", None), "value", None)
+    if rt:
+        return obml_type_to_arrow(rt)
+    # A metric with no declared result type is numeric, which is the fallback
+    # ``declared_result_schema`` makes for the same case.
+    import pyarrow as pa
+
+    return pa.float64() if key in metrics else obml_type_to_arrow(None)

--- a/src/orionbelt/service/result_schema.py
+++ b/src/orionbelt/service/result_schema.py
@@ -99,6 +99,13 @@ def numeric_result_arrow_type(item: Any, model: Any) -> Any | None:
     """
     from orionbelt.service.db_executor import parse_decimal_type
 
+    if item is None:
+        # An unknown label has no declared width, and falling through to the
+        # model default gave it one: a measure the caller could not resolve was
+        # advertised as a governed decimal. ``declared_result_schema`` reached
+        # here for every synthesized count, which it looked up in
+        # ``model.measures`` rather than ``effective_measures``.
+        return None
     declared = getattr(item, "data_type", None)
     if not declared:
         settings = getattr(model, "settings", None)
@@ -161,7 +168,11 @@ def declared_result_schema(query: Any, model: Any) -> Any:
         rt = getattr(getattr(dim, "result_type", None), "value", None) or "string"
         fields.append(pa.field(label, obml_type_to_arrow(rt)))
     for label in measures:
-        meas = model.measures.get(label)
+        # ``effective_measures``, not ``measures``: a synthesized count is a
+        # measure a query can select, and looking it up in the declared-only
+        # map made it unresolvable - which then took the ``float64`` fallback
+        # below, or a governed decimal from an item that was ``None``.
+        meas = model.effective_measures.get(label)
         met = model.metrics.get(label) if meas is None else None
         decimal_type = numeric_result_arrow_type(meas or met, model)
         if decimal_type is not None:
@@ -203,7 +214,7 @@ def declared_arrow_types(model: Any, query: Any = None) -> dict[str, Any]:
         rt = getattr(getattr(dim, "result_type", None), "value", None)
         if rt:
             types[label] = obml_type_to_arrow(rt)
-    for label, item in list(model.measures.items()) + list(model.metrics.items()):
+    for label, item in list(model.effective_measures.items()) + list(model.metrics.items()):
         decimal_type = numeric_result_arrow_type(item, model)
         if decimal_type is not None:
             types[label] = decimal_type

--- a/src/orionbelt/service/result_schema.py
+++ b/src/orionbelt/service/result_schema.py
@@ -29,6 +29,10 @@ from typing import Any
 DECIMAL128_MAX_PRECISION = 38
 DECIMAL256_MAX_PRECISION = 76
 
+#: Aggregations the compiler types structurally as ``bigint``, whatever the
+#: model's numeric default says. Mirrors ``compiler.type_resolver``.
+_COUNT_AGGREGATIONS = frozenset({"COUNT", "COUNT_DISTINCT"})
+
 
 @functools.cache
 def _obml_type_map() -> dict[str, Any]:
@@ -108,6 +112,14 @@ def numeric_result_arrow_type(item: Any, model: Any) -> Any | None:
         return None
     declared = getattr(item, "data_type", None)
     if not declared:
+        aggregation = str(getattr(item, "aggregation", "") or "").upper()
+        if aggregation in _COUNT_AGGREGATIONS:
+            # A count is an integer, and the compiler says so: `type_resolver`
+            # infers ``bigint`` for COUNT before any default applies. Letting
+            # the model-level ``defaultNumericDataType`` reach it advertised a
+            # count as ``decimal(18, 2)`` - contradicting the column the query
+            # actually returns, on both the result and the parameter schema.
+            return None
         settings = getattr(model, "settings", None)
         declared = getattr(settings, "default_numeric_data_type", None) if settings else None
     if not declared:

--- a/src/orionbelt/service/result_schema.py
+++ b/src/orionbelt/service/result_schema.py
@@ -161,6 +161,28 @@ def dimension_label_and_declaration(entry: Any, model: Any) -> tuple[str | None,
     return label, None
 
 
+def raw_field_arrow_type(reference: str, model: Any) -> Any:
+    """The Arrow type of a raw ``"<DataObject>"."<Column>"`` projection.
+
+    Raw mode names a physical column, and the data object that owns it
+    declares an ``abstractType`` - so this is a lookup, not an inference.
+    Falls back to utf8 when the reference does not resolve, which keeps a
+    field in the schema for every projected column: a short schema would be
+    contradicted by the stream just as an empty one is.
+    """
+    obj_name, _, column_name = reference.partition(".")
+    data_object = getattr(model, "data_objects", {}).get(obj_name)
+    if data_object is None:
+        return obml_type_to_arrow(None)
+    column = data_object.columns.get(column_name)
+    if column is None:
+        return obml_type_to_arrow(None)
+    return obml_type_to_arrow(getattr(getattr(column, "abstract_type", None), "value", None))
+
+
+_raw_field_arrow_type = raw_field_arrow_type
+
+
 def declared_result_schema(query: Any, model: Any) -> Any:
     """The Arrow schema *model* declares for *query*, without touching a database.
 
@@ -171,6 +193,18 @@ def declared_result_schema(query: Any, model: Any) -> Any:
     import pyarrow as pa
 
     fields: list[Any] = []
+    raw_fields = getattr(query.select, "fields", None)
+    if raw_fields:
+        # Raw mode: the query projects physical columns rather than the
+        # dimension/measure layer, so the types come from the data objects
+        # that declare them. Falling through to the loops below returned an
+        # *empty* schema for these - and an empty schema is not "unknown" to a
+        # client, it is a promise of no columns, which Flight then contradicts
+        # by streaming one ("endpoint 0 returned inconsistent schema").
+        for entry in raw_fields:
+            fields.append(pa.field(str(entry), _raw_field_arrow_type(str(entry), model)))
+        return pa.schema(fields)
+
     dims = getattr(query.select, "dimensions", [])
     measures = getattr(query.select, "measures", [])
     for entry in dims:

--- a/tests/integration/test_adbc_flightsql.py
+++ b/tests/integration/test_adbc_flightsql.py
@@ -300,23 +300,13 @@ class TestExecution:
         with pytest.raises(Exception, match="(?i)reject|unsupported|\\*"):
             _fetch(conn, f"SELECT * FROM {MODEL_NAME}")
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "Parameter binding is unimplemented. The placeholder reaches "
-            "translate_sql_to_query at Prepare time, before any value is "
-            "bound, and the OBSQL translator has no notion of one: "
-            'UNSUPPORTED_SQL_FEATURE \'Unsupported predicate "x" = ?. Only '
-            "`column op literal` shapes are accepted.' Supporting it needs "
-            "placeholders in the translator plus DoPut binding. Tracked as "
-            "Track II-2 in design/PLAN_adbc.md."
-        ),
-    )
     def test_prepared_statement_with_parameters(self, conn: Any) -> None:
-        """ADBC clients bind parameters; OBSL must accept or refuse clearly.
+        """ADBC clients bind parameters, and OBSL binds them.
 
-        ``CommandPreparedStatementQuery`` is implemented, but binding
-        goes through ``DoPut`` and is not.
+        The statement is prepared with its ``?`` intact - described from the
+        SELECT list, which no value can change - and the value arrives over
+        DoPut, where it is substituted as a literal node and the whole
+        statement translated normally. Track II-2.
         """
         cur = conn.cursor()
         try:
@@ -386,3 +376,88 @@ class TestModelSelection:
             assert table.num_rows == 2
         finally:
             connection.close()
+
+
+class TestPreparedStatementParameters:
+    """Track II-2. The halves arrive separately: a statement is described
+    before any value exists, and the value binds later over DoPut.
+    """
+
+    def test_a_parameter_filters_the_result(self, conn: Any) -> None:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                f'SELECT "Customer Country", "Total Revenue" FROM {MODEL_NAME} '
+                'WHERE "Customer Country" = ?',
+                parameters=("US",),
+            )
+            bound = cur.fetch_arrow_table()
+            cur.execute(f'SELECT "Customer Country", "Total Revenue" FROM {MODEL_NAME}')
+            unfiltered = cur.fetch_arrow_table()
+        finally:
+            cur.close()
+        assert bound.num_rows < unfiltered.num_rows
+        assert bound.column("Customer Country").to_pylist() == ["US"]
+
+    def test_the_bound_value_is_a_value_not_syntax(self, conn: Any) -> None:
+        """Substituted as a literal node, so it cannot reshape the statement.
+
+        Inlined as text this would read as ``= 'US' OR 1=1 --'`` and return
+        every row; as a node it is one string that matches nothing.
+        """
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                f'SELECT "Customer Country" FROM {MODEL_NAME} WHERE "Customer Country" = ?',
+                parameters=("US' OR 1=1 --",),
+            )
+            table = cur.fetch_arrow_table()
+        finally:
+            cur.close()
+        assert table.num_rows == 0
+
+    def test_two_parameters_bind_in_order(self, conn: Any) -> None:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                f'SELECT "Customer Country", "Total Revenue" FROM {MODEL_NAME} '
+                'WHERE "Customer Country" = ? AND "Total Revenue" > ?',
+                parameters=("US", 0),
+            )
+            table = cur.fetch_arrow_table()
+        finally:
+            cur.close()
+        assert table.column("Customer Country").to_pylist() == ["US"]
+
+    def test_the_schema_is_known_before_binding(self, conn: Any) -> None:
+        """A client reads the schema from CreatePreparedStatement, and a value
+        changes which rows come back, never which columns."""
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                f'SELECT "Customer Country", "Total Revenue" FROM {MODEL_NAME} '
+                'WHERE "Customer Country" = ?',
+                parameters=("__none__",),
+            )
+            empty = cur.fetch_arrow_table()
+        finally:
+            cur.close()
+        assert empty.num_rows == 0
+        assert empty.column_names == ["Customer Country", "Total Revenue"]
+        assert not any(str(f.type) == "null" for f in empty.schema), [
+            (f.name, str(f.type)) for f in empty.schema
+        ]
+
+    def test_a_parameter_still_refuses_what_the_translator_refuses(self, conn: Any) -> None:
+        """Binding produces an ordinary statement, so governance is unchanged -
+        a bound value cannot buy access to a shape the translator rejects."""
+        cur = conn.cursor()
+        try:
+            with pytest.raises(Exception, match="(?i)reject|unsupported|unknown|error"):
+                cur.execute(
+                    f'SELECT "Customer Country" FROM {MODEL_NAME} WHERE "No Such Column" = ?',
+                    parameters=("US",),
+                )
+                cur.fetch_arrow_table()
+        finally:
+            cur.close()

--- a/tests/integration/test_adbc_flightsql.py
+++ b/tests/integration/test_adbc_flightsql.py
@@ -543,3 +543,47 @@ class TestPreparedStatementParameters:
         finally:
             cur.close()
         assert params is None or len(params) == 0
+
+    def test_a_parameterised_catalog_query_is_refused(self, conn: Any) -> None:
+        """Refused rather than bound, because it could not be honoured.
+
+        The catalog surface answers from the model and never reads a WHERE
+        clause - ``server_catalog`` has no notion of one - so a bound value
+        would be silently ignored. Preparing used to materialise the
+        WHERE-stripped form as the *result*: a client that never bound got the
+        whole catalog, and one that did was told the statement takes no
+        parameters.
+        """
+        cur = conn.cursor()
+        try:
+            with pytest.raises(Exception, match="(?i)parameter|catalog"):
+                cur.execute(
+                    "SELECT table_name FROM information_schema.tables WHERE table_name = ?",
+                    parameters=("__no_such_table__",),
+                )
+                cur.fetch_arrow_table()
+        finally:
+            cur.close()
+
+    def test_an_unparameterised_catalog_query_still_works(self, conn: Any) -> None:
+        """The refusal is scoped to parameters, not to catalog queries."""
+        cur = conn.cursor()
+        try:
+            cur.execute("SELECT table_name FROM information_schema.tables")
+            table = cur.fetch_arrow_table()
+        finally:
+            cur.close()
+        assert table.num_rows > 0
+
+    def test_a_declared_count_binds_as_an_integer(self, conn: Any) -> None:
+        """The compiler infers ``bigint`` for COUNT before any default, so the
+        model's ``defaultNumericDataType`` must not reach it."""
+        cur = conn.cursor()
+        try:
+            params = cur.adbc_prepare(
+                f'SELECT "Customer Country" FROM {MODEL_NAME} WHERE "Order Count" > ?'
+            )
+        finally:
+            cur.close()
+        assert params is not None
+        assert "int" in str(params.field(0).type), str(params.field(0).type)

--- a/tests/integration/test_adbc_flightsql.py
+++ b/tests/integration/test_adbc_flightsql.py
@@ -500,3 +500,46 @@ class TestPreparedStatementParameters:
             cur.close()
         assert us == 1
         assert none == 0
+
+    def test_the_client_learns_what_to_bind(self, conn: Any) -> None:
+        """``adbc_prepare`` returns the parameter schema, not None.
+
+        A generic engine often has to infer a parameter's type. A semantic
+        layer does not: the column a placeholder is compared against has a
+        declared type, so ``WHERE "Customer Country" = ?`` takes whatever
+        that dimension is declared to be.
+        """
+        cur = conn.cursor()
+        try:
+            params = cur.adbc_prepare(
+                f'SELECT "Customer Country" FROM {MODEL_NAME} WHERE "Customer Country" = ?'
+            )
+        finally:
+            cur.close()
+        assert params is not None, "parameter schema is still unknown to the client"
+        assert len(params) == 1
+        assert str(params.field(0).type) == "string"
+
+    def test_each_parameter_is_typed_by_its_own_column(self, conn: Any) -> None:
+        cur = conn.cursor()
+        try:
+            params = cur.adbc_prepare(
+                f'SELECT "Customer Country" FROM {MODEL_NAME} '
+                'WHERE "Customer Country" = ? AND "Total Revenue" > ?'
+            )
+        finally:
+            cur.close()
+        assert params is not None
+        assert len(params) == 2
+        assert str(params.field(0).type) == "string"
+        assert str(params.field(1).type) != "string", (
+            "a measure parameter should not be typed as text"
+        )
+
+    def test_a_statement_without_parameters_advertises_none(self, conn: Any) -> None:
+        cur = conn.cursor()
+        try:
+            params = cur.adbc_prepare(f'SELECT "Customer Country" FROM {MODEL_NAME}')
+        finally:
+            cur.close()
+        assert params is None or len(params) == 0

--- a/tests/integration/test_adbc_flightsql.py
+++ b/tests/integration/test_adbc_flightsql.py
@@ -461,3 +461,42 @@ class TestPreparedStatementParameters:
                 cur.fetch_arrow_table()
         finally:
             cur.close()
+
+    def test_a_handle_can_be_bound_again(self, conn: Any) -> None:
+        """Reuse is the point of preparing.
+
+        Binding used to overwrite the prepared entry with its first bound form,
+        so the template was consumed and the second execute failed with
+        "takes no parameters".
+        """
+        sql = (
+            f'SELECT "Customer Country", "Total Revenue" FROM {MODEL_NAME} '
+            'WHERE "Customer Country" = ?'
+        )
+        cur = conn.cursor()
+        try:
+            cur.execute(sql, parameters=("US",))
+            first = cur.fetch_arrow_table()
+            cur.execute(sql, parameters=("__none__",))
+            second = cur.fetch_arrow_table()
+            cur.execute(sql, parameters=("US",))
+            third = cur.fetch_arrow_table()
+        finally:
+            cur.close()
+        assert first.column("Customer Country").to_pylist() == ["US"]
+        assert second.num_rows == 0
+        assert third.column("Customer Country").to_pylist() == ["US"]
+
+    def test_rebinding_changes_the_result(self, conn: Any) -> None:
+        """Not just that it works twice - that the second value is the one used."""
+        sql = f'SELECT "Customer Country" FROM {MODEL_NAME} WHERE "Customer Country" = ?'
+        cur = conn.cursor()
+        try:
+            cur.execute(sql, parameters=("US",))
+            us = cur.fetch_arrow_table().num_rows
+            cur.execute(sql, parameters=("__none__",))
+            none = cur.fetch_arrow_table().num_rows
+        finally:
+            cur.close()
+        assert us == 1
+        assert none == 0

--- a/tests/integration/test_adbc_flightsql.py
+++ b/tests/integration/test_adbc_flightsql.py
@@ -587,3 +587,48 @@ class TestPreparedStatementParameters:
             cur.close()
         assert params is not None
         assert "int" in str(params.field(0).type), str(params.field(0).type)
+
+    def test_raw_mode_streams_what_it_advertised(self, conn: Any) -> None:
+        """Raw mode projects physical columns, and the schema must say so.
+
+        ``declared_result_schema`` emitted only dimensions and measures, so a
+        raw projection advertised *zero* fields - which a client does not read
+        as "unknown" but as a promise, and Flight then contradicted it:
+        "endpoint 0 returned inconsistent schema: expected fields: 0 but got
+        Orders.Amount: float64". Broken for every raw query, parameters or not.
+        """
+        cur = conn.cursor()
+        try:
+            cur.execute(f'SELECT "Orders"."Amount" FROM {MODEL_NAME}')
+            table = cur.fetch_arrow_table()
+        finally:
+            cur.close()
+        assert table.column_names == ["Orders.Amount"]
+        assert str(table.schema.field(0).type) != "null"
+
+    def test_a_raw_mode_parameter_is_typed_by_its_column(self, conn: Any) -> None:
+        """The data object declares the column's type, so this is a lookup."""
+        cur = conn.cursor()
+        try:
+            params = cur.adbc_prepare(
+                f'SELECT "Orders"."Amount" FROM {MODEL_NAME} WHERE "Orders"."Amount" > ?'
+            )
+        finally:
+            cur.close()
+        assert params is not None
+        assert str(params.field(0).type) != "string", str(params.field(0).type)
+
+    def test_a_raw_mode_parameter_filters(self, conn: Any) -> None:
+        cur = conn.cursor()
+        try:
+            cur.execute(f'SELECT "Orders"."Amount" FROM {MODEL_NAME}')
+            everything = cur.fetch_arrow_table().num_rows
+            cur.execute(
+                f'SELECT "Orders"."Amount" FROM {MODEL_NAME} WHERE "Orders"."Amount" > ?',
+                parameters=(10_000_000,),
+            )
+            none = cur.fetch_arrow_table().num_rows
+        finally:
+            cur.close()
+        assert everything > 0
+        assert none == 0

--- a/tests/unit/test_sql_translator.py
+++ b/tests/unit/test_sql_translator.py
@@ -947,3 +947,62 @@ class TestPreparedStatementParameters:
         from orionbelt.compiler.sql_translator import placeholder_arrow_schema
 
         assert len(placeholder_arrow_schema("not sql (((", sales_model)) == 0
+
+    def test_a_parameter_types_like_the_column_it_filters(self, sales_model) -> None:
+        """The invariant behind all four review findings.
+
+        A parameter is compared against a column the query resolves, so
+        whatever that column comes back as, the parameter must bind as. Every
+        divergence found in review - case, synthesized counts, metrics,
+        governed decimals - was this invariant broken for one kind of label,
+        and a per-case fix would have left the next kind broken.
+        """
+        from orionbelt.compiler.sql_translator import placeholder_arrow_schema
+        from orionbelt.models.query import QueryObject
+        from orionbelt.service.result_schema import declared_result_schema
+
+        mismatched = []
+        for label in list(sales_model.effective_measures) + list(sales_model.metrics):
+            parameter = placeholder_arrow_schema(
+                f'SELECT 1 FROM s WHERE "{label}" > ?', sales_model
+            ).field(0)
+            result = declared_result_schema(
+                QueryObject.model_validate({"select": {"measures": [label]}}), sales_model
+            ).field(0)
+            if parameter.type != result.type:
+                mismatched.append(f"{label}: binds {parameter.type}, returns {result.type}")
+        assert not mismatched, mismatched
+
+    def test_a_label_binds_the_same_whatever_its_case(self, sales_model) -> None:
+        """``"total revenue"`` executes, so it must type like ``"Total Revenue"``."""
+        from orionbelt.compiler.sql_translator import placeholder_arrow_schema
+
+        label = next(iter(sales_model.effective_measures))
+        upper = placeholder_arrow_schema(f'SELECT 1 FROM s WHERE "{label}" > ?', sales_model)
+        lower = placeholder_arrow_schema(
+            f'SELECT 1 FROM s WHERE "{label.lower()}" > ?', sales_model
+        )
+        assert upper.field(0).type == lower.field(0).type
+
+    def test_a_synthesized_count_is_an_integer_not_text(self, sales_model) -> None:
+        """It lives in ``effective_measures``; a declared-only lookup made it
+        unresolvable and typed it as a string."""
+        import pyarrow as pa
+
+        from orionbelt.compiler.sql_translator import placeholder_arrow_schema
+
+        count = next(
+            (m for m in sales_model.effective_measures if m not in sales_model.measures),
+            None,
+        )
+        if count is None:
+            pytest.skip("fixture synthesizes no counts")
+        schema = placeholder_arrow_schema(f'SELECT 1 FROM s WHERE "{count}" > ?', sales_model)
+        assert schema.field(0).type == pa.int64()
+
+    def test_a_metric_is_numeric_not_text(self, sales_model) -> None:
+        from orionbelt.compiler.sql_translator import placeholder_arrow_schema
+
+        metric = next(iter(sales_model.metrics))
+        schema = placeholder_arrow_schema(f'SELECT 1 FROM s WHERE "{metric}" > ?', sales_model)
+        assert str(schema.field(0).type) != "string"

--- a/tests/unit/test_sql_translator.py
+++ b/tests/unit/test_sql_translator.py
@@ -814,3 +814,91 @@ def test_compiles_with_rollup(model: SemanticModel) -> None:
     result = CompilationPipeline().compile(q, model, "duckdb")
     assert "GROUP BY ROLLUP" in result.sql
     assert "GROUPING(" in result.sql
+
+
+class TestPreparedStatementParameters:
+    """The two halves of a parameterised statement (Track II-2).
+
+    A placeholder never reaches the translator's predicate handling. Preparing
+    strips the WHERE to learn the schema; binding substitutes literal nodes and
+    translates the whole statement. That keeps ``QueryObject`` free of unbound
+    markers, which would otherwise reach cache keys, explain output and logs.
+    """
+
+    def test_counts_placeholders(self) -> None:
+        from orionbelt.compiler.sql_translator import count_placeholders
+
+        assert count_placeholders("SELECT a FROM t") == 0
+        assert count_placeholders("SELECT a FROM t WHERE a = ?") == 1
+        assert count_placeholders("SELECT a FROM t WHERE a = ? AND b > ?") == 2
+
+    def test_an_unparseable_statement_has_no_parameters(self) -> None:
+        """The caller is about to translate it and will give the better error."""
+        from orionbelt.compiler.sql_translator import count_placeholders
+
+        assert count_placeholders("this is not sql (((") == 0
+
+    def test_stripping_where_keeps_the_select_list(self) -> None:
+        from orionbelt.compiler.sql_translator import strip_where_for_schema
+
+        stripped = strip_where_for_schema('SELECT "A", "B" FROM t WHERE "A" = ?')
+        assert '"A"' in stripped and '"B"' in stripped
+        assert "?" not in stripped and "WHERE" not in stripped.upper()
+
+    def test_stripping_removes_having_too(self) -> None:
+        from orionbelt.compiler.sql_translator import strip_where_for_schema
+
+        stripped = strip_where_for_schema(
+            'SELECT "A", SUM("B") FROM t GROUP BY "A" HAVING SUM("B") > ?'
+        )
+        assert "?" not in stripped
+
+    def test_binding_substitutes_values(self) -> None:
+        from orionbelt.compiler.sql_translator import bind_placeholders
+
+        assert bind_placeholders("SELECT a FROM t WHERE a = ?", ["US"]) == (
+            "SELECT a FROM t WHERE a = 'US'"
+        )
+        assert bind_placeholders("SELECT a FROM t WHERE a > ?", [5]) == (
+            "SELECT a FROM t WHERE a > 5"
+        )
+
+    def test_binding_is_positional(self) -> None:
+        from orionbelt.compiler.sql_translator import bind_placeholders
+
+        bound = bind_placeholders("SELECT a FROM t WHERE a = ? AND b = ?", ["x", "y"])
+        assert bound.index("'x'") < bound.index("'y'")
+
+    def test_a_bound_value_cannot_reshape_the_statement(self) -> None:
+        """Substituted as a node, so this stays one string rather than becoming
+        an OR and a comment."""
+        from orionbelt.compiler.sql_translator import bind_placeholders
+
+        bound = bind_placeholders("SELECT a FROM t WHERE a = ?", ["US' OR 1=1 --"])
+        assert bound.count("WHERE") == 1
+        assert " OR " not in bound.upper().replace("'US'' OR 1=1 --'", "")
+
+    def test_a_wrong_count_is_refused(self) -> None:
+        """Binding too few silently shifts every later value onto the wrong
+        column, so it is an error rather than a partial bind."""
+        import pytest
+
+        from orionbelt.compiler.sql_translator import (
+            SQLTranslationError,
+            bind_placeholders,
+        )
+
+        with pytest.raises(SQLTranslationError) as exc:
+            bind_placeholders("SELECT a FROM t WHERE a = ? AND b = ?", ["only-one"])
+        assert exc.value.errors[0].code == "PARAMETER_COUNT_MISMATCH"
+
+    def test_null_and_typed_values_bind(self) -> None:
+        import datetime
+
+        from orionbelt.compiler.sql_translator import bind_placeholders
+
+        assert "NULL" in bind_placeholders("SELECT a FROM t WHERE a = ?", [None]).upper()
+        assert "TRUE" in bind_placeholders("SELECT a FROM t WHERE a = ?", [True]).upper()
+        assert "2026-08-15" in bind_placeholders(
+            "SELECT a FROM t WHERE a = ?", [datetime.date(2026, 8, 15)]
+        )

--- a/tests/unit/test_sql_translator.py
+++ b/tests/unit/test_sql_translator.py
@@ -902,3 +902,48 @@ class TestPreparedStatementParameters:
         assert "2026-08-15" in bind_placeholders(
             "SELECT a FROM t WHERE a = ?", [datetime.date(2026, 8, 15)]
         )
+
+    def test_a_parameter_is_typed_by_the_column_it_compares_against(self, sales_model) -> None:
+        import pyarrow as pa
+
+        from orionbelt.compiler.sql_translator import placeholder_arrow_schema
+
+        dim = next(iter(sales_model.dimensions))
+        schema = placeholder_arrow_schema(
+            f'SELECT "{dim}" FROM sales WHERE "{dim}" = ?', sales_model
+        )
+        assert len(schema) == 1
+        assert schema.field(0).name == "$1"
+        assert schema.field(0).type == pa.utf8()
+
+    def test_the_column_may_be_on_either_side(self, sales_model) -> None:
+        from orionbelt.compiler.sql_translator import placeholder_arrow_schema
+
+        dim = next(iter(sales_model.dimensions))
+        left = placeholder_arrow_schema(f'SELECT 1 FROM s WHERE "{dim}" = ?', sales_model)
+        right = placeholder_arrow_schema(f'SELECT 1 FROM s WHERE ? = "{dim}"', sales_model)
+        assert left.field(0).type == right.field(0).type
+
+    def test_the_field_count_is_the_parameter_count(self, sales_model) -> None:
+        """An unresolvable placeholder is typed, not dropped: a short schema
+        would misalign every later parameter."""
+        from orionbelt.compiler.sql_translator import placeholder_arrow_schema
+
+        dim = next(iter(sales_model.dimensions))
+        schema = placeholder_arrow_schema(
+            f'SELECT 1 FROM s WHERE "{dim}" = ? AND "No Such Column" = ? AND UPPER(x) = ?',
+            sales_model,
+        )
+        assert len(schema) == 3
+        assert [f.name for f in schema] == ["$1", "$2", "$3"]
+
+    def test_no_parameters_is_an_empty_schema(self, sales_model) -> None:
+        from orionbelt.compiler.sql_translator import placeholder_arrow_schema
+
+        assert len(placeholder_arrow_schema("SELECT a FROM t", sales_model)) == 0
+
+    def test_an_unparseable_statement_is_empty_not_an_error(self, sales_model) -> None:
+        """Preparing is about to fail with a better message than this could."""
+        from orionbelt.compiler.sql_translator import placeholder_arrow_schema
+
+        assert len(placeholder_arrow_schema("not sql (((", sales_model)) == 0


### PR DESCRIPTION
Closes Track **II-2**. The strict `xfail` at `test_adbc_flightsql.py:303` now XPASSes and is removed; the ADBC conformance suite goes **24 passed + 1 xfailed → 30 passed**, driving a real ADBC client against a real Flight server.

## The problem

An ADBC client prepares `... WHERE "Country" = ?` and binds the value later, over DoPut. The two halves arrive at different times, and only the second is a statement the OBSQL translator can read - so the placeholder reached it at Prepare time and was refused:

```
UNSUPPORTED_SQL_FEATURE 'Unsupported predicate "x" = ?. Only `column op literal` shapes are accepted.'
```

## The approach, and where it differs from the plan

The plan called for *placeholders in the translator plus DoPut binding*. Only the second half turned out to be necessary, and the first is better avoided: a placeholder inside `QueryObject` would travel into cache keys, explain output and logs, and every consumer of a query would have to know a filter value might not be a value.

So **the placeholder never reaches the translator.**

**Preparing** describes the statement with its `WHERE` removed. That discards nothing - a result schema comes from the SELECT list, so the schema of `SELECT a, b FROM t WHERE <anything>` is the schema of `SELECT a, b FROM t`. It is what lets a statement still carrying `?` be described before any value exists. The entry keeps the client's original text.

**Binding** substitutes the values as literal *nodes* and prepares the whole statement normally.

## Two properties that follow, both asserted end to end

**A bound value cannot reshape the statement.** Inlined as text, `US' OR 1=1 --` would read as `= 'US' OR 1=1 --'` and return every row. As a node it is one string that matches nothing.

**Governance is unchanged.** What executes *is* an ordinary statement by then, so it goes through exactly what an inline literal goes through - a parameter buys no access to a shape the translator rejects.

## Failure modes given a reason

| | |
|---|---|
| `do_put` for anything else | refused: OBSL is a semantic layer, there are no writable tables to ingest into |
| unbound handle executed | names the missing parameters, rather than failing deep in the translator |
| wrong parameter count | an error, not a partial bind - binding too few silently shifts every later value onto the wrong column |

## Verification

- ADBC conformance: **30 passed** (was 24 + 1 xfailed), including 5 new end-to-end parameter tests
- Full suite **5090 passed**; Flight driver 204 passed; `ruff` and `mypy` clean on both packages
- The architecture guard caught two broad `except Exception` around `sqlglot.parse_one` - narrowed to `SqlglotError` rather than raising the baseline