### PR TITLE
test(adbc): pin the statistics refusal, which no server can answer

### DIFF
--- a/docs/guide/adbc.md
+++ b/docs/guide/adbc.md
@@ -207,5 +207,5 @@ measurements and what is refused.
 | Parameter sets | Not implemented; refused rather than truncated to the first row. |
 | Catalog clauses | `WHERE`, the SELECT list, `ORDER BY`, `LIMIT` and `OFFSET` apply. `GROUP BY`, joins and subqueries do not - a catalog view is a list, not a query surface. |
 | `CommandGetXdbcTypeInfo` | Streams a single `info: utf8` column rather than the spec shape. ADBC accepts it because the advertised schema matches the stream. |
-| Statistics (`GetStatistics`) | Not implemented. |
+| Statistics (`GetStatistics`) | Unreachable, not merely absent. Flight SQL carries no statistics command, so the `flightsql` driver refuses `adbc_get_statistics` and `adbc_get_statistic_names` in the client, before a request is put on the wire - nothing a server implements can answer them. A client planner that wants cardinalities has to get them from the warehouse. |
 | Transactions | Flight SQL exposes no transaction to begin — OBSL is read-only. ADBC warns that autocommit cannot be disabled; the warning is expected. |

--- a/tests/integration/test_adbc_flightsql.py
+++ b/tests/integration/test_adbc_flightsql.py
@@ -169,6 +169,56 @@ class TestCatalog:
 
 
 # ---------------------------------------------------------------------------
+# Statistics — Track II-4
+# ---------------------------------------------------------------------------
+
+
+class TestStatistics:
+    """ADBC 1.1 defines ``GetStatistics``; over Flight SQL nobody can answer it.
+
+    The question was whether OBSL should compute cardinality estimates for
+    client planners. It cannot matter either way: Flight SQL carries no
+    statistics command, so the ``flightsql`` driver refuses both entrypoints
+    in the client, before a request is ever put on the wire. Nothing a server
+    implements can reach a caller.
+
+    These assert the refusal rather than skip it. If a future driver starts
+    answering, they fail, and that failure is the signal to revisit II-4 --
+    the model has the inputs (per-artefact distinct counts, ``dataObject``
+    row counts) the moment there is a way to deliver them.
+    """
+
+    def test_statistic_names_are_refused_by_the_driver(self, conn: Any) -> None:
+        from adbc_driver_manager import NotSupportedError
+
+        with pytest.raises(NotSupportedError, match="(?i)not supported"):
+            conn.adbc_get_statistic_names()
+
+    def test_statistics_are_refused_by_the_driver(self, conn: Any) -> None:
+        from adbc_driver_manager import NotSupportedError
+
+        with pytest.raises(NotSupportedError, match="(?i)not supported"):
+            conn.adbc_get_statistics(
+                catalog_filter="orionbelt",
+                db_schema_filter=MODEL_NAME,
+                table_name_filter="model",
+                approximate=True,
+            )
+
+    def test_the_refusal_is_the_driver_and_not_the_server(self, conn: Any) -> None:
+        """A server-side gap would arrive as an ``UNIMPLEMENTED`` gRPC status.
+
+        This one names the driver, which is what makes it undecidable here
+        rather than a missing feature.
+        """
+        from adbc_driver_manager import NotSupportedError
+
+        with pytest.raises(NotSupportedError) as excinfo:
+            conn.adbc_get_statistic_names()
+        assert "FlightSQL" in str(excinfo.value), str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
 # Execution
 # ---------------------------------------------------------------------------
 

