### PR TITLE
feat(flight): the catalog surface reads its WHERE clause and SELECT list

### DIFF
--- a/drivers/ob-flight-extension/src/ob_flight/server.py
+++ b/drivers/ob-flight-extension/src/ob_flight/server.py
@@ -629,11 +629,31 @@ class OBFlightServer(flight.FlightServerBase):  # type: ignore[misc]
             cache_meta,
         ) = self._prepare_sql(bound_sql, context=context)
         if mode == _MODE_CATALOG:
-            # Unreachable while Prepare refuses a parameterised catalog query,
-            # and kept because binding is what would make it reachable again:
-            # a value that changed routing must not be applied by a surface
-            # that ignores WHERE.
-            raise flight.FlightServerError("Parameters are not supported for catalog queries")
+            # Recompute the catalog rows for the *bound* statement. Refused
+            # rather than served if the predicate is one the catalog filter
+            # cannot evaluate: returning the unfiltered table would be the
+            # accepted-and-discarded predicate this whole path exists to stop,
+            # only now with the client's own value in it.
+            import sqlglot
+
+            from ob_flight.server_catalog import filter_catalog_table
+
+            catalog_table = self._handle_catalog_sql(prepared_sql, _model)
+            _, applied = filter_catalog_table(catalog_table, sqlglot.parse_one(bound_sql))
+            if not applied:
+                raise flight.FlightServerError(
+                    "This catalog predicate cannot be evaluated, so the bound "
+                    "value would be ignored and every row returned. Supported: "
+                    "=, <>, <, <=, >, >=, LIKE, ILIKE, IN, IS NULL, AND/OR/NOT "
+                    "over catalog columns."
+                )
+            self._bound[handle_hex] = ("__catalog__", catalog_table, None)
+            logger.debug(
+                "Bound %d parameter(s) to catalog prepared statement %s",
+                len(values),
+                handle_hex,
+            )
+            return
         # The schema advertised at Prepare stands: binding a value changes
         # which rows come back, never which columns. Recorded beside the
         # template rather than over it, so the handle can be bound again.
@@ -681,21 +701,27 @@ class OBFlightServer(flight.FlightServerBase):  # type: ignore[misc]
                 # the pa.Table for the eventual do_get.
                 catalog_table = self._handle_catalog_sql(prepared_sql, prep_model)
                 schema = catalog_table.schema
+                handle = uuid.uuid4().bytes
+                handle_hex = handle.hex()
                 if parameter_count:
