### PR TITLE
fix(flight): take the driver's Arrow schema instead of guessing one

### DIFF
--- a/drivers/ob-duckdb/src/ob_duckdb/cursor.py
+++ b/drivers/ob-duckdb/src/ob_duckdb/cursor.py
@@ -126,8 +126,17 @@ class Cursor:
         Returns a ``pyarrow.Table``.  This avoids materialising intermediate
         Python row objects and is significantly more memory-efficient for
         large result sets.
+
+        DuckDB renamed its own ``fetch_arrow_table`` to ``to_arrow_table`` and
+        deprecated the old name, so calling it emits a ``DeprecationWarning``
+        per query. Prefer the new name and fall back for the older releases
+        ``pyproject`` still allows (``duckdb>=1.0``). The PEP 249 name here
+        does not change - it is what every OB driver exposes.
         """
         self._check_open()
+        to_arrow = getattr(self._native, "to_arrow_table", None)
+        if to_arrow is not None:
+            return to_arrow()
         return self._native.fetch_arrow_table()
 
     def close(self) -> None:

--- a/drivers/ob-flight-extension/src/ob_flight/server_execution.py
+++ b/drivers/ob-flight-extension/src/ob_flight/server_execution.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any
 import pyarrow as pa
 import pyarrow.compute as pc
 from ob_driver_core.detection import is_obml, parse_obml
-from orionbelt.service.db_executor import arrow_type_to_hint
+from orionbelt.service.db_executor import arrow_type_to_hint, try_fetch_arrow
 from pyarrow import flight
 
 from ob_flight.converters import rows_to_batch, schema_from_description
@@ -677,6 +677,49 @@ def _wall_clock_where_naive(table: pa.Table, schema: pa.Schema) -> pa.Table:
     return table
 
 
+def _result_table(server: OBFlightServer, cursor: Any) -> pa.Table:
+    """The result as Arrow: the driver's own table where it has one.
+
+    Preferring the driver is the whole point. The fallback below builds a
+    schema with ``schema_from_description``, which infers Arrow types from
+    *sampled values* -- so a column the first batch under-represents gets a
+    type the rest of the result then has to fit into. That is the same
+    inference class that typed empty columns ``null`` in the cache and
+    narrowed governed decimals (#136), and part of what
+    ``align_cached_table`` exists to repair afterwards. A driver that hands
+    back Arrow has already been told the widths by the warehouse.
+
+    It also makes Flight agree with REST and pgwire by construction: they
+    ask the same cursors the same question through
+    ``db_executor.try_fetch_arrow``, and two paths inferring types two ways
+    is how one column ends up with two types.
+
+    The row path stays for a cursor that offers no Arrow at all.
+    """
+    table = try_fetch_arrow(cursor)
+    if table is not None:
+        return table
+
+    # Scan rows for type inference: UNION ALL queries may have NULL-padded
+    # columns in early rows.
+    first_rows = cursor.fetchmany(server._batch_size)
+    schema = schema_from_description(cursor.description, sample_rows=first_rows)
+
+    batches: list[pa.RecordBatch] = []
+    if first_rows:
+        batches.append(rows_to_batch(first_rows, schema))
+    while True:
+        rows = cursor.fetchmany(server._batch_size)
+        if not rows:
+            break
+        batches.append(rows_to_batch(rows, schema))
+
+    if not batches:
+        batches = [rows_to_batch([], schema)]
+
+    return pa.Table.from_batches(batches)
+
+
 def execute_sql(
     server: OBFlightServer,
     sql: str,
@@ -731,24 +774,7 @@ def execute_sql(
             table = pa.Table.from_batches([batch])
             return flight.RecordBatchStream(table)
 
-        # Fetch first batch and scan rows for Arrow type inference
-        # (UNION ALL queries may have NULL-padded columns in early rows)
-        first_rows = cursor.fetchmany(server._batch_size)
-        schema = schema_from_description(cursor.description, sample_rows=first_rows)
-
-        batches: list[pa.RecordBatch] = []
-        if first_rows:
-            batches.append(rows_to_batch(first_rows, schema))
-        while True:
-            rows = cursor.fetchmany(server._batch_size)
-            if not rows:
-                break
-            batches.append(rows_to_batch(rows, schema))
-
-        if not batches:
-            batches = [rows_to_batch([], schema)]
-
-        table = pa.Table.from_batches(batches)
+        table = _result_table(server, cursor)
 
         # Cast to the schema advertised in FlightInfo so the streamed schema
         # matches what the client was promised — e.g. a governed DECIMAL column

--- a/drivers/ob-flight-extension/tests/test_server.py
+++ b/drivers/ob-flight-extension/tests/test_server.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import threading
+from decimal import Decimal
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -270,6 +271,10 @@ class TestDoGet:
         mock_cursor = MagicMock()
         mock_cursor.description = (("n", NUMBER, None, None, None, None, None),)
         mock_cursor.fetchmany.side_effect = [[(42.0,)], []]
+        # A driver with no Arrow of its own, so the row fallback runs. Without
+        # the delete a MagicMock answers ``fetch_arrow_table`` with a mock,
+        # which is neither a table nor an honest test.
+        del mock_cursor.fetch_arrow_table
 
         mock_conn = MagicMock()
         mock_conn.cursor.return_value = mock_cursor
@@ -282,6 +287,75 @@ class TestDoGet:
         # Ticket should be consumed
         assert ticket_id not in server._pending
         mock_conn.close.assert_called_once()
+
+    def test_prefers_the_driver_arrow_table(self, monkeypatch) -> None:
+        """The driver's schema, not one inferred from sampled values.
+
+        ``schema_from_description`` reads Arrow types off the first rows, so
+        a decimal wider than its first batch suggests, or an all-NULL CFL
+        pad, gets a type the rest of the result then has to fit into. Seven
+        of the eight drivers already know what the warehouse said.
+        """
+        from ob_flight import server_execution
+
+        server = _make_server()
+        ticket_id = "arrow-ticket"
+        server._store_pending(ticket_id, ("sql", "SELECT amount FROM t", "duckdb"))
+
+        # decimal128(18, 2) is the case in point: inferring from a value of
+        # 1.50 sizes the column decimal128(3, 2) and loses the declared width.
+        table = pa.table({"amount": pa.array([Decimal("1.50")], pa.decimal128(18, 2))})
+
+        mock_cursor = MagicMock()
+        mock_cursor.description = (("amount", None, None, None, None, None, None),)
+        mock_cursor.fetch_arrow_table.return_value = table
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+
+        captured: dict[str, Any] = {}
+
+        class FakeStream:
+            def __init__(self, streamed) -> None:
+                captured["table"] = streamed
+
+        monkeypatch.setattr(server_execution.flight, "RecordBatchStream", FakeStream)
+
+        with patch("ob_flight.server.db_connect", return_value=mock_conn):
+            server.do_get(MagicMock(), flight.Ticket(ticket_id.encode("utf-8")))
+
+        assert captured["table"].schema.field("amount").type == pa.decimal128(18, 2)
+        mock_cursor.fetchmany.assert_not_called()
+        mock_conn.close.assert_called_once()
+
+    def test_row_fallback_still_infers_when_a_driver_has_no_arrow(self, monkeypatch) -> None:
+        """MySQL aside, this path is now the exception - but it has to work."""
+        from ob_driver_core.type_codes import STRING
+
+        from ob_flight import server_execution
+
+        server = _make_server()
+        ticket_id = "fallback-ticket"
+        server._store_pending(ticket_id, ("sql", "SELECT name FROM t", "duckdb"))
+
+        mock_cursor = MagicMock()
+        mock_cursor.description = (("name", STRING, None, None, None, None, None),)
+        mock_cursor.fetchmany.side_effect = [[("a",)], []]
+        del mock_cursor.fetch_arrow_table
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+
+        captured: dict[str, Any] = {}
+
+        class FakeStream:
+            def __init__(self, streamed) -> None:
+                captured["table"] = streamed
+
+        monkeypatch.setattr(server_execution.flight, "RecordBatchStream", FakeStream)
+
+        with patch("ob_flight.server.db_connect", return_value=mock_conn):
+            server.do_get(MagicMock(), flight.Ticket(ticket_id.encode("utf-8")))
+
+        assert captured["table"].column("name").to_pylist() == ["a"]
 
     def test_ddl_query_returns_ok(self):
         server = _make_server()
@@ -313,6 +387,7 @@ class TestDoGet:
         mock_cursor = MagicMock()
         mock_cursor.description = (("name", STRING, None, None, None, None, None),)
         mock_cursor.fetchmany.return_value = []  # no rows
+        del mock_cursor.fetch_arrow_table  # row fallback, as above
 
         mock_conn = MagicMock()
         mock_conn.cursor.return_value = mock_cursor

--- a/src/orionbelt/service/db_executor.py
+++ b/src/orionbelt/service/db_executor.py
@@ -1078,11 +1078,16 @@ def ensure_arrow() -> bool:
     return False
 
 
-def _try_fetch_arrow(cursor: Any) -> Any:
+def try_fetch_arrow(cursor: Any) -> Any:
     """Try to fetch results as an Arrow Table. Returns None on failure.
 
     Disabled when pyarrow is not loaded to avoid triggering heavy gRPC
     initialization inside uvicorn on macOS.
+
+    Public because the Flight driver asks the same question of the same
+    cursors. It used to answer it differently - by inferring Arrow types
+    from sampled row values - and two paths inferring types two ways is
+    how a column ends up with one type on REST and another on Flight.
     """
     import sys
 
@@ -1095,3 +1100,7 @@ def _try_fetch_arrow(cursor: Any) -> Any:
         return fetch_fn()
     except Exception:
         return None
+
+
+#: The historical private name, kept for the call sites in this module.
+_try_fetch_arrow = try_fetch_arrow

--- a/tests/unit/test_flight_result_table.py
+++ b/tests/unit/test_flight_result_table.py
@@ -1,0 +1,114 @@
+"""The Flight executor takes the driver's Arrow schema, not one it guesses.
+
+``ob_flight.server_execution`` used to build every result by reading rows out
+of a PEP 249 cursor and inferring Arrow types from the values in the first
+batch. That is the inference class behind the empty-column-typed-``null``
+cache bug and the governed-decimal narrowing of #136 - both of which
+``align_cached_table`` then repairs downstream.
+
+These run a real DuckDB cursor through the real ``ob_duckdb`` driver, because
+the point is what an actual driver reports, and compare the two paths on the
+same query.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+
+import pytest
+
+pa = pytest.importorskip("pyarrow")
+duckdb = pytest.importorskip("duckdb")
+pytest.importorskip("ob_flight")
+
+from ob_flight.converters import rows_to_batch, schema_from_description  # noqa: E402
+from ob_flight.server_execution import _result_table  # noqa: E402
+
+
+class _Server:
+    """Only the attribute ``_result_table`` reads."""
+
+    _batch_size = 1024
+
+
+def _cursor(sql: str) -> Any:
+    """A real ob_duckdb cursor over an in-memory database."""
+    ob_duckdb = pytest.importorskip("ob_duckdb", reason="ob-duckdb not installed")
+    connection = ob_duckdb.connect(database=":memory:")
+    cursor = connection.cursor()
+    cursor.execute(sql)
+    return cursor
+
+
+def _inferred(sql: str) -> pa.Table:
+    """What the row path would have produced for the same query."""
+    cursor = _cursor(sql)
+    first = cursor.fetchmany(1024)
+    schema = schema_from_description(cursor.description, sample_rows=first)
+    batches = [rows_to_batch(first, schema)] if first else [rows_to_batch([], schema)]
+    return pa.Table.from_batches(batches)
+
+
+class TestDecimalWidth:
+    QUERY = "SELECT CAST(1.50 AS DECIMAL(18,2)) AS amount"
+
+    def test_the_declared_width_survives(self) -> None:
+        table = _result_table(_Server(), _cursor(self.QUERY))
+        assert table.schema.field("amount").type == pa.decimal128(18, 2)
+        assert table.column("amount").to_pylist() == [Decimal("1.50")]
+
+    def test_and_the_row_path_would_have_narrowed_it(self) -> None:
+        """Pins the reason this change exists rather than asserting it.
+
+        If this ever stops narrowing, the inference improved and the fallback
+        matters less - but the fix above still stands, because a driver that
+        was told the width should not have to be guessed at.
+        """
+        narrowed = _inferred(self.QUERY).schema.field("amount").type
+        assert narrowed != pa.decimal128(18, 2), (
+            f"row-path inference produced {narrowed}; the two paths now agree"
+        )
+
+
+class TestEmptyResult:
+    QUERY = "SELECT CAST(1 AS BIGINT) AS n, 'x' AS s WHERE 1=0"
+
+    def test_an_empty_result_keeps_its_column_types(self) -> None:
+        """The shape that made a cache hit stream ``null``-typed columns."""
+        table = _result_table(_Server(), _cursor(self.QUERY))
+        assert table.num_rows == 0
+        assert table.schema.field("n").type == pa.int64()
+        assert pa.types.is_string(table.schema.field("s").type)
+
+
+class TestNullFirstBatch:
+    QUERY = """
+        SELECT CAST(NULL AS BIGINT) AS n UNION ALL SELECT CAST(7 AS BIGINT) ORDER BY n NULLS FIRST
+    """
+
+    def test_a_leading_null_does_not_decide_the_type(self) -> None:
+        """The CFL pad case the row path scans extra rows to work around.
+
+        Taking the driver's schema removes the need to scan at all.
+        """
+        table = _result_table(_Server(), _cursor(self.QUERY))
+        assert table.schema.field("n").type == pa.int64()
+        assert table.column("n").to_pylist() == [None, 7]
+
+
+class TestFallback:
+    def test_a_cursor_without_arrow_still_works(self) -> None:
+        """MySQL aside this is now the exception, but it has to keep working."""
+
+        class RowOnlyCursor:
+            description = (("name", None, None, None, None, None, None),)
+
+            def __init__(self) -> None:
+                self._chunks = [[("a",), ("b",)], []]
+
+            def fetchmany(self, size: int) -> list[tuple[Any, ...]]:
+                return self._chunks.pop(0) if self._chunks else []
+
+        table = _result_table(_Server(), RowOnlyCursor())
+        assert table.column("name").to_pylist() == ["a", "b"]


### PR DESCRIPTION
The Flight executor built every result by pulling tuples out of a PEP 249 cursor and inferring Arrow types from the values in the first batch (`schema_from_description(..., sample_rows=...)` + `rows_to_batch`). So the one surface whose protocol is *made* of record batches was the one that never asked a driver for Arrow: a Postgres or Dremio result that arrived as Arrow got torn down into Python objects and rebuilt with re-inferred types, while REST and pgwire asked those same cursors for the table directly.

Inference from sampled values is the class of bug that typed empty columns `null` in the cache and narrowed governed decimals (#136) - part of what `align_cached_table` exists to repair after the fact. Seven of the eight drivers already know what the warehouse said.

## The difference, on a real cursor

`tests/unit/test_flight_result_table.py` runs a real DuckDB cursor through the real `ob_duckdb` driver and compares both paths on the same query:

| Query | Driver's Arrow | Row-path inference |
|---|---|---|
| `CAST(1.50 AS DECIMAL(18,2))` | `decimal128(18, 2)` | `decimal128(3, 2)` |
| `SELECT ... WHERE 1=0` | `int64`, `string` | inferred from no values |
| a leading `NULL` (the CFL pad case) | `int64` | needs a multi-row scan to avoid `null` |

One of those tests asserts the row path *still narrows*, so it fails if the two paths ever converge - the reason for the change stays pinned rather than becoming folklore.

## Also in here

`try_fetch_arrow` is now public in `db_executor`, so both paths ask the same question the same way rather than each having its own idea of what a driver offers. The row path stays for a cursor with no Arrow at all (MySQL is row-shaped at the source).

Calling it surfaced a second thing: `ob_duckdb.fetch_arrow_table()` called DuckDB's *deprecated* `fetch_arrow_table`, so every Flight query on DuckDB started emitting a `DeprecationWarning` - 122 warnings in a full run, back to 85 now. It prefers `to_arrow_table` where the installed duckdb has it, which `db_executor` already did on the native path.

## Not a performance change

Measured on DuckDB, warm, median of 5, over a real `GROUP BY`:

| rows | row path | driver Arrow |
|---:|---:|---:|
| 100 | 24.9 ms | 23.2 ms |
| 1,000 | 27.6 ms | 23.7 ms |
| 10,000 | 45.2 ms | 25.6 ms |
| 100,000 | 231.5 ms | 26.9 ms |
| 1,000,000 | 1047.4 ms | 33.3 ms |

~23 ms is the query itself. At the sizes semantic-layer aggregations actually produce the two are within noise; the gap only opens past ~10k rows. This is a correctness cleanup that happens to be faster, not the other way round.

## Verification

`uv run pytest` 5117 passed / 1065 skipped. `pytest -m adbc_flight` (real Flight server, real ADBC client, real DuckDB) 97 passed / 1 skipped. `pytest drivers/ob-flight-extension/tests` 287 passed. ruff and mypy clean at the root and in both driver packages.

Two existing `TestDoGet` tests needed `del mock_cursor.fetch_arrow_table` to keep exercising the row path they were written for - a bare `MagicMock` answers any attribute, which would have made them assert nothing. Both now say which path they are on, and there is a new test for each.