### PR TITLE
docs(adbc): a guide to the Flight SQL surface, with every sample asserted

### DIFF
--- a/docs/guide/adbc.md
+++ b/docs/guide/adbc.md
@@ -100,16 +100,19 @@ A refusal arrives as an exception, not as zero rows — a client can tell
 Prepared statements bind over DoPut, and the client can discover what to bind:
 
 ```python
-with conn.cursor() as cur:
-    parameters = cur.adbc_prepare(
-        'SELECT "Customer Country", "Total Revenue" FROM sales '
-        'WHERE "Customer Country" = ?'
-    )
-    print(parameters)          # $1: string
+sql = (
+    'SELECT "Customer Country", "Total Revenue" FROM sales '
+    'WHERE "Customer Country" = ?'
+)
 
-    cur.execute(..., parameters=("US",))
+with conn.cursor() as cur:
+    parameters = cur.adbc_prepare(sql)
+    print(parameters)                        # $1: string
+
+    cur.execute(sql, parameters=("US",))
     us = cur.fetch_arrow_table()
-    cur.execute(..., parameters=("DE",))   # the same handle, bound again
+
+    cur.execute(sql, parameters=("DE",))     # the same handle, bound again
     de = cur.fetch_arrow_table()
 ```
 

--- a/docs/guide/adbc.md
+++ b/docs/guide/adbc.md
@@ -1,0 +1,174 @@
+# Connecting via ADBC (Arrow Flight SQL)
+
+OBSL's Arrow Flight SQL surface (`FLIGHT_ENABLED=true`) speaks the protocol
+ADBC's `flightsql` driver talks, so any ADBC client can query a loaded model
+and get Arrow back without a translation hop. Where the
+[Postgres wire surface](postgres-wire-bi-tools.md) exists so BI tools can use
+a connector they already ship, this one exists for programs that want columnar
+data: a client that reads Arrow gets the server's Arrow, unconverted.
+
+Everything on this page is asserted by `tests/integration/test_adbc_flightsql.py`,
+which drives a real ADBC client against a real Flight server. Run it with
+`uv run pytest -m adbc_flight`.
+
+## Start the server
+
+```bash
+DB_VENDOR=duckdb \
+DUCKDB_DATABASE=/path/to/warehouse.duckdb \
+MODEL_FILES=/path/to/model.yaml \
+FLIGHT_ENABLED=true \
+FLIGHT_PORT=8815 \
+uv run orionbelt-api
+```
+
+`FLIGHT_ENABLED` implies `QUERY_EXECUTE`. The gRPC URI is then
+`grpc://<host>:8815` — or `grpc+tls://` behind TLS.
+
+## Connect
+
+```python
+from adbc_driver_flightsql import dbapi
+
+with dbapi.connect("grpc://127.0.0.1:8815") as conn:
+    with conn.cursor() as cur:
+        cur.execute('SELECT "Customer Country", "Total Revenue" FROM sales')
+        table = cur.fetch_arrow_table()
+```
+
+`fetch_arrow_table()` is the point: the rows never become Python objects on
+the way past.
+
+### Picking a model
+
+A deployment can serve several models (`MODEL_FILES` loads each into its own
+named session). Flight reads the model from the gRPC `database` /
+`x-obsl-model` header, and ADBC sets arbitrary call headers:
+
+```python
+conn = dbapi.connect(
+    "grpc://127.0.0.1:8815",
+    db_kwargs={"adbc.flight.sql.rpc.call_header.x-obsl-model": "sales"},
+)
+```
+
+### Authenticating
+
+With `AUTH_MODE=api_key`, the Flight server validates the handshake credential
+against the same key store the REST surface uses. The key goes in as the
+Basic-auth password:
+
+```python
+conn = dbapi.connect(
+    "grpc://127.0.0.1:8815",
+    db_kwargs={"username": "obsl", "password": "<your API key>"},
+)
+```
+
+## What you can send
+
+The Flight surface takes **OBSQL** — `SELECT <dimension|measure> FROM <model>`,
+where the names are the model's, not the warehouse's. It is a semantic layer,
+not a SQL proxy, so a statement is compiled against the model rather than
+forwarded:
+
+```sql
+SELECT "Customer Country", "Total Revenue"
+FROM sales
+WHERE "Customer Country" = 'US'
+```
+
+Raw physical columns are addressable too, qualified by data object:
+
+```sql
+SELECT "Orders"."Amount" FROM sales
+```
+
+### What is refused, and why
+
+| Statement | Result |
+|---|---|
+| `SELECT * FROM sales` | Refused. A model has no `*` — a star would have to invent a column list, and which columns a semantic layer returns is a governance decision. |
+| `SELECT ... FROM nonexistent_relation` | Refused, as an error rather than an empty result. |
+| Arbitrary warehouse SQL | Not forwarded. There is no escape hatch to the underlying database. |
+
+A refusal arrives as an exception, not as zero rows — a client can tell
+"nothing matched" from "that was not allowed".
+
+## Prepared statements and parameters
+
+Prepared statements bind over DoPut, and the client can discover what to bind:
+
+```python
+with conn.cursor() as cur:
+    parameters = cur.adbc_prepare(
+        'SELECT "Customer Country", "Total Revenue" FROM sales '
+        'WHERE "Customer Country" = ?'
+    )
+    print(parameters)          # $1: string
+
+    cur.execute(..., parameters=("US",))
+    us = cur.fetch_arrow_table()
+    cur.execute(..., parameters=("DE",))   # the same handle, bound again
+    de = cur.fetch_arrow_table()
+```
+
+The parameter schema is **the model's**, not an inference: the column a
+placeholder is compared against has a declared type, so a `decimal(18, 2)`
+measure binds at that width and a count binds as an integer. A raw-mode
+parameter takes the type its data object declares.
+
+A bound value is substituted as a parsed literal, never spliced into text, so
+it cannot change the shape of the statement it lands in — and what executes has
+been through the same governance an inline literal gets.
+
+| | |
+|---|---|
+| Rebinding a handle | Supported — that is what preparing is for. |
+| Parameter *sets* (one execution per row) | Refused by name. Bind and execute once per row. |
+| Wrong parameter count | Refused. Binding too few silently shifts every later value onto the wrong column. |
+| Executing without binding | Refused, naming how many parameters are missing. |
+
+## Catalog and discovery
+
+`GetCatalogs`, `GetDbSchemas`, `GetTables`, `GetColumns` and `GetTableTypes`
+are answered from the model — no warehouse hop. So are the SQL forms BI tools
+send: `SHOW TABLES`, `DESCRIBE <model>`, and selects against
+`information_schema.tables` / `.columns` and their `pg_catalog` equivalents.
+
+These honour the statement they are given:
+
+```sql
+SELECT table_name FROM information_schema.tables WHERE table_type = 'VIEW'
+SELECT column_name FROM information_schema.columns WHERE ordinal_position > ?
+```
+
+Supported predicates are `=`, `<>`, `<`, `<=`, `>`, `>=`, `LIKE`, `ILIKE`,
+`IN`, `IS NULL`, and `AND`/`OR`/`NOT` over them, with the column on either
+side. A predicate outside that set leaves the result unfiltered rather than
+failing, since clients probe a long tail of system tables — but a *parameter*
+cannot be bound into one, because a bound value that is then ignored is worse
+than a refusal.
+
+## Types
+
+A column's type is a property of the model, not of the engine behind it. Where
+a warehouse cannot express a declared type, OBSL reconciles it: MySQL has no
+boolean, so a declared one arrives as `true`/`false` rather than `1`/`0`, and
+Dremio's `date64[ms]` narrows to the `date32[day]` every other engine returns.
+
+Reconciliation is deliberately narrow — an engine answering *more* precisely
+than the declaration is not drift, so a `decimal(38, 2)` behind a measure
+declared `float` is left alone. See
+[Arrow type fidelity](../reference/type-fidelity.md) for the per-engine
+measurements and what is refused.
+
+## Known limitations
+
+| | |
+|---|---|
+| Parameter sets | Not implemented; refused rather than truncated to the first row. |
+| Catalog projection | Row selection and column projection apply; other clauses (`ORDER BY`, `LIMIT`) on catalog views do not. |
+| `CommandGetXdbcTypeInfo` | Streams a single `info: utf8` column rather than the spec shape. ADBC accepts it because the advertised schema matches the stream. |
+| Statistics (`GetStatistics`) | Not implemented. |
+| Transactions | Flight SQL exposes no transaction to begin — OBSL is read-only. ADBC warns that autocommit cannot be disabled; the warning is expected. |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -146,6 +146,7 @@ nav:
       - Gradio UI: guide/ui.md
       - AI Integrations: guide/integrations.md
       - Postgres Wire (BI Tools): guide/postgres-wire-bi-tools.md