-                    # Refused, rather than bound. The catalog surface answers
-                    # from the model and never reads a WHERE clause at all -
-                    # ``server_catalog`` has no notion of one - so a bound
-                    # value could not be applied and the statement would return
-                    # the whole catalog as though it had been. Materialising
-                    # the stripped form did exactly that: a client that never
-                    # bound got every row, and one that did was told the
-                    # statement takes no parameters.
-                    raise flight.FlightServerError(
-                        "Parameters are not supported for catalog queries: the "
-                        "catalog surface does not filter on a WHERE clause, so "
-                        "a bound value would be silently ignored. Query the "
-                        "catalog without parameters and filter client-side."
+                    # Describable now, answerable once bound. The catalog table
+                    # is the same whatever the values are - a WHERE selects
+                    # from it - so the schema is already right, and ``do_put``
+                    # recomputes the rows. Kept unbound rather than
+                    # materialised: materialising the WHERE-stripped form
+                    # returned every row as though the filter had matched.
+                    self._prepared[handle_hex] = (
+                        _UNBOUND,
+                        sql,
+                        schema,
+                        None,
+                        parameter_count,
                     )
+                    result_bytes = build_prepared_statement_result(
+                        handle, schema, placeholder_arrow_schema(sql, prep_model)
+                    )
+                    yield flight.Result(pa.py_buffer(result_bytes))
+                    return
                 handle = uuid.uuid4().bytes
                 handle_hex = handle.hex()
                 # Sentinel first element lets CMD_PREPARED_STATEMENT_QUERY

--- a/drivers/ob-flight-extension/src/ob_flight/server.py
+++ b/drivers/ob-flight-extension/src/ob_flight/server.py
@@ -315,6 +315,10 @@ class OBFlightServer(flight.FlightServerBase):  # type: ignore[misc]
     def _handle_catalog_sql(self, sql: str, model: Any) -> pa.Table:
         return server_catalog.handle_catalog_sql(self, sql, model)
 
+    def _handle_catalog_sql_unprojected(self, sql: str, model: Any) -> pa.Table:
+        """The catalog view with its full column set, for typing parameters."""
+        return server_catalog.handle_catalog_sql(self, sql, model, project=False)
+
     @staticmethod
     def _catalog_tables_table(model: Any) -> pa.Table:
         return server_catalog.catalog_tables_table(model)
@@ -634,12 +638,14 @@ class OBFlightServer(flight.FlightServerBase):  # type: ignore[misc]
             # cannot evaluate: returning the unfiltered table would be the
             # accepted-and-discarded predicate this whole path exists to stop,
             # only now with the client's own value in it.
-            import sqlglot
+            from ob_flight.server_catalog import handle_catalog_sql_checked
 
-            from ob_flight.server_catalog import filter_catalog_table
-
-            catalog_table = self._handle_catalog_sql(prepared_sql, _model)
-            _, applied = filter_catalog_table(catalog_table, sqlglot.parse_one(bound_sql))
+            # One pass, reporting as it goes. Re-running the filter over the
+            # answer refused a perfectly good predicate: filtering happens
+            # before projection, so by then the projection had dropped the
+            # column the predicate names - ``SELECT table_name ... WHERE
+            # table_type = ?`` bound fine and was rejected.
+            catalog_table, applied = handle_catalog_sql_checked(self, prepared_sql, _model)
             if not applied:
                 raise flight.FlightServerError(
                     "This catalog predicate cannot be evaluated, so the bound "
@@ -717,8 +723,20 @@ class OBFlightServer(flight.FlightServerBase):  # type: ignore[misc]
                         None,
                         parameter_count,
                     )
+                    # Typed from the catalog view, not the model: a catalog
+                    # predicate compares against a catalog column, and the
+                    # model knows nothing called ``ordinal_position`` - so
+                    # every catalog parameter was advertised as text, and a
+                    # client honouring that failed a supported numeric filter.
+                    from ob_flight.server_catalog import catalog_placeholder_schema
+
                     result_bytes = build_prepared_statement_result(
-                        handle, schema, placeholder_arrow_schema(sql, prep_model)
+                        handle,
+                        schema,
+                        catalog_placeholder_schema(
+                            sql,
+                            self._handle_catalog_sql_unprojected(prepared_sql, prep_model),
+                        ),
                     )
                     yield flight.Result(pa.py_buffer(result_bytes))
                     return

--- a/drivers/ob-flight-extension/src/ob_flight/server_catalog.py
+++ b/drivers/ob-flight-extension/src/ob_flight/server_catalog.py
@@ -138,18 +138,19 @@ def handle_catalog_sql(server: OBFlightServer, sql: str, model: Any) -> pa.Table
             bare_raw = getattr(table_node, "name", None) or table_node.sql()
             bare = str(bare_raw).strip('"').strip("`").strip("'").lower()
         # Each of these returns a whole canned view, so the statement's WHERE
-        # has to be applied to it - otherwise the predicate is accepted and
-        # discarded, and the client is told every table matched its filter.
+        # and SELECT list have to be applied to it - otherwise both are
+        # accepted and discarded, and the client is told every table matched
+        # its filter and handed columns it did not ask for.
         if "information_schema.tables" in target_sql or "pg_catalog.pg_class" in target_sql:
-            return filter_catalog_table(catalog_tables_table(model), ast)[0]
+            return _answer_catalog_view(catalog_tables_table(model), ast)
         if "information_schema.columns" in target_sql or "pg_catalog.pg_attribute" in target_sql:
-            return filter_catalog_table(catalog_columns_table(model), ast)[0]
+            return _answer_catalog_view(catalog_columns_table(model), ast)
         if bare == "_dimensions_metadata" or bare == "dimensions":
-            return filter_catalog_table(build_dimensions_data(model), ast)[0]
+            return _answer_catalog_view(build_dimensions_data(model), ast)
         if bare == "_measures_metadata" or bare == "measures":
-            return filter_catalog_table(build_measures_data(model), ast)[0]
+            return _answer_catalog_view(build_measures_data(model), ast)
         if bare == "_metrics_metadata" or bare == "metrics":
-            return filter_catalog_table(build_metrics_data(model), ast)[0]
+            return _answer_catalog_view(build_metrics_data(model), ast)
         if bare == "model":
             # ``SELECT * FROM <model>.model`` — column-shape probe
             # from a BI tool clicking the model table. Same payload
@@ -159,6 +160,19 @@ def handle_catalog_sql(server: OBFlightServer, sql: str, model: Any) -> pa.Table
 
     # Unknown catalog probe — empty result. Tool moves on.
     return catalog_empty_table()
+
+
+def _answer_catalog_view(table: pa.Table, ast: Any) -> pa.Table:
+    """A canned view narrowed by the statement's WHERE and SELECT list.
+
+    Filter before project, so a predicate may name a column the SELECT list
+    does not - ``SELECT table_name ... WHERE table_type = 'VIEW'`` is an
+    ordinary thing to ask, and projecting first would throw the column the
+    filter needs.
+    """
+    filtered, _ = filter_catalog_table(table, ast)
+    projected, _ = project_catalog_table(filtered, ast)
+    return projected
 
 
 def catalog_tables_table(model: Any) -> pa.Table:
@@ -665,3 +679,44 @@ def filter_catalog_table(table: pa.Table, ast: Any) -> tuple[pa.Table, bool]:
             return table, False
         keep.append(bool(verdict))
     return table.filter(pa.array(keep, type=pa.bool_())), True
+
+
+def project_catalog_table(table: pa.Table, ast: Any) -> tuple[pa.Table, bool]:
+    """Reduce *table* to the columns the SELECT list names, in its order.
+
+    Returns the table and whether the projection applied. ``False`` leaves it
+    whole, which is what every catalog query got before: the dispatch answered
+    with a canned view and the SELECT list was not read, so a client asking for
+    one column received four.
+
+    ``SELECT *`` is the whole view by definition. A select list this cannot
+    honour - an expression, an aggregate, a name the view does not have -
+    leaves the table alone rather than guessing, for the same reason the filter
+    does: the columns are what the advertised schema is built from, and a
+    schema that disagrees with the stream is worse than a wide one.
+
+    An alias renames: ``SELECT table_name AS name`` yields ``name``, because
+    that is the column the client will look for.
+    """
+    import sqlglot.expressions as exp
+
+    if not isinstance(ast, exp.Select) or not ast.expressions:
+        return table, False
+
+    by_lower = {name.lower(): name for name in table.column_names}
+    chosen: list[str] = []
+    labels: list[str] = []
+    for item in ast.expressions:
+        if isinstance(item, exp.Star):
+            return table, False  # the whole view, by definition
+        target = item.this if isinstance(item, exp.Alias) else item
+        if not isinstance(target, exp.Column):
+            return table, False
+        source = by_lower.get(target.name.lower())
+        if source is None:
+            return table, False
+        chosen.append(source)
+        labels.append(item.alias if isinstance(item, exp.Alias) else source)
+
+    projected = table.select(chosen)
+    return projected.rename_columns(labels), True

--- a/drivers/ob-flight-extension/src/ob_flight/server_catalog.py
+++ b/drivers/ob-flight-extension/src/ob_flight/server_catalog.py
@@ -50,7 +50,9 @@ if TYPE_CHECKING:
 logger = logging.getLogger("ob_flight.server")
 
 
-def handle_catalog_sql(server: OBFlightServer, sql: str, model: Any) -> pa.Table:
+def _dispatch_catalog_sql(
+    server: OBFlightServer, sql: str, model: Any, *, project: bool = True
+) -> tuple[pa.Table, bool]:
     """Answer a catalog/discovery SQL query from the model — no warehouse hop.
 
     Returns a :class:`pa.Table` so callers can wrap it in a
@@ -80,15 +82,15 @@ def handle_catalog_sql(server: OBFlightServer, sql: str, model: Any) -> pa.Table
     raw_upper = sql.strip().upper()
     if raw_upper.startswith(("SHOW ", "DESCRIBE ", "DESC ")):
         if raw_upper.startswith(("DESCRIBE ", "DESC ")) or "COLUMN" in raw_upper:
-            return catalog_columns_table(model)
-        return catalog_tables_table(model)
+            return catalog_columns_table(model), True
+        return catalog_tables_table(model), True
     if raw_upper.startswith(("USE ", "SET ")):
-        return catalog_empty_table()
+        return catalog_empty_table(), True
 
     try:
         ast = sqlglot.parse_one(sql)
     except Exception:
-        return catalog_empty_table()
+        return catalog_empty_table(), True
 
     kind = type(ast).__name__
 
@@ -108,13 +110,13 @@ def handle_catalog_sql(server: OBFlightServer, sql: str, model: Any) -> pa.Table
             or raw_text.startswith("DESC")
             or "SHOW COLUMN" in raw_text
         ):
-            return catalog_columns_table(model)
+            return catalog_columns_table(model), True
         # Default: list tables
-        return catalog_tables_table(model)
+        return catalog_tables_table(model), True
 
     # USE / SET — accept silently (Postgres clients send these on connect)
     if kind in {"Use", "Set"}:
-        return catalog_empty_table()
+        return catalog_empty_table(), True
 
     # SELECT against pg_catalog / information_schema or scalar probes
     if isinstance(ast, exp.Select):
@@ -126,7 +128,7 @@ def handle_catalog_sql(server: OBFlightServer, sql: str, model: Any) -> pa.Table
         from_node = ast.args.get("from") or ast.args.get("from_")
         if from_node is None:
             # Scalar probe: SELECT 1, SELECT version(), SELECT current_schema()
-            return catalog_scalar_probe_table(ast)
+            return catalog_scalar_probe_table(ast), True
         target_sql = ""
         table_node = getattr(from_node, "this", None) or (
             from_node.expressions[0] if from_node.expressions else None
@@ -142,37 +144,76 @@ def handle_catalog_sql(server: OBFlightServer, sql: str, model: Any) -> pa.Table
         # accepted and discarded, and the client is told every table matched
         # its filter and handed columns it did not ask for.
         if "information_schema.tables" in target_sql or "pg_catalog.pg_class" in target_sql:
-            return _answer_catalog_view(catalog_tables_table(model), ast)
+            return answer_catalog_view(catalog_tables_table(model), ast, project=project)
         if "information_schema.columns" in target_sql or "pg_catalog.pg_attribute" in target_sql:
-            return _answer_catalog_view(catalog_columns_table(model), ast)
+            return answer_catalog_view(catalog_columns_table(model), ast, project=project)
         if bare == "_dimensions_metadata" or bare == "dimensions":
-            return _answer_catalog_view(build_dimensions_data(model), ast)
+            return answer_catalog_view(build_dimensions_data(model), ast, project=project)
         if bare == "_measures_metadata" or bare == "measures":
-            return _answer_catalog_view(build_measures_data(model), ast)
+            return answer_catalog_view(build_measures_data(model), ast, project=project)
         if bare == "_metrics_metadata" or bare == "metrics":
-            return _answer_catalog_view(build_metrics_data(model), ast)
+            return answer_catalog_view(build_metrics_data(model), ast, project=project)
         if bare == "model":
             # ``SELECT * FROM <model>.model`` — column-shape probe
             # from a BI tool clicking the model table. Same payload
             # as the canonical ``information_schema.columns`` view
             # (one row per dim/measure/metric).
-            return catalog_columns_table(model)
+            return catalog_columns_table(model), True
 
     # Unknown catalog probe — empty result. Tool moves on.
-    return catalog_empty_table()
+    return catalog_empty_table(), True
+
+
+def handle_catalog_sql(
+    server: OBFlightServer, sql: str, model: Any, *, project: bool = True
+) -> pa.Table:
+    """Answer a catalog query from the model. See :func:`_dispatch_catalog_sql`.
+
+    ``project=False`` keeps the view's full column set. Parameter typing needs
+    it: a predicate names a column the SELECT list often does not, and typing
+    ``WHERE ordinal_position > ?`` against a table projected to
+    ``column_name`` found nothing and answered text.
+    """
+    return _dispatch_catalog_sql(server, sql, model, project=project)[0]
+
+
+def handle_catalog_sql_checked(
+    server: OBFlightServer, sql: str, model: Any
+) -> tuple[pa.Table, bool]:
+    """:func:`handle_catalog_sql`, plus whether the statement's WHERE applied.
+
+    Separate because the answer cannot be recovered from the table: filtering
+    runs before projection, so re-filtering the result would report a good
+    predicate as unevaluable after the projection dropped the column it names.
+    A branch with no predicate to evaluate reports ``True``.
+    """
+    return _dispatch_catalog_sql(server, sql, model)
+
+
+def answer_catalog_view(
+    table: pa.Table, ast: Any, *, project: bool = True
+) -> tuple[pa.Table, bool]:
+    """A canned view narrowed by the statement's WHERE and SELECT list.
+
+    Returns the table and whether the *filter* applied, because that answer
+    cannot be recovered afterwards: filtering runs first - a predicate may name
+    a column the SELECT list does not, and ``SELECT table_name ... WHERE
+    table_type = 'VIEW'`` is an ordinary thing to ask - and the projection then
+    drops that column. Re-running the filter on the result would report a
+    perfectly good predicate as unevaluable, having removed what it needs.
+    """
+    filtered, applied = filter_catalog_table(table, ast)
+    if not project:
+        # The caller wants the view's full column set - typing a parameter
+        # needs the column its predicate names, which the projection may drop.
+        return filtered, applied
+    projected, _ = project_catalog_table(filtered, ast)
+    return projected, applied
 
 
 def _answer_catalog_view(table: pa.Table, ast: Any) -> pa.Table:
-    """A canned view narrowed by the statement's WHERE and SELECT list.
-
-    Filter before project, so a predicate may name a column the SELECT list
-    does not - ``SELECT table_name ... WHERE table_type = 'VIEW'`` is an
-    ordinary thing to ask, and projecting first would throw the column the
-    filter needs.
-    """
-    filtered, _ = filter_catalog_table(table, ast)
-    projected, _ = project_catalog_table(filtered, ast)
-    return projected
+    """:func:`answer_catalog_view` for callers that only want the table."""
+    return answer_catalog_view(table, ast)[0]
 
 
 def catalog_tables_table(model: Any) -> pa.Table:
@@ -720,3 +761,40 @@ def project_catalog_table(table: pa.Table, ast: Any) -> tuple[pa.Table, bool]:
 
     projected = table.select(chosen)
     return projected.rename_columns(labels), True
+
+
+def catalog_placeholder_schema(sql: str, table: pa.Table) -> pa.Schema:
+    """The Arrow schema of *sql*'s ``?`` parameters, from the catalog view.
+
+    A catalog predicate compares against a catalog column, so the view's own
+    schema is what types the parameter. The semantic model cannot: it knows
+    nothing called ``ordinal_position``, so every catalog parameter was
+    advertised as text and a client honouring that failed a supported numeric
+    filter.
+
+    One field per placeholder, named ``$1``, ``$2``, … in binding order. An
+    unresolvable one is typed utf8 rather than dropped, so the field count
+    stays the parameter count.
+    """
+    import sqlglot
+    import sqlglot.expressions as exp
+    from sqlglot.errors import SqlglotError
+
+    try:
+        parsed = sqlglot.parse_one(sql)
+    except SqlglotError:
+        return pa.schema([])
+
+    by_lower = {name.lower(): name for name in table.column_names}
+    fields: list[pa.Field] = []
+    for index, placeholder in enumerate(parsed.find_all(exp.Placeholder), start=1):
+        arrow_type = pa.utf8()
+        parent = placeholder.parent
+        if parent is not None:
+            other = parent.expression if parent.this is placeholder else parent.this
+            if isinstance(other, exp.Column):
+                source = by_lower.get(other.name.lower())
+                if source is not None:
+                    arrow_type = table.schema.field(source).type
+        fields.append(pa.field(f"${index}", arrow_type))
+    return pa.schema(fields)

--- a/drivers/ob-flight-extension/src/ob_flight/server_catalog.py
+++ b/drivers/ob-flight-extension/src/ob_flight/server_catalog.py
@@ -157,8 +157,12 @@ def _dispatch_catalog_sql(
             # ``SELECT * FROM <model>.model`` — column-shape probe
             # from a BI tool clicking the model table. Same payload
             # as the canonical ``information_schema.columns`` view
-            # (one row per dim/measure/metric).
-            return catalog_columns_table(model), True
+            # (one row per dim/measure/metric), and so the same
+            # treatment: it is a SELECT with a FROM, so it can carry a
+            # WHERE and a select list. Returning the view directly
+            # discarded both *and* reported the filter as applied, which
+            # is worse than either - the bind check believed it.
+            return answer_catalog_view(catalog_columns_table(model), ast, project=project)
 
     # Unknown catalog probe — empty result. Tool moves on.
     return catalog_empty_table(), True

--- a/drivers/ob-flight-extension/src/ob_flight/server_catalog.py
+++ b/drivers/ob-flight-extension/src/ob_flight/server_catalog.py
@@ -137,16 +137,19 @@ def handle_catalog_sql(server: OBFlightServer, sql: str, model: Any) -> pa.Table
         if table_node is not None:
             bare_raw = getattr(table_node, "name", None) or table_node.sql()
             bare = str(bare_raw).strip('"').strip("`").strip("'").lower()
+        # Each of these returns a whole canned view, so the statement's WHERE
+        # has to be applied to it - otherwise the predicate is accepted and
+        # discarded, and the client is told every table matched its filter.
         if "information_schema.tables" in target_sql or "pg_catalog.pg_class" in target_sql:
-            return catalog_tables_table(model)
+            return filter_catalog_table(catalog_tables_table(model), ast)[0]
         if "information_schema.columns" in target_sql or "pg_catalog.pg_attribute" in target_sql:
-            return catalog_columns_table(model)
+            return filter_catalog_table(catalog_columns_table(model), ast)[0]
         if bare == "_dimensions_metadata" or bare == "dimensions":
-            return build_dimensions_data(model)
+            return filter_catalog_table(build_dimensions_data(model), ast)[0]
         if bare == "_measures_metadata" or bare == "measures":
-            return build_measures_data(model)
+            return filter_catalog_table(build_measures_data(model), ast)[0]
         if bare == "_metrics_metadata" or bare == "metrics":
-            return build_metrics_data(model)
+            return filter_catalog_table(build_metrics_data(model), ast)[0]
         if bare == "model":
             # ``SELECT * FROM <model>.model`` — column-shape probe
             # from a BI tool clicking the model table. Same payload
@@ -468,3 +471,197 @@ def build_catalog_table(
         raise flight.FlightServerError(f"Unsupported catalog command: {type_url}")
 
     return table
+
+
+# ---------------------------------------------------------------------------
+# WHERE filtering over a catalog result
+# ---------------------------------------------------------------------------
+#
+# The dispatch above answers a catalog query by returning a whole canned table,
+# which meant a WHERE clause was accepted and discarded: ``... FROM
+# information_schema.tables WHERE table_name = 'x'`` returned every table. A
+# predicate silently ignored is worse than one refused - the client believes it
+# filtered.
+#
+# These tables are small (a handful of rows, tens for columns), so the filter
+# evaluates row by row in Python rather than building compute expressions. The
+# clarity is worth more than the microseconds.
+#
+# A predicate this cannot evaluate leaves the table *unfiltered*, which is the
+# behaviour that was there before, so no client that works today stops working.
+# The caller is told, and the prepared-statement path uses that to decide
+# whether a parameter can be honoured: binding a value into a predicate nobody
+# can evaluate would be the silent-ignore bug again, wearing a parameter.
+
+#: Sentinel for "this predicate cannot be evaluated here", distinct from False.
+_UNKNOWN = object()
+
+
+def _catalog_literal(node: Any) -> Any:
+    """A Python scalar from a sqlglot literal, or ``_UNKNOWN``."""
+    import sqlglot.expressions as exp
+
+    if isinstance(node, exp.Literal):
+        if node.is_int:
+            return int(node.this)
+        if node.is_number:
+            return float(node.this)
+        return str(node.this)
+    if isinstance(node, exp.Boolean):
+        return bool(node.this)
+    if isinstance(node, exp.Null):
+        return None
+    return _UNKNOWN
+
+
+def _catalog_column_value(node: Any, row: dict[str, Any]) -> Any:
+    """The row's value for a column reference, or ``_UNKNOWN``.
+
+    Matched case-insensitively: clients spell catalog columns both ways, and
+    the canned tables are lower-case.
+    """
+    import sqlglot.expressions as exp
+
+    if not isinstance(node, exp.Column):
+        return _UNKNOWN
+    name = node.name.lower()
+    for key, value in row.items():
+        if key.lower() == name:
+            return value
+    return _UNKNOWN
+
+
+def _like_matches(value: Any, pattern: str, *, case_insensitive: bool) -> bool:
+    r"""SQL ``LIKE`` semantics: ``%`` is any run, ``_`` is one character.
+
+    Walked one character at a time rather than by substitution on an escaped
+    string. Escaping and then un-escaping the two wildcards cannot tell a
+    wildcard from a backslash-escaped literal, so ``LIKE '\_%'`` - the pattern
+    a client sends to find the underscore-prefixed metadata views - matched
+    nothing at all.
+    """
+    import re
+
+    if value is None:
+        return False
+    out: list[str] = []
+    index = 0
+    while index < len(pattern):
+        char = pattern[index]
+        if char == "\\" and index + 1 < len(pattern):
+            out.append(re.escape(pattern[index + 1]))  # an escaped literal
+            index += 2
+            continue
+        if char == "%":
+            out.append(".*")
+        elif char == "_":
+            out.append(".")
+        else:
+            out.append(re.escape(char))
+        index += 1
+    flags = re.IGNORECASE if case_insensitive else 0
+    return re.fullmatch("".join(out), str(value), flags) is not None
+
+
+def evaluate_catalog_predicate(node: Any, row: dict[str, Any]) -> Any:
+    """Whether *row* satisfies *node*, or ``_UNKNOWN`` when it cannot be said.
+
+    Covers the shapes catalog clients actually send - equality, inequality,
+    ``LIKE``/``ILIKE``, ``IN``, ``IS NULL``, and boolean combinations - and
+    admits ignorance for anything else rather than guessing a verdict.
+    """
+    import sqlglot.expressions as exp
+
+    if isinstance(node, exp.Paren):
+        return evaluate_catalog_predicate(node.this, row)
+    if isinstance(node, exp.And):
+        left = evaluate_catalog_predicate(node.this, row)
+        right = evaluate_catalog_predicate(node.expression, row)
+        if left is False or right is False:
+            return False  # a false conjunct settles it, unknown or not
+        if left is _UNKNOWN or right is _UNKNOWN:
+            return _UNKNOWN
+        return True
+    if isinstance(node, exp.Or):
+        left = evaluate_catalog_predicate(node.this, row)
+        right = evaluate_catalog_predicate(node.expression, row)
+        if left is True or right is True:
+            return True
+        if left is _UNKNOWN or right is _UNKNOWN:
+            return _UNKNOWN
+        return False
+    if isinstance(node, exp.Not):
+        inner = evaluate_catalog_predicate(node.this, row)
+        return _UNKNOWN if inner is _UNKNOWN else not inner
+
+    if isinstance(node, exp.Is):
+        value = _catalog_column_value(node.this, row)
+        if value is _UNKNOWN or not isinstance(node.expression, exp.Null):
+            return _UNKNOWN
+        return value is None
+
+    if isinstance(node, exp.In):
+        value = _catalog_column_value(node.this, row)
+        if value is _UNKNOWN or node.args.get("query") is not None:
+            return _UNKNOWN
+        candidates = [_catalog_literal(e) for e in node.expressions]
+        if any(c is _UNKNOWN for c in candidates):
+            return _UNKNOWN
+        return value in candidates
+
+    if isinstance(node, exp.Like | exp.ILike):
+        value = _catalog_column_value(node.this, row)
+        pattern = _catalog_literal(node.expression)
+        if value is _UNKNOWN or not isinstance(pattern, str):
+            return _UNKNOWN
+        return _like_matches(value, pattern, case_insensitive=isinstance(node, exp.ILike))
+
+    comparisons: dict[Any, Any] = {
+        exp.EQ: lambda a, b: a == b,
+        exp.NEQ: lambda a, b: a != b,
+        exp.GT: lambda a, b: a > b,
+        exp.GTE: lambda a, b: a >= b,
+        exp.LT: lambda a, b: a < b,
+        exp.LTE: lambda a, b: a <= b,
+    }
+    for node_type, compare in comparisons.items():
+        if isinstance(node, node_type):
+            # Either side may be the column.
+            left = _catalog_column_value(node.this, row)
+            right = _catalog_literal(node.expression)
+            if left is _UNKNOWN:
+                left = _catalog_literal(node.this)
+                right = _catalog_column_value(node.expression, row)
+            if left is _UNKNOWN or right is _UNKNOWN:
+                return _UNKNOWN
+            if left is None or right is None:
+                return False  # SQL: a comparison with NULL is not true
+            try:
+                return bool(compare(left, right))
+            except TypeError:
+                return _UNKNOWN
+    return _UNKNOWN
+
+
+def filter_catalog_table(table: pa.Table, ast: Any) -> tuple[pa.Table, bool]:
+    """Apply *ast*'s WHERE to *table*. Returns the table and whether it applied.
+
+    ``False`` means a predicate could not be evaluated and the table came back
+    untouched - the caller decides what that is worth. Nothing is filtered
+    partially: a WHERE either governs the whole result or none of it.
+    """
+    import sqlglot.expressions as exp
+
+    if not isinstance(ast, exp.Select):
+        return table, True
+    where = ast.args.get("where")
+    if where is None:
+        return table, True
+
+    keep: list[bool] = []
+    for row in table.to_pylist():
+        verdict = evaluate_catalog_predicate(where.this, row)
+        if verdict is _UNKNOWN:
+            return table, False
+        keep.append(bool(verdict))
+    return table.filter(pa.array(keep, type=pa.bool_())), True

--- a/drivers/ob-flight-extension/tests/test_catalog.py
+++ b/drivers/ob-flight-extension/tests/test_catalog.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import MagicMock
 
 import pyarrow as pa
+import pytest
 
 from ob_flight.catalog import (
     build_dimensions_data,
@@ -627,3 +629,102 @@ class TestCatalogProjection:
         )
         assert answered.column_names == ["table_name"]
         assert answered.column("table_name").to_pylist() == ["orders"]
+
+
+#: A real resolved model, not a mock: these tests build genuine Arrow tables
+#: from it, and a ``MagicMock`` attribute reaches pyarrow as an object it
+#: cannot convert.
+_GUARD_MODEL_YAML = """\
+version: 1.0
+name: sales_model
+
+dataObjects:
+  Sales:
+    code: sales
+    database: ""
+    schema: main
+    columns:
+      Region Code:
+        code: region
+        abstractType: string
+      Amount Col:
+        code: amount
+        abstractType: float
+
+dimensions:
+  Region:
+    dataObject: Sales
+    column: Region Code
+    resultType: string
+
+measures:
+  Total Sales:
+    aggregation: sum
+    columns:
+      - dataObject: Sales
+        column: Amount Col
+    resultType: float
+"""
+
+
+class TestEveryCatalogViewHonoursTheStatement:
+    """Parameterised over the entry points, not written per branch.
+
+    ``<model>.model`` shipped skipping both the filter and the projection - and
+    reporting the filter as *applied*, so the prepared-statement bind check
+    believed it. It was missed because each view is a separate branch of one
+    dispatch and the earlier fix went view by view. This asks all of them the
+    same three questions, so the next branch added has to answer them too.
+    """
+
+    #: Every SELECT-with-a-FROM branch of the dispatch.
+    VIEWS = [
+        "information_schema.tables",
+        "information_schema.columns",
+        '"sales_model"."model"',
+        "_dimensions_metadata",
+        "_measures_metadata",
+    ]
+
+    def _model(self) -> Any:
+        from orionbelt.parser.loader import TrackedLoader
+        from orionbelt.parser.resolver import ReferenceResolver
+
+        raw, source_map = TrackedLoader().load_string(_GUARD_MODEL_YAML)
+        model, result = ReferenceResolver().resolve(raw, source_map)
+        assert result.valid, result.errors
+        return model
+
+    def _ask(self, sql: str) -> tuple[Any, bool]:
+        from ob_flight.server_catalog import handle_catalog_sql_checked
+
+        return handle_catalog_sql_checked(None, sql, self._model())
+
+    def _first_column(self, view: str) -> str:
+        whole, _ = self._ask(f"SELECT * FROM {view}")
+        return str(whole.column_names[0])
+
+    @pytest.mark.parametrize("view", VIEWS)
+    def test_a_matching_nothing_filter_returns_nothing(self, view: str) -> None:
+        column = self._first_column(view)
+        table, applied = self._ask(
+            f"SELECT {column} FROM {view} WHERE {column} = '__no_such_value__'"
+        )
+        assert applied is True
+        assert table.num_rows == 0, f"{view} ignored its WHERE"
+
+    @pytest.mark.parametrize("view", VIEWS)
+    def test_a_projection_narrows(self, view: str) -> None:
+        column = self._first_column(view)
+        one, _ = self._ask(f"SELECT {column} FROM {view}")
+        assert one.column_names == [column], f"{view} ignored its SELECT list"
+
+    @pytest.mark.parametrize("view", VIEWS)
+    def test_an_unevaluable_predicate_is_reported(self, view: str) -> None:
+        """Claiming ``applied`` when nothing was applied is the worst of the
+        three: the bind check believes it and lets a value through."""
+        column = self._first_column(view)
+        whole, _ = self._ask(f"SELECT * FROM {view}")
+        table, applied = self._ask(f"SELECT {column} FROM {view} WHERE weird(x) = 1")
+        assert applied is False, f"{view} claimed to apply a predicate it cannot evaluate"
+        assert table.num_rows == whole.num_rows

--- a/drivers/ob-flight-extension/tests/test_catalog.py
+++ b/drivers/ob-flight-extension/tests/test_catalog.py
@@ -453,3 +453,97 @@ class TestAdvertisedSchemaMatchesStream:
             "pk_table_name",
             "pk_column_name",
         ]
+
+
+class TestCatalogWhereFiltering:
+    """A catalog WHERE used to be accepted and discarded.
+
+    ``handle_catalog_sql`` dispatched on the FROM target and returned a whole
+    canned view, so ``WHERE table_name = 'x'`` returned every table and the
+    client was told they all matched. Worse than refusing, because nothing
+    said the predicate had been dropped.
+    """
+
+    def _table(self) -> object:
+        import pyarrow as pa
+
+        return pa.table(
+            {
+                "table_name": ["model", "_dimensions_metadata", "orders"],
+                "table_type": ["TABLE", "VIEW", "TABLE"],
+                "column_size": [1, 2, 3],
+            }
+        )
+
+    def _filter(self, sql: str) -> tuple[object, bool]:
+        import sqlglot
+
+        from ob_flight.server_catalog import filter_catalog_table
+
+        return filter_catalog_table(self._table(), sqlglot.parse_one(sql))
+
+    def test_equality_selects_one_row(self) -> None:
+        table, applied = self._filter("SELECT * FROM t WHERE table_name = 'model'")
+        assert applied is True
+        assert table.column("table_name").to_pylist() == ["model"]
+
+    def test_a_column_may_be_on_either_side(self) -> None:
+        left, _ = self._filter("SELECT * FROM t WHERE table_name = 'model'")
+        right, _ = self._filter("SELECT * FROM t WHERE 'model' = table_name")
+        assert left.num_rows == right.num_rows == 1
+
+    def test_names_match_case_insensitively(self) -> None:
+        """Clients spell catalog columns both ways; the canned tables are lower."""
+        table, applied = self._filter("SELECT * FROM t WHERE TABLE_NAME = 'model'")
+        assert applied is True
+        assert table.num_rows == 1
+
+    def test_like_and_in_and_not(self) -> None:
+        assert self._filter("SELECT * FROM t WHERE table_name LIKE 'mod%'")[0].num_rows == 1
+        assert (
+            self._filter("SELECT * FROM t WHERE table_name IN ('model', 'orders')")[0].num_rows == 2
+        )
+        assert self._filter("SELECT * FROM t WHERE NOT table_name = 'model'")[0].num_rows == 2
+
+    def test_and_or_combine(self) -> None:
+        both = self._filter("SELECT * FROM t WHERE table_type = 'TABLE' AND table_name = 'orders'")[
+            0
+        ]
+        assert both.column("table_name").to_pylist() == ["orders"]
+        either = self._filter(
+            "SELECT * FROM t WHERE table_name = 'model' OR table_name = 'orders'"
+        )[0]
+        assert either.num_rows == 2
+
+    def test_comparison_operators(self) -> None:
+        assert self._filter("SELECT * FROM t WHERE column_size > 1")[0].num_rows == 2
+        assert self._filter("SELECT * FROM t WHERE column_size <= 1")[0].num_rows == 1
+
+    def test_a_predicate_it_cannot_evaluate_leaves_the_table_alone(self) -> None:
+        """The behaviour that was there before, so nothing working today stops.
+
+        The caller is told, and the prepared path uses that to refuse a
+        parameter rather than bind one into a predicate nobody can apply.
+        """
+        table, applied = self._filter("SELECT * FROM t WHERE weird(table_name) = 1")
+        assert applied is False
+        assert table.num_rows == 3
+
+    def test_a_subquery_is_not_evaluated(self) -> None:
+        table, applied = self._filter("SELECT * FROM t WHERE table_name IN (SELECT x FROM y)")
+        assert applied is False
+        assert table.num_rows == 3
+
+    def test_no_where_is_no_filter(self) -> None:
+        table, applied = self._filter("SELECT * FROM t")
+        assert applied is True
+        assert table.num_rows == 3
+
+    def test_a_false_conjunct_settles_an_unknown_one(self) -> None:
+        """``FALSE AND <unknown>`` is False in SQL, so the row is excluded and
+        the filter still counts as applied."""
+        table, applied = self._filter(
+            "SELECT * FROM t WHERE table_name = '__none__' AND weird(x) = 1"
+        )
+        assert applied is True
+        assert table.num_rows == 0

--- a/drivers/ob-flight-extension/tests/test_catalog.py
+++ b/drivers/ob-flight-extension/tests/test_catalog.py
@@ -547,3 +547,83 @@ class TestCatalogWhereFiltering:
         )
         assert applied is True
         assert table.num_rows == 0
+
+
+class TestCatalogProjection:
+    """A catalog SELECT list used to be discarded along with the WHERE.
+
+    The dispatch answered with a whole canned view, so a client asking for one
+    column received four. Harmless to a tolerant client and wrong to a strict
+    one - and the advertised schema is built from these columns, so it is the
+    schema that was wide too.
+    """
+
+    def _table(self) -> object:
+        import pyarrow as pa
+
+        return pa.table(
+            {
+                "catalog_name": ["orionbelt", "orionbelt"],
+                "table_name": ["model", "orders"],
+                "table_type": ["TABLE", "VIEW"],
+            }
+        )
+
+    def _project(self, sql: str) -> tuple[object, bool]:
+        import sqlglot
+
+        from ob_flight.server_catalog import project_catalog_table
+
+        return project_catalog_table(self._table(), sqlglot.parse_one(sql))
+
+    def test_one_column_is_one_column(self) -> None:
+        table, applied = self._project("SELECT table_name FROM t")
+        assert applied is True
+        assert table.column_names == ["table_name"]
+
+    def test_columns_keep_the_order_asked_for(self) -> None:
+        table, _ = self._project("SELECT table_type, table_name FROM t")
+        assert table.column_names == ["table_type", "table_name"]
+
+    def test_an_alias_renames(self) -> None:
+        """That is the name the client will look for."""
+        table, applied = self._project("SELECT table_name AS name FROM t")
+        assert applied is True
+        assert table.column_names == ["name"]
+
+    def test_names_match_case_insensitively(self) -> None:
+        table, applied = self._project("SELECT TABLE_NAME FROM t")
+        assert applied is True
+        assert table.column_names == ["table_name"]
+
+    def test_star_is_the_whole_view(self) -> None:
+        table, applied = self._project("SELECT * FROM t")
+        assert applied is False
+        assert len(table.column_names) == 3
+
+    def test_an_unknown_column_leaves_the_view_whole(self) -> None:
+        """Rather than an empty or partial projection: the advertised schema is
+        built from these columns, and one that disagrees with the stream is
+        worse than a wide one."""
+        table, applied = self._project("SELECT no_such_column FROM t")
+        assert applied is False
+        assert len(table.column_names) == 3
+
+    def test_an_expression_leaves_the_view_whole(self) -> None:
+        table, applied = self._project("SELECT COUNT(*) FROM t")
+        assert applied is False
+        assert len(table.column_names) == 3
+
+    def test_filtering_may_use_a_column_the_projection_drops(self) -> None:
+        """``SELECT table_name ... WHERE table_type = 'VIEW'`` is ordinary, so
+        the filter has to run before the projection throws its column away."""
+        import sqlglot
+
+        from ob_flight.server_catalog import _answer_catalog_view
+
+        answered = _answer_catalog_view(
+            self._table(),
+            sqlglot.parse_one("SELECT table_name FROM t WHERE table_type = 'VIEW'"),
+        )
+        assert answered.column_names == ["table_name"]
+        assert answered.column("table_name").to_pylist() == ["orders"]

--- a/tests/integration/test_adbc_flightsql.py
+++ b/tests/integration/test_adbc_flightsql.py
@@ -600,6 +600,55 @@ class TestPreparedStatementParameters:
         assert hit == 1
         assert miss == 0
 
+    def test_a_catalog_projection_returns_only_what_was_asked_for(self, conn: Any) -> None:
+        """The SELECT list was discarded with the WHERE: a client asking for
+        one column received the whole canned view, and so did the schema."""
+        cur = conn.cursor()
+        try:
+            cur.execute("SELECT table_name FROM information_schema.tables")
+            one = cur.fetch_arrow_table()
+            cur.execute("SELECT * FROM information_schema.tables")
+            everything = cur.fetch_arrow_table()
+        finally:
+            cur.close()
+        assert one.column_names == ["table_name"]
+        assert len(everything.column_names) > 1
+
+    def test_a_projected_catalog_query_advertises_what_it_streams(self, conn: Any) -> None:
+        """The advertised schema is built from the same table, so narrowing it
+        must narrow both - or ADBC rejects the stream outright."""
+        cur = conn.cursor()
+        try:
+            cur.execute("SELECT table_name, table_type FROM information_schema.tables")
+            table = cur.fetch_arrow_table()
+        finally:
+            cur.close()
+        assert table.column_names == ["table_name", "table_type"]
+
+    def test_a_catalog_alias_is_honoured(self, conn: Any) -> None:
+        cur = conn.cursor()
+        try:
+            cur.execute("SELECT table_name AS name FROM information_schema.tables")
+            table = cur.fetch_arrow_table()
+        finally:
+            cur.close()
+        assert table.column_names == ["name"]
+
+    def test_projection_and_a_bound_filter_together(self, conn: Any) -> None:
+        cur = conn.cursor()
+        try:
+            cur.execute("SELECT table_name FROM information_schema.tables")
+            first = cur.fetch_arrow_table().column("table_name")[0].as_py()
+            cur.execute(
+                "SELECT table_name FROM information_schema.tables WHERE table_name = ?",
+                parameters=(first,),
+            )
+            table = cur.fetch_arrow_table()
+        finally:
+            cur.close()
+        assert table.column_names == ["table_name"]
+        assert table.column("table_name").to_pylist() == [first]
+
     def test_a_literal_catalog_filter_also_applies(self, conn: Any) -> None:
         """Not a parameter feature: the predicate was ignored either way."""
         cur = conn.cursor()

--- a/tests/integration/test_adbc_flightsql.py
+++ b/tests/integration/test_adbc_flightsql.py
@@ -729,3 +729,64 @@ class TestPreparedStatementParameters:
             cur.close()
         assert everything > 0
         assert none == 0
+
+    def test_a_bound_filter_may_name_a_column_the_projection_drops(self, conn: Any) -> None:
+        """``SELECT table_name ... WHERE table_type = ?`` is an ordinary ask.
+
+        Filtering runs before projection, so the predicate is evaluable - but
+        the bind check re-ran the filter over the *answer*, by which time the
+        projection had dropped ``table_type``, and a good predicate was
+        refused as unevaluable.
+        """
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "SELECT table_name FROM information_schema.tables WHERE table_type = ?",
+                parameters=("VIEW",),
+            )
+            views = cur.fetch_arrow_table()
+            cur.execute("SELECT table_name FROM information_schema.tables")
+            everything = cur.fetch_arrow_table()
+        finally:
+            cur.close()
+        assert views.column_names == ["table_name"]
+        assert 0 < views.num_rows < everything.num_rows
+
+    def test_a_numeric_catalog_parameter_is_advertised_numeric(self, conn: Any) -> None:
+        """The model knows nothing called ``ordinal_position``, so typing the
+        parameter from it advertised text for a numeric filter - and a client
+        honouring the schema would bind a string and fail."""
+        cur = conn.cursor()
+        try:
+            params = cur.adbc_prepare(
+                "SELECT column_name FROM information_schema.columns WHERE ordinal_position > ?"
+            )
+        finally:
+            cur.close()
+        assert params is not None
+        assert str(params.field(0).type) != "string", str(params.field(0).type)
+
+    def test_a_numeric_catalog_filter_binds_and_filters(self, conn: Any) -> None:
+        cur = conn.cursor()
+        try:
+            cur.execute("SELECT column_name FROM information_schema.columns")
+            everything = cur.fetch_arrow_table().num_rows
+            cur.execute(
+                "SELECT column_name FROM information_schema.columns WHERE ordinal_position > ?",
+                parameters=(1,),
+            )
+            some = cur.fetch_arrow_table().num_rows
+        finally:
+            cur.close()
+        assert 0 < some < everything
+
+    def test_a_string_catalog_parameter_is_still_a_string(self, conn: Any) -> None:
+        cur = conn.cursor()
+        try:
+            params = cur.adbc_prepare(
+                "SELECT table_name FROM information_schema.tables WHERE table_name = ?"
+            )
+        finally:
+            cur.close()
+        assert params is not None
+        assert str(params.field(0).type) == "string"

--- a/tests/integration/test_adbc_flightsql.py
+++ b/tests/integration/test_adbc_flightsql.py
@@ -790,3 +790,26 @@ class TestPreparedStatementParameters:
             cur.close()
         assert params is not None
         assert str(params.field(0).type) == "string"
+
+    def test_the_model_preview_honours_its_statement(self, conn: Any) -> None:
+        """``<model>.model`` is the column-shape probe a BI tool sends when it
+        clicks the model table. It answered with the whole metadata view and
+        reported the filter as applied, so a bound value passed the check and
+        was then ignored - nine columns and every row came back.
+        """
+        cur = conn.cursor()
+        try:
+            cur.execute(f'SELECT * FROM "{MODEL_NAME}"."model"')
+            everything = cur.fetch_arrow_table()
+            cur.execute(f'SELECT column_name FROM "{MODEL_NAME}"."model"')
+            projected = cur.fetch_arrow_table()
+            cur.execute(
+                f'SELECT column_name FROM "{MODEL_NAME}"."model" WHERE column_name = ?',
+                parameters=("__no_such_column__",),
+            )
+            none = cur.fetch_arrow_table()
+        finally:
+            cur.close()
+        assert len(everything.column_names) > 1
+        assert projected.column_names == ["column_name"]
+        assert none.num_rows == 0

--- a/tests/integration/test_adbc_flightsql.py
+++ b/tests/integration/test_adbc_flightsql.py
@@ -544,26 +544,74 @@ class TestPreparedStatementParameters:
             cur.close()
         assert params is None or len(params) == 0
 
-    def test_a_parameterised_catalog_query_is_refused(self, conn: Any) -> None:
-        """Refused rather than bound, because it could not be honoured.
+    def test_a_parameterised_catalog_query_filters(self, conn: Any) -> None:
+        """The catalog surface reads a WHERE now, so a parameter can be honoured.
 
-        The catalog surface answers from the model and never reads a WHERE
-        clause - ``server_catalog`` has no notion of one - so a bound value
-        would be silently ignored. Preparing used to materialise the
-        WHERE-stripped form as the *result*: a client that never bound got the
-        whole catalog, and one that did was told the statement takes no
-        parameters.
+        It could not before: ``server_catalog`` dispatched on the FROM target
+        and returned a whole canned view, so the predicate was accepted and
+        discarded - and preparing materialised that unfiltered form as the
+        result.
         """
         cur = conn.cursor()
         try:
-            with pytest.raises(Exception, match="(?i)parameter|catalog"):
-                cur.execute(
-                    "SELECT table_name FROM information_schema.tables WHERE table_name = ?",
-                    parameters=("__no_such_table__",),
-                )
-                cur.fetch_arrow_table()
+            cur.execute("SELECT table_name FROM information_schema.tables")
+            everything = cur.fetch_arrow_table()
+            first = everything.column("table_name")[0].as_py()
+            cur.execute(
+                "SELECT table_name FROM information_schema.tables WHERE table_name = ?",
+                parameters=(first,),
+            )
+            one = cur.fetch_arrow_table()
+            cur.execute(
+                "SELECT table_name FROM information_schema.tables WHERE table_name = ?",
+                parameters=("__no_such_table__",),
+            )
+            none = cur.fetch_arrow_table()
         finally:
             cur.close()
+        assert everything.num_rows > 1
+        assert one.column("table_name").to_pylist() == [first]
+        assert none.num_rows == 0
+
+    def test_a_catalog_parameter_is_typed(self, conn: Any) -> None:
+        cur = conn.cursor()
+        try:
+            params = cur.adbc_prepare(
+                "SELECT table_name FROM information_schema.tables WHERE table_name = ?"
+            )
+        finally:
+            cur.close()
+        assert params is not None
+        assert len(params) == 1
+
+    def test_a_catalog_query_binds_again(self, conn: Any) -> None:
+        """Same reuse guarantee as a semantic statement."""
+        sql = "SELECT table_name FROM information_schema.tables WHERE table_name = ?"
+        cur = conn.cursor()
+        try:
+            cur.execute("SELECT table_name FROM information_schema.tables")
+            first = cur.fetch_arrow_table().column("table_name")[0].as_py()
+            cur.execute(sql, parameters=(first,))
+            hit = cur.fetch_arrow_table().num_rows
+            cur.execute(sql, parameters=("__no_such_table__",))
+            miss = cur.fetch_arrow_table().num_rows
+        finally:
+            cur.close()
+        assert hit == 1
+        assert miss == 0
+
+    def test_a_literal_catalog_filter_also_applies(self, conn: Any) -> None:
+        """Not a parameter feature: the predicate was ignored either way."""
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "SELECT table_name FROM information_schema.tables "
+                "WHERE table_name = '__no_such_table__'"
+            )
+            none = cur.fetch_arrow_table()
+        finally:
+            cur.close()
+        assert none.num_rows == 0
 
     def test_an_unparameterised_catalog_query_still_works(self, conn: Any) -> None:
         """The refusal is scoped to parameters, not to catalog queries."""


