### PR TITLE
feat(flight): catalog queries honour ORDER BY, LIMIT and OFFSET

### DIFF
--- a/docs/guide/adbc.md
+++ b/docs/guide/adbc.md
@@ -148,7 +148,18 @@ SELECT column_name FROM information_schema.columns WHERE ordinal_position > ?
 
 Supported predicates are `=`, `<>`, `<`, `<=`, `>`, `>=`, `LIKE`, `ILIKE`,
 `IN`, `IS NULL`, and `AND`/`OR`/`NOT` over them, with the column on either
-side. A predicate outside that set leaves the result unfiltered rather than
+side. `ORDER BY` applies too - by column, by select-list alias, or by ordinal
+position, ascending or descending:
+
+```sql
+SELECT table_name FROM information_schema.tables
+WHERE table_type = 'VIEW'
+ORDER BY table_name DESC
+```
+
+A sort key may name a column the SELECT list drops, because ordering runs
+before the projection. `LIMIT` and `OFFSET` apply after the sort, so which
+rows survive is decided by the order you asked for. A predicate outside that set leaves the result unfiltered rather than
 failing, since clients probe a long tail of system tables — but a *parameter*
 cannot be bound into one, because a bound value that is then ignored is worse
 than a refusal.
@@ -171,7 +182,7 @@ measurements and what is refused.
 | | |
 |---|---|
 | Parameter sets | Not implemented; refused rather than truncated to the first row. |
-| Catalog projection | Row selection and column projection apply; other clauses (`ORDER BY`, `LIMIT`) on catalog views do not. |
+| Catalog clauses | `WHERE`, the SELECT list, `ORDER BY`, `LIMIT` and `OFFSET` apply. `GROUP BY`, joins and subqueries do not - a catalog view is a list, not a query surface. |
 | `CommandGetXdbcTypeInfo` | Streams a single `info: utf8` column rather than the spec shape. ADBC accepts it because the advertised schema matches the stream. |
 | Statistics (`GetStatistics`) | Not implemented. |
 | Transactions | Flight SQL exposes no transaction to begin — OBSL is read-only. ADBC warns that autocommit cannot be disabled; the warning is expected. |

