### PR TITLE
feat(dremio): execute over ADBC Flight SQL, deleting the hand-rolled client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to OrionBelt Semantic Layer are documented here.
 
 ## [Unreleased]
 
+### Changed
+
+- **`ob-dremio` executes over ADBC Flight SQL (#TBD).** The driver was the only one in the set that
+  spoke a wire protocol by hand: a `pyarrow.flight` client that built descriptors, called
+  `get_flight_info` + `do_get`, and threaded the bearer token from `authenticate_basic_token()`
+  through every RPC because a Cython `FlightClient` refuses ad-hoc attributes. Dremio serves Flight
+  SQL natively, so `adbc-driver-flightsql` is its driver, and all of that protocol code is deleted
+  rather than replaced. The PEP 249 surface is unchanged - `rowcount`, `description` type
+  constants, `fetch_arrow_table()` and the Arrow types (`date64[ms]`, `timestamp[ms]`,
+  `decimal128(18, 2)`) are what they were, verified against a live Dremio container.
+
+  Two things get better. `?` parameters now bind: before, the statement went to Dremio with its
+  placeholders intact and came back as a Calcite `RexDynamicParam` internal error, which is why the
+  driver documented parameters as unsupported. And a failing statement raises a DB-API error
+  instead of `pyarrow.lib.ArrowInvalid`.
+
+  One hazard is deliberately designed around: ADBC skips re-preparing when the SQL text has not
+  changed, and Dremio then answers the second execution with the **first** execution's rows, with
+  new parameters bound and no error. The driver therefore opens one statement per execution, which
+  is also what the hand-rolled client effectively did. A live test pins it, because the failure is
+  a wrong number rather than an exception.
+
+  Two Dremio-side limits are now documented rather than discovered: a *prepared* `COUNT` is refused
+  because Dremio describes it `NOT NULL` and streams it nullable, and `executemany` over `DoPut` is
+  not implemented. Neither is reachable from OBSL, which compiles literals and never binds.
+
 ## [2.26.0] - 2026-08-25
 
 ### Upgrading

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to OrionBelt Semantic Layer are documented here.
 
 ### Changed
 
-- **`ob-dremio` executes over ADBC Flight SQL (#TBD).** The driver was the only one in the set that
+- **`ob-dremio` executes over ADBC Flight SQL (#427).** The driver was the only one in the set that
   spoke a wire protocol by hand: a `pyarrow.flight` client that built descriptors, called
   `get_flight_info` + `do_get`, and threaded the bearer token from `authenticate_basic_token()`
   through every RPC because a Cython `FlightClient` refuses ad-hoc attributes. Dremio serves Flight

--- a/docs/drivers.md
+++ b/docs/drivers.md
@@ -18,7 +18,7 @@ All drivers work against the **OrionBelt REST API in admin-curated mode** (`MODE
 | `ob-postgres`         | PostgreSQL              | `adbc-driver-postgresql`     | `postgres`   | `qmark`    | ADBC native           |
 | `ob-snowflake`        | Snowflake               | `snowflake-connector-python` | `snowflake`  | `pyformat` | `fetch_arrow_all()`   |
 | `ob-clickhouse`       | ClickHouse              | `clickhouse-connect`         | `clickhouse` | `pyformat` | `query_arrow()`       |
-| `ob-dremio`           | Dremio                  | `pyarrow.flight`             | `dremio`     | `qmark`    | Flight native         |
+| `ob-dremio`           | Dremio                  | `adbc-driver-flightsql`      | `dremio`     | `qmark`    | ADBC native           |
 | `ob-databricks`       | Databricks              | `databricks-sql-connector`   | `databricks` | `pyformat` | `fetchall_arrow()`    |
 | `ob-flight-extension` | Arrow Flight SQL server | `pyarrow.flight`             | all          | —          | —                     |
 
@@ -197,7 +197,7 @@ conn = ob_duckdb.connect(ob_api_url="http://my-api:9000")
 | `ob-postgres`   | `dsn`, `host`, `port`, `dbname`, `user`, `password`, `sslmode`                            |
 | `ob-snowflake`  | `account`, `user`, `password`, `database`, `schema`, `warehouse`, `role`, `authenticator` |
 | `ob-clickhouse` | `host`, `port`, `username`, `password`, `database`, `secure`                              |
-| `ob-dremio`     | `host`, `port`, `username`, `password`, `tls`                                             |
+| `ob-dremio`     | `host`, `port`, `username`, `password`, `tls`, `db_kwargs`                                |
 | `ob-databricks` | `server_hostname`, `http_path`, `access_token`, `catalog`, `schema`                       |
 
 ## Running Driver Tests

--- a/drivers/ob-dremio/AGENTS.md
+++ b/drivers/ob-dremio/AGENTS.md
@@ -2,10 +2,10 @@
 
 ## Purpose
 
-PEP 249 DB-API 2.0 driver wrapping `pyarrow = ">=16.0"
-pyarrow-hotfix = ">=0.6"` that intercepts OBML YAML
-queries, compiles them to dremio SQL via the OrionBelt CompilationPipeline
-(direct import) or OB REST API (standalone), and executes them natively.
+PEP 249 DB-API 2.0 driver wrapping `adbc-driver-flightsql` that intercepts
+OBML YAML queries, compiles them to dremio SQL via the OrionBelt
+CompilationPipeline (direct import) or OB REST API (standalone), and
+executes them natively.
 
 **OB dialect string:** `"dremio"`
 **Author:** Ralf Becher / RALFORION d.o.o. (info@orionbelt.ai)
@@ -31,6 +31,7 @@ queries, compiles them to dremio SQL via the OrionBelt CompilationPipeline
 ### dremio-specific
 | host | str | Dremio host |
 | port | int | Arrow Flight port (default: 32010) |
+| db_kwargs | dict | Extra ADBC options (e.g. Dremio routing headers); merged last |
 | username | str | Dremio username |
 | password | str | Dremio password |
 | schema | str | Space/schema path (e.g. "@user.myspace") |
@@ -68,10 +69,35 @@ def compile_obml(obml: dict, model, dialect: str) -> str:
 
 ## Vendor-Specific Notes
 
-- Dremio connects via Arrow Flight (port 32010), NOT JDBC/ODBC
-- Use pyarrow.flight.FlightClient with BasicAuth middleware for auth
-- execute() sends query via do_get() with TicketStatementQuery
-- This driver is unique: it IS already a Flight client internally
+- Dremio connects via Arrow Flight SQL (port 32010), NOT JDBC/ODBC
+- Dremio speaks Flight SQL natively, so the generic `adbc-driver-flightsql`
+  **is** the Dremio driver — there is no vendor SDK in this path
+- Auth is `AuthenticateBasicToken`, run by the driver: pass `username` /
+  `password` as ADBC options and the bearer token is attached to every call.
+  The old hand-rolled client called `authenticate_basic_token()` itself and
+  threaded `FlightCallOptions` through every RPC
+- `?` parameters bind as prepared-statement values. They could not before:
+  the statement went out with placeholders intact and Dremio answered with a
+  Calcite `RexDynamicParam` error
+- **One native cursor per execution, never reused.** ADBC skips re-preparing
+  when the SQL text is unchanged, and Dremio then answers the second
+  execution with the *first* execution's rows even though new parameters
+  were bound - silently, no error. The same reuse against OBSL's own Flight
+  server rebinds correctly, which puts the fault on Dremio's side. This is
+  also what the hand-rolled client effectively did: one `get_flight_info` +
+  `do_get` per statement
+- `executemany()` runs one statement per parameter set. ADBC's own
+  `executemany` binds the batch over `DoPut`, which Dremio refuses with
+  `acceptPut is not implemented`
+- A **prepared** `COUNT` is refused: Dremio describes it as `int64` NOT NULL
+  and streams it nullable, and ADBC compares the two. `SUM` / `MAX` and an
+  unparameterised `COUNT` are fine, and OBSL only ever emits the latter
+- `description` is built from the Arrow schema, not from the native cursor's
+  own `description` — ADBC reports PyArrow `DataType` objects where PEP 249
+  expects a type constant
+- Dremio answers `GetSqlInfo` with an empty endpoint list, so
+  `adbc_get_info()` raises and `adbc_get_objects()` returns no catalogs.
+  Nothing in this driver calls them
 - COPY INTO SQL with German locale formatting was a prior pain point — always use . as decimal separator
 - Space paths use dot notation: SELECT * FROM "myspace"."mytable"
 
@@ -79,7 +105,10 @@ def compile_obml(obml: dict, model, dialect: str) -> str:
 
 ## Type System
 
-Dremio uses Arrow Flight natively — cursor maps Arrow schema directly.
+Dremio uses Arrow Flight SQL natively — cursor maps Arrow schema directly.
+The Arrow types are identical to what the hand-rolled Flight client
+returned, verified against a live Dremio container: `date64[ms]`,
+`timestamp[ms]`, `decimal128(18, 2)`, `int32`.
 pa.int32() → int, pa.float64() → float, pa.utf8() → str, pa.timestamp() → datetime.
 
 ---
@@ -97,8 +126,8 @@ Session 4: SQLAlchemy dialect (ob+dremio:// URL scheme)
 
 ```toml
 [project.dependencies]
+adbc-driver-flightsql = ">=1.0"
 pyarrow = ">=16.0"
-pyarrow-hotfix = ">=0.6"
 pyyaml = ">=6.0"
 
 [project.optional-dependencies]

--- a/drivers/ob-dremio/pyproject.toml
+++ b/drivers/ob-dremio/pyproject.toml
@@ -14,6 +14,7 @@ keywords = ["dremio", "semantic-layer", "obml", "db-api", "orionbelt"]
 requires-python = ">=3.12"
 dependencies = [
     "ob-driver-core>=0.1",
+    "adbc-driver-flightsql>=1.0",
     "pyarrow>=16.0",
 ]
 
@@ -58,7 +59,7 @@ files = ["src/ob_dremio"]
 
 # Untyped upstream - neither ships a py.typed marker.
 [[tool.mypy.overrides]]
-module = ["pyarrow.*"]
+module = ["pyarrow.*", "adbc_driver_flightsql.*"]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]

--- a/drivers/ob-dremio/src/ob_dremio/__init__.py
+++ b/drivers/ob-dremio/src/ob_dremio/__init__.py
@@ -3,7 +3,9 @@
 Requires the OrionBelt REST API running in single-model mode (MODEL_FILE set).
 OBML queries are compiled to SQL via ``POST /v1/query/sql``.
 
-Dremio is accessed via Arrow Flight protocol using ``pyarrow.flight``.
+Dremio is reached over Arrow Flight SQL through ``adbc-driver-flightsql``.
+Dremio speaks Flight SQL natively, so the generic driver *is* the Dremio
+driver -- there is no vendor SDK in this path, and none to maintain.
 
 Usage::
 
@@ -16,6 +18,10 @@ Usage::
 """
 
 from __future__ import annotations
+
+from typing import Any
+
+import adbc_driver_flightsql.dbapi
 
 from ob_dremio.connection import Connection
 from ob_dremio.exceptions import (
@@ -44,11 +50,12 @@ def connect(
     username: str | None = None,
     password: str | None = None,
     tls: bool = False,
+    db_kwargs: dict[str, str] | None = None,
     # OrionBelt parameters
     ob_api_url: str = "http://localhost:8000",
     ob_timeout: int = 30,
 ) -> Connection:
-    """Open a Dremio connection via Arrow Flight with OBML support.
+    """Open a Dremio connection over Arrow Flight SQL with OBML support.
 
     Parameters
     ----------
@@ -62,32 +69,38 @@ def connect(
         Dremio password for authentication.
     tls : bool
         Use TLS for the Flight connection (default: ``False``).
+    db_kwargs : dict, optional
+        Extra ADBC database options, e.g.
+        ``{"adbc.flight.sql.rpc.call_header.routing_queue": "…"}`` for
+        Dremio's workload-management headers. Merged last, so a caller can
+        override anything derived from the arguments above.
     ob_api_url : str
         OrionBelt REST API URL (must be running in single-model mode).
     ob_timeout : int
         HTTP timeout in seconds for OBML compilation.
+
+    Notes
+    -----
+    Authentication is Flight SQL's ``AuthenticateBasicToken``: the driver
+    exchanges the credentials for a bearer token once and attaches it to
+    every later call. Doing that by hand is what this driver used to carry
+    a ``FlightCallOptions`` field for.
     """
-    import pyarrow.flight
-
     scheme = "grpc+tls" if tls else "grpc"
-    location = f"{scheme}://{host}:{port}"
-    client = pyarrow.flight.FlightClient(location)
+    uri = f"{scheme}://{host}:{port}"
 
-    call_options: pyarrow.flight.FlightCallOptions | None = None
-    if username is not None and password is not None:
-        token_pair = client.authenticate_basic_token(username, password)
-        # The bearer token returned by authenticate_basic_token must be
-        # attached to every subsequent get_flight_info / do_get call.
-        # pyarrow's FlightClient is a Cython object that rejects ad-hoc
-        # attribute writes (`AttributeError: 'pyarrow._flight.FlightClient'
-        # object has no attribute '_ob_call_options'`) — so we stash the
-        # options on our Python-owned Connection/Cursor wrappers instead
-        # and pass them through to each RPC.
-        call_options = pyarrow.flight.FlightCallOptions(headers=[token_pair])
+    options: dict[str, str] = {}
+    if username is not None:
+        options["username"] = username
+    if password is not None:
+        options["password"] = password
+    if db_kwargs:
+        options.update(db_kwargs)
+
+    native: Any = adbc_driver_flightsql.dbapi.connect(uri, db_kwargs=options)
 
     return Connection(
-        client,
-        call_options=call_options,
+        native,
         ob_api_url=ob_api_url,
         ob_timeout=ob_timeout,
     )

--- a/drivers/ob-dremio/src/ob_dremio/__init__.py
+++ b/drivers/ob-dremio/src/ob_dremio/__init__.py
@@ -97,7 +97,12 @@ def connect(
     if db_kwargs:
         options.update(db_kwargs)
 
-    native: Any = adbc_driver_flightsql.dbapi.connect(uri, db_kwargs=options)
+    # ``autocommit=True`` states what is already true rather than enabling
+    # anything: ADBC otherwise tries to *disable* autocommit on connect, and
+    # Dremio -- which has no transactions -- refuses, so every connection
+    # warned "conn will not be DB-API 2.0 compliant". Same reason
+    # ``Connection.commit()`` and ``rollback()`` are no-ops.
+    native: Any = adbc_driver_flightsql.dbapi.connect(uri, db_kwargs=options, autocommit=True)
 
     return Connection(
         native,

--- a/drivers/ob-dremio/src/ob_dremio/connection.py
+++ b/drivers/ob-dremio/src/ob_dremio/connection.py
@@ -1,37 +1,35 @@
-"""PEP 249 Connection wrapping a pyarrow Flight client for Dremio.
+"""PEP 249 Connection wrapping ``adbc_driver_flightsql.dbapi.Connection``.
 
 Dremio has no transactions — ``commit()`` and ``rollback()`` are no-ops
-that simply verify the connection is still open.
+that simply verify the connection is still open. ADBC exposes both, but
+calling them would ask Dremio to manage a transaction it does not have.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import Any
 
 from ob_dremio.cursor import Cursor
 from ob_dremio.exceptions import ProgrammingError
 
-if TYPE_CHECKING:
-    import pyarrow.flight
-
 
 class Connection:
-    """DB-API 2.0 connection wrapping a pyarrow FlightClient for Dremio.
+    """DB-API 2.0 connection that wraps an ADBC Flight SQL connection.
 
+    Dremio serves Arrow Flight SQL natively, so results arrive as Arrow and
+    cursors expose ``fetch_arrow_table()`` without a conversion hop.
     OBML queries are compiled to SQL via the OrionBelt REST API
     (single-model mode, ``/v1/query/sql`` shortcut).
     """
 
     def __init__(
         self,
-        client: pyarrow.flight.FlightClient,
+        native: Any,
         *,
-        call_options: pyarrow.flight.FlightCallOptions | None = None,
         ob_api_url: str = "http://localhost:8000",
         ob_timeout: int = 30,
     ) -> None:
-        self._client = client
-        self._call_options = call_options
+        self._native = native
         self._closed = False
         self._ob_api_url = ob_api_url
         self._ob_timeout = ob_timeout
@@ -41,15 +39,15 @@ class Connection:
             raise ProgrammingError("Connection is closed.")
 
     def cursor(self) -> Cursor:
-        """Return a new Cursor backed by the shared FlightClient.
+        """Return a new Cursor bound to this connection.
 
-        pyarrow FlightClient does not have its own cursor concept — our
-        ``Cursor`` wraps the client directly.
+        The native statement is created per execution rather than per cursor
+        — see :meth:`Cursor._execute_sql` for why reuse is unsafe against
+        Dremio.
         """
         self._check_open()
         return Cursor(
-            self._client,
-            call_options=self._call_options,
+            self._native,
             ob_api_url=self._ob_api_url,
             ob_timeout=self._ob_timeout,
         )
@@ -63,9 +61,9 @@ class Connection:
         self._check_open()
 
     def close(self) -> None:
-        """Close the connection and the underlying FlightClient."""
+        """Close the connection and the underlying ADBC connection."""
         if not self._closed:
-            self._client.close()
+            self._native.close()
             self._closed = True
 
     def __enter__(self) -> Connection:

--- a/drivers/ob-dremio/src/ob_dremio/cursor.py
+++ b/drivers/ob-dremio/src/ob_dremio/cursor.py
@@ -1,10 +1,11 @@
-"""PEP 249 Cursor wrapping a pyarrow Flight client for Dremio.
+"""PEP 249 Cursor executing over an ADBC Flight SQL connection to Dremio.
 
-Dremio exposes query execution via Arrow Flight.  This cursor wraps a
-``pyarrow.flight.FlightClient`` and adapts it to PEP 249 semantics.
+Dremio exposes query execution via Arrow Flight SQL, so the generic
+``adbc-driver-flightsql`` driver is its driver.  This cursor adapts that
+to PEP 249 semantics.
 
 Each ``execute()`` fetches the entire result set into memory (client-side
-buffering) by converting the Arrow table to Python tuples.
+buffering) and converts the Arrow table to Python tuples on first fetch.
 """
 
 from __future__ import annotations
@@ -18,29 +19,30 @@ from ob_dremio.type_codes import ARROW_TYPE_MAP, STRING
 
 if TYPE_CHECKING:
     import pyarrow as pa
-    import pyarrow.flight
 
 
 class Cursor:
-    """DB-API 2.0 cursor wrapping a pyarrow Flight client for Dremio.
+    """DB-API 2.0 cursor executing over an ADBC Flight SQL connection.
 
-    The underlying ``FlightClient.get_flight_info()`` + ``do_get()`` returns
-    an Arrow record batch reader.  This cursor reads the full table, converts
-    it to rows, and exposes them through the standard ``fetch*()`` methods.
+    Each statement runs on its own native cursor, so the result is Arrow and
+    the table is kept here; ``description`` comes from its schema and rows
+    are materialised lazily for the standard ``fetch*()`` methods.
+
+    ``description`` is derived from the Arrow schema rather than from the
+    native cursor's own ``description``, which reports PyArrow ``DataType``
+    objects in the type-code slot where PEP 249 expects a type constant.
     """
 
     arraysize: int = 1
 
     def __init__(
         self,
-        client: pyarrow.flight.FlightClient,
+        native_connection: Any,
         *,
-        call_options: pyarrow.flight.FlightCallOptions | None = None,
         ob_api_url: str = "http://localhost:8000",
         ob_timeout: int = 30,
     ) -> None:
-        self._client = client
-        self._call_options = call_options
+        self._native_connection = native_connection
         self._closed = False
         self._ob_api_url = ob_api_url
         self._ob_timeout = ob_timeout
@@ -87,24 +89,34 @@ class Cursor:
             ob_timeout=self._ob_timeout,
         )
 
-    def _execute_sql(self, sql: str) -> pa.Table:
-        """Execute SQL via Arrow Flight and return the result as an Arrow Table.
+    def _execute_sql(self, sql: str, parameters: Sequence[object] | None = None) -> pa.Table:
+        """Execute SQL over Flight SQL and return the result as an Arrow Table.
 
-        Uses ``FlightDescriptor.for_command()`` + ``get_flight_info()`` +
-        ``do_get()`` to retrieve results.
+        Auth is the driver's problem now: ADBC exchanges the credentials for
+        a bearer token during the handshake and attaches it to every call,
+        which this driver used to carry ``FlightCallOptions`` to do by hand.
+
+        One native cursor per statement, closed as soon as the table is in
+        hand. Reusing it would be the natural thing to do, and against Dremio
+        it is wrong: ADBC skips re-preparing when the SQL text has not
+        changed, and Dremio then answers the second execution with the
+        **first** execution's rows -- silently, with different parameters
+        bound. The same reuse against OBSL's own Flight server rebinds
+        correctly, which is what places the fault on Dremio's side of the
+        wire. A fresh statement per execution is also exactly what the
+        hand-rolled Flight client did, one ``get_flight_info`` + ``do_get``
+        at a time.
         """
-        import pyarrow.flight as _pf
-
-        descriptor = _pf.FlightDescriptor.for_command(sql.encode("utf-8"))
-        # When the connection was authenticated, every Flight RPC needs the
-        # bearer token in its call options — Dremio rejects unauthenticated
-        # do_get with `UNAUTHENTICATED` otherwise.
-        rpc_args: tuple[_pf.FlightCallOptions, ...] = (
-            (self._call_options,) if self._call_options is not None else ()
-        )
-        info = self._client.get_flight_info(descriptor, *rpc_args)
-        reader = self._client.do_get(info.endpoints[0].ticket, *rpc_args)
-        return reader.read_all()
+        native = self._native_connection.cursor()
+        try:
+            if parameters is not None:
+                native.execute(sql, parameters)
+            else:
+                native.execute(sql)
+            table: pa.Table = native.fetch_arrow_table()
+            return table
+        finally:
+            native.close()
 
     def _build_description(self, schema: pa.Schema) -> None:
         """Build PEP 249 description from an Arrow schema."""
@@ -134,13 +146,14 @@ class Cursor:
     def execute(self, operation: str, parameters: Sequence[object] | None = None) -> Cursor:
         """Execute a query — OBML YAML or plain SQL.
 
-        Parameters are not supported for Dremio Flight queries.  If
-        ``parameters`` is provided it is ignored (Dremio Flight SQL does
-        not support parameterised queries via this interface).
+        ``parameters`` bind as Flight SQL prepared-statement values.  The
+        hand-rolled Flight client had nowhere to put them, so it passed the
+        statement through with its placeholders intact and Dremio answered
+        with a Calcite internal error about ``RexDynamicParam``.
         """
         self._check_open()
         sql = self._resolve_sql(operation)
-        table = self._execute_sql(sql)
+        table = self._execute_sql(sql, parameters)
         self._arrow_table = table  # keep Arrow — converted lazily
         self._rows = []
         self._pos = 0
@@ -157,13 +170,17 @@ class Cursor:
     def executemany(self, operation: str, seq_of_parameters: Sequence[Sequence[object]]) -> None:
         """Execute against all parameter sequences.
 
+        Executed one statement per parameter set rather than through ADBC's
+        ``executemany``, which binds a whole batch over ``DoPut`` — Dremio
+        answers that with ``acceptPut is not implemented``.
+
         OBML queries are not supported with executemany — raises NotSupportedError.
         """
         self._check_open()
         if is_obml(operation):
             raise NotSupportedError("executemany() is not supported for OBML queries.")
-        for _params in seq_of_parameters:
-            self._execute_sql(operation)
+        for params in seq_of_parameters:
+            self._execute_sql(operation, params)
         self._description = None
         self._rows = []
         self._pos = 0
@@ -224,8 +241,10 @@ class Cursor:
     def close(self) -> None:
         """Close the cursor.
 
-        Does **not** close the underlying FlightClient — the client is owned
-        by the Connection and shared across cursors.
+        The native statement is already closed — ``_execute_sql`` opens one
+        per execution and releases it as soon as the Arrow table is in hand.
+        The connection stays open: it is owned by :class:`Connection` and
+        shared across cursors.
         """
         if not self._closed:
             self._closed = True

--- a/drivers/ob-dremio/tests/test_driver.py
+++ b/drivers/ob-dremio/tests/test_driver.py
@@ -119,7 +119,9 @@ def test_connect_returns_connection() -> None:
         mock_adbc_connect.return_value = _make_mock_connection()
         conn = ob_dremio.connect(host="dremio-host", port=32010)
         assert isinstance(conn, Connection)
-        mock_adbc_connect.assert_called_once_with("grpc://dremio-host:32010", db_kwargs={})
+        mock_adbc_connect.assert_called_once_with(
+            "grpc://dremio-host:32010", db_kwargs={}, autocommit=True
+        )
 
 
 def test_connect_with_tls() -> None:
@@ -143,6 +145,15 @@ def test_connect_with_auth() -> None:
             "username": "user",
             "password": "pass",
         }
+
+
+def test_connect_declares_autocommit() -> None:
+    """Otherwise ADBC tries to *disable* autocommit, Dremio refuses, and every
+    connection warns "conn will not be DB-API 2.0 compliant"."""
+    with patch(_ADBC_CONNECT) as mock_adbc_connect:
+        mock_adbc_connect.return_value = _make_mock_connection()
+        ob_dremio.connect()
+        assert mock_adbc_connect.call_args.kwargs["autocommit"] is True
 
 
 def test_connect_omits_absent_credentials() -> None:

--- a/drivers/ob-dremio/tests/test_driver.py
+++ b/drivers/ob-dremio/tests/test_driver.py
@@ -1,7 +1,11 @@
 """Unit tests for the ob-dremio DB-API 2.0 driver.
 
-All tests mock pyarrow.flight — no live Dremio needed.
+All tests mock the ADBC Flight SQL connection — no live Dremio needed.
 OBML tests additionally mock the REST API call to ``/v1/query/sql``.
+
+The live counterpart is ``tests/integration/dremio/test_dremio_adbc_driver.py``
+in the repository root, which runs this driver against a real Dremio
+container. Mocks prove the wiring; only Dremio proves the protocol.
 """
 
 from __future__ import annotations
@@ -16,18 +20,20 @@ from ob_dremio.cursor import Cursor
 from ob_dremio.exceptions import NotSupportedError, ProgrammingError
 from ob_dremio.type_codes import BINARY, DATETIME, NUMBER, STRING
 
+_ADBC_CONNECT = "adbc_driver_flightsql.dbapi.connect"
+
+
 # ---------------------------------------------------------------------------
-# Helpers to build mock pyarrow Flight objects
+# Helpers to build a mock ADBC connection and Arrow objects
 # ---------------------------------------------------------------------------
 
 
-def _make_mock_client() -> MagicMock:
-    """Return a mock pyarrow.flight.FlightClient."""
-    client = MagicMock()
+def _make_mock_connection() -> MagicMock:
+    """Return a mock ``adbc_driver_flightsql.dbapi.Connection``."""
+    native = MagicMock()
     # Default: return empty table
-    table = _make_arrow_table([], [], [])
-    _setup_flight_response(client, table)
-    return client
+    _set_result(native, _make_arrow_table([], [], []))
+    return native
 
 
 def _make_arrow_field(name: str, type_str: str) -> MagicMock:
@@ -67,19 +73,15 @@ def _make_arrow_table(
     return table
 
 
-def _setup_flight_response(client: MagicMock, table: MagicMock) -> None:
-    """Configure a mock FlightClient to return the given table on do_get."""
-    # get_flight_info returns FlightInfo with endpoints
-    info = MagicMock()
-    endpoint = MagicMock()
-    endpoint.ticket = MagicMock()
-    info.endpoints = [endpoint]
-    client.get_flight_info.return_value = info
+def _set_result(native: MagicMock, table: MagicMock) -> None:
+    """Configure a mock ADBC connection so its cursor yields the given table."""
+    native.cursor.return_value.fetch_arrow_table.return_value = table
 
-    # do_get returns a reader whose read_all() returns the table
-    reader = MagicMock()
-    reader.read_all.return_value = table
-    client.do_get.return_value = reader
+
+def _native_cursor(native: MagicMock) -> MagicMock:
+    """The single mock cursor ``Connection.cursor()`` hands out."""
+    cursor: MagicMock = native.cursor.return_value
+    return cursor
 
 
 def _mock_api_response(sql: str) -> MagicMock:
@@ -113,54 +115,75 @@ def test_paramstyle() -> None:
 
 
 def test_connect_returns_connection() -> None:
-    with patch("pyarrow.flight.FlightClient") as mock_flight_cls:
-        mock_client = _make_mock_client()
-        mock_flight_cls.return_value = mock_client
+    with patch(_ADBC_CONNECT) as mock_adbc_connect:
+        mock_adbc_connect.return_value = _make_mock_connection()
         conn = ob_dremio.connect(host="dremio-host", port=32010)
         assert isinstance(conn, Connection)
-        mock_flight_cls.assert_called_once_with("grpc://dremio-host:32010")
+        mock_adbc_connect.assert_called_once_with("grpc://dremio-host:32010", db_kwargs={})
 
 
 def test_connect_with_tls() -> None:
-    with patch("pyarrow.flight.FlightClient") as mock_flight_cls:
-        mock_client = _make_mock_client()
-        mock_flight_cls.return_value = mock_client
+    with patch(_ADBC_CONNECT) as mock_adbc_connect:
+        mock_adbc_connect.return_value = _make_mock_connection()
         ob_dremio.connect(host="dremio-host", port=32010, tls=True)
-        mock_flight_cls.assert_called_once_with("grpc+tls://dremio-host:32010")
+        assert mock_adbc_connect.call_args.args == ("grpc+tls://dremio-host:32010",)
 
 
 def test_connect_with_auth() -> None:
-    with (
-        patch("pyarrow.flight.FlightClient") as mock_flight_cls,
-        patch("pyarrow.flight.FlightCallOptions") as mock_opts_cls,
-    ):
-        mock_client = _make_mock_client()
-        mock_client.authenticate_basic_token.return_value = (
-            b"authorization",
-            b"Bearer token123",
-        )
-        mock_flight_cls.return_value = mock_client
-        mock_opts_cls.return_value = MagicMock()
+    """Credentials become ADBC options; the driver runs the token exchange.
+
+    The hand-rolled client called ``authenticate_basic_token`` and then had
+    to attach the returned bearer to every later RPC by hand.
+    """
+    with patch(_ADBC_CONNECT) as mock_adbc_connect:
+        mock_adbc_connect.return_value = _make_mock_connection()
         conn = ob_dremio.connect(host="dremio-host", username="user", password="pass")
         assert isinstance(conn, Connection)
-        mock_client.authenticate_basic_token.assert_called_once_with("user", "pass")
+        assert mock_adbc_connect.call_args.kwargs["db_kwargs"] == {
+            "username": "user",
+            "password": "pass",
+        }
+
+
+def test_connect_omits_absent_credentials() -> None:
+    """An anonymous connection must not send an empty username."""
+    with patch(_ADBC_CONNECT) as mock_adbc_connect:
+        mock_adbc_connect.return_value = _make_mock_connection()
+        ob_dremio.connect(host="dremio-host")
+        assert mock_adbc_connect.call_args.kwargs["db_kwargs"] == {}
+
+
+def test_connect_db_kwargs_override_derived_options() -> None:
+    """The escape hatch for Dremio's routing headers, and it wins."""
+    with patch(_ADBC_CONNECT) as mock_adbc_connect:
+        mock_adbc_connect.return_value = _make_mock_connection()
+        ob_dremio.connect(
+            username="user",
+            db_kwargs={
+                "username": "override",
+                "adbc.flight.sql.rpc.call_header.routing_queue": "bi",
+            },
+        )
+        assert mock_adbc_connect.call_args.kwargs["db_kwargs"] == {
+            "username": "override",
+            "adbc.flight.sql.rpc.call_header.routing_queue": "bi",
+        }
 
 
 def test_connect_custom_port() -> None:
-    with patch("pyarrow.flight.FlightClient") as mock_flight_cls:
-        mock_client = _make_mock_client()
-        mock_flight_cls.return_value = mock_client
+    with patch(_ADBC_CONNECT) as mock_adbc_connect:
+        mock_adbc_connect.return_value = _make_mock_connection()
         ob_dremio.connect(port=443, tls=True)
-        mock_flight_cls.assert_called_once_with("grpc+tls://localhost:443")
+        assert mock_adbc_connect.call_args.args == ("grpc+tls://localhost:443",)
 
 
 def test_connect_context_manager() -> None:
-    with patch("pyarrow.flight.FlightClient") as mock_flight_cls:
-        mock_client = _make_mock_client()
-        mock_flight_cls.return_value = mock_client
+    with patch(_ADBC_CONNECT) as mock_adbc_connect:
+        mock_conn = _make_mock_connection()
+        mock_adbc_connect.return_value = mock_conn
         with ob_dremio.connect() as conn:
             assert isinstance(conn, Connection)
-        mock_client.close.assert_called_once()
+        mock_conn.close.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
@@ -169,16 +192,16 @@ def test_connect_context_manager() -> None:
 
 
 def test_connection_close_is_idempotent() -> None:
-    mock_client = _make_mock_client()
-    conn = Connection(mock_client)
+    mock_conn = _make_mock_connection()
+    conn = Connection(mock_conn)
     conn.close()
     conn.close()  # should not raise
-    mock_client.close.assert_called_once()
+    mock_conn.close.assert_called_once()
 
 
 def test_connection_cursor_after_close_raises() -> None:
-    mock_client = _make_mock_client()
-    conn = Connection(mock_client)
+    mock_conn = _make_mock_connection()
+    conn = Connection(mock_conn)
     conn.close()
     with pytest.raises(ProgrammingError, match="closed"):
         conn.cursor()
@@ -186,14 +209,14 @@ def test_connection_cursor_after_close_raises() -> None:
 
 def test_connection_commit_noop() -> None:
     """commit() is a no-op — Dremio has no transactions."""
-    mock_client = _make_mock_client()
-    conn = Connection(mock_client)
+    mock_conn = _make_mock_connection()
+    conn = Connection(mock_conn)
     conn.commit()  # should not raise
 
 
 def test_connection_commit_after_close_raises() -> None:
-    mock_client = _make_mock_client()
-    conn = Connection(mock_client)
+    mock_conn = _make_mock_connection()
+    conn = Connection(mock_conn)
     conn.close()
     with pytest.raises(ProgrammingError, match="closed"):
         conn.commit()
@@ -201,29 +224,29 @@ def test_connection_commit_after_close_raises() -> None:
 
 def test_connection_rollback_noop() -> None:
     """rollback() is a no-op — Dremio has no transactions."""
-    mock_client = _make_mock_client()
-    conn = Connection(mock_client)
+    mock_conn = _make_mock_connection()
+    conn = Connection(mock_conn)
     conn.rollback()  # should not raise
 
 
 def test_connection_rollback_after_close_raises() -> None:
-    mock_client = _make_mock_client()
-    conn = Connection(mock_client)
+    mock_conn = _make_mock_connection()
+    conn = Connection(mock_conn)
     conn.close()
     with pytest.raises(ProgrammingError, match="closed"):
         conn.rollback()
 
 
 def test_connection_cursor_returns_cursor() -> None:
-    mock_client = _make_mock_client()
-    conn = Connection(mock_client)
+    mock_conn = _make_mock_connection()
+    conn = Connection(mock_conn)
     cur = conn.cursor()
     assert isinstance(cur, Cursor)
 
 
 def test_connection_passes_ob_params_to_cursor() -> None:
-    mock_client = _make_mock_client()
-    conn = Connection(mock_client, ob_api_url="http://my-api:9000", ob_timeout=60)
+    mock_conn = _make_mock_connection()
+    conn = Connection(mock_conn, ob_api_url="http://my-api:9000", ob_timeout=60)
     cur = conn.cursor()
     assert cur._ob_api_url == "http://my-api:9000"
     assert cur._ob_timeout == 60
@@ -234,32 +257,83 @@ def test_connection_passes_ob_params_to_cursor() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_cursor_execute_calls_flight() -> None:
-    mock_client = _make_mock_client()
-    conn = Connection(mock_client)
+def test_cursor_execute_runs_on_the_native_cursor() -> None:
+    mock_conn = _make_mock_connection()
+    conn = Connection(mock_conn)
     with conn.cursor() as cur:
         cur.execute("SELECT 1")
-        mock_client.get_flight_info.assert_called_once()
-        mock_client.do_get.assert_called_once()
+        _native_cursor(mock_conn).execute.assert_called_once_with("SELECT 1")
+        _native_cursor(mock_conn).fetch_arrow_table.assert_called_once()
+
+
+def test_cursor_execute_binds_parameters() -> None:
+    """Placeholders reach the native cursor instead of Dremio's parser.
+
+    The Flight client this driver used to hold had nowhere to put bound
+    values, so the statement went out with its ``?`` intact and Dremio
+    failed it with a Calcite ``RexDynamicParam`` error.
+    """
+    mock_conn = _make_mock_connection()
+    conn = Connection(mock_conn)
+    with conn.cursor() as cur:
+        cur.execute("SELECT x FROM t WHERE y = ?", ("US",))
+    _native_cursor(mock_conn).execute.assert_called_once_with(
+        "SELECT x FROM t WHERE y = ?", ("US",)
+    )
+
+
+def test_cursor_execute_without_parameters_passes_none_along() -> None:
+    """A statement with no parameters must not send an empty binding."""
+    mock_conn = _make_mock_connection()
+    conn = Connection(mock_conn)
+    with conn.cursor() as cur:
+        cur.execute("SELECT 1")
+    _native_cursor(mock_conn).execute.assert_called_once_with("SELECT 1")
+
+
+def test_each_execute_gets_its_own_native_cursor() -> None:
+    """Re-preparing per execution, deliberately.
+
+    ADBC skips re-preparing when the SQL text is unchanged, and Dremio then
+    answers the second execution with the first one's rows even though new
+    parameters were bound. Silent, wrong, and only reachable through reuse.
+    """
+    mock_conn = _make_mock_connection()
+    conn = Connection(mock_conn)
+    with conn.cursor() as cur:
+        cur.execute("SELECT x FROM t WHERE y = ?", ("a",))
+        cur.execute("SELECT x FROM t WHERE y = ?", ("b",))
+    assert mock_conn.cursor.call_count == 2
+    # And each is released as soon as its table is in hand.
+    assert _native_cursor(mock_conn).close.call_count == 2
+
+
+def test_a_statement_is_released_even_when_it_fails() -> None:
+    mock_conn = _make_mock_connection()
+    _native_cursor(mock_conn).execute.side_effect = RuntimeError("boom")
+    conn = Connection(mock_conn)
+    with conn.cursor() as cur, pytest.raises(RuntimeError, match="boom"):
+        cur.execute("SELECT 1")
+    _native_cursor(mock_conn).close.assert_called_once()
 
 
 def test_cursor_execute_returns_self() -> None:
-    mock_client = _make_mock_client()
-    conn = Connection(mock_client)
+    mock_conn = _make_mock_connection()
+    conn = Connection(mock_conn)
     with conn.cursor() as cur:
         result = cur.execute("SELECT 1")
         assert result is cur
 
 
 def test_cursor_description_with_arrow_types() -> None:
-    mock_client = _make_mock_client()
+    mock_conn = _make_mock_connection()
     table = _make_arrow_table(
         rows=[(42, "hello", "2024-01-15")],
         column_names=["num", "txt", "dt"],
         column_types=["int64", "utf8", "timestamp[ns]"],
     )
-    _setup_flight_response(mock_client, table)
-    conn = Connection(mock_client)
+    _set_result(mock_conn, table)
+    conn = Connection(mock_conn)
     cur = conn.cursor()
     cur.execute("SELECT 1")
     desc = cur.description
@@ -276,14 +350,14 @@ def test_cursor_description_with_arrow_types() -> None:
 
 def test_cursor_description_decimal_with_params() -> None:
     """decimal128(18, 2) should map to NUMBER after stripping params."""
-    mock_client = _make_mock_client()
+    mock_conn = _make_mock_connection()
     table = _make_arrow_table(
         rows=[(3.14,)],
         column_names=["price"],
         column_types=["decimal128(18, 2)"],
     )
-    _setup_flight_response(mock_client, table)
-    conn = Connection(mock_client)
+    _set_result(mock_conn, table)
+    conn = Connection(mock_conn)
     cur = conn.cursor()
     cur.execute("SELECT 1")
     desc = cur.description
@@ -292,42 +366,42 @@ def test_cursor_description_decimal_with_params() -> None:
 
 
 def test_cursor_description_none_before_execute() -> None:
-    mock_client = _make_mock_client()
-    conn = Connection(mock_client)
+    mock_conn = _make_mock_connection()
+    conn = Connection(mock_conn)
     cur = conn.cursor()
     assert cur.description is None
 
 
 def test_cursor_rowcount_after_execute() -> None:
-    mock_client = _make_mock_client()
+    mock_conn = _make_mock_connection()
     table = _make_arrow_table(
         rows=[(1,), (2,), (3,)],
         column_names=["id"],
         column_types=["int32"],
     )
-    _setup_flight_response(mock_client, table)
-    conn = Connection(mock_client)
+    _set_result(mock_conn, table)
+    conn = Connection(mock_conn)
     cur = conn.cursor()
     cur.execute("SELECT id FROM t")
     assert cur.rowcount == 3
 
 
 def test_cursor_rowcount_default() -> None:
-    mock_client = _make_mock_client()
-    conn = Connection(mock_client)
+    mock_conn = _make_mock_connection()
+    conn = Connection(mock_conn)
     cur = conn.cursor()
     assert cur.rowcount == -1
 
 
 def test_cursor_fetchone() -> None:
-    mock_client = _make_mock_client()
+    mock_conn = _make_mock_connection()
     table = _make_arrow_table(
         rows=[(42, "hello")],
         column_names=["a", "b"],
         column_types=["int32", "utf8"],
     )
-    _setup_flight_response(mock_client, table)
-    conn = Connection(mock_client)
+    _set_result(mock_conn, table)
+    conn = Connection(mock_conn)
     cur = conn.cursor()
     cur.execute("SELECT 1")
     row = cur.fetchone()
@@ -335,8 +409,8 @@ def test_cursor_fetchone() -> None:
 
 
 def test_cursor_fetchone_exhausted() -> None:
-    mock_client = _make_mock_client()
-    conn = Connection(mock_client)
+    mock_conn = _make_mock_connection()
+    conn = Connection(mock_conn)
     cur = conn.cursor()
     cur.execute("SELECT 1")  # empty result
     assert cur.fetchone() is None
@@ -344,14 +418,14 @@ def test_cursor_fetchone_exhausted() -> None:
 
 def test_cursor_fetchone_sequential() -> None:
     """fetchone() should advance through rows one at a time."""
-    mock_client = _make_mock_client()
+    mock_conn = _make_mock_connection()
     table = _make_arrow_table(
         rows=[(1,), (2,), (3,)],
         column_names=["id"],
         column_types=["int32"],
     )
-    _setup_flight_response(mock_client, table)
-    conn = Connection(mock_client)
+    _set_result(mock_conn, table)
+    conn = Connection(mock_conn)
     cur = conn.cursor()
     cur.execute("SELECT id FROM t")
     assert cur.fetchone() == (1,)
@@ -361,14 +435,14 @@ def test_cursor_fetchone_sequential() -> None:
 
 
 def test_cursor_fetchall() -> None:
-    mock_client = _make_mock_client()
+    mock_conn = _make_mock_connection()
     table = _make_arrow_table(
         rows=[(1, "a"), (2, "b"), (3, "c")],
         column_names=["id", "name"],
         column_types=["int32", "utf8"],
     )
-    _setup_flight_response(mock_client, table)
-    conn = Connection(mock_client)
+    _set_result(mock_conn, table)
+    conn = Connection(mock_conn)
     cur = conn.cursor()
     cur.execute("SELECT 1")
     rows = cur.fetchall()
@@ -379,14 +453,14 @@ def test_cursor_fetchall() -> None:
 
 def test_cursor_fetchall_after_fetchone() -> None:
     """fetchall() should return only remaining rows."""
-    mock_client = _make_mock_client()
+    mock_conn = _make_mock_connection()
     table = _make_arrow_table(
         rows=[(1,), (2,), (3,)],
         column_names=["id"],
         column_types=["int32"],
     )
-    _setup_flight_response(mock_client, table)
-    conn = Connection(mock_client)
+    _set_result(mock_conn, table)
+    conn = Connection(mock_conn)
     cur = conn.cursor()
     cur.execute("SELECT 1")
     cur.fetchone()  # consume first row
@@ -396,14 +470,14 @@ def test_cursor_fetchall_after_fetchone() -> None:
 
 
 def test_cursor_fetchmany() -> None:
-    mock_client = _make_mock_client()
+    mock_conn = _make_mock_connection()
     table = _make_arrow_table(
         rows=[(1,), (2,), (3,), (4,), (5,)],
         column_names=["id"],
         column_types=["int32"],
     )
-    _setup_flight_response(mock_client, table)
-    conn = Connection(mock_client)
+    _set_result(mock_conn, table)
+    conn = Connection(mock_conn)
     cur = conn.cursor()
     cur.execute("SELECT 1")
     batch = cur.fetchmany(3)
@@ -416,14 +490,14 @@ def test_cursor_fetchmany() -> None:
 
 
 def test_cursor_fetchmany_default_arraysize() -> None:
-    mock_client = _make_mock_client()
+    mock_conn = _make_mock_connection()
     table = _make_arrow_table(
         rows=[(1,), (2,), (3,)],
         column_names=["id"],
         column_types=["int32"],
     )
-    _setup_flight_response(mock_client, table)
-    conn = Connection(mock_client)
+    _set_result(mock_conn, table)
+    conn = Connection(mock_conn)
     cur = conn.cursor()
     cur.arraysize = 2
     cur.execute("SELECT 1")
@@ -432,14 +506,14 @@ def test_cursor_fetchmany_default_arraysize() -> None:
 
 
 def test_cursor_iteration() -> None:
-    mock_client = _make_mock_client()
+    mock_conn = _make_mock_connection()
     table = _make_arrow_table(
         rows=[(0,), (1,), (2,)],
         column_names=["id"],
         column_types=["int32"],
     )
-    _setup_flight_response(mock_client, table)
-    conn = Connection(mock_client)
+    _set_result(mock_conn, table)
+    conn = Connection(mock_conn)
     cur = conn.cursor()
     cur.execute("SELECT 1")
     rows = list(cur)
@@ -449,8 +523,8 @@ def test_cursor_iteration() -> None:
 
 
 def test_cursor_close_then_fetch_raises() -> None:
-    mock_client = _make_mock_client()
-    conn = Connection(mock_client)
+    mock_conn = _make_mock_connection()
+    conn = Connection(mock_conn)
     cur = conn.cursor()
     cur.close()
     with pytest.raises(ProgrammingError, match="closed"):
@@ -458,8 +532,8 @@ def test_cursor_close_then_fetch_raises() -> None:
 
 
 def test_cursor_close_then_fetchall_raises() -> None:
-    mock_client = _make_mock_client()
-    conn = Connection(mock_client)
+    mock_conn = _make_mock_connection()
+    conn = Connection(mock_conn)
     cur = conn.cursor()
     cur.close()
     with pytest.raises(ProgrammingError, match="closed"):
@@ -467,8 +541,8 @@ def test_cursor_close_then_fetchall_raises() -> None:
 
 
 def test_cursor_close_then_fetchmany_raises() -> None:
-    mock_client = _make_mock_client()
-    conn = Connection(mock_client)
+    mock_conn = _make_mock_connection()
+    conn = Connection(mock_conn)
     cur = conn.cursor()
     cur.close()
     with pytest.raises(ProgrammingError, match="closed"):
@@ -476,8 +550,8 @@ def test_cursor_close_then_fetchmany_raises() -> None:
 
 
 def test_cursor_close_then_execute_raises() -> None:
-    mock_client = _make_mock_client()
-    conn = Connection(mock_client)
+    mock_conn = _make_mock_connection()
+    conn = Connection(mock_conn)
     cur = conn.cursor()
     cur.close()
     with pytest.raises(ProgrammingError, match="closed"):
@@ -485,8 +559,8 @@ def test_cursor_close_then_execute_raises() -> None:
 
 
 def test_cursor_executemany_obml_raises() -> None:
-    mock_client = _make_mock_client()
-    conn = Connection(mock_client)
+    mock_conn = _make_mock_connection()
+    conn = Connection(mock_conn)
     cur = conn.cursor()
     obml = "select:\n  dimensions:\n    - Region\n  measures:\n    - Revenue\n"
     with pytest.raises(NotSupportedError, match="executemany"):
@@ -494,38 +568,40 @@ def test_cursor_executemany_obml_raises() -> None:
 
 
 def test_cursor_executemany_plain_sql() -> None:
-    mock_client = _make_mock_client()
-    conn = Connection(mock_client)
+    mock_conn = _make_mock_connection()
+    conn = Connection(mock_conn)
     cur = conn.cursor()
     cur.executemany("INSERT INTO t VALUES (?)", [("a",), ("b",)])
-    # Two calls to get_flight_info (one per iteration)
-    assert mock_client.get_flight_info.call_count == 2
+    # One statement per parameter set — ADBC's own executemany binds the
+    # batch over DoPut, which Dremio answers with "acceptPut is not
+    # implemented".
+    assert _native_cursor(mock_conn).execute.call_count == 2
 
 
 def test_cursor_setinputsizes_noop() -> None:
-    mock_client = _make_mock_client()
-    conn = Connection(mock_client)
+    mock_conn = _make_mock_connection()
+    conn = Connection(mock_conn)
     cur = conn.cursor()
     cur.setinputsizes([])  # should not raise
 
 
 def test_cursor_setoutputsize_noop() -> None:
-    mock_client = _make_mock_client()
-    conn = Connection(mock_client)
+    mock_conn = _make_mock_connection()
+    conn = Connection(mock_conn)
     cur = conn.cursor()
     cur.setoutputsize(1000)  # should not raise
 
 
 def test_cursor_lastrowid_is_none() -> None:
-    mock_client = _make_mock_client()
-    conn = Connection(mock_client)
+    mock_conn = _make_mock_connection()
+    conn = Connection(mock_conn)
     cur = conn.cursor()
     assert cur.lastrowid is None
 
 
 def test_cursor_context_manager() -> None:
-    mock_client = _make_mock_client()
-    conn = Connection(mock_client)
+    mock_conn = _make_mock_connection()
+    conn = Connection(mock_conn)
     with conn.cursor() as cur:
         assert isinstance(cur, Cursor)
     # After exiting, cursor should be closed
@@ -540,28 +616,28 @@ def test_cursor_context_manager() -> None:
 
 def test_obml_compile_and_execute() -> None:
     """OBML query is compiled via REST API then executed on Dremio Flight."""
-    mock_client = _make_mock_client()
+    mock_conn = _make_mock_connection()
     compiled_sql = "SELECT region, sum(amount) AS revenue FROM orders GROUP BY region"
     table = _make_arrow_table(
         rows=[("EMEA", 300.0), ("APAC", 150.0), ("AMER", 550.0)],
         column_names=["region", "revenue"],
         column_types=["utf8", "double"],
     )
-    _setup_flight_response(mock_client, table)
-    conn = Connection(mock_client)
+    _set_result(mock_conn, table)
+    conn = Connection(mock_conn)
     with patch("httpx.post", return_value=_mock_api_response(compiled_sql)):
         with conn.cursor() as cur:
             cur.execute("select:\n  dimensions:\n    - Region\n  measures:\n    - Revenue\n")
             rows = cur.fetchall()
             assert len(rows) == 3
-            # Verify get_flight_info was called (i.e., Flight execution happened)
-            mock_client.get_flight_info.assert_called_once()
+            # Verify the compiled SQL reached the native cursor
+            _native_cursor(mock_conn).execute.assert_called_once()
 
 
 def test_obml_rest_dialect_is_dremio() -> None:
     """REST API is called with dialect=dremio."""
-    mock_client = _make_mock_client()
-    conn = Connection(mock_client)
+    mock_conn = _make_mock_connection()
+    conn = Connection(mock_conn)
     compiled_sql = "SELECT 1"
     with patch("httpx.post", return_value=_mock_api_response(compiled_sql)) as mock_post:
         with conn.cursor() as cur:
@@ -573,8 +649,8 @@ def test_obml_rest_dialect_is_dremio() -> None:
 
 def test_obml_custom_api_url() -> None:
     """Custom ob_api_url is forwarded to the REST call."""
-    mock_client = _make_mock_client()
-    conn = Connection(mock_client, ob_api_url="http://my-api:9000")
+    mock_conn = _make_mock_connection()
+    conn = Connection(mock_conn, ob_api_url="http://my-api:9000")
     compiled_sql = "SELECT 1"
     with patch("httpx.post", return_value=_mock_api_response(compiled_sql)) as mock_post:
         with conn.cursor() as cur:
@@ -585,25 +661,25 @@ def test_obml_custom_api_url() -> None:
 
 def test_plain_sql_passthrough() -> None:
     """Plain SQL is passed through without OBML compilation — no REST call."""
-    mock_client = _make_mock_client()
-    conn = Connection(mock_client)
+    mock_conn = _make_mock_connection()
+    conn = Connection(mock_conn)
     with patch("httpx.post") as mock_post, conn.cursor() as cur:
         cur.execute("SELECT count(*) FROM orders")
         mock_post.assert_not_called()
-        mock_client.get_flight_info.assert_called_once()
+        _native_cursor(mock_conn).execute.assert_called_once()
 
 
 def test_obml_execute_with_description() -> None:
     """After OBML execute, description should reflect compiled result columns."""
-    mock_client = _make_mock_client()
+    mock_conn = _make_mock_connection()
     compiled_sql = "SELECT region, sum(amount) AS revenue FROM orders GROUP BY region"
     table = _make_arrow_table(
         rows=[("EMEA", 300.0)],
         column_names=["region", "revenue"],
         column_types=["utf8", "double"],
     )
-    _setup_flight_response(mock_client, table)
-    conn = Connection(mock_client)
+    _set_result(mock_conn, table)
+    conn = Connection(mock_conn)
     with patch("httpx.post", return_value=_mock_api_response(compiled_sql)):
         with conn.cursor() as cur:
             cur.execute("select:\n  dimensions:\n    - Region\n  measures:\n    - Revenue\n")
@@ -623,14 +699,14 @@ def test_obml_execute_with_description() -> None:
 
 def test_unknown_type_defaults_to_string() -> None:
     """Unknown Arrow types should default to STRING."""
-    mock_client = _make_mock_client()
+    mock_conn = _make_mock_connection()
     table = _make_arrow_table(
         rows=[([1, 2, 3],)],
         column_names=["arr"],
         column_types=["list<int32>"],
     )
-    _setup_flight_response(mock_client, table)
-    conn = Connection(mock_client)
+    _set_result(mock_conn, table)
+    conn = Connection(mock_conn)
     cur = conn.cursor()
     cur.execute("SELECT 1")
     desc = cur.description
@@ -661,14 +737,14 @@ def test_type_map_covers_common_arrow_types() -> None:
 
 def test_timestamp_with_params_maps_to_datetime() -> None:
     """timestamp[ns, tz=UTC] should map to DATETIME after stripping params."""
-    mock_client = _make_mock_client()
+    mock_conn = _make_mock_connection()
     table = _make_arrow_table(
         rows=[("2024-01-15T10:30:00",)],
         column_names=["ts"],
         column_types=["timestamp[ns, tz=UTC]"],
     )
-    _setup_flight_response(mock_client, table)
-    conn = Connection(mock_client)
+    _set_result(mock_conn, table)
+    conn = Connection(mock_conn)
     cur = conn.cursor()
     cur.execute("SELECT 1")
     desc = cur.description

--- a/tests/integration/dremio/README.md
+++ b/tests/integration/dremio/README.md
@@ -1,20 +1,30 @@
-# Dremio ↔ OBSL pgwire compatibility tests (Stage 1)
+# Dremio ↔ OBSL integration tests
 
-This suite spins up Dremio OSS and registers OBSL's pgwire surface as a
-**Postgres source** in Dremio, then exercises catalog reflection and a
-real semantic query through Dremio's JDBC pushdown.
+This suite spins up Dremio OSS beside OBSL and exercises the connection in
+both directions:
 
-It is the highest-value real-world stress test of the v2.5.0 pgwire compat
-work: Dremio's Postgres connector probes `pg_catalog` aggressively (much
-like Tableau / pgjdbc) before any user SQL runs.
+- **Dremio → OBSL** (Stage 1): OBSL's pgwire surface registered as a
+  **Postgres source** in Dremio, driving catalog reflection and a real
+  semantic query through Dremio's JDBC pushdown. The highest-value
+  real-world stress test of the v2.5.0 pgwire compat work: Dremio's Postgres
+  connector probes `pg_catalog` aggressively (much like Tableau / pgjdbc)
+  before any user SQL runs.
+- **OBSL → Dremio** (Stage 2): OBSL compiles to its `dremio` dialect and
+  executes back against the same container through the `ob-dremio` driver,
+  which speaks Arrow Flight SQL over ADBC.
+- **`ob-dremio` on its own**: the driver against Dremio's Flight SQL port,
+  with nothing of OBSL in between.
 
 ## Layout
 
 | File | Purpose |
 |---|---|
-| `docker-compose.yml` | OBSL (pgwire on :5432) + Dremio OSS (REST :9047, Flight :31010) on a shared bridge network |
-| `conftest.py` | Session-scoped fixture: waits for Dremio, bootstraps the admin user, registers the OBSL Postgres source via `/api/v3/catalog` |
-| `test_dremio_postgres_source.py` | Three asserts: source registers, `INFORMATION_SCHEMA.TABLES` reflects, semantic SELECT round-trips |
+| `docker-compose.yml` | OBSL (pgwire on :5432) + Dremio OSS (REST :9047, legacy :31010, Flight SQL :32010) on a shared bridge network |
+| `conftest.py` | Session-scoped fixtures: `dremio_admin_token` waits for Dremio and bootstraps the admin user; `dremio_session` adds the OBSL Postgres source via `/api/v3/catalog` |
+| `test_dremio_postgres_source.py` | Stage 1 — source registers, `INFORMATION_SCHEMA.TABLES` reflects, semantic SELECT round-trips |
+| `test_dremio_full_circle.py` | Stage 2 — Dremio → OBSL pgwire → `ob-dremio` → Dremio, on the `dremio_info_schema` model |
+| `test_dremio_function_catalog.py`, `test_dremio_measure_sweep.py` | Stage 2 breadth — functions and measures compiled to Dremio SQL and executed |
+| `test_dremio_adbc_driver.py` | The `ob-dremio` driver straight against Flight SQL :32010: PEP 249 surface, Arrow types, parameter binding |
 | `run.sh` | One-shot runner — build, up, pytest, down |
 
 ## Why opt-in
@@ -46,7 +56,8 @@ Host port map:
 | OBSL REST API | 8080 | 18080 |
 | OBSL pgwire | 5432 | 15432 |
 | Dremio REST/UI | 9047 | 19047 |
-| Dremio Flight | 31010 | 31010 |
+| Dremio legacy Flight | 31010 | 31010 |
+| Dremio Flight SQL | 32010 | 32010 |
 
 Dremio admin during the test run: `obsl_admin` / `obsl_admin_pw_123!`
 (visit `http://localhost:19047` if you need to poke around manually).
@@ -61,11 +72,13 @@ The fixtures honour the following env vars for CI or non-default ports:
 | `OBSL_PGWIRE_HOST` | `obsl` (the docker network alias) |
 | `OBSL_PGWIRE_PORT` | `5432` |
 | `OBSL_MODEL_NAME` | `orionbelt_1_commerce` (what the compose stack in this directory serves). Export `commerce` to point the suite at the separate `demo/dremio/` stack instead |
+| `DREMIO_FLIGHT_HOST` | `localhost` (the `ob-dremio` suite connects from the host) |
+| `DREMIO_FLIGHT_PORT` | `32010` |
 
 ## What this suite does NOT cover
 
-This is **Stage 1**. It only validates that Dremio can use OBSL as a
-Postgres source. The "full circle" picture (Dremio executes the SQL
-OBSL emits via its `dremio` dialect against real lakehouse data) is
-Stage 2 and would add an Iceberg/Nessie dataset inside Dremio plus an
-OBSL model that points at it.
+Stage 2 runs against Dremio's own `INFORMATION_SCHEMA`, which is always
+present and needs no setup. It does not run against **real lakehouse
+data**: an Iceberg/Nessie dataset inside Dremio, with an OBSL model
+pointing at it, would exercise pushdown and partitioning that system
+tables cannot.

--- a/tests/integration/dremio/conftest.py
+++ b/tests/integration/dremio/conftest.py
@@ -47,6 +47,12 @@ OBSL_MODEL_NAME = os.environ.get("OBSL_MODEL_NAME", "orionbelt_1_commerce")
 # back against the same Dremio container via the ob-dremio Flight driver.
 OBSL_STAGE2_MODEL_NAME = os.environ.get("OBSL_STAGE2_MODEL_NAME", "dremio_info_schema")
 
+# Dremio's Arrow Flight SQL endpoint, host side. The compose file publishes
+# the container's :32010 unchanged; ``ob_dremio`` connects here directly,
+# without going through OBSL.
+DREMIO_FLIGHT_HOST = os.environ.get("DREMIO_FLIGHT_HOST", "localhost")
+DREMIO_FLIGHT_PORT = int(os.environ.get("DREMIO_FLIGHT_PORT", "32010"))
+
 # Dremio first-user bootstrap. The container has no preexisting admin
 # until the very first PUT /apiv2/bootstrap/firstuser succeeds.
 DREMIO_ADMIN_USER = "obsl_admin"
@@ -158,8 +164,14 @@ def _ensure_postgres_source(client: httpx.Client, token: str) -> None:
 
 
 @pytest.fixture(scope="session")
-def dremio_session() -> Iterator[DremioSession]:
-    """Wait for Dremio + OBSL, bootstrap the admin user, register the source."""
+def dremio_admin_token() -> str:
+    """Wait for Dremio, bootstrap its first admin user, return a login token.
+
+    Held apart from :func:`dremio_session` because not every test needs the
+    OBSL Postgres source: the ob-dremio driver suite talks straight to
+    Dremio's Flight SQL port and would otherwise be coupled to the OBSL
+    container being up.
+    """
 
     with httpx.Client(base_url=DREMIO_REST_URL) as client:
         # Fast probe first so a default ``pytest`` run with no stack up
@@ -180,12 +192,19 @@ def dremio_session() -> Iterator[DremioSession]:
                 pytest.fail(f"Dremio at {DREMIO_REST_URL} stopped responding mid-bootstrap")
             time.sleep(_BOOTSTRAP_POLL_INTERVAL)
 
-        token = _bootstrap_first_user(client)
-        _ensure_postgres_source(client, token)
+        return _bootstrap_first_user(client)
+
+
+@pytest.fixture(scope="session")
+def dremio_session(dremio_admin_token: str) -> Iterator[DremioSession]:
+    """Wait for Dremio + OBSL, bootstrap the admin user, register the source."""
+
+    with httpx.Client(base_url=DREMIO_REST_URL) as client:
+        _ensure_postgres_source(client, dremio_admin_token)
 
         yield DremioSession(
             base_url=DREMIO_REST_URL,
-            token=token,
+            token=dremio_admin_token,
             source_name=DREMIO_SOURCE_NAME,
         )
 

--- a/tests/integration/dremio/docker-compose.yml
+++ b/tests/integration/dremio/docker-compose.yml
@@ -75,6 +75,10 @@ services:
     ports:
       - "19047:9047"
       - "31010:31010"
+      # Arrow Flight SQL. Published so the ob-dremio driver suite can reach
+      # Dremio from the host, the same way ob_dremio reaches it from inside
+      # the OBSL container.
+      - "32010:32010"
     environment:
       DREMIO_JAVA_SERVER_EXTRA_OPTS: -Xms1g -Xmx2g
     volumes:

--- a/tests/integration/dremio/test_dremio_adbc_driver.py
+++ b/tests/integration/dremio/test_dremio_adbc_driver.py
@@ -102,10 +102,17 @@ class TestItIsActuallyADBC:
 
 
 class TestConnectIsQuiet:
-    def test_connecting_emits_no_warning(self) -> None:
+    def test_connecting_emits_no_warning(self, dremio_admin_token: str) -> None:
         """ADBC disables autocommit on connect unless told not to bother, and
         Dremio -- which has no transactions -- refuses, so every connection
-        used to warn that it "will not be DB-API 2.0 compliant"."""
+        used to warn that it "will not be DB-API 2.0 compliant".
+
+        Opens its own connection, since the warning happens at connect and
+        the shared ``dremio_conn`` is already past it. It still takes
+        ``dremio_admin_token``: that fixture carries the suite's
+        reachability skip, and a test that connects without it fails with
+        "connection refused" wherever the stack is not up.
+        """
         import warnings
 
         import ob_dremio

--- a/tests/integration/dremio/test_dremio_adbc_driver.py
+++ b/tests/integration/dremio/test_dremio_adbc_driver.py
@@ -101,6 +101,27 @@ class TestItIsActuallyADBC:
             assert len(cur.fetchall()) == 1
 
 
+class TestConnectIsQuiet:
+    def test_connecting_emits_no_warning(self) -> None:
+        """ADBC disables autocommit on connect unless told not to bother, and
+        Dremio -- which has no transactions -- refuses, so every connection
+        used to warn that it "will not be DB-API 2.0 compliant"."""
+        import warnings
+
+        import ob_dremio
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            connection = ob_dremio.connect(
+                host=DREMIO_FLIGHT_HOST,
+                port=DREMIO_FLIGHT_PORT,
+                username=DREMIO_ADMIN_USER,
+                password=DREMIO_ADMIN_PASS,
+            )
+            connection.close()
+        assert [str(w.message) for w in caught] == []
+
+
 class TestPep249Surface:
     """The published surface has to survive the swap unchanged."""
 

--- a/tests/integration/dremio/test_dremio_adbc_driver.py
+++ b/tests/integration/dremio/test_dremio_adbc_driver.py
@@ -1,0 +1,289 @@
+"""The ob-dremio driver against a live Dremio, over ADBC Flight SQL.
+
+Track I-2 of ``design/PLAN_adbc.md``: Dremio is the pilot for OBSL as an
+ADBC *client*. It was the obvious first dialect because it is the only one
+whose driver was a hand-rolled Flight client — so the migration deletes
+protocol code rather than swapping one vendor SDK for another, and it
+exercises ``adbc_driver_flightsql``, the same dependency Track II's clients
+use to reach OBSL.
+
+These talk straight to Dremio's Flight SQL port; nothing here goes through
+OBSL. ``test_dremio_full_circle.py`` covers the other direction, where OBSL
+compiles to the Dremio dialect and executes through this driver.
+
+Backing data is Dremio's own ``INFORMATION_SCHEMA``, always present, so no
+dataset promotion is needed.
+
+Run with the stack from this directory up::
+
+    tests/integration/dremio/run.sh
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+from tests.integration.dremio.conftest import (
+    DREMIO_ADMIN_PASS,
+    DREMIO_ADMIN_USER,
+    DREMIO_FLIGHT_HOST,
+    DREMIO_FLIGHT_PORT,
+)
+
+pytestmark = pytest.mark.dremio
+
+# A row source that exists in every Dremio, with a column of each type that
+# the migration had to keep answering identically.
+TYPED_QUERY = (
+    "SELECT CAST(1 AS INT) AS i, CAST(2 AS BIGINT) AS bi, CAST(1.5 AS DOUBLE) AS d, "
+    "CAST('x' AS VARCHAR) AS s, CAST('2020-01-02' AS DATE) AS dt, "
+    "CAST('2020-01-02 03:04:05' AS TIMESTAMP) AS ts, "
+    "CAST(12.34 AS DECIMAL(18,2)) AS dcm, true AS b "
+    "FROM (VALUES(1))"
+)
+
+
+@pytest.fixture(scope="module")
+def dremio_conn(dremio_admin_token: str) -> Iterator[Any]:
+    """An ``ob_dremio`` connection to the live container.
+
+    Depends on ``dremio_admin_token`` rather than ``dremio_session``: the
+    admin user has to exist before Flight will authenticate anyone, but the
+    OBSL Postgres source is irrelevant here.
+    """
+    ob_dremio = pytest.importorskip("ob_dremio", reason="ob-dremio not installed")
+
+    connection = ob_dremio.connect(
+        host=DREMIO_FLIGHT_HOST,
+        port=DREMIO_FLIGHT_PORT,
+        username=DREMIO_ADMIN_USER,
+        password=DREMIO_ADMIN_PASS,
+    )
+    try:
+        yield connection
+    finally:
+        connection.close()
+
+
+class TestItIsActuallyADBC:
+    def test_the_connection_is_an_adbc_connection(self, dremio_conn: Any) -> None:
+        """Guards the point of the exercise: no hand-rolled Flight client.
+
+        Every other test here would pass just as well against the old
+        ``pyarrow.flight`` implementation — that is the intent, since the
+        migration is meant to be invisible — so one test has to check what
+        is underneath.
+        """
+        import adbc_driver_manager.dbapi
+
+        native = dremio_conn._native
+        assert isinstance(native, adbc_driver_manager.dbapi.Connection), (
+            f"native connection is {type(native).__module__}.{type(native).__name__}"
+        )
+
+    def test_the_adbc_driver_behind_it_is_flightsql(self, dremio_conn: Any) -> None:
+        """``dbapi.Connection`` is the manager's shared class, so the type
+        alone does not say which driver loaded. Errors carry the driver's
+        own tag, and only one of them says ``[FlightSQL]``."""
+        from adbc_driver_manager import NotSupportedError
+
+        with pytest.raises(NotSupportedError, match=r"\[FlightSQL\]"):
+            dremio_conn._native.adbc_get_statistic_names()
+
+    def test_authentication_happened(self, dremio_conn: Any) -> None:
+        """Dremio refuses unauthenticated Flight calls, so a row proves the
+        driver ran the basic-token exchange and reused the bearer."""
+        with dremio_conn.cursor() as cur:
+            cur.execute("SELECT TABLE_NAME FROM INFORMATION_SCHEMA.COLUMNS LIMIT 1")
+            assert len(cur.fetchall()) == 1
+
+
+class TestPep249Surface:
+    """The published surface has to survive the swap unchanged."""
+
+    def test_rowcount_is_the_row_count(self, dremio_conn: Any) -> None:
+        with dremio_conn.cursor() as cur:
+            cur.execute("SELECT TABLE_NAME FROM INFORMATION_SCHEMA.COLUMNS LIMIT 3")
+            assert cur.rowcount == 3
+
+    def test_description_reports_pep249_type_constants(self, dremio_conn: Any) -> None:
+        """Not PyArrow ``DataType`` objects, which is what ADBC's own cursor
+        puts in that slot — ``db_executor`` maps this to a type hint."""
+        from ob_dremio.type_codes import DATETIME, NUMBER, STRING
+
+        with dremio_conn.cursor() as cur:
+            cur.execute(TYPED_QUERY)
+            by_name = {d[0]: d[1] for d in cur.description}
+        assert by_name["i"] == NUMBER
+        assert by_name["dcm"] == NUMBER
+        assert by_name["s"] == STRING
+        assert by_name["dt"] == DATETIME
+        assert by_name["ts"] == DATETIME
+
+    def test_fetch_methods_walk_the_result_once(self, dremio_conn: Any) -> None:
+        """Each fetch consumes what it returns, and the cursor then empties."""
+        with dremio_conn.cursor() as cur:
+            cur.execute(
+                "SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS ORDER BY COLUMN_NAME LIMIT 3"
+            )
+            first = cur.fetchone()
+            middle = cur.fetchmany(1)
+            rest = cur.fetchall()
+            exhausted = cur.fetchone()
+        assert isinstance(first, tuple)
+        assert len(middle) == 1
+        assert len(rest) == 1
+        assert exhausted is None
+        assert len({first, middle[0], rest[0]}) == 3, "a row was handed out twice"
+
+    def test_iteration_yields_rows(self, dremio_conn: Any) -> None:
+        with dremio_conn.cursor() as cur:
+            cur.execute("SELECT TABLE_NAME FROM INFORMATION_SCHEMA.COLUMNS LIMIT 2")
+            assert len([row for row in cur]) == 2
+
+
+class TestArrowFidelity:
+    """The types OBSL's reconciliation layer is written against."""
+
+    def test_arrow_types_are_what_dremio_always_returned(self, dremio_conn: Any) -> None:
+        with dremio_conn.cursor() as cur:
+            cur.execute(TYPED_QUERY)
+            table = cur.fetch_arrow_table()
+        types = {f.name: str(f.type) for f in table.schema}
+        assert types == {
+            "i": "int32",
+            "bi": "int64",
+            "d": "double",
+            "s": "string",
+            # date64, not date32 — the narrowing OBSL applies downstream
+            # is written against exactly this.
+            "dt": "date64[ms]",
+            "ts": "timestamp[ms]",
+            "dcm": "decimal128(18, 2)",
+            "b": "bool",
+        }
+
+    def test_values_survive_the_round_trip(self, dremio_conn: Any) -> None:
+        import datetime
+        from decimal import Decimal
+
+        with dremio_conn.cursor() as cur:
+            cur.execute(TYPED_QUERY)
+            row = cur.fetch_arrow_table().to_pylist()[0]
+        assert row["dcm"] == Decimal("12.34")
+        assert row["dt"] == datetime.date(2020, 1, 2)
+        assert row["ts"] == datetime.datetime(2020, 1, 2, 3, 4, 5)
+
+    def test_an_empty_result_keeps_its_schema(self, dremio_conn: Any) -> None:
+        """A null-typed empty column is the bug that broke Flight cache hits."""
+        with dremio_conn.cursor() as cur:
+            cur.execute("SELECT TABLE_NAME FROM INFORMATION_SCHEMA.COLUMNS WHERE 1=0")
+            table = cur.fetch_arrow_table()
+        assert table.num_rows == 0
+        assert str(table.schema.field("TABLE_NAME").type) == "string"
+
+
+class TestParameterBinding:
+    """New with ADBC. The hand-rolled client had nowhere to put a value, so
+    it sent the statement with its placeholders intact and Dremio answered
+    with a Calcite ``RexDynamicParam`` internal error.
+    """
+
+    def test_a_bound_value_filters(self, dremio_conn: Any) -> None:
+        with dremio_conn.cursor() as cur:
+            cur.execute(
+                "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = ? LIMIT 5",
+                ("COLUMNS",),
+            )
+            rows = cur.fetchall()
+        assert rows, "bound filter matched nothing"
+        assert {r[0] for r in rows} == {"COLUMNS"}
+
+    def test_rebinding_gives_a_different_answer(self, dremio_conn: Any) -> None:
+        """The regression that decided how ``_execute_sql`` is written.
+
+        Reusing one native cursor makes ADBC skip re-preparing when the SQL
+        text is unchanged, and Dremio then returns the *first* execution's
+        rows for the second binding - the same number, no error. This test
+        fails with a stale answer rather than an exception, which is why the
+        driver opens a statement per execution.
+        """
+        sql = "SELECT SUM(ORDINAL_POSITION) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = ?"
+        with dremio_conn.cursor() as cur:
+            cur.execute(sql, ("COLUMNS",))
+            columns = cur.fetchone()[0]
+            cur.execute(sql, ("__no_such_table__",))
+            missing = cur.fetchone()[0]
+        assert columns > 0
+        assert missing is None, "no rows matched, so SUM has nothing to add"
+
+    def test_count_in_a_prepared_statement_is_refused_by_dremio(self, dremio_conn: Any) -> None:
+        """A live limitation, not a driver defect — and Dremio's, not ours.
+
+        Dremio describes a prepared ``COUNT`` as ``int64`` NOT NULL and then
+        streams it nullable. ADBC compares the two and refuses the endpoint;
+        the hand-rolled client never compared, but it also could not bind a
+        parameter at all, so nothing that works today stops working.
+
+        Exactly the defect class the OBSL Flight server was caught in by its
+        own ADBC harness: catalog schemas marked every field nullable where
+        the spec says NOT NULL, and only ADBC noticed.
+
+        Aggregates that are nullable on both sides (``SUM``, ``MAX``) are
+        fine, as is an unparameterised ``COUNT``.
+        """
+        from adbc_driver_manager import OperationalError
+
+        with (
+            pytest.raises(OperationalError, match="(?i)inconsistent schema"),
+            dremio_conn.cursor() as cur,
+        ):
+            cur.execute(
+                "SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = ?",
+                ("COLUMNS",),
+            )
+
+    def test_an_unparameterised_count_is_unaffected(self, dremio_conn: Any) -> None:
+        """The shape OBSL itself emits: literals compiled in, no placeholders."""
+        with dremio_conn.cursor() as cur:
+            cur.execute(
+                "SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'COLUMNS'"
+            )
+            assert cur.fetchone()[0] > 0
+
+    def test_executemany_runs_one_statement_per_parameter_set(self, dremio_conn: Any) -> None:
+        """ADBC's own ``executemany`` binds the batch over ``DoPut``, which
+        Dremio refuses with ``acceptPut is not implemented`` — so this
+        driver loops instead."""
+        with dremio_conn.cursor() as cur:
+            cur.executemany(
+                "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = ?",
+                [("COLUMNS",), ("TABLES",)],
+            )
+
+
+class TestErrors:
+    def test_a_bad_statement_raises(self, dremio_conn: Any) -> None:
+        with (
+            pytest.raises(Exception, match="(?i)not found|no_such|validation|table"),
+            dremio_conn.cursor() as cur,
+        ):
+            cur.execute("SELECT * FROM no_such_table_xyz")
+            cur.fetchall()
+
+    def test_a_closed_connection_refuses_a_cursor(self, dremio_conn: Any) -> None:
+        import ob_dremio
+        from ob_dremio.exceptions import ProgrammingError
+
+        connection = ob_dremio.connect(
+            host=DREMIO_FLIGHT_HOST,
+            port=DREMIO_FLIGHT_PORT,
+            username=DREMIO_ADMIN_USER,
+            password=DREMIO_ADMIN_PASS,
+        )
+        connection.close()
+        with pytest.raises(ProgrammingError, match="closed"):
+            connection.cursor()

--- a/uv.lock
+++ b/uv.lock
@@ -2268,6 +2268,7 @@ name = "ob-dremio"
 version = "2.6.1"
 source = { editable = "drivers/ob-dremio" }
 dependencies = [
+    { name = "adbc-driver-flightsql" },
     { name = "ob-driver-core" },
     { name = "pyarrow" },
 ]
@@ -2286,6 +2287,7 @@ sqlalchemy = [
 
 [package.metadata]
 requires-dist = [
+    { name = "adbc-driver-flightsql", specifier = ">=1.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10" },
     { name = "ob-driver-core", editable = "drivers/ob-driver-core" },
     { name = "pyarrow", specifier = ">=16.0" },


### PR DESCRIPTION
Track I-2 of the ADBC plan: the Dremio pilot for OBSL as an ADBC *client*.

Dremio was the right dialect to go first. It is the only one whose driver was a hand-rolled Flight client, so the migration **deletes protocol code** rather than swapping one vendor SDK for another, and it exercises `adbc_driver_flightsql` - the same dependency Track II's clients use to reach OBSL, now validated from both ends.

## What was there

`ob_dremio` built `FlightDescriptor.for_command`, called `get_flight_info` + `do_get`, and carried the bearer token from `authenticate_basic_token()` in a `FlightCallOptions` field threaded through every RPC, because a Cython `FlightClient` refuses ad-hoc attribute writes. All of that is gone; auth is a connect option now.

## The surface does not move

Deliberately, because `ob-dremio` is published and an internals swap should not be a major version bump:

| | Before | After |
|---|---|---|
| `rowcount` | row count | row count |
| `description[i][1]` | PEP 249 type constant | PEP 249 type constant |
| Arrow types | `int32`, `date64[ms]`, `timestamp[ms]`, `decimal128(18, 2)` | identical |
| `fetch_arrow_table()` | Arrow | Arrow |

`description` keeps being built from the Arrow schema rather than delegated: ADBC's own cursor puts PyArrow `DataType` objects in the type-code slot, and `db_executor` maps that slot to a type hint.

## What gets better

- **`?` parameters bind.** They never did. The old client had nowhere to put a value, so the statement went out with its placeholders intact and Dremio answered with a Calcite `RexDynamicParam` internal error - which is why the driver documented parameters as unsupported.
- **Failures raise DB-API errors** instead of `pyarrow.lib.ArrowInvalid`.

## The find worth reading

ADBC skips re-preparing when the SQL text has not changed. Dremio then answers the second execution with the **first** execution's rows - new parameters bound, no error, just a wrong number:

```
SUM(...) WHERE TABLE_NAME = 'COLUMNS'  -> 153
SUM(...) WHERE TABLE_NAME = '__none__' -> 153   # should be NULL
```

The same reuse against OBSL's own Flight server rebinds correctly, which puts the fault on Dremio's side of the wire. The driver therefore opens one statement per execution and releases it as soon as the Arrow table is in hand - which is also what the hand-rolled client effectively did, one `get_flight_info` + `do_get` at a time. A live test pins it, because this failure is a wrong answer rather than an exception.

Two further Dremio limits are documented rather than left to be discovered:

- a **prepared `COUNT`** is refused, because Dremio describes it `int64` NOT NULL and streams it nullable and ADBC compares the two. Exactly the defect class the ADBC harness caught in *our* Flight server. `SUM`/`MAX` and an unparameterised `COUNT` are fine.
- **`executemany`** over `DoPut` answers `acceptPut is not implemented`, so the driver loops one statement per parameter set.

Neither is reachable from OBSL, which compiles literals and never binds.

## Verification

`tests/integration/dremio/run.sh`: **110 passed**. That includes the 93 pre-existing tests that execute OBSL measures through this driver inside the container (`test_dremio_measure_sweep`, `test_dremio_function_catalog`, `test_dremio_full_circle`) and 17 new ones in `test_dremio_adbc_driver.py`, which assert the Arrow types, the PEP 249 surface, parameter binding, the rebinding regression, and that the connection underneath really is ADBC.

Also: `uv run pytest` 5112 passed / 1064 skipped; `ruff check`, `ruff format --check` and `mypy` clean at the root and in the driver package; `pytest drivers/ob-dremio/tests` 69 passed, rewritten from mocking `FlightClient` to mocking an ADBC connection.

The compose file now publishes Dremio's `:32010` so the driver suite can reach it from the host, and the conftest's bootstrap is split out of `dremio_session` so a test that only needs Flight is not coupled to the OBSL container.