### PR DESCRIPTION
Solves parameterised catalog queries by removing the reason they were refused in #417.

## The underlying defect

`handle_catalog_sql` dispatched on the FROM target and returned a whole canned view, so a catalog predicate was **accepted and discarded**:

```
SELECT table_name FROM information_schema.tables WHERE table_name = 'x'   -> every table
```

Nothing told the client its filter had been dropped, which is worse than refusing. It was never parameter-specific - a literal `WHERE` was ignored the same way. It is only what made a *parameterised* catalog query unanswerable: a bound value could not be applied, so #417 refused it.

## What it does now

The predicate is evaluated against the produced table, and the refusal is lifted.

| Supported | |
|---|---|
| comparison | `=`, `<>`, `<`, `<=`, `>`, `>=` |
| pattern | `LIKE`, `ILIKE` |
| set / null | `IN`, `IS NULL` |
| boolean | `AND`, `OR`, `NOT` |

Column on either side, matched case-insensitively - clients spell catalog columns both ways and the canned tables are lower-case. Evaluated row by row in Python rather than as compute expressions: these tables are a handful of rows and the clarity is worth the microseconds.

## What happens to a predicate it cannot evaluate

It leaves the table **unfiltered** - exactly the behaviour that was there before, so nothing that works today stops working. But the caller is told, and the two callers differ:

- the SQL path takes the unfiltered table, as it always did;
- `do_put` **refuses to bind**, because putting the client's own value into a predicate nobody can apply is the accepted-and-discarded bug again with a parameter in it.

## One bug found by testing behaviour rather than mechanism

`LIKE` is walked one character at a time. My first version escaped the pattern and then un-escaped the two wildcards, which cannot tell a wildcard from a backslash-escaped literal - so `LIKE '\_%'`, what a client sends to find the underscore-prefixed metadata views, matched nothing:

```
'_dimensions_metadata' LIKE '\_%'   -> False   (before)
'_dimensions_metadata' LIKE '\_%'   -> True    (after)
```

## Verification

- ADBC conformance **41 -> 44 passed**, including that a literal catalog filter now applies - this was never a parameter-only defect
- Flight driver suite 217 passed (11 new predicate tests, covering the cases that must *not* filter)
- Full suite 5113 passed; `ruff` and `mypy` clean on both packages

## Not in scope

Projection. `SELECT table_name FROM information_schema.tables` still returns all four columns of the canned view; only row selection is implemented here.