+      - ADBC / Arrow Flight SQL: guide/adbc.md
       - Authentication: guide/authentication.md
       - OSI Interoperability: guide/osi.md
   - API:

--- a/tests/integration/test_adbc_docs_claims.py
+++ b/tests/integration/test_adbc_docs_claims.py
@@ -1,0 +1,132 @@
+"""Every claim `docs/guide/adbc.md` makes, run against a real ADBC client.
+
+The page tells people what to type. A documented recipe that does not run is
+worse than no page: it costs the reader the time to find out. So the samples
+live here too, phrased as assertions.
+"""
+
+# ruff: noqa: F811 — pytest fixtures are imported by name and then shadowed by
+# the parameters that request them, which is how sharing a fixture across
+# modules works. The alternative is a conftest, which would move the harness
+# away from the suite that owns it.
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+pytestmark = pytest.mark.adbc_flight
+
+from tests.integration.test_adbc_flightsql import (  # noqa: E402
+    MODEL_NAME,
+    conn,  # noqa: F401
+    flight_uri,  # noqa: F401
+)
+
+
+class TestTheConnectRecipe:
+    def test_the_first_sample_runs(self, conn: Any) -> None:
+        """The `Connect` block, verbatim."""
+        with conn.cursor() as cur:
+            cur.execute(f'SELECT "Customer Country", "Total Revenue" FROM {MODEL_NAME}')
+            table = cur.fetch_arrow_table()
+        assert table.num_rows > 0
+        assert table.column_names == ["Customer Country", "Total Revenue"]
+
+    def test_model_selection_by_call_header(self, flight_uri: str) -> None:
+        """The `Picking a model` block."""
+        from adbc_driver_flightsql import dbapi
+
+        connection = dbapi.connect(
+            flight_uri,
+            db_kwargs={"adbc.flight.sql.rpc.call_header.x-obsl-model": MODEL_NAME},
+        )
+        try:
+            with connection.cursor() as cur:
+                cur.execute(f'SELECT "Customer Country" FROM {MODEL_NAME}')
+                assert cur.fetch_arrow_table().num_rows > 0
+        finally:
+            connection.close()
+
+
+class TestWhatYouCanSend:
+    def test_the_obsql_sample(self, conn: Any) -> None:
+        with conn.cursor() as cur:
+            cur.execute(
+                f'SELECT "Customer Country", "Total Revenue" FROM {MODEL_NAME} '
+                "WHERE \"Customer Country\" = 'US'"
+            )
+            table = cur.fetch_arrow_table()
+        assert table.column("Customer Country").to_pylist() == ["US"]
+
+    def test_the_raw_column_sample(self, conn: Any) -> None:
+        with conn.cursor() as cur:
+            cur.execute(f'SELECT "Orders"."Amount" FROM {MODEL_NAME}')
+            table = cur.fetch_arrow_table()
+        assert table.column_names == ["Orders.Amount"]
+
+    def test_select_star_is_refused_as_documented(self, conn: Any) -> None:
+        with conn.cursor() as cur, pytest.raises(Exception, match="(?i)reject|unsupported|\\*"):
+            cur.execute(f"SELECT * FROM {MODEL_NAME}")
+            cur.fetch_arrow_table()
+
+    def test_an_unknown_relation_errors_rather_than_returning_nothing(self, conn: Any) -> None:
+        """The page promises a client can tell 'nothing matched' from
+        'not allowed'."""
+        with conn.cursor() as cur, pytest.raises(Exception, match="(?i)error|reject|unknown|not"):
+            cur.execute("SELECT x FROM nonexistent_relation_xyz")
+            cur.fetch_arrow_table()
+
+
+class TestThePreparedStatementSample:
+    def test_it_runs_and_rebinds(self, conn: Any) -> None:
+        sql = (
+            f'SELECT "Customer Country", "Total Revenue" FROM {MODEL_NAME} '
+            'WHERE "Customer Country" = ?'
+        )
+        with conn.cursor() as cur:
+            parameters = cur.adbc_prepare(sql)
+            assert parameters is not None
+            assert str(parameters.field(0).type) == "string"
+            cur.execute(sql, parameters=("US",))
+            us = cur.fetch_arrow_table()
+            cur.execute(sql, parameters=("__none__",))
+            none = cur.fetch_arrow_table()
+        assert us.num_rows == 1
+        assert none.num_rows == 0
+
+    def test_the_documented_parameter_name_is_dollar_one(self, conn: Any) -> None:
+        """The page prints ``$1: string``."""
+        with conn.cursor() as cur:
+            parameters = cur.adbc_prepare(
+                f'SELECT "Customer Country" FROM {MODEL_NAME} WHERE "Customer Country" = ?'
+            )
+        assert parameters.names == ["$1"]
+
+
+class TestTheCatalogSamples:
+    def test_the_two_catalog_statements_run(self, conn: Any) -> None:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT table_name FROM information_schema.tables WHERE table_type = 'VIEW'"
+            )
+            views = cur.fetch_arrow_table()
+            cur.execute(
+                "SELECT column_name FROM information_schema.columns WHERE ordinal_position > ?",
+                parameters=(1,),
+            )
+            columns = cur.fetch_arrow_table()
+        assert views.column_names == ["table_name"]
+        assert columns.column_names == ["column_name"]
+
+    @pytest.mark.parametrize("statement", ["SHOW TABLES", "DESCRIBE " + MODEL_NAME])
+    def test_the_bi_tool_forms_answer(self, conn: Any, statement: str) -> None:
+        with conn.cursor() as cur:
+            cur.execute(statement)
+            assert cur.fetch_arrow_table().num_rows > 0
+
+    def test_an_unsupported_predicate_does_not_fail_the_query(self, conn: Any) -> None:
+        """The page says it is left unfiltered rather than failing."""
+        with conn.cursor() as cur:
+            cur.execute("SELECT table_name FROM information_schema.tables WHERE weird(x) = 1")
+            assert cur.fetch_arrow_table().num_rows > 0