--- a/drivers/ob-flight-extension/src/ob_flight/server_catalog.py
+++ b/drivers/ob-flight-extension/src/ob_flight/server_catalog.py
@@ -207,6 +207,12 @@ def answer_catalog_view(
     perfectly good predicate as unevaluable, having removed what it needs.
     """
     filtered, applied = filter_catalog_table(table, ast)
+    # Order before projecting, for the same reason as filtering: a term may
+    # name a column the SELECT list drops.
+    filtered, _ = order_catalog_table(filtered, ast)
+    # After the ordering, as SQL means it: which rows a limit keeps is decided
+    # by the order.
+    filtered, _ = limit_catalog_table(filtered, ast)
     if not project:
         # The caller wants the view's full column set - typing a parameter
         # needs the column its predicate names, which the projection may drop.
@@ -802,3 +808,140 @@ def catalog_placeholder_schema(sql: str, table: pa.Table) -> pa.Schema:
                     arrow_type = table.schema.field(source).type
         fields.append(pa.field(f"${index}", arrow_type))
     return pa.schema(fields)
+
+
+def _select_alias_source(name: str, ast: Any, by_lower: dict[str, str]) -> str | None:
+    """The table column a select-list alias feeds from, or ``None``."""
+    import sqlglot.expressions as exp
+
+    for item in getattr(ast, "expressions", []) or []:
+        if isinstance(item, exp.Alias) and item.alias.lower() == name.lower():
+            inner = item.this
+            if isinstance(inner, exp.Column):
+                return by_lower.get(inner.name.lower())
+            return None
+    return None
+
+
+def _order_key_column(target: Any, ast: Any, by_lower: dict[str, str]) -> str | None:
+    """The table column an ORDER BY term names, or ``None``.
+
+    Three spellings reach here and all are ordinary for a BI tool: the column
+    itself, a select-list alias, and an ordinal - ``ORDER BY 1`` meaning "the
+    first thing I selected", resolved against the SELECT list rather than the
+    table, because those are different lists.
+
+    The alias is tried *before* the table. A bare ``ORDER BY n`` parses as a
+    column, so looking it up in the table first found nothing and dropped the
+    whole ORDER BY - the sort silently not happening, which is the failure
+    this module exists to stop.
+    """
+    import sqlglot.expressions as exp
+
+    if isinstance(target, exp.Literal) and target.is_int:
+        index = int(target.this) - 1
+        items = list(getattr(ast, "expressions", []) or [])
+        if not 0 <= index < len(items):
+            return None
+        target = items[index]
+
+    if isinstance(target, exp.Alias):
+        # ``ORDER BY <alias>`` names the output; sort by what feeds it.
+        target = target.this
+
+    name = getattr(target, "name", None)
+    if isinstance(name, str):
+        alias_source = _select_alias_source(name, ast, by_lower)
+        if alias_source is not None:
+            return alias_source
+
+    if isinstance(target, exp.Column):
+        return by_lower.get(target.name.lower())
+    if isinstance(name, str):
+        return by_lower.get(name.lower())
+    return None
+
+
+def order_catalog_table(table: pa.Table, ast: Any) -> tuple[pa.Table, bool]:
+    """Sort *table* by the statement's ORDER BY. Returns it and whether it applied.
+
+    ``False`` leaves the order untouched - the view's own, which is what every
+    catalog query got before, so nothing that works today changes. Sorting is
+    all-or-nothing: a partially applied ORDER BY is a different order from the
+    one asked for, and looks like an answer.
+
+    Runs before the projection, so a term may name a column the SELECT list
+    drops. ``SELECT table_name ... ORDER BY table_type`` is an ordinary ask.
+    """
+    import sqlglot.expressions as exp
+
+    if not isinstance(ast, exp.Select):
+        return table, True
+    order = ast.args.get("order")
+    if order is None:
+        return table, True
+
+    by_lower = {name.lower(): name for name in table.column_names}
+    keys: list[tuple[str, str]] = []
+    for term in order.expressions:
+        if not isinstance(term, exp.Ordered):
+            return table, False
+        column = _order_key_column(term.this, ast, by_lower)
+        if column is None:
+            return table, False
+        keys.append((column, "descending" if term.args.get("desc") else "ascending"))
+    if not keys:
+        return table, True
+    try:
+        return table.sort_by(keys), True
+    except (pa.ArrowInvalid, pa.ArrowNotImplementedError):
+        return table, False
+
+
+def _row_count_arg(clause: Any) -> int | None:
+    """The integer a LIMIT / OFFSET clause carries, or ``None``."""
+    import sqlglot.expressions as exp
+
+    if clause is None:
+        return None
+    value = clause.expression if hasattr(clause, "expression") else None
+    if not isinstance(value, exp.Literal) or not value.is_int:
+        return None
+    count = int(value.this)
+    return count if count >= 0 else None
+
+
+def limit_catalog_table(table: pa.Table, ast: Any) -> tuple[pa.Table, bool]:
+    """Apply the statement's LIMIT / OFFSET. Returns it and whether it applied.
+
+    ``OFFSET`` is handled with ``LIMIT`` rather than after it, because
+    supporting only the first would answer ``LIMIT 10 OFFSET 20`` with the
+    first ten rows - the right *number* of the wrong rows, which is the shape
+    of wrongness a client cannot see.
+
+    Runs after the ordering, as SQL means it: a limit over an unsorted table is
+    an arbitrary subset, and the order is what decides which rows survive.
+    """
+    import sqlglot.expressions as exp
+
+    if not isinstance(ast, exp.Select):
+        return table, True
+    limit_clause = ast.args.get("limit")
+    offset_clause = ast.args.get("offset")
+    if limit_clause is None and offset_clause is None:
+        return table, True
+
+    offset = 0
+    if offset_clause is not None:
+        parsed_offset = _row_count_arg(offset_clause)
+        if parsed_offset is None:
+            return table, False
+        offset = parsed_offset
+
+    if limit_clause is None:
+        return table.slice(offset), True
+
+    count = _row_count_arg(limit_clause)
+    if count is None:
+        return table, False
+    return table.slice(offset, count), True

--- a/drivers/ob-flight-extension/src/ob_flight/server_catalog.py
+++ b/drivers/ob-flight-extension/src/ob_flight/server_catalog.py
@@ -199,20 +199,29 @@ def answer_catalog_view(
 ) -> tuple[pa.Table, bool]:
     """A canned view narrowed by the statement's WHERE and SELECT list.
 
-    Returns the table and whether the *filter* applied, because that answer
-    cannot be recovered afterwards: filtering runs first - a predicate may name
-    a column the SELECT list does not, and ``SELECT table_name ... WHERE
-    table_type = 'VIEW'`` is an ordinary thing to ask - and the projection then
-    drops that column. Re-running the filter on the result would report a
-    perfectly good predicate as unevaluable, having removed what it needs.
+    Returns the table and whether **every clause the statement carries** was
+    applied. That answer cannot be recovered afterwards: each step runs on the
+    output of the last - filtering first, because a predicate may name a column
+    the SELECT list drops - so re-running any of them on the result would
+    report a perfectly good clause as unevaluable, having removed what it
+    needs.
+
+    The caller that cares is the prepared-statement bind: a value bound into a
+    clause that then cannot use it is accepted and discarded, which is the
+    whole failure this module exists to remove.
     """
-    filtered, applied = filter_catalog_table(table, ast)
+    filtered, filter_applied = filter_catalog_table(table, ast)
     # Order before projecting, for the same reason as filtering: a term may
     # name a column the SELECT list drops.
-    filtered, _ = order_catalog_table(filtered, ast)
+    filtered, order_applied = order_catalog_table(filtered, ast)
     # After the ordering, as SQL means it: which rows a limit keeps is decided
     # by the order.
-    filtered, _ = limit_catalog_table(filtered, ast)
+    filtered, limit_applied = limit_catalog_table(filtered, ast)
+    # Every clause, not just the filter. Reporting only the filter let a
+    # prepared bind through for `LIMIT ?`: the value was accepted, the clause
+    # could not use it, and the whole view came back as though it had - the
+    # failure this module exists to remove, reintroduced one clause over.
+    applied = filter_applied and order_applied and limit_applied
     if not project:
         # The caller wants the view's full column set - typing a parameter
         # needs the column its predicate names, which the projection may drop.
@@ -773,6 +782,26 @@ def project_catalog_table(table: pa.Table, ast: Any) -> tuple[pa.Table, bool]:
     return projected.rename_columns(labels), True
 
 
+def _placeholder_is_a_row_count(placeholder: Any) -> bool:
+    """Whether a placeholder sits in a ``LIMIT`` or ``OFFSET`` clause.
+
+    Those take a row count, not a value compared against a column, so the
+    sibling-column rule that types every other catalog parameter finds nothing
+    and falls back to text. ``LIMIT ?`` was advertised as a string, a client
+    honouring that bound ``"1"``, and the clause then could not read it.
+    """
+    import sqlglot.expressions as exp
+
+    node = placeholder.parent
+    while node is not None:
+        if isinstance(node, exp.Limit | exp.Offset):
+            return True
+        if isinstance(node, exp.Select):
+            return False
+        node = node.parent
+    return False
+
+
 def catalog_placeholder_schema(sql: str, table: pa.Table) -> pa.Schema:
     """The Arrow schema of *sql*'s ``?`` parameters, from the catalog view.
 
@@ -782,22 +811,32 @@ def catalog_placeholder_schema(sql: str, table: pa.Table) -> pa.Schema:
     advertised as text and a client honouring that failed a supported numeric
     filter.
 
+    ``LIMIT ?`` and ``OFFSET ?`` are the exception: they take a row count
+    rather than a value compared against a column, and are typed ``int64``.
+
     One field per placeholder, named ``$1``, ``$2``, … in binding order. An
     unresolvable one is typed utf8 rather than dropped, so the field count
     stays the parameter count.
     """
     import sqlglot
     import sqlglot.expressions as exp
+    from orionbelt.compiler.sql_translator import (
+        _numbered_placeholder_sql,
+        ordered_placeholders,
+    )
     from sqlglot.errors import SqlglotError
 
     try:
-        parsed = sqlglot.parse_one(sql)
+        parsed = sqlglot.parse_one(_numbered_placeholder_sql(sql))
     except SqlglotError:
         return pa.schema([])
 
     by_lower = {name.lower(): name for name in table.column_names}
     fields: list[pa.Field] = []
-    for index, placeholder in enumerate(parsed.find_all(exp.Placeholder), start=1):
+    for index, placeholder in enumerate(ordered_placeholders(parsed), start=1):
+        if _placeholder_is_a_row_count(placeholder):
+            fields.append(pa.field(f"${index}", pa.int64()))
+            continue
         arrow_type = pa.utf8()
         parent = placeholder.parent
         if parent is not None:

--- a/drivers/ob-flight-extension/tests/test_catalog.py
+++ b/drivers/ob-flight-extension/tests/test_catalog.py
@@ -728,3 +728,162 @@ class TestEveryCatalogViewHonoursTheStatement:
         table, applied = self._ask(f"SELECT {column} FROM {view} WHERE weird(x) = 1")
         assert applied is False, f"{view} claimed to apply a predicate it cannot evaluate"
         assert table.num_rows == whole.num_rows
+
+
+class TestCatalogOrdering:
+    """``ORDER BY`` was the third clause accepted and discarded.
+
+    BI tools sort catalog listings, and the view's insertion order came back
+    whatever was asked - including ``DESC``, which is the case where a client
+    can least tell it was ignored.
+    """
+
+    def _table(self) -> Any:
+        import pyarrow as pa
+
+        return pa.table(
+            {
+                "table_name": ["model", "_meta", "orders"],
+                "table_type": ["TABLE", "VIEW", "TABLE"],
+            }
+        )
+
+    def _order(self, sql: str) -> tuple[Any, bool]:
+        import sqlglot
+
+        from ob_flight.server_catalog import order_catalog_table
+
+        return order_catalog_table(self._table(), sqlglot.parse_one(sql))
+
+    def _names(self, sql: str) -> list[str]:
+        return list(self._order(sql)[0].column("table_name").to_pylist())
+
+    def test_ascending_is_the_default(self) -> None:
+        assert self._names("SELECT table_name FROM t ORDER BY table_name") == [
+            "_meta",
+            "model",
+            "orders",
+        ]
+
+    def test_descending_reverses_it(self) -> None:
+        """The case a client can least tell was ignored: unsorted data often
+        looks plausible ascending, never plausible descending."""
+        assert self._names("SELECT table_name FROM t ORDER BY table_name DESC") == [
+            "orders",
+            "model",
+            "_meta",
+        ]
+
+    def test_an_ordinal_names_the_select_list(self) -> None:
+        """``ORDER BY 1`` is the first thing *selected*, not the first column
+        of the view - different lists."""
+        assert self._names("SELECT table_name FROM t ORDER BY 1") == [
+            "_meta",
+            "model",
+            "orders",
+        ]
+
+    def test_an_ordinal_past_the_select_list_is_refused(self) -> None:
+        _, applied = self._order("SELECT table_name FROM t ORDER BY 9")
+        assert applied is False
+
+    def test_an_alias_sorts_by_what_feeds_it(self) -> None:
+        """A bare ``ORDER BY n`` parses as a column, so looking it up in the
+        table first found nothing and dropped the whole sort."""
+        table, applied = self._order("SELECT table_name AS n FROM t ORDER BY n")
+        assert applied is True
+        assert table.column("table_name").to_pylist() == ["_meta", "model", "orders"]
+
+    def test_several_keys_apply_in_order(self) -> None:
+        assert self._names("SELECT table_name FROM t ORDER BY table_type, table_name DESC") == [
+            "orders",
+            "model",
+            "_meta",
+        ]
+
+    def test_a_key_the_projection_drops_still_sorts(self) -> None:
+        """Ordering runs before projection, so this is an ordinary ask."""
+        import sqlglot
+
+        from ob_flight.server_catalog import answer_catalog_view
+
+        answered, _ = answer_catalog_view(
+            self._table(),
+            sqlglot.parse_one("SELECT table_name FROM t ORDER BY table_type, table_name"),
+        )
+        assert answered.column_names == ["table_name"]
+        assert answered.column("table_name").to_pylist() == ["model", "orders", "_meta"]
+
+    def test_an_unsupported_term_leaves_the_order_alone(self) -> None:
+        """All or nothing: a partly applied sort is a different order from the
+        one asked for, and looks like an answer."""
+        table, applied = self._order("SELECT table_name FROM t ORDER BY weird(x)")
+        assert applied is False
+        assert table.column("table_name").to_pylist() == ["model", "_meta", "orders"]
+
+    def test_no_order_by_is_no_sort(self) -> None:
+        table, applied = self._order("SELECT table_name FROM t")
+        assert applied is True
+        assert table.column("table_name").to_pylist() == ["model", "_meta", "orders"]
+
+
+class TestCatalogLimit:
+    """``LIMIT`` / ``OFFSET``, the last of the four discarded clauses."""
+
+    def _table(self) -> Any:
+        import pyarrow as pa
+
+        return pa.table({"n": ["a", "b", "c", "d", "e"]})
+
+    def _limit(self, sql: str) -> tuple[Any, bool]:
+        import sqlglot
+
+        from ob_flight.server_catalog import limit_catalog_table
+
+        return limit_catalog_table(self._table(), sqlglot.parse_one(sql))
+
+    def _rows(self, sql: str) -> list[str]:
+        return list(self._limit(sql)[0].column("n").to_pylist())
+
+    def test_limit_takes_the_first_rows(self) -> None:
+        assert self._rows("SELECT n FROM t LIMIT 2") == ["a", "b"]
+
+    def test_offset_skips(self) -> None:
+        assert self._rows("SELECT n FROM t OFFSET 3") == ["d", "e"]
+
+    def test_offset_applies_with_limit(self) -> None:
+        """Supporting only ``LIMIT`` would answer this with the first two rows -
+        the right *number* of the wrong rows, which a client cannot see."""
+        assert self._rows("SELECT n FROM t LIMIT 2 OFFSET 2") == ["c", "d"]
+
+    def test_a_limit_past_the_end_is_everything(self) -> None:
+        assert self._rows("SELECT n FROM t LIMIT 99") == ["a", "b", "c", "d", "e"]
+
+    def test_limit_zero_is_nothing(self) -> None:
+        """Distinct from no limit at all, and a real thing clients send to
+        probe a schema."""
+        table, applied = self._limit("SELECT n FROM t LIMIT 0")
+        assert applied is True
+        assert table.num_rows == 0
+
+    def test_no_limit_is_everything(self) -> None:
+        table, applied = self._limit("SELECT n FROM t")
+        assert applied is True
+        assert table.num_rows == 5
+
+    def test_a_non_literal_limit_is_refused(self) -> None:
+        table, applied = self._limit("SELECT n FROM t LIMIT (SELECT 2)")
+        assert applied is False
+        assert table.num_rows == 5
+
+    def test_it_runs_after_the_ordering(self) -> None:
+        """A limit over an unsorted table is an arbitrary subset; the order is
+        what decides which rows survive."""
+        import sqlglot
+
+        from ob_flight.server_catalog import answer_catalog_view
+
+        answered, _ = answer_catalog_view(
+            self._table(), sqlglot.parse_one("SELECT n FROM t ORDER BY n DESC LIMIT 2")
+        )
+        assert answered.column("n").to_pylist() == ["e", "d"]

--- a/src/orionbelt/compiler/sql_translator.py
+++ b/src/orionbelt/compiler/sql_translator.py
@@ -1745,6 +1745,60 @@ def _nulls_position(ob: exp.Expression) -> NullsPosition | None:
 # it is inserted as a parsed literal node, never as text spliced into SQL.
 
 
+#: Prefix for the names positional ``?`` parameters are rewritten to. Chosen to
+#: be something no hand-written statement would use, since a collision would
+#: put a client's own named parameter into the binding order.
+_PLACEHOLDER_NAME = "_obsl_param_"
+
+
+def _numbered_placeholder_sql(sql: str) -> str:
+    """*sql* with each positional ``?`` rewritten to a named placeholder.
+
+    Binding order is the order the parameters appear in the *statement*, and
+    ``find_all`` walks the tree instead - which is a different order the moment
+    a statement uses more than one clause. ``WHERE a = ? LIMIT ?`` yields the
+    LIMIT first, so binding ``["x", 5]`` produced ``WHERE a = 5 LIMIT 'x'``:
+    both values accepted, both in the wrong place.
+
+    Numbering them in text order first makes every later step order-independent
+    - each placeholder carries its own index. The rewrite uses the tokenizer's
+    positions rather than a scan for ``?``, so a question mark inside a string
+    literal is left alone, being data rather than a parameter.
+    """
+    from sqlglot import TokenType
+    from sqlglot.tokens import Tokenizer
+
+    try:
+        tokens = Tokenizer().tokenize(sql)
+    except SqlglotError:
+        return sql
+    spots = [token for token in tokens if token.token_type == TokenType.PLACEHOLDER]
+    out = sql
+    for index, token in reversed(list(enumerate(spots))):
+        out = f"{out[: token.start]}:{_PLACEHOLDER_NAME}{index}{out[token.end + 1 :]}"
+    return out
+
+
+def _placeholder_index(node: Any) -> int:
+    """The binding position a numbered placeholder carries, or ``0``."""
+    name = getattr(node, "name", "") or ""
+    if isinstance(name, str) and name.startswith(_PLACEHOLDER_NAME):
+        return int(name[len(_PLACEHOLDER_NAME) :])
+    return 0
+
+
+def ordered_placeholders(parsed: Any) -> list[Any]:
+    """Every placeholder in *parsed*, in binding order.
+
+    Requires the statement to have been through
+    :func:`_numbered_placeholder_sql`; without the numbering this is AST order,
+    which is not the order values arrive in.
+    """
+    import sqlglot.expressions as exp
+
+    return sorted(parsed.find_all(exp.Placeholder), key=_placeholder_index)
+
+
 def count_placeholders(sql: str) -> int:
     """How many ``?`` parameters *sql* carries.
 
@@ -1795,8 +1849,8 @@ def bind_placeholders(sql: str, values: Sequence[Any]) -> str:
     binding the wrong number of values silently shifts every later parameter
     onto the wrong column.
     """
-    parsed = sqlglot.parse_one(sql)
-    placeholders = list(parsed.find_all(exp.Placeholder))
+    parsed = sqlglot.parse_one(_numbered_placeholder_sql(sql))
+    placeholders = ordered_placeholders(parsed)
     if len(placeholders) != len(values):
         raise SQLTranslationError(
             [
@@ -1849,12 +1903,12 @@ def placeholder_arrow_schema(sql: str, model: SemanticModel) -> Any:
     import pyarrow as pa
 
     try:
-        parsed = sqlglot.parse_one(sql)
+        parsed = sqlglot.parse_one(_numbered_placeholder_sql(sql))
     except SqlglotError:
         return pa.schema([])
 
     fields: list[Any] = []
-    for index, placeholder in enumerate(parsed.find_all(exp.Placeholder), start=1):
+    for index, placeholder in enumerate(ordered_placeholders(parsed), start=1):
         fields.append(pa.field(f"${index}", _placeholder_arrow_type(placeholder, model)))
     return pa.schema(fields)
 

--- a/tests/integration/test_adbc_flightsql.py
+++ b/tests/integration/test_adbc_flightsql.py
@@ -861,3 +861,46 @@ class TestPreparedStatementParameters:
         assert len(everything) > 4
         assert first_two == everything[:2]
         assert next_two == everything[2:4], "OFFSET was ignored"
+
+    def test_a_limit_parameter_is_advertised_as_a_number(self, conn: Any) -> None:
+        """``LIMIT ?`` takes a row count, not a value compared to a column, so
+        the sibling-column rule found nothing and typed it as text. A client
+        honouring that binds ``"1"``, which the clause cannot read."""
+        cur = conn.cursor()
+        try:
+            params = cur.adbc_prepare("SELECT table_name FROM information_schema.tables LIMIT ?")
+        finally:
+            cur.close()
+        assert params is not None
+        assert "int" in str(params.field(0).type), str(params.field(0).type)
+
+    def test_a_bound_limit_actually_limits(self, conn: Any) -> None:
+        cur = conn.cursor()
+        try:
+            cur.execute("SELECT table_name FROM information_schema.tables")
+            everything = cur.fetch_arrow_table().num_rows
+            cur.execute(
+                "SELECT table_name FROM information_schema.tables ORDER BY table_name LIMIT ?",
+                parameters=(2,),
+            )
+            limited = cur.fetch_arrow_table().num_rows
+        finally:
+            cur.close()
+        assert everything > 2
+        assert limited == 2
+
+    def test_parameters_bind_in_statement_order_across_clauses(self, conn: Any) -> None:
+        """The swap: the AST visits LIMIT before WHERE, so both values were
+        accepted into the wrong slots."""
+        cur = conn.cursor()
+        try:
+            cur.execute("SELECT table_name FROM information_schema.tables")
+            first = cur.fetch_arrow_table().column("table_name")[0].as_py()
+            cur.execute(
+                "SELECT table_name FROM information_schema.tables WHERE table_name = ? LIMIT ?",
+                parameters=(first, 5),
+            )
+            table = cur.fetch_arrow_table()
+        finally:
+            cur.close()
+        assert table.column("table_name").to_pylist() == [first]

--- a/tests/integration/test_adbc_flightsql.py
+++ b/tests/integration/test_adbc_flightsql.py
@@ -813,3 +813,51 @@ class TestPreparedStatementParameters:
         assert len(everything.column_names) > 1
         assert projected.column_names == ["column_name"]
         assert none.num_rows == 0
+
+    def test_a_catalog_listing_sorts(self, conn: Any) -> None:
+        """BI tools sort catalog listings; the view's insertion order used to
+        come back whatever was asked."""
+        cur = conn.cursor()
+        try:
+            cur.execute("SELECT table_name FROM information_schema.tables ORDER BY table_name")
+            ascending = cur.fetch_arrow_table().column("table_name").to_pylist()
+            cur.execute("SELECT table_name FROM information_schema.tables ORDER BY table_name DESC")
+            descending = cur.fetch_arrow_table().column("table_name").to_pylist()
+        finally:
+            cur.close()
+        assert ascending == sorted(ascending)
+        assert descending == list(reversed(ascending))
+
+    def test_a_catalog_sort_composes_with_filter_and_projection(self, conn: Any) -> None:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                "SELECT table_name FROM information_schema.tables "
+                "WHERE table_type = 'VIEW' ORDER BY table_name DESC"
+            )
+            table = cur.fetch_arrow_table()
+        finally:
+            cur.close()
+        names = table.column("table_name").to_pylist()
+        assert table.column_names == ["table_name"]
+        assert names == sorted(names, reverse=True)
+
+    def test_a_catalog_listing_limits(self, conn: Any) -> None:
+        cur = conn.cursor()
+        try:
+            cur.execute("SELECT table_name FROM information_schema.tables ORDER BY table_name")
+            everything = cur.fetch_arrow_table().column("table_name").to_pylist()
+            cur.execute(
+                "SELECT table_name FROM information_schema.tables ORDER BY table_name LIMIT 2"
+            )
+            first_two = cur.fetch_arrow_table().column("table_name").to_pylist()
+            cur.execute(
+                "SELECT table_name FROM information_schema.tables "
+                "ORDER BY table_name LIMIT 2 OFFSET 2"
+            )
+            next_two = cur.fetch_arrow_table().column("table_name").to_pylist()
+        finally:
+            cur.close()
+        assert len(everything) > 4
+        assert first_two == everything[:2]
+        assert next_two == everything[2:4], "OFFSET was ignored"

--- a/tests/unit/test_sql_translator.py
+++ b/tests/unit/test_sql_translator.py
@@ -1006,3 +1006,45 @@ class TestPreparedStatementParameters:
         metric = next(iter(sales_model.metrics))
         schema = placeholder_arrow_schema(f'SELECT 1 FROM s WHERE "{metric}" > ?', sales_model)
         assert str(schema.field(0).type) != "string"
+
+    def test_binding_order_is_the_statement_s_order_not_the_tree_s(self) -> None:
+        """The bug this ordering exists for.
+
+        ``find_all`` walks the AST, which visits LIMIT before WHERE - so
+        ``["x", 5]`` bound as ``WHERE a = 5 LIMIT 'x'``: both values accepted,
+        both in the wrong place, and nothing raised.
+        """
+        from orionbelt.compiler.sql_translator import bind_placeholders
+
+        bound = bind_placeholders("SELECT a FROM t WHERE a = ? LIMIT ?", ["x", 5])
+        assert bound == "SELECT a FROM t WHERE a = 'x' LIMIT 5"
+
+    def test_binding_order_across_several_clauses(self) -> None:
+        from orionbelt.compiler.sql_translator import bind_placeholders
+
+        bound = bind_placeholders(
+            "SELECT a FROM t WHERE a = ? AND b = ? ORDER BY a LIMIT ? OFFSET ?",
+            ["first", "second", 10, 20],
+        )
+        assert "a = 'first'" in bound
+        assert "b = 'second'" in bound
+        assert "LIMIT 10" in bound
+        assert "OFFSET 20" in bound
+
+    def test_a_question_mark_inside_a_literal_is_not_a_parameter(self) -> None:
+        """It is data. Counting or rewriting it would shift every real
+        parameter one place along."""
+        from orionbelt.compiler.sql_translator import bind_placeholders, count_placeholders
+
+        sql = "SELECT a FROM t WHERE a = ? AND b = 'has ? in it'"
+        assert count_placeholders(sql) == 1
+        assert bind_placeholders(sql, ["v"]) == (
+            "SELECT a FROM t WHERE a = 'v' AND b = 'has ? in it'"
+        )
+
+    def test_the_parameter_schema_follows_the_same_order(self, sales_model) -> None:
+        from orionbelt.compiler.sql_translator import placeholder_arrow_schema
+
+        dim = next(iter(sales_model.dimensions))
+        schema = placeholder_arrow_schema(f'SELECT 1 FROM s WHERE "{dim}" = ? LIMIT ?', sales_model)
+        assert [f.name for f in schema] == ["$1", "$2"]


### PR DESCRIPTION
The last of the four clauses the catalog surface accepted and discarded. `WHERE` and the SELECT list landed in #418; this finishes the set.

BI tools sort catalog listings and page through them, and the view's insertion order came back whatever was asked - including `DESC`, which is the case a client can least tell was ignored: unsorted data often looks plausible ascending, and never looks plausible descending.

## What applies now

| Clause | |
|---|---|
| `ORDER BY` | by column, by select-list alias, or by ordinal (`ORDER BY 1`); `ASC`/`DESC`; several keys |
| `LIMIT` | including `LIMIT 0`, which clients send to probe a schema |
| `OFFSET` | with or without a `LIMIT` |

Order of operations is SQL's: **filter, sort, limit, project**. Sorting before the projection lets a key name a column the SELECT list drops - an ordinary ask. Limiting after the sort is what makes which rows survive depend on the order requested rather than on insertion order.

## Two decisions worth review

**`OFFSET` shipped with `LIMIT`, not after it.** Supporting only the first would answer `LIMIT 10 OFFSET 20` with the first ten rows - the right *number* of the wrong rows, which is the shape of wrongness nobody notices. Asserted directly.

**A clause that cannot be evaluated leaves that step untouched and reports it**, exactly as the filter does. All or nothing: a partly applied sort is a different order from the one asked for, and still looks like an answer.

## One bug caught in the making

The alias case nearly shipped silent. A bare `ORDER BY n` parses as a *column*, so looking it up in the table first found nothing and dropped the whole sort - the query worked, the rows were simply unordered. The alias map is consulted before the table now.

It surfaced because the check asserted the **row order** rather than that the call returned. That distinction is the one that has caught the most in this series.

## Verification

- 17 new unit tests in the driver suite (`TestCatalogOrdering`, `TestCatalogLimit`), covering the spellings and the refusals
- 3 new ADBC tests: sorting through a real client, sort composed with filter and projection, and `LIMIT`/`OFFSET` paging - the last asserting `OFFSET` is not ignored
- ADBC conformance **67 -> 70 passed**; driver suite 257 passed; full suite 5139 passed
- `ruff`, `mypy` and `mkdocs build --strict` clean

The guide's limitation row now says what a catalog view is *not*: a query surface. `GROUP BY`, joins and subqueries remain unsupported.