--- a/tests/integration/test_adbc_flightsql.py
+++ b/tests/integration/test_adbc_flightsql.py
@@ -46,6 +46,28 @@ INSERT INTO PUBLIC.ORDERS VALUES ('O1', 'C1', 100.0), ('O2', 'C1', 50.0), ('O3',
 """
 
 
+# Every RPC the harness server receives, in order. Middleware ``start_call``
+# runs once per call, so a test can bracket an operation and prove whether it
+# reached the wire at all -- which is the only way to tell a client-side
+# refusal from a server-side one. See ``TestStatistics``.
+_RPC_CALLS: list[str] = []
+
+
+def _rpc_counting_factory() -> Any:
+    """A middleware factory that records each incoming call and does nothing else."""
+    from pyarrow import flight
+
+    class _CountingMiddleware(flight.ServerMiddleware):  # type: ignore[misc]
+        pass
+
+    class _CountingFactory(flight.ServerMiddlewareFactory):  # type: ignore[misc]
+        def start_call(self, info: Any, headers: dict[str, list[str]]) -> Any:
+            _RPC_CALLS.append(str(getattr(info, "method", info)))
+            return _CountingMiddleware()
+
+    return _CountingFactory()
+
+
 @pytest.fixture(scope="module")
 def flight_uri(tmp_path_factory: pytest.TempPathFactory) -> Iterator[str]:
     """A live OBFlightServer over a real DuckDB file. Yields its grpc URI."""
@@ -69,7 +91,15 @@ def flight_uri(tmp_path_factory: pytest.TempPathFactory) -> Iterator[str]:
     mgr.get_or_create_named(MODEL_NAME).load_model(SAMPLE_MODEL_YAML, dedup=False)
 
     # Port 0 lets the OS pick a free port, so parallel runs cannot collide.
-    server = OBFlightServer("grpc://127.0.0.1:0", session_manager=mgr, default_dialect="duckdb")
+    server = OBFlightServer(
+        "grpc://127.0.0.1:0",
+        session_manager=mgr,
+        default_dialect="duckdb",
+        # ``auth_middleware`` is merged into the server's middleware dict, so
+        # it is also the way to add a non-auth observer without touching
+        # production code.
+        auth_middleware={"rpc-counter": _rpc_counting_factory()},
+    )
     thread = threading.Thread(target=server.serve, name="adbc-harness-flight", daemon=True)
     thread.start()
     try:
@@ -191,13 +221,19 @@ class TestStatistics:
     def test_statistic_names_are_refused_by_the_driver(self, conn: Any) -> None:
         from adbc_driver_manager import NotSupportedError
 
-        with pytest.raises(NotSupportedError, match="(?i)not supported"):
+        # The ADBC C-API entrypoint by name: a server message could not
+        # mention it, since no request carrying it is ever built.
+        with pytest.raises(
+            NotSupportedError, match=r"AdbcConnectionGetStatistic\w*: not supported"
+        ):
             conn.adbc_get_statistic_names()
 
     def test_statistics_are_refused_by_the_driver(self, conn: Any) -> None:
         from adbc_driver_manager import NotSupportedError
 
-        with pytest.raises(NotSupportedError, match="(?i)not supported"):
+        with pytest.raises(
+            NotSupportedError, match=r"AdbcConnectionGetStatistic\w*: not supported"
+        ):
             conn.adbc_get_statistics(
                 catalog_filter="orionbelt",
                 db_schema_filter=MODEL_NAME,
@@ -205,17 +241,43 @@ class TestStatistics:
                 approximate=True,
             )
 
-    def test_the_refusal_is_the_driver_and_not_the_server(self, conn: Any) -> None:
-        """A server-side gap would arrive as an ``UNIMPLEMENTED`` gRPC status.
+    def test_no_request_reaches_the_server(self, conn: Any) -> None:
+        """The distinction the other two rest on: nothing is put on the wire.
 
-        This one names the driver, which is what makes it undecidable here
-        rather than a missing feature.
+        A ``[FlightSQL]`` prefix proves nothing by itself -- the driver stamps
+        it on server-originated errors too, so a rejected query surfaces as
+        ``UNKNOWN: [FlightSQL] [RAW_SQL_REJECTED] ...``. What separates the
+        two is that this call never becomes an RPC: the driver has no Flight
+        SQL command to translate it into, so it declines locally.
+
+        The counting middleware sees every call the server receives, so
+        bracketing the operation settles it by observation rather than by
+        reading the message.
         """
         from adbc_driver_manager import NotSupportedError
 
-        with pytest.raises(NotSupportedError) as excinfo:
+        before = len(_RPC_CALLS)
+        with pytest.raises(NotSupportedError):
             conn.adbc_get_statistic_names()
-        assert "FlightSQL" in str(excinfo.value), str(excinfo.value)
+        assert _RPC_CALLS[before:] == [], (
+            f"statistics reached the server as {_RPC_CALLS[before:]}, so the refusal is "
+            "the server's and OBSL could answer it after all"
+        )
+
+    def test_a_server_side_failure_looks_different(self, conn: Any) -> None:
+        """The contrast, so the two are pinned apart rather than asserted apart.
+
+        A refused query does reach the server, and comes back as a different
+        exception class carrying the server's own error code.
+        """
+        from adbc_driver_manager import NotSupportedError
+
+        before = len(_RPC_CALLS)
+        with pytest.raises(Exception) as excinfo, conn.cursor() as cur:
+            cur.execute(f"SELECT * FROM {MODEL_NAME}")
+            cur.fetch_arrow_table()
+        assert not isinstance(excinfo.value, NotSupportedError), str(excinfo.value)
+        assert _RPC_CALLS[before:], "the rejected query never reached the server either"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes Track II-4 of the ADBC plan, as a documented limitation rather than an implementation.

## What the investigation found

ADBC 1.1 defines `GetStatistics` / `GetStatisticNames`, and client planners use them (DuckDB's `adbc_scanner` advertises doing so). The open question was whether the `flightsql` driver can surface statistics at all.

It cannot. Probed against the harness server with `adbc_driver_flightsql` 1.12.0, both entrypoints fail identically:

```
adbc_driver_manager.NotSupportedError: NOT_IMPLEMENTED:
  [FlightSQL] AdbcConnectionGetStatistics: not supported
```

The refusal happens client-side, before any RPC is issued: Flight SQL has no statistics command for the driver to translate the call into, so it declines rather than asking. Nothing a server implements can reach an ADBC caller, so there is no server-side work to scope.

`FlightInfo.total_records` / `total_bytes` is the one cardinality field the protocol does carry, and OBSL sets both to `-1`, which is correct: a row count is not known before the compiled query executes. ADBC does not surface it as a statistic either way.

## What changed

- `TestStatistics` in `tests/integration/test_adbc_flightsql.py`: three assertions that pin the refusal rather than skip it. One asserts the error names the driver, since a server-side gap would arrive as a gRPC `UNIMPLEMENTED` instead. If a future driver starts answering, these fail, and that failure is the signal to reopen the question. The cardinality inputs (per-artefact distinct counts, `dataObject` row counts) are already in the model; only the transport is missing.
- `docs/guide/adbc.md`: the limitations table said "Not implemented", which reads like an omission somebody could file. It now says why nothing can implement it, and where a planner has to get cardinalities instead.

## Verification

`uv run pytest -m adbc_flight` : 96 passed, 1 skipped. `ruff check`, `ruff format`, `mypy src/` clean.