--- a/tests/integration/test_adbc_docs_claims.py
+++ b/tests/integration/test_adbc_docs_claims.py
@@ -130,3 +130,38 @@ class TestTheCatalogSamples:
         with conn.cursor() as cur:
             cur.execute("SELECT table_name FROM information_schema.tables WHERE weird(x) = 1")
             assert cur.fetch_arrow_table().num_rows > 0
+
+
+class TestThePageItselfRuns:
+    """Executes the guide's code blocks verbatim, rather than transcribing them.
+
+    Transcribing is what let the prepared-statement sample ship broken: it
+    passed ``...`` where the SQL belongs - the Ellipsis object, not a
+    statement - while the test beside it used a real ``sql`` variable and
+    passed. Two texts claiming to be the same thing, only one of them checked.
+
+    Only blocks that drive an existing connection are run. The ones that call
+    ``dbapi.connect`` name a fixed host and port that no test server listens
+    on, and rewriting them here would put the transcription back.
+    """
+
+    GUIDE = "docs/guide/adbc.md"
+
+    def _runnable_blocks(self) -> list[str]:
+        import pathlib
+        import re
+
+        text = (pathlib.Path(__file__).resolve().parents[2] / self.GUIDE).read_text()
+        blocks = re.findall(r"```python\n(.*?)```", text, re.S)
+        return [b for b in blocks if "conn.cursor()" in b and "dbapi.connect" not in b]
+
+    def test_there_are_blocks_to_run(self) -> None:
+        """Guards the guard: a renamed page or fence would pass everything."""
+        assert self._runnable_blocks(), f"no runnable python blocks found in {self.GUIDE}"
+
+    def test_every_runnable_block_executes(self, conn: Any) -> None:
+        for index, block in enumerate(self._runnable_blocks()):
+            try:
+                exec(compile(block, f"{self.GUIDE}#block{index}", "exec"), {"conn": conn})
+            except Exception as exc:  # noqa: BLE001 — the failure *is* the result
+                pytest.fail(f"{self.GUIDE} block {index} does not run: {exc}\n\n{block}")


