### PR TITLE
feat(flight): authenticate ADBC clients, which no mechanism could before

### DIFF
--- a/docs/guide/adbc.md
+++ b/docs/guide/adbc.md
@@ -85,6 +85,9 @@ directly, which is what a BI tool with a free-text header field can do.
 A wrong or absent key fails the call with `UNAUTHENTICATED`, naming the header
 to send — it never returns an empty result instead.
 
+Flight's older `Handshake` — where the key travels on the stream rather than in
+a header — keeps working alongside these, for clients that still speak it.
+
 ## What you can send
 
 The Flight surface takes **OBSQL** — `SELECT <dimension|measure> FROM <model>`,

--- a/docs/guide/adbc.md
+++ b/docs/guide/adbc.md
@@ -58,9 +58,17 @@ conn = dbapi.connect(
 
 ### Authenticating
 
-With `AUTH_MODE=api_key`, the Flight server validates the handshake credential
-against the same key store the REST surface uses. The key goes in as the
-Basic-auth password:
+With `AUTH_MODE=api_key`, the Flight server validates the credential against the
+same key store the REST surface uses. There is no account behind it — OBSL has
+keys, not users — so whatever a client sends as a username is ignored.
+
+Three ways to send the key, all equivalent:
+
+| How the client sends it | `db_kwargs` |
+|---|---|
+| Basic auth | `{"username": "obsl", "password": "<key>"}` |
+| `authorization` header | `{"adbc.flight.sql.authorization_header": "Bearer <key>"}` |
+| `x-api-key` call header | `{"adbc.flight.sql.rpc.call_header.x-api-key": "<key>"}` |
 
 ```python
 conn = dbapi.connect(
@@ -68,6 +76,14 @@ conn = dbapi.connect(
     db_kwargs={"username": "obsl", "password": "<your API key>"},
 )
 ```
+
+The first form is Flight SQL's `AuthenticateBasicToken`: the driver sends the key
+once, the server answers with the bearer token to use from then on, and the
+driver attaches it to every later call. The other two put the key on every call
+directly, which is what a BI tool with a free-text header field can do.
+
+A wrong or absent key fails the call with `UNAUTHENTICATED`, naming the header
+to send — it never returns an empty result instead.
 
 ## What you can send
 

--- a/drivers/ob-flight-extension/src/ob_flight/auth.py
+++ b/drivers/ob-flight-extension/src/ob_flight/auth.py
@@ -1,18 +1,26 @@
 """Authentication handlers for the Flight SQL server.
 
 When OBSL's shared auth subsystem is in ``api_key`` mode, the Flight server
-validates the handshake credential (the API key, sent as the Basic-auth
-password or handshake token) against the shared key store via
-:class:`SharedKeyAuthHandler`. The legacy ``FLIGHT_AUTH_MODE=token`` /
-``FLIGHT_API_TOKEN`` path still works for one release with a deprecation
-warning. See design/PLAN_authentication.md §3.2.
+validates the API key against the shared key store two ways, because clients
+differ on how they send it:
+
+* :class:`AuthMiddlewareFactory` reads it from the call headers. This is the
+  path every current client takes - see the long note below.
+* :class:`SharedKeyAuthHandler` answers Flight's legacy ``Handshake``, kept for
+  anything that still speaks it.
+
+The legacy ``FLIGHT_AUTH_MODE=token`` / ``FLIGHT_API_TOKEN`` path still works
+for one release with a deprecation warning. See design/PLAN_authentication.md
+§3.2.
 """
 
 from __future__ import annotations
 
+import base64
+import binascii
 import logging
 import os
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from typing import Any
 
 from pyarrow import flight
@@ -121,3 +129,126 @@ def create_auth_handler(
         )
         return TokenAuthHandler(token)
     return NoopAuthHandler()
+
+
+# ---------------------------------------------------------------------------
+# Header-based authentication (what ADBC actually speaks)
+# ---------------------------------------------------------------------------
+#
+# ``ServerAuthHandler`` implements Flight's *legacy* ``Handshake``. No current
+# client uses it: ADBC and pyarrow's own ``authenticate_basic_token`` both call
+# ``AuthenticateBasicToken``, the Flight SQL standard, which carries the
+# credential in an ``authorization`` header and expects the *response* to carry
+# the issued bearer token in one. A handshake handler can do neither - it reads
+# a stream that this RPC does not open, and writes to a stream the client does
+# not read - so with ``AUTH_MODE=api_key`` every ADBC connection failed with
+# "Stream is closed" whether the key was right or wrong.
+#
+# Middleware sees the headers on every call and can set them on the way out,
+# which is the whole protocol. Three spellings are accepted, and they are the
+# three a client actually sends:
+#
+#     authorization: Basic  <base64(user:key)>   ADBC username/password
+#     authorization: Bearer <key>                ADBC authorization_header
+#     x-api-key: <key>                           the header REST uses
+#
+# The username in the Basic form is ignored, as it was by the handshake
+# handler: OBSL has API keys, not accounts.
+
+AUTH_MIDDLEWARE_KEY = "obsl_auth"
+
+_BEARER_PREFIX = "bearer "
+_BASIC_PREFIX = "basic "
+
+
+def _credential_from_headers(headers: Mapping[str, Any]) -> str | None:
+    """The API key a call carries, in whichever of the three forms it used."""
+    lowered: dict[str, Any] = {str(k).lower(): v for k, v in headers.items()}
+
+    def first(name: str) -> str | None:
+        value = lowered.get(name)
+        if value is None:
+            return None
+        if isinstance(value, list | tuple):
+            value = value[0] if value else None
+        if value is None:
+            return None
+        return _decode_token(value)
+
+    api_key = first("x-api-key")
+    if api_key:
+        return api_key
+
+    authorization = first("authorization")
+    if not authorization:
+        return None
+    if authorization.lower().startswith(_BEARER_PREFIX):
+        return authorization[len(_BEARER_PREFIX) :].strip()
+    if authorization.lower().startswith(_BASIC_PREFIX):
+        encoded = authorization[len(_BASIC_PREFIX) :].strip()
+        # ADBC sends this unpadded, which ``b64decode`` rejects outright - so
+        # a correct key looked like no key at all, and the client was told to
+        # send one it had already sent. Padding is re-added rather than the
+        # error tolerated: an undecodable credential and an absent one deserve
+        # different answers.
+        encoded += "=" * (-len(encoded) % 4)
+        try:
+            decoded = base64.b64decode(encoded).decode("utf-8", errors="replace")
+        except (ValueError, binascii.Error):
+            return None
+        # ``user:key`` - the username is ignored; OBSL has keys, not accounts.
+        _, _, key = decoded.partition(":")
+        return key or None
+    return None
+
+
+class _AuthMiddleware(flight.ServerMiddleware):  # type: ignore[misc]
+    """Carries the issued bearer token back to the client."""
+
+    def __init__(self, token: str | None) -> None:
+        super().__init__()
+        self._token = token
+
+    def sending_headers(self) -> dict[str, str]:
+        if not self._token:
+            return {}
+        # ``AuthenticateBasicToken`` answers with the token to use from here
+        # on. Echoing the validated key keeps one secret rather than minting a
+        # second one with its own lifetime - the client already holds it, and
+        # `Bearer <key>` is a form this same middleware accepts.
+        return {"authorization": f"Bearer {self._token}"}
+
+
+class AuthMiddlewareFactory(flight.ServerMiddlewareFactory):  # type: ignore[misc]
+    """Reject any call that does not carry a valid API key.
+
+    Enforced per call rather than once per connection, because that is what
+    the protocol gives us: a Flight client may open several streams, and a
+    ticket issued to one caller must not be redeemable by another.
+    """
+
+    def __init__(self, validate_fn: Callable[[str], bool]) -> None:
+        super().__init__()
+        self._validate = validate_fn
+
+    def start_call(self, info: Any, headers: Mapping[str, Any]) -> Any:
+        credential = _credential_from_headers(headers)
+        if credential is None:
+            raise flight.FlightUnauthenticatedError(
+                "Missing API key. Send it as 'authorization: Bearer <key>', "
+                "'x-api-key: <key>', or the password of a Basic credential."
+            )
+        if not self._validate(credential):
+            raise flight.FlightUnauthenticatedError("Invalid API key")
+        return _AuthMiddleware(credential)
+
+
+def build_auth_middleware() -> dict[str, Any]:
+    """Header-auth middleware bound to OBSL's shared validator.
+
+    Called only in ``api_key`` mode; every other mode passes no middleware at
+    all, so an unauthenticated Flight surface does no per-call work.
+    """
+    from orionbelt.auth import validate_credential
+
+    return {AUTH_MIDDLEWARE_KEY: AuthMiddlewareFactory(validate_credential)}

--- a/drivers/ob-flight-extension/src/ob_flight/auth.py
+++ b/drivers/ob-flight-extension/src/ob_flight/auth.py
@@ -190,8 +190,30 @@ def _is_handshake(info: Any) -> bool:
         return False
 
 
+#: The headers a client puts a credential in. Offering one of these and no key
+#: is a different thing from offering nothing, and must not be read as silence.
+_CREDENTIAL_HEADERS = ("x-api-key", "authorization", _HANDSHAKE_TOKEN_HEADER)
+
+
+def _presents_a_credential(headers: Mapping[str, Any]) -> bool:
+    """Whether the call offered a credential at all, valid or not.
+
+    An ``authorization: Basic`` whose password is empty parses to no key, the
+    same as a call that sent no header - but the two mean opposite things. One
+    is a client that tried and has nothing; the other is a legacy client about
+    to send its key on the handshake stream. Only the second may pass.
+    """
+    lowered = {str(k).lower() for k in headers}
+    return any(name in lowered for name in _CREDENTIAL_HEADERS)
+
+
 def _credential_from_headers(headers: Mapping[str, Any]) -> str | None:
-    """The API key a call carries, in whichever of the three forms it used."""
+    """The API key a call carries, in whichever of the three forms it used.
+
+    ``None`` means no key could be read - which is not the same as no key
+    having been offered. Callers that care about the difference ask
+    :func:`_presents_a_credential`.
+    """
     lowered: dict[str, Any] = {str(k).lower(): v for k, v in headers.items()}
 
     def first(name: str) -> str | None:
@@ -220,7 +242,7 @@ def _credential_from_headers(headers: Mapping[str, Any]) -> str | None:
     if not authorization:
         return None
     if authorization.lower().startswith(_BEARER_PREFIX):
-        return authorization[len(_BEARER_PREFIX) :].strip()
+        return authorization[len(_BEARER_PREFIX) :].strip() or None
     if authorization.lower().startswith(_BASIC_PREFIX):
         encoded = authorization[len(_BASIC_PREFIX) :].strip()
         # ADBC sends this unpadded, which ``b64decode`` rejects outright - so
@@ -274,13 +296,23 @@ class AuthMiddlewareFactory(flight.ServerMiddlewareFactory):  # type: ignore[mis
     def start_call(self, info: Any, headers: Mapping[str, Any]) -> Any:
         credential = _credential_from_headers(headers)
         if credential is None:
+            if _presents_a_credential(headers):
+                # A credential header holding no key - an empty Basic password,
+                # a bare "Bearer", undecodable base64. The client offered
+                # something and it was not a key; saying so beats letting it
+                # through as though it had offered nothing.
+                raise flight.FlightUnauthenticatedError(
+                    "No API key in the credential header. Send it as "
+                    "'authorization: Bearer <key>', 'x-api-key: <key>', or the "
+                    "password of a Basic credential."
+                )
             if self._handshake_handler_installed and _is_handshake(info):
-                # A handshake carrying no header is the legacy protocol, where
-                # the key travels on the stream - so there is nothing to check
-                # here yet, and the ServerAuthHandler refuses it if it is
-                # wrong. Only this one credential-less call is let through: a
-                # handshake that *does* carry a header is AuthenticateBasicToken
-                # and is validated below like any other call.
+                # A handshake offering no credential at all is the legacy
+                # protocol, where the key travels on the stream - so there is
+                # nothing to check here yet, and the ServerAuthHandler refuses
+                # it if it is wrong. Only this one call is let through: a
+                # handshake that carries a credential header is
+                # AuthenticateBasicToken and is validated like any other call.
                 return None
             raise flight.FlightUnauthenticatedError(
                 "Missing API key. Send it as 'authorization: Bearer <key>', "

--- a/drivers/ob-flight-extension/src/ob_flight/auth.py
+++ b/drivers/ob-flight-extension/src/ob_flight/auth.py
@@ -76,32 +76,50 @@ class SharedKeyAuthHandler(flight.ServerAuthHandler):  # type: ignore[misc]
     session token, which ``is_valid`` re-checks on every subsequent call.
     """
 
-    def __init__(self, validate_fn: Callable[[str], bool]) -> None:
+    def __init__(
+        self, validate_fn: Callable[[str], bool], *, header_auth_installed: bool = False
+    ) -> None:
         super().__init__()
         self._validate = validate_fn
+        self._header_auth_installed = header_auth_installed
 
     def authenticate(self, outgoing: Any, incoming: Any) -> None:
-        token = incoming.read()
+        # Two protocols arrive here. The legacy Handshake puts the key on the
+        # stream. AuthenticateBasicToken - what every current client speaks -
+        # reuses the same RPC but puts the key in a header and sends nothing,
+        # so this read fails with "Stream is closed". That error was the whole
+        # symptom: it is not a broken client, it is a client speaking the
+        # newer of the two protocols this RPC carries.
+        try:
+            token = incoming.read()
+        except OSError:
+            token = b""
+        if not token:
+            if self._header_auth_installed:
+                # The middleware read the header, validated it, and will return
+                # the bearer token in the response. Nothing to do here.
+                return
+            raise flight.FlightUnauthenticatedError(
+                "No API key on the handshake stream. This server accepts the "
+                "legacy handshake only; enable api_key mode for header auth."
+            )
         if not self._validate(_decode_token(token)):
             raise flight.FlightUnauthenticatedError("Invalid API key")
         outgoing.write(token)
 
     def is_valid(self, token: bytes) -> str:
+        if not token and self._header_auth_installed:
+            # A client that authenticated by header never handshook, so there
+            # is no token here to check. Rejecting it would veto every current
+            # client - which is exactly what this server did. The middleware
+            # has already accepted or refused this call; say nothing and let
+            # its answer stand. Never reachable unless that middleware is
+            # installed: ``build_api_key_auth`` is the only way to set this,
+            # and it builds the pair together.
+            return ""
         if not self._validate(_decode_token(token)):
             raise flight.FlightUnauthenticatedError("Invalid API key")
         return "authenticated"
-
-
-def build_shared_key_handler() -> SharedKeyAuthHandler:
-    """Build a handler bound to OBSL's shared credential validator.
-
-    Imported lazily so this module stays importable when ``orionbelt`` is not
-    installed (standalone Flight use). In practice the Flight server runs
-    in-process with the OBSL API, so the import resolves.
-    """
-    from orionbelt.auth import validate_credential
-
-    return SharedKeyAuthHandler(validate_credential)
 
 
 def create_auth_handler(
@@ -160,6 +178,17 @@ AUTH_MIDDLEWARE_KEY = "obsl_auth"
 _BEARER_PREFIX = "bearer "
 _BASIC_PREFIX = "basic "
 
+#: Where pyarrow puts the token a legacy handshake issued.
+_HANDSHAKE_TOKEN_HEADER = "auth-token-bin"
+
+
+def _is_handshake(info: Any) -> bool:
+    """Whether this call is the Handshake RPC itself."""
+    try:
+        return bool(getattr(info, "method", None) == flight.FlightMethod.HANDSHAKE)
+    except AttributeError:  # pragma: no cover - older pyarrow without the enum
+        return False
+
 
 def _credential_from_headers(headers: Mapping[str, Any]) -> str | None:
     """The API key a call carries, in whichever of the three forms it used."""
@@ -178,6 +207,14 @@ def _credential_from_headers(headers: Mapping[str, Any]) -> str | None:
     api_key = first("x-api-key")
     if api_key:
         return api_key
+
+    # What a legacy handshake issues, sent on every call after it. The token
+    # is the key itself (``authenticate`` echoes it back), so it validates the
+    # same way - without this, a handshake would succeed and every call after
+    # it would be refused.
+    handshake_token = first(_HANDSHAKE_TOKEN_HEADER)
+    if handshake_token:
+        return handshake_token
 
     authorization = first("authorization")
     if not authorization:
@@ -227,13 +264,24 @@ class AuthMiddlewareFactory(flight.ServerMiddlewareFactory):  # type: ignore[mis
     ticket issued to one caller must not be redeemable by another.
     """
 
-    def __init__(self, validate_fn: Callable[[str], bool]) -> None:
+    def __init__(
+        self, validate_fn: Callable[[str], bool], *, handshake_handler_installed: bool = False
+    ) -> None:
         super().__init__()
         self._validate = validate_fn
+        self._handshake_handler_installed = handshake_handler_installed
 
     def start_call(self, info: Any, headers: Mapping[str, Any]) -> Any:
         credential = _credential_from_headers(headers)
         if credential is None:
+            if self._handshake_handler_installed and _is_handshake(info):
+                # A handshake carrying no header is the legacy protocol, where
+                # the key travels on the stream - so there is nothing to check
+                # here yet, and the ServerAuthHandler refuses it if it is
+                # wrong. Only this one credential-less call is let through: a
+                # handshake that *does* carry a header is AuthenticateBasicToken
+                # and is validated below like any other call.
+                return None
             raise flight.FlightUnauthenticatedError(
                 "Missing API key. Send it as 'authorization: Bearer <key>', "
                 "'x-api-key: <key>', or the password of a Basic credential."
@@ -243,12 +291,28 @@ class AuthMiddlewareFactory(flight.ServerMiddlewareFactory):  # type: ignore[mis
         return _AuthMiddleware(credential)
 
 
-def build_auth_middleware() -> dict[str, Any]:
-    """Header-auth middleware bound to OBSL's shared validator.
+def build_api_key_auth(
+    validate_fn: Callable[[str], bool] | None = None,
+) -> tuple[SharedKeyAuthHandler, dict[str, Any]]:
+    """The handler and middleware for ``api_key`` mode, built as one pair.
 
-    Called only in ``api_key`` mode; every other mode passes no middleware at
-    all, so an unauthenticated Flight surface does no per-call work.
+    They are returned together because neither is correct alone here. The
+    handler must not veto calls that carry no handshake token, and the
+    middleware must not refuse the Handshake RPC - each of those concessions
+    is safe only because the other half is installed to cover it. Handing back
+    a tuple is what stops the two from drifting apart in the caller, which is
+    how the production wiring came to refuse every client while the parts
+    passed their own tests.
     """
-    from orionbelt.auth import validate_credential
+    if validate_fn is None:
+        # Imported lazily so this module stays importable when ``orionbelt``
+        # is not installed (standalone Flight use).
+        from orionbelt.auth import validate_credential
 
-    return {AUTH_MIDDLEWARE_KEY: AuthMiddlewareFactory(validate_credential)}
+        validate_fn = validate_credential
+
+    handler = SharedKeyAuthHandler(validate_fn, header_auth_installed=True)
+    middleware = {
+        AUTH_MIDDLEWARE_KEY: AuthMiddlewareFactory(validate_fn, handshake_handler_installed=True)
+    }
+    return handler, middleware

--- a/drivers/ob-flight-extension/src/ob_flight/server.py
+++ b/drivers/ob-flight-extension/src/ob_flight/server.py
@@ -154,16 +154,23 @@ class OBFlightServer(flight.FlightServerBase):  # type: ignore[misc]
         location: str = "grpc://0.0.0.0:8815",
         *,
         auth_handler: flight.ServerAuthHandler | None = None,
+        auth_middleware: dict[str, Any] | None = None,
         session_manager: Any = None,
         default_dialect: str = "duckdb",
         batch_size: int = 1024,
         cache: Any = None,
         cache_config: Any = None,
     ) -> None:
+        # Header auth is middleware, not a ``ServerAuthHandler``: the standard
+        # ``AuthenticateBasicToken`` carries the credential in a header and
+        # expects the issued token back in one, and a handshake handler can do
+        # neither. See ``ob_flight.auth``.
+        middleware: dict[str, Any] = {_ROUTING_MIDDLEWARE_KEY: _SessionRoutingFactory()}
+        middleware.update(auth_middleware or {})
         super().__init__(
             location,
             auth_handler=auth_handler,
-            middleware={_ROUTING_MIDDLEWARE_KEY: _SessionRoutingFactory()},
+            middleware=middleware,
         )
         self._session_manager = session_manager
         self._default_dialect = default_dialect

--- a/drivers/ob-flight-extension/src/ob_flight/startup.py
+++ b/drivers/ob-flight-extension/src/ob_flight/startup.py
@@ -19,6 +19,7 @@ def start_flight_background(
     session_manager: Any = None,
     port: int | None = None,
     auth_handler: Any = None,
+    auth_middleware: Any = None,
     default_dialect: str | None = None,
     cache: Any = None,
     cache_config: Any = None,
@@ -52,6 +53,7 @@ def start_flight_background(
     _server = OBFlightServer(
         location,
         auth_handler=auth_handler,
+        auth_middleware=auth_middleware,
         session_manager=session_manager,
         default_dialect=default_dialect,
         cache=cache,

--- a/drivers/ob-flight-extension/tests/test_auth.py
+++ b/drivers/ob-flight-extension/tests/test_auth.py
@@ -9,11 +9,13 @@ import pytest
 from pyarrow import flight
 
 from ob_flight.auth import (
+    AUTH_MIDDLEWARE_KEY,
     AuthMiddlewareFactory,
     NoopAuthHandler,
     SharedKeyAuthHandler,
     TokenAuthHandler,
     _credential_from_headers,
+    build_api_key_auth,
     create_auth_handler,
 )
 
@@ -182,3 +184,63 @@ class TestAuthMiddlewareFactory:
         factory = AuthMiddlewareFactory(lambda key: key == "good-key")
         with pytest.raises(flight.FlightUnauthenticatedError):
             factory.start_call(MagicMock(), {})
+
+
+class TestTheHalvesAreStrictOnTheirOwn:
+    """Each half makes one concession, and only the pair makes it safe.
+
+    ``build_api_key_auth`` is the only thing that turns these on. Built alone -
+    which is what every other mode does - both must still refuse.
+    """
+
+    def test_a_handler_alone_refuses_a_call_that_never_handshook(self):
+        handler = SharedKeyAuthHandler(lambda key: key == "good-key")
+        with pytest.raises(flight.FlightUnauthenticatedError):
+            handler.is_valid(b"")
+
+    def test_a_handler_alone_refuses_an_empty_handshake_stream(self):
+        # Without middleware there is no header to have authenticated this.
+        incoming = MagicMock()
+        incoming.read.return_value = b""
+        handler = SharedKeyAuthHandler(lambda key: True)
+        with pytest.raises(flight.FlightUnauthenticatedError):
+            handler.authenticate(MagicMock(), incoming)
+
+    def test_middleware_alone_refuses_a_credential_less_handshake(self):
+        factory = AuthMiddlewareFactory(lambda key: True)
+        info = MagicMock()
+        info.method = flight.FlightMethod.HANDSHAKE
+        with pytest.raises(flight.FlightUnauthenticatedError):
+            factory.start_call(info, {})
+
+
+class TestTheApiKeyPair:
+    """What ``app.py`` installs. The halves are only correct together."""
+
+    def test_the_handler_defers_and_the_middleware_admits_the_handshake(self):
+        handler, middleware = build_api_key_auth(lambda key: key == "good-key")
+        # No token: the middleware has already ruled on this call.
+        assert handler.is_valid(b"") == ""
+        info = MagicMock()
+        info.method = flight.FlightMethod.HANDSHAKE
+        assert middleware[AUTH_MIDDLEWARE_KEY].start_call(info, {}) is None
+
+    def test_the_handshake_exemption_is_not_a_way_past_a_wrong_key(self):
+        """A handshake *carrying* a credential is AuthenticateBasicToken, and
+        is checked like any other call - the exemption covers only the legacy
+        protocol, where the key is still on the wire."""
+        _, middleware = build_api_key_auth(lambda key: key == "good-key")
+        info = MagicMock()
+        info.method = flight.FlightMethod.HANDSHAKE
+        with pytest.raises(flight.FlightUnauthenticatedError):
+            middleware[AUTH_MIDDLEWARE_KEY].start_call(info, {"x-api-key": "bad-key"})
+
+    def test_a_legacy_token_still_has_to_be_valid(self):
+        handler, _ = build_api_key_auth(lambda key: key == "good-key")
+        with pytest.raises(flight.FlightUnauthenticatedError):
+            handler.is_valid(b"bad-key")
+
+    def test_the_token_a_handshake_issued_is_accepted_on_later_calls(self):
+        """pyarrow sends it in its own header, not ``authorization`` - without
+        this the handshake would succeed and every call after it be refused."""
+        assert _credential_from_headers({"auth-token-bin": "the-key"}) == "the-key"

--- a/drivers/ob-flight-extension/tests/test_auth.py
+++ b/drivers/ob-flight-extension/tests/test_auth.py
@@ -15,9 +15,15 @@ from ob_flight.auth import (
     SharedKeyAuthHandler,
     TokenAuthHandler,
     _credential_from_headers,
+    _presents_a_credential,
     build_api_key_auth,
     create_auth_handler,
 )
+
+
+def _b64(raw: str) -> str:
+    """Base64 as a client sends it - unpadded, the way ADBC does."""
+    return base64.b64encode(raw.encode()).decode().rstrip("=")
 
 
 class TestNoopAuthHandler:
@@ -244,3 +250,42 @@ class TestTheApiKeyPair:
         """pyarrow sends it in its own header, not ``authorization`` - without
         this the handshake would succeed and every call after it be refused."""
         assert _credential_from_headers({"auth-token-bin": "the-key"}) == "the-key"
+
+
+class TestOfferingNoKeyIsNotTheSameAsOfferingNothing:
+    """A credential header holding no key must be refused, not read as silence.
+
+    The handshake exemption exists for legacy clients, which send no credential
+    header at all. A client that sent ``Basic dXNlcjo=`` - user, empty password
+    - has offered something, and it was not a key. Letting that take the
+    exemption answered it with a protocol error instead of UNAUTHENTICATED.
+    """
+
+    @pytest.mark.parametrize(
+        ("label", "headers"),
+        [
+            ("empty basic password", {"authorization": "Basic " + _b64("user:")}),
+            ("basic with no colon", {"authorization": "Basic " + _b64("nocolon")}),
+            ("undecodable basic", {"authorization": "Basic !!!"}),
+            ("bare bearer", {"authorization": "Bearer "}),
+            ("empty x-api-key", {"x-api-key": ""}),
+        ],
+    )
+    def test_it_is_refused_even_on_the_handshake(self, label: str, headers: dict) -> None:
+        _, middleware = build_api_key_auth(lambda key: True)
+        info = MagicMock()
+        info.method = flight.FlightMethod.HANDSHAKE
+        with pytest.raises(flight.FlightUnauthenticatedError, match="No API key"):
+            middleware[AUTH_MIDDLEWARE_KEY].start_call(info, headers)
+
+    def test_a_handshake_offering_nothing_still_passes(self) -> None:
+        """The exemption itself must survive: this is the legacy client."""
+        _, middleware = build_api_key_auth(lambda key: True)
+        info = MagicMock()
+        info.method = flight.FlightMethod.HANDSHAKE
+        assert middleware[AUTH_MIDDLEWARE_KEY].start_call(info, {"user-agent": "legacy"}) is None
+
+    def test_presenting_a_credential_is_about_the_header_not_its_value(self) -> None:
+        assert _presents_a_credential({"authorization": ""})
+        assert _presents_a_credential({"X-Api-Key": "anything"})
+        assert not _presents_a_credential({"user-agent": "adbc"})

--- a/drivers/ob-flight-extension/tests/test_auth.py
+++ b/drivers/ob-flight-extension/tests/test_auth.py
@@ -2,15 +2,18 @@
 
 from __future__ import annotations
 
+import base64
 from unittest.mock import MagicMock
 
 import pytest
 from pyarrow import flight
 
 from ob_flight.auth import (
+    AuthMiddlewareFactory,
     NoopAuthHandler,
     SharedKeyAuthHandler,
     TokenAuthHandler,
+    _credential_from_headers,
     create_auth_handler,
 )
 
@@ -102,3 +105,80 @@ class TestCreateAuthHandler:
         monkeypatch.delenv("FLIGHT_API_TOKEN", raising=False)
         with pytest.raises(ValueError, match="FLIGHT_API_TOKEN"):
             create_auth_handler()
+
+
+class TestCredentialFromHeaders:
+    """The decoder behind ``AuthenticateBasicToken``.
+
+    ``SharedKeyAuthHandler`` above answers Flight's *legacy* ``Handshake``.
+    Current clients use ``AuthenticateBasicToken`` instead, which puts the
+    credential in a call header - so this is the path a real ADBC connection
+    takes, and these are the shapes it arrives in.
+    """
+
+    @pytest.mark.parametrize(
+        ("key", "padding"),
+        [("k" * 34, 0), ("k" * 33, 1), ("k" * 35, 2)],
+        ids=["no-padding", "one-pad", "two-pads"],
+    )
+    def test_basic_is_accepted_without_its_padding(self, key: str, padding: int) -> None:
+        """ADBC sends the base64 unpadded and ``b64decode`` rejects that, so a
+        correct key looked like no key at all. All three residues are covered
+        because a key whose length happens to need no padding proves nothing.
+        """
+        raw = f"obsl:{key}".encode()
+        encoded = base64.b64encode(raw).decode()
+        assert encoded.count("=") == padding, "this case does not test what it claims"
+
+        assert _credential_from_headers({"authorization": f"Basic {encoded.rstrip('=')}"}) == key
+
+    def test_the_username_is_ignored(self):
+        # OBSL has keys, not accounts - whatever the client puts before the
+        # colon is not a subject we can authenticate.
+        encoded = base64.b64encode(b"anyone-at-all:the-key").decode()
+        assert _credential_from_headers({"authorization": f"Basic {encoded}"}) == "the-key"
+
+    def test_basic_without_a_colon_is_not_a_credential(self):
+        encoded = base64.b64encode(b"no-colon-here").decode()
+        assert _credential_from_headers({"authorization": f"Basic {encoded}"}) is None
+
+    def test_undecodable_basic_is_not_a_credential(self):
+        assert _credential_from_headers({"authorization": "Basic !!!not-base64!!!"}) is None
+
+    def test_bearer_is_taken_verbatim(self):
+        assert _credential_from_headers({"authorization": "Bearer the-key"}) == "the-key"
+
+    def test_the_scheme_is_matched_case_insensitively(self):
+        # gRPC lowercases header names; clients vary on the scheme itself.
+        assert _credential_from_headers({"authorization": "bearer the-key"}) == "the-key"
+
+    def test_x_api_key_is_read(self):
+        assert _credential_from_headers({"x-api-key": "the-key"}) == "the-key"
+
+    def test_header_values_may_arrive_as_lists(self):
+        # Flight hands middleware the gRPC metadata, where each name maps to
+        # every value sent under it.
+        assert _credential_from_headers({"x-api-key": ["the-key"]}) == "the-key"
+
+    def test_no_credential_at_all(self):
+        assert _credential_from_headers({"user-agent": ["adbc"]}) is None
+
+
+class TestAuthMiddlewareFactory:
+    def test_a_valid_key_passes_and_is_echoed_back(self):
+        factory = AuthMiddlewareFactory(lambda key: key == "good-key")
+        middleware = factory.start_call(MagicMock(), {"x-api-key": "good-key"})
+        # ``AuthenticateBasicToken`` expects the token to use from here on in
+        # the response headers; without this the client reports that it never
+        # got one, even though the key was right.
+        assert middleware.sending_headers() == {"authorization": "Bearer good-key"}
+
+    def test_a_wrong_key_is_refused(self):
+        factory = AuthMiddlewareFactory(lambda key: key == "good-key")
+        with pytest.raises(flight.FlightUnauthenticatedError):
+            factory.start_call(MagicMock(), {"x-api-key": "bad-key"})
+
+    def test_a_missing_key_is_refused(self):
+        factory = AuthMiddlewareFactory(lambda key: key == "good-key")
+        with pytest.raises(flight.FlightUnauthenticatedError):
+            factory.start_call(MagicMock(), {})

--- a/src/orionbelt/api/app.py
+++ b/src/orionbelt/api/app.py
@@ -396,16 +396,15 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
 
             flight_auth_middleware: dict[str, Any] = {}
             if get_mode() == MODE_API_KEY:
-                from ob_flight.auth import build_auth_middleware, build_shared_key_handler
+                from ob_flight.auth import build_api_key_auth
 
-                flight_auth_handler = build_shared_key_handler()
-                # The handler alone cannot authenticate an ADBC client: it
-                # implements Flight's legacy Handshake, and every current
-                # client uses the standard AuthenticateBasicToken, which
-                # carries the credential in a header. The middleware is what
-                # reads those. Both are installed - the handler keeps the
-                # legacy path working for anything that still speaks it.
-                flight_auth_middleware = build_auth_middleware()
+                # Built as a pair, and installed as a pair. The handler alone
+                # cannot authenticate a current client - it implements Flight's
+                # legacy Handshake, while ADBC uses AuthenticateBasicToken,
+                # which carries the credential in a header - and the middleware
+                # alone would refuse the legacy handshake. Each covers what the
+                # other cannot.
+                flight_auth_handler, flight_auth_middleware = build_api_key_auth()
             elif settings.flight_auth_mode == "token":
                 # Legacy static-token auth (deprecated). Fail CLOSED if the
                 # operator asked for token auth but did not supply a token -

--- a/src/orionbelt/api/app.py
+++ b/src/orionbelt/api/app.py
@@ -394,10 +394,18 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
             #   3. otherwise            -> no auth (NoopAuthHandler) + warning
             from orionbelt.auth import MODE_API_KEY, get_mode
 
+            flight_auth_middleware: dict[str, Any] = {}
             if get_mode() == MODE_API_KEY:
-                from ob_flight.auth import build_shared_key_handler
+                from ob_flight.auth import build_auth_middleware, build_shared_key_handler
 
                 flight_auth_handler = build_shared_key_handler()
+                # The handler alone cannot authenticate an ADBC client: it
+                # implements Flight's legacy Handshake, and every current
+                # client uses the standard AuthenticateBasicToken, which
+                # carries the credential in a header. The middleware is what
+                # reads those. Both are installed - the handler keeps the
+                # legacy path working for anything that still speaks it.
+                flight_auth_middleware = build_auth_middleware()
             elif settings.flight_auth_mode == "token":
                 # Legacy static-token auth (deprecated). Fail CLOSED if the
                 # operator asked for token auth but did not supply a token -
@@ -433,6 +441,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
                 session_manager=mgr,
                 port=settings.flight_port,
                 auth_handler=flight_auth_handler,
+                auth_middleware=flight_auth_middleware,
                 default_dialect=settings.db_vendor,
                 cache=cache,
                 cache_config=cache_config,

--- a/tests/integration/test_adbc_auth.py
+++ b/tests/integration/test_adbc_auth.py
@@ -318,3 +318,32 @@ class TestTheProductionWiring:
         finally:
             reset_session_manager()
             reset_auth()
+
+
+class TestAnEmptyCredentialIsRefusedAsOne:
+    """A client that offers a credential and no key gets UNAUTHENTICATED.
+
+    It used to take the legacy-handshake exemption - which exists for clients
+    that offer *nothing* - and so was answered with a protocol error the page
+    does not promise, rather than the refusal it does.
+    """
+
+    def test_an_empty_basic_password_is_refused(self, authenticated_uri: str) -> None:
+        with pytest.raises(Exception, match="(?i)unauth|no api key"):
+            _query(authenticated_uri, db_kwargs={"username": "obsl", "password": ""})
+
+    def test_pyarrow_will_not_hand_back_an_empty_token(self, authenticated_uri: str) -> None:
+        import pyarrow.flight as flight
+
+        client = flight.FlightClient(authenticated_uri)
+        with pytest.raises(flight.FlightUnauthenticatedError):
+            client.authenticate_basic_token(b"user", b"")
+
+    def test_the_refusal_is_the_documented_one(self, authenticated_uri: str) -> None:
+        """`docs/guide/adbc.md` promises UNAUTHENTICATED naming the header, for
+        a wrong *or absent* key. An empty one is absent."""
+        with pytest.raises(Exception) as raised:
+            _query(authenticated_uri, db_kwargs={"username": "obsl", "password": ""})
+        message = str(raised.value).lower()
+        assert "unauthenticated" in message
+        assert "authorization" in message or "x-api-key" in message

--- a/tests/integration/test_adbc_auth.py
+++ b/tests/integration/test_adbc_auth.py
@@ -11,6 +11,13 @@ whether the key was right or wrong.
 Each row here is a way a client actually sends a key, paired with its negative:
 a mechanism that accepts the right key and also accepts the wrong one is worse
 than one that accepts neither.
+
+The first version of this suite used ``NoopAuthHandler`` beside the middleware
+and passed while production - which installs the *real* handler beside it -
+refused every client. The handshake RPC carries two protocols, and each half
+was refusing the other's callers. So the fixture below builds its auth the one
+way ``app.py`` does, and :class:`TestTheProductionWiring` drives the objects
+``app.py`` actually hands to Flight.
 """
 
 # ruff: noqa: F811 — pytest fixtures are imported by name and then shadowed by
@@ -18,6 +25,7 @@ than one that accepts neither.
 # works.
 from __future__ import annotations
 
+import contextlib
 import os
 import threading
 from collections.abc import Iterator
@@ -37,22 +45,21 @@ from tests.integration.test_adbc_flightsql import (  # noqa: E402
 
 #: Deliberately a length whose ``obsl:<key>`` base64 needs padding - ADBC
 #: strips it, and a key that happens to encode padding-free would let the
-#: decoder regress without a single test noticing.
-API_KEY = "obsl-test-api-key-0123456789abcdefg"
-WRONG_KEY = "obsl-test-api-key-wrong-00000000000"
+#: decoder regress without a single test noticing. Strong enough for
+#: ``API_KEYS`` to accept it, so the production wiring can be driven with it.
+API_KEY = "obsl_pat_a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c"
+WRONG_KEY = "obsl_pat_0000000000000000000000000000000000000000w"
 
 
-@pytest.fixture(scope="module")
-def authenticated_uri(tmp_path_factory: pytest.TempPathFactory) -> Iterator[str]:
-    """A Flight server that requires the API key, as api_key mode configures."""
-    pytest.importorskip("adbc_driver_flightsql")
+@contextlib.contextmanager
+def _serving(db_dir: Any, handler: Any, middleware: Any) -> Iterator[str]:
+    """Run a Flight server on the given auth pair and yield its URI."""
     import duckdb
-    from ob_flight.auth import AUTH_MIDDLEWARE_KEY, AuthMiddlewareFactory, NoopAuthHandler
     from ob_flight.server import OBFlightServer
 
     from orionbelt.service.session_manager import SessionManager
 
-    db_path = tmp_path_factory.mktemp("adbc-auth") / "sample.duckdb"
+    db_path = db_dir / "sample.duckdb"
     connection = duckdb.connect(str(db_path))
     connection.execute(_SETUP_SQL)
     connection.close()
@@ -66,8 +73,8 @@ def authenticated_uri(tmp_path_factory: pytest.TempPathFactory) -> Iterator[str]
         "grpc://127.0.0.1:0",
         session_manager=manager,
         default_dialect="duckdb",
-        auth_handler=NoopAuthHandler(),
-        auth_middleware={AUTH_MIDDLEWARE_KEY: AuthMiddlewareFactory(lambda key: key == API_KEY)},
+        auth_handler=handler,
+        auth_middleware=middleware,
     )
     thread = threading.Thread(target=server.serve, name="adbc-auth-flight", daemon=True)
     thread.start()
@@ -80,6 +87,18 @@ def authenticated_uri(tmp_path_factory: pytest.TempPathFactory) -> Iterator[str]
             os.environ.pop("DUCKDB_DATABASE", None)
         else:
             os.environ["DUCKDB_DATABASE"] = previous
+
+
+@pytest.fixture(scope="module")
+def authenticated_uri(tmp_path_factory: pytest.TempPathFactory) -> Iterator[str]:
+    """A Flight server that requires the API key, as api_key mode configures."""
+    pytest.importorskip("adbc_driver_flightsql")
+    from ob_flight.auth import build_api_key_auth
+
+    # The pair app.py installs, built the one way it can be built.
+    handler, middleware = build_api_key_auth(lambda key: key == API_KEY)
+    with _serving(tmp_path_factory.mktemp("adbc-auth"), handler, middleware) as uri:
+        yield uri
 
 
 def _query(uri: str, **db_kwargs: Any) -> int:
@@ -205,3 +224,97 @@ class TestTheAuthenticationGuideRecipe:
         client = flight.FlightClient(authenticated_uri)
         with pytest.raises(flight.FlightUnauthenticatedError):
             client.authenticate_basic_token(b"token", WRONG_KEY.encode())
+
+
+class TestTheLegacyHandshake:
+    """The one path that *did* work before, and must keep working.
+
+    ``AuthenticateBasicToken`` reuses the Handshake RPC but sends its key in a
+    header, leaving the stream empty. Reading that stream is how the legacy
+    protocol receives its key, so the two are told apart by whether a header
+    credential is present - not by the RPC.
+    """
+
+    def _handshake(self, uri: str, key: str) -> int:
+        import pyarrow.flight as flight
+
+        class Handshake(flight.ClientAuthHandler):  # type: ignore[misc]
+            def __init__(self) -> None:
+                super().__init__()
+                self.token = b""
+
+            def authenticate(self, outgoing: Any, incoming: Any) -> None:
+                outgoing.write(key.encode())
+                self.token = incoming.read()
+
+            def get_token(self) -> bytes:
+                return self.token
+
+        client = flight.FlightClient(uri)
+        client.authenticate(Handshake())
+        return len(list(client.list_flights()))
+
+    def test_the_right_key_is_accepted(self, authenticated_uri: str) -> None:
+        self._handshake(authenticated_uri, API_KEY)
+
+    def test_the_wrong_key_is_refused(self, authenticated_uri: str) -> None:
+        import pyarrow.flight as flight
+
+        with pytest.raises(flight.FlightUnauthenticatedError):
+            self._handshake(authenticated_uri, WRONG_KEY)
+
+
+class TestTheProductionWiring:
+    """Drives the objects `app.py` hands to Flight, not a stand-in for them.
+
+    This is the test that was missing. Every other test here builds its own
+    auth; this one runs the real lifespan in api_key mode, takes what it passes
+    to ``start_flight_background``, and connects to a server built from exactly
+    that. The bug it guards - a handler and middleware that each work alone and
+    refuse everything together - is invisible to any test that assembles the
+    pair itself.
+    """
+
+    async def test_what_the_lifespan_installs_authenticates_a_real_client(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any
+    ) -> None:
+        pytest.importorskip("adbc_driver_flightsql")
+        import ob_flight.startup as ob_startup
+
+        from orionbelt.api.app import create_app
+        from orionbelt.api.deps import reset_session_manager
+        from orionbelt.auth import reset_auth
+        from orionbelt.settings import Settings
+
+        captured: dict[str, Any] = {}
+
+        def _recorder(**kwargs: object) -> object:
+            captured.update(kwargs)
+            return object()
+
+        monkeypatch.setattr(ob_startup, "start_flight_background", _recorder)
+        settings = Settings(
+            flight_enabled=True,
+            auth_mode="api_key",
+            api_keys=API_KEY,
+            pgwire_enabled=False,
+            api_server_port=0,
+        )
+        app = create_app(settings=settings)
+        try:
+            # Inside the lifespan: the captured handler validates against the
+            # process-wide key store, which only exists while auth is live.
+            async with app.router.lifespan_context(app):
+                assert captured.get("auth_handler") is not None, "Flight was not started"
+                with _serving(
+                    tmp_path, captured["auth_handler"], captured["auth_middleware"]
+                ) as uri:
+                    assert _query(uri, db_kwargs={"username": "obsl", "password": API_KEY}) > 0
+                    # Proves the key store is enforcing, not that auth is off.
+                    with pytest.raises(Exception, match="(?i)unauth|invalid|denied"):
+                        _query(uri, db_kwargs={"username": "obsl", "password": WRONG_KEY})
+                    with pytest.raises(Exception, match="(?i)unauth|missing|invalid"):
+                        _query(uri)
+        finally:
+            reset_session_manager()
+            reset_auth()

--- a/tests/integration/test_adbc_auth.py
+++ b/tests/integration/test_adbc_auth.py
@@ -1,0 +1,207 @@
+"""Track II-3: the ADBC auth matrix, driven through a real client.
+
+Before this, none of it worked. ``SharedKeyAuthHandler`` implements Flight's
+*legacy* ``Handshake``, and every current client - ADBC, and pyarrow's own
+``authenticate_basic_token`` - uses the standard ``AuthenticateBasicToken``,
+which carries the credential in an ``authorization`` header and expects the
+issued token back in one. A handshake handler can do neither, so with
+``AUTH_MODE=api_key`` every ADBC connection failed with "Stream is closed"
+whether the key was right or wrong.
+
+Each row here is a way a client actually sends a key, paired with its negative:
+a mechanism that accepts the right key and also accepts the wrong one is worse
+than one that accepts neither.
+"""
+
+# ruff: noqa: F811 — pytest fixtures are imported by name and then shadowed by
+# the parameters that request them, which is how sharing one across modules
+# works.
+from __future__ import annotations
+
+import os
+import threading
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+pytestmark = pytest.mark.adbc_flight
+
+from tests.conftest import SAMPLE_MODEL_YAML  # noqa: E402
+from tests.integration.test_adbc_flightsql import (  # noqa: E402
+    _SETUP_SQL,
+    MODEL_NAME,
+    conn,  # noqa: F401
+    flight_uri,  # noqa: F401
+)
+
+#: Deliberately a length whose ``obsl:<key>`` base64 needs padding - ADBC
+#: strips it, and a key that happens to encode padding-free would let the
+#: decoder regress without a single test noticing.
+API_KEY = "obsl-test-api-key-0123456789abcdefg"
+WRONG_KEY = "obsl-test-api-key-wrong-00000000000"
+
+
+@pytest.fixture(scope="module")
+def authenticated_uri(tmp_path_factory: pytest.TempPathFactory) -> Iterator[str]:
+    """A Flight server that requires the API key, as api_key mode configures."""
+    pytest.importorskip("adbc_driver_flightsql")
+    import duckdb
+    from ob_flight.auth import AUTH_MIDDLEWARE_KEY, AuthMiddlewareFactory, NoopAuthHandler
+    from ob_flight.server import OBFlightServer
+
+    from orionbelt.service.session_manager import SessionManager
+
+    db_path = tmp_path_factory.mktemp("adbc-auth") / "sample.duckdb"
+    connection = duckdb.connect(str(db_path))
+    connection.execute(_SETUP_SQL)
+    connection.close()
+
+    previous = os.environ.get("DUCKDB_DATABASE")
+    os.environ["DUCKDB_DATABASE"] = str(db_path)
+
+    manager = SessionManager(ttl_seconds=3600, cleanup_interval=9999)
+    manager.get_or_create_named(MODEL_NAME).load_model(SAMPLE_MODEL_YAML, dedup=False)
+    server = OBFlightServer(
+        "grpc://127.0.0.1:0",
+        session_manager=manager,
+        default_dialect="duckdb",
+        auth_handler=NoopAuthHandler(),
+        auth_middleware={AUTH_MIDDLEWARE_KEY: AuthMiddlewareFactory(lambda key: key == API_KEY)},
+    )
+    thread = threading.Thread(target=server.serve, name="adbc-auth-flight", daemon=True)
+    thread.start()
+    try:
+        yield f"grpc://127.0.0.1:{server.port}"
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        if previous is None:
+            os.environ.pop("DUCKDB_DATABASE", None)
+        else:
+            os.environ["DUCKDB_DATABASE"] = previous
+
+
+def _query(uri: str, **db_kwargs: Any) -> int:
+    """Connect with the given credential and run a query. Returns the row count."""
+    from adbc_driver_flightsql import dbapi
+
+    connection = dbapi.connect(uri, **db_kwargs)
+    try:
+        with connection.cursor() as cur:
+            cur.execute(f'SELECT "Customer Country" FROM {MODEL_NAME}')
+            return int(cur.fetch_arrow_table().num_rows)
+    finally:
+        connection.close()
+
+
+#: Every way a client sends the key, as ``(label, db_kwargs builder)``.
+MECHANISMS = [
+    ("basic", lambda key: {"db_kwargs": {"username": "obsl", "password": key}}),
+    (
+        "authorization_header",
+        lambda key: {"db_kwargs": {"adbc.flight.sql.authorization_header": f"Bearer {key}"}},
+    ),
+    (
+        "x-api-key",
+        lambda key: {"db_kwargs": {"adbc.flight.sql.rpc.call_header.x-api-key": key}},
+    ),
+]
+
+
+class TestTheAuthMatrix:
+    @pytest.mark.parametrize(("label", "build"), MECHANISMS, ids=[m[0] for m in MECHANISMS])
+    def test_the_right_key_is_accepted(
+        self, authenticated_uri: str, label: str, build: Any
+    ) -> None:
+        assert _query(authenticated_uri, **build(API_KEY)) > 0
+
+    @pytest.mark.parametrize(("label", "build"), MECHANISMS, ids=[m[0] for m in MECHANISMS])
+    def test_the_wrong_key_is_refused(self, authenticated_uri: str, label: str, build: Any) -> None:
+        """Paired with the row above on purpose: a mechanism that accepts the
+        right key and also the wrong one is worse than one that accepts
+        neither."""
+        with pytest.raises(Exception, match="(?i)unauth|invalid|denied"):
+            _query(authenticated_uri, **build(WRONG_KEY))
+
+    def test_no_credential_is_refused(self, authenticated_uri: str) -> None:
+        with pytest.raises(Exception, match="(?i)unauth|missing|invalid"):
+            _query(authenticated_uri)
+
+    def test_the_refusal_says_what_to_send(self, authenticated_uri: str) -> None:
+        """A client that cannot connect should learn how from the error."""
+        with pytest.raises(Exception) as raised:
+            _query(authenticated_uri)
+        message = str(raised.value).lower()
+        assert "authorization" in message or "x-api-key" in message
+
+
+class TestAnUnauthenticatedServerIsUnaffected:
+    def test_no_credential_still_works(self, conn: Any) -> None:
+        """The default surface takes no key; the middleware is only installed
+        in api_key mode, so it costs nothing here."""
+        with conn.cursor() as cur:
+            cur.execute(f'SELECT "Customer Country" FROM {MODEL_NAME}')
+            assert cur.fetch_arrow_table().num_rows > 0
+
+
+class TestTheGuideDocumentsWhatWorks:
+    """`docs/guide/adbc.md` lists the mechanisms; this list is what was measured.
+
+    Documenting a fourth way to send a key, or dropping a row for one that
+    works, should fail here rather than in a reader's terminal.
+    """
+
+    GUIDE = "docs/guide/adbc.md"
+
+    def _documented_kwargs(self) -> list[frozenset[str]]:
+        import ast
+        import pathlib
+        import re
+
+        text = (pathlib.Path(__file__).resolve().parents[2] / self.GUIDE).read_text()
+        section = re.search(r"### Authenticating\n(.*?)\n## ", text, re.S)
+        assert section, f"no Authenticating section in {self.GUIDE}"
+        rows = re.findall(r"^\|.*?\|\s*`(\{.*?\})`\s*\|$", section.group(1), re.M)
+        return [frozenset(ast.literal_eval(row)) for row in rows]
+
+    def test_the_table_was_found(self) -> None:
+        """Guards the guard: a reformatted table would otherwise pass silently."""
+        assert len(self._documented_kwargs()) > 1
+
+    def test_every_documented_mechanism_is_one_the_matrix_proves(self) -> None:
+        measured = {frozenset(build("k")["db_kwargs"]) for _, build in MECHANISMS}
+        assert set(self._documented_kwargs()) == measured
+
+
+class TestTheAuthenticationGuideRecipe:
+    """`docs/guide/authentication.md` shows a raw pyarrow client, not ADBC.
+
+    It was broken by the same cause - ``authenticate_basic_token`` is
+    ``AuthenticateBasicToken`` - so it is worth proving separately rather than
+    assuming the ADBC rows cover it.
+    """
+
+    def test_authenticate_basic_token_returns_a_usable_header(self, authenticated_uri: str) -> None:
+        import pyarrow.flight as flight
+
+        client = flight.FlightClient(authenticated_uri)
+        token = client.authenticate_basic_token(b"token", API_KEY.encode())
+        # The guide passes this pair straight into FlightCallOptions.
+        assert token[0].lower() == b"authorization"
+        options = flight.FlightCallOptions(headers=[token])
+        list(client.list_flights(b"", options))
+
+    def test_the_same_call_without_the_token_is_refused(self, authenticated_uri: str) -> None:
+        import pyarrow.flight as flight
+
+        client = flight.FlightClient(authenticated_uri)
+        with pytest.raises(flight.FlightUnauthenticatedError):
+            list(client.list_flights(b""))
+
+    def test_a_wrong_key_never_yields_a_token(self, authenticated_uri: str) -> None:
+        import pyarrow.flight as flight
+
+        client = flight.FlightClient(authenticated_uri)
+        with pytest.raises(flight.FlightUnauthenticatedError):
+            client.authenticate_basic_token(b"token", WRONG_KEY.encode())

--- a/tests/unit/test_flight_auth_selection.py
+++ b/tests/unit/test_flight_auth_selection.py
@@ -124,3 +124,26 @@ async def test_api_key_mode_uses_shared_handler(monkeypatch, caplog) -> None:
 
     assert isinstance(captured["auth_handler"], ob_auth.SharedKeyAuthHandler)
     assert not any("WITHOUT authentication" in r.message for r in caplog.records)
+
+    # The handler is only half of it. Header auth - what every current client
+    # speaks - lives in middleware, and the two must be installed together:
+    # alone, the handler refuses every header-authenticated call and the
+    # middleware refuses the legacy handshake. Asserting only the handler is
+    # what let that ship.
+    middleware = captured["auth_middleware"]
+    assert ob_auth.AUTH_MIDDLEWARE_KEY in middleware
+    assert isinstance(middleware[ob_auth.AUTH_MIDDLEWARE_KEY], ob_auth.AuthMiddlewareFactory)
+
+
+async def test_other_modes_install_no_auth_middleware(monkeypatch) -> None:
+    """The middleware exists for api_key mode only, so an unauthenticated
+    surface pays nothing per call."""
+    settings = Settings(
+        flight_enabled=True,
+        flight_auth_mode="none",
+        pgwire_enabled=False,
+        api_server_port=0,
+    )
+    captured = await _run_lifespan_capture(monkeypatch, settings)
+
+    assert not captured["auth_middleware"]


### PR DESCRIPTION
## What this fixes

With `AUTH_MODE=api_key`, **no client could connect to the Flight surface**.

`SharedKeyAuthHandler` implements Flight's legacy `Handshake`. ADBC and pyarrow's own `authenticate_basic_token` both call the standard `AuthenticateBasicToken`, which carries the credential in an `authorization` header and expects the issued bearer token back in a response header. A `ServerAuthHandler` can do neither, so every connection failed with "Stream is closed" whether the key was right or wrong.

## What changed

Header auth moves to middleware, which sees the headers on every call and can set them on the way out. Three spellings are accepted, because they are the three a client actually sends:

| How the client sends it | ADBC `db_kwargs` |
|---|---|
| Basic auth | `{"username": "obsl", "password": "<key>"}` |
| `authorization` header | `{"adbc.flight.sql.authorization_header": "Bearer <key>"}` |
| `x-api-key` call header | `{"adbc.flight.sql.rpc.call_header.x-api-key": "<key>"}` |

The Handshake RPC carries two protocols. The legacy one puts the key on the stream; `AuthenticateBasicToken` puts it in a header and sends nothing, which is why reading that stream failed. They are told apart by whether a header credential is present, not by the RPC.

So the handler and middleware each yield where the other is authoritative: the handler defers when there is no token, the middleware admits a handshake that carries no credential header. Both concessions are safe only in the pair, so `build_api_key_auth()` returns them together and is the only thing that enables either. Built alone, each still refuses. The legacy handshake, which was the one path that worked before, keeps working.

A credential header holding no key is not silence: an empty Basic password, a bare `Bearer`, undecodable base64 and an empty `x-api-key` are all UNAUTHENTICATED, rather than taking the handshake exemption and answering with a protocol error.

Nothing changes when auth is off. The middleware is built only in `api_key` mode.

ADBC sends the Basic base64 unpadded, which `b64decode` rejects outright. The padding is re-added rather than the error tolerated: an undecodable credential and an absent one deserve different answers.

## Tests

The measured matrix, each acceptance paired with its negative: three ADBC mechanisms, the raw pyarrow client and the legacy handshake, with wrong keys, empty keys and no key at all.

The tests were the original defect. They asserted what `app.py` passes rather than whether it works, so the parts passed while the whole refused everyone. The fixture now builds auth the one way `app.py` can, and `TestTheProductionWiring` runs the real lifespan and connects to a server made from the objects it hands to Flight.

Every part of the fix was verified by deleting it and confirming a test goes red: the handler's deferral (6 tests), the handshake exemption (1), the empty-stream branch (3), the tri-state credential check (8), the base64 padding (3), the token echo (2).

`docs/guide/adbc.md` documents the three mechanisms, and a guard ties that table to the matrix so the page cannot list a fourth. Removes `build_shared_key_handler`, superseded and unreferenced.

## Verification

- `uv run pytest -q`: 5167 passed, 1046 skipped
- `uv run pytest -m adbc_flight -q`: 93 passed
- `drivers/ob-flight-extension`: 278 passed, mypy clean
- `ruff check`, `ruff format`, `mypy src/`, `mkdocs build --strict` clean