### PR DESCRIPTION
Track **II-5**. ADBC appeared once in the whole documentation set - a table cell in `docs/drivers.md` - so the surface with 53 conformance tests behind it had no page telling anyone how to use it.

## The page

`docs/guide/adbc.md`, in the Guide nav beside the Postgres wire page. Covers what a reader needs in the order they need it:

- starting the server and connecting
- picking a model over the gRPC call header
- authenticating with an API key
- what OBSQL accepts, and **what it refuses and why**
- prepared statements, parameters, and rebinding
- the catalog forms BI tools send, and which predicates apply
- how types follow the model rather than the engine

The refusals get as much space as the features. `SELECT *` is declined because a model has no `*` - which columns a semantic layer returns is a governance decision, not a shorthand - and a refusal arrives as an exception rather than zero rows, so a client can tell *nothing matched* from *not allowed*.

## Every sample is asserted

`tests/integration/test_adbc_docs_claims.py` runs the page against a real ADBC client and a real Flight server:

| Documented | Asserted |
|---|---|
| the connect recipe | returns rows with the named columns |
| call-header model selection | connects and queries |
| the OBSQL and raw-column statements | both, including `Orders.Amount` |
| `SELECT *` and unknown-relation refusals | raise rather than return empty |
| the prepared-statement block | including the `$1: string` it prints |
| the two catalog statements | project and filter as shown |
| `SHOW TABLES` / `DESCRIBE` | answer non-empty |
| an unsupported catalog predicate | leaves the query working, as the page says |

Verified to have teeth by changing the documented parameter name to something wrong - the test fails.

A documented recipe that does not run is worse than no page, because it costs the reader the time to find out. This way the page cannot drift without the suite going red.

## Limitations listed, and checked rather than recalled

No `GetStatistics` (confirmed: the command constant does not exist), `CommandGetXdbcTypeInfo` streaming a single `info: utf8` column, no parameter sets, no `ORDER BY`/`LIMIT` on catalog views, and the ADBC autocommit warning being expected on a read-only surface.

## Verification

ADBC conformance **53 -> 65 passed** (12 new doc-claim tests). Full suite 5134 passed. `ruff`, `mypy` and `mkdocs build --strict` clean.