### PR TITLE
fix(cache): one entry, one representation, on every surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to OrionBelt Semantic Layer are documented here.
 
 ## [Unreleased]
 
+### Fixed
+
+- **One cache entry now means the same thing to every surface (#429).** REST, pgwire and Flight
+  share a result cache - same key, same blob - but they did not share a representation. REST and
+  pgwire encoded rows that had already been serialised, so a timestamp column was stored as an ISO
+  `string`, a date as a `string` and binary as base64; Flight stored its Arrow table verbatim, so
+  the same three columns were `timestamp[us]`, `date32` and `binary`. Whichever surface ran the
+  query first decided what the others read, and each read path only understood its own writer's
+  convention.
+
+  The driver's table is what gets stored now, and a hit is materialised through the same serialiser
+  a miss is - so a hit returns what its miss returned, cell for cell, including the ADBC opaque
+  NUMERIC that arrives as a string in Arrow and a `Decimal` in a row.
+
+  Two visible consequences. `format=arrow` returns the warehouse's types instead of ISO strings
+  under an envelope that called them datetimes, and a raw-arrow cache hit therefore ships the same
+  bytes a miss does. And `reconcile_to_declared` works on a cache hit, where a row-backed rebuild
+  made it a silent no-op - the trap four read paths rediscovered one at a time.
+
+  `KEY_VERSION` moves 4 -> 5: entries written under v4 hold serialised values, miss once and age
+  out. `encode_data` stays as the fallback for a result with no Arrow table at all; the schema-hint
+  machinery it needed to approximate types from serialised rows is gone.
+
 ### Changed
 
 - **`ob-dremio` executes over ADBC Flight SQL (#427).** The driver was the only one in the set that

--- a/docs/reference/type-fidelity.md
+++ b/docs/reference/type-fidelity.md
@@ -130,7 +130,22 @@ Every type defect OBSL has actually shipped lived between the driver and the
 caller, not in the driver - the cache codec typing a column from the values it
 happened to hold (#410), the executor never importing pyarrow so no result
 carried a schema at all (#412), the same reconciliation missing from one read
-path at a time (#414) - and a driver-level probe is blind to all of them.
+path at a time (#414), and one cache entry meaning two different things
+depending on which surface wrote it (#429) - and a driver-level probe is blind
+to all of them.
+
+## What a cache entry holds
+
+The blob is the driver's Arrow table, so a cached column has the type the
+warehouse gave it: `timestamp[us]` stays `timestamp[us]`, `date32` stays
+`date32`, `binary` stays `binary`. Serialisation to the JSON shapes below
+happens on delivery, once, in the same function for a hit and a miss.
+
+It was not always so. REST and pgwire used to encode their already-serialised
+rows, storing an ISO `string` for a timestamp and base64 for binary, while
+Flight stored its table verbatim - in the same shared key. So `format=arrow`
+returned a `string` column under an envelope that called it a datetime, and
+which types you got depended on which surface ran the query first.
 
 So `tests/integration/test_type_fidelity.py` asserts through
 `db_executor.execute_sql`, the path REST, pgwire and the CLI share, on DuckDB -

--- a/src/orionbelt/api/query_cache.py
+++ b/src/orionbelt/api/query_cache.py
@@ -27,7 +27,7 @@ from orionbelt.api.schemas import (
 )
 from orionbelt.cache import build_datasource_key
 from orionbelt.cache.protocol import Cache
-from orionbelt.cache.result_codec import decode_data, encode_data, table_to_rows
+from orionbelt.cache.result_codec import decode_data, encode_data, encode_table
 from orionbelt.cache.ttl import TtlResult
 from orionbelt.compiler.validator import format_sql
 from orionbelt.service.db_executor import (
@@ -279,6 +279,7 @@ async def try_cache_set(
     cache: Cache,
     key: str,
     columns: list[ColumnMetadata],
+    table: Any,
     rows: list[list[Any]],
     sql: str,
     dialect: str,
@@ -287,18 +288,21 @@ async def try_cache_set(
     ttl_seconds: int,
     datasource: str,
     model_id: str,
-    schema: Any,
 ) -> None:
     """Encode and store the row data + column schema. Failures are logged.
 
-    ``schema`` is the executor's driver Arrow schema
-    (``ExecutionResult.arrow_schema``), or ``None`` when the result came from
-    a PEP 249 driver that has none. It is **required, not defaulted**: rows
-    alone cannot type an empty or all-null column, so a writer that omits it
-    silently stores an Arrow ``null`` column that a raw ``format=arrow`` hit
-    then serves verbatim against numeric column metadata. Making callers pass
-    it explicitly turns that omission into a signature error instead of a
-    payload that contradicts its own envelope.
+    ``table`` is the executor's Arrow table (``ExecutionResult.arrow_table``),
+    read before ``rows`` materialises and frees it. Where there is one it is
+    stored **verbatim**, so the blob carries the warehouse's own types.
+    ``rows`` is the fallback for a PEP 249 result that has no table - a driver
+    with no Arrow at all, or a process that never imported pyarrow - and there
+    the types are inferred from the serialised values, as they always were.
+
+    Storing the table is what makes one entry mean the same thing to every
+    surface. Encoding from serialised rows instead put an ISO ``string`` in a
+    timestamp column and base64 in a binary one, while Flight - which already
+    stored its table verbatim - put ``timestamp[us]`` and ``binary`` in the
+    same key. Whoever wrote first decided what the other read.
 
     Only the row data (blob) and the result's column schema + row count (entry
     sidecar) are cached; the response envelope (sql, explain, timing, ``cached``
@@ -312,7 +316,11 @@ async def try_cache_set(
     from orionbelt.cache import key as cache_key_mod
 
     try:
-        payload = encode_data([c.name for c in columns], rows, schema)
+        payload = (
+            encode_table(table)
+            if table is not None
+            else encode_data([c.name for c in columns], rows)
+        )
     except Exception:
         logger.debug("cache encode failed", exc_info=True)
         return
@@ -478,10 +486,11 @@ async def execute_query_with_cache(
     columns = build_result_columns(
         model, exec_result, query=query, skipped=frozenset(n for n, _ in declared_skips)
     )
-    # Read before ``rows`` is touched below; ``arrow_schema`` is captured at
-    # construction so this is safe regardless, but keeping it explicit
-    # documents that the encoders want the driver's declared types.
-    arrow_schema = exec_result.arrow_schema
+    # Read before ``rows`` is touched below, which materialises the table and
+    # frees it. The table is what gets stored: encoding from serialised rows
+    # instead is how the same key came to hold ISO strings when REST wrote it
+    # and ``timestamp[us]`` when Flight did.
+    arrow_table = exec_result.arrow_table
 
     if (
         cacheable
@@ -493,7 +502,8 @@ async def execute_query_with_cache(
             cache=cache,
             key=cache_key,
             columns=columns,
-            rows=exec_result.rows,
+            table=arrow_table,
+            rows=exec_result.rows if arrow_table is None else [],
             sql=format_sql(compile_result.sql, dialect),
             dialect=dialect,
             physical_tables=compile_result.physical_tables,
@@ -501,7 +511,6 @@ async def execute_query_with_cache(
             ttl_seconds=ttl_outcome.ttl.seconds,
             datasource=ds,
             model_id=model_id,
-            schema=arrow_schema,
         )
 
     return CachedExecution(
@@ -571,20 +580,24 @@ def execution_result_from_data(
     The blob holds only row data; columns come from the stored schema sidecar
     (``columns``) when present — preserving exact types for empty / all-null
     results — else from the Arrow schema. ``execution_time_ms`` is the
-    per-request value (cache fetch time on a hit), never a stored one. ``tz`` is
-    the resolved fallback timezone used to label the response (the stored rows
-    are already materialized, so it is a label only).
+    per-request value (cache fetch time on a hit), never a stored one.
+
+    The result is **table-backed**, like a fresh one. That is the whole point:
+    ``rows`` then runs the same ``_arrow_to_rows`` a miss runs, so a hit and
+    the miss that filled it serialise identically instead of a hit returning
+    whatever the stored cells happened to be. It also makes
+    ``reconcile_to_declared`` work on a hit rather than silently doing nothing
+    for want of a table, which is the trap four read paths rediscovered.
+
+    ``tz`` labels naive timestamps exactly as it does on a miss.
     """
     cols = exec_columns_from_sidecar(columns) if columns else exec_columns_from_table(data_table)
     return ExecutionResult(
         columns=cols,
-        raw_rows=table_to_rows(data_table),
+        arrow_table=data_table,
         row_count=data_table.num_rows,
         execution_time_ms=execution_time_ms,
         tz=tz,
-        # The table's own schema, so a re-encode on the way out keeps the types
-        # rather than re-inferring them from the rows.
-        arrow_schema=data_table.schema,
     )
 
 

--- a/src/orionbelt/api/routers/oneshot.py
+++ b/src/orionbelt/api/routers/oneshot.py
@@ -424,6 +424,11 @@ async def _run_query(
                 error=OneshotBatchQueryError(code="EXECUTION_ERROR", message=str(exc)),
             )
 
+        # Before the envelope, which reads ``rows`` and frees the table. The
+        # cache stores the table itself, so a oneshot-written entry means the
+        # same thing as one written by /query/execute or by Flight.
+        arrow_table = exec_result.arrow_table
+
         # Reuse the standard execute response builder so column metadata,
         # type hints, and format strings stay consistent with /query/execute.
         envelope = _build_execute_response(
@@ -459,7 +464,7 @@ async def _run_query(
                 model_id=model_id,
                 dialect=dialect,
                 physical_tables=physical_tables,
-                schema=exec_result.arrow_schema,
+                table=arrow_table,
             )
         elif ttl_outcome.no_cache_reason is not None:
             ttl_source = (
@@ -695,21 +700,22 @@ async def _try_oneshot_cache_set(
     model_id: str,
     dialect: str,
     physical_tables: list[str],
-    schema: Any = None,
+    table: Any = None,
 ) -> None:
     """Best-effort cache set for oneshot batch entries (row data only).
 
-    ``schema`` is the executor's driver Arrow schema. The envelope has
-    already reduced the result to JSON rows, so without it an empty or
-    all-null column would be stored as Arrow ``null`` — and this writer
-    populates the *shared* cache, so a later raw ``format=arrow`` hit would
-    serve that blob verbatim against numeric column metadata.
+    ``table`` is the executor's Arrow table, read before the envelope
+    materialised its rows. This writer populates the *shared* cache, so a blob
+    it writes is one a REST arrow request or Flight will later read: storing
+    the table keeps its types the warehouse's rather than whatever the
+    envelope's already-serialised rows imply.
     """
     await try_cache_set(
         cache=cache,
         key=key,
         columns=list(envelope.columns),
-        rows=list(envelope.rows),
+        table=table,
+        rows=list(envelope.rows) if table is None else [],
         sql=envelope.sql,
         dialect=envelope.dialect,
         physical_tables=physical_tables,
@@ -717,5 +723,4 @@ async def _try_oneshot_cache_set(
         ttl_seconds=ttl_seconds,
         datasource=datasource,
         model_id=model_id,
-        schema=schema,
     )

--- a/src/orionbelt/api/services/query_execution.py
+++ b/src/orionbelt/api/services/query_execution.py
@@ -177,7 +177,7 @@ def _render_response(
     timezone: str | None,
     cached: bool = False,
     cached_at: str | None = None,
-    arrow_schema: Any = None,
+    arrow_table: Any = None,
 ) -> QueryExecuteResponse | Response:
     """Render already-resolved columns + RAW rows into the requested surface.
 
@@ -199,6 +199,8 @@ def _render_response(
         # encoded into the Arrow data, mirroring the JSON format_values variant.
         arrow_rows: list[list[Any]]
         if format_values:
+            # Every cell is a display string by construction, so there is no
+            # driver type left to preserve and the table is the wrong source.
             arrow_rows = [
                 cast(
                     list[Any],
@@ -212,15 +214,21 @@ def _render_response(
                 )
                 for row in rows
             ]
+            gzipped_data = result_codec.encode_data(column_names, arrow_rows)
         else:
+            # The driver's table, verbatim, so the bytes a miss returns are the
+            # bytes the cache stored and a later hit hands back. Encoding from
+            # ``rows`` instead re-inferred the types from values that had
+            # already been serialised, which is how a timestamp column left as
+            # ``string`` in an Arrow response whose own envelope called it a
+            # datetime. Falls back to the rows for a result with no table (a
+            # PEP 249 driver, or a process without pyarrow).
             arrow_rows = rows
-        # ``arrow_schema`` keeps an empty / all-null column from decoding as
-        # ``null`` while the envelope's column metadata calls it numeric. It
-        # is irrelevant under format_values, where every cell is a display
-        # string by construction.
-        gzipped_data = result_codec.encode_data(
-            column_names, arrow_rows, None if format_values else arrow_schema
-        )
+            gzipped_data = (
+                result_codec.encode_table(arrow_table)
+                if arrow_table is not None
+                else result_codec.encode_data(column_names, arrow_rows)
+            )
         meta = _arrow_envelope_dict(
             columns_meta=columns_meta,
             sql=sql,
@@ -404,6 +412,8 @@ def _build_execute_response(
     columns_meta, fmt_map, type_map = _columns_and_maps(
         model, exec_result.columns, query, frozenset(name for name, _ in skips)
     )
+    # Before ``rows`` below, which materialises the table and frees it.
+    arrow_table = exec_result.arrow_table
 
     return _render_response(
         response_format=response_format,
@@ -412,7 +422,7 @@ def _build_execute_response(
         accept_encoding=accept_encoding,
         columns_meta=columns_meta,
         rows=exec_result.rows,
-        arrow_schema=exec_result.arrow_schema,
+        arrow_table=arrow_table,
         fmt_map=fmt_map,
         type_map=type_map,
         sql=format_sql(compile_result.sql, compile_result.dialect),
@@ -580,18 +590,16 @@ async def _run_with_cache(
         # from the cached data table (columns from the schema sidecar, so exact
         # types survive empty / all-null results) and render like a fresh run.
         assert cached.data_table is not None
-        # Reconcile the *table*, not the rebuilt result.
-        # ``execution_result_from_data`` hands back ``raw_rows`` rather than an
-        # Arrow table - deliberately, because ``table_to_rows`` keeps native
-        # dates where the executor's own row builder serialises them to ISO
-        # strings, so swapping it would change what a hit returns. But it also
-        # leaves ``arrow_schema`` None, so reconciling the result is a no-op and
-        # a hit reported none of the warnings its miss did.
+        # Reconcile the table here rather than leaving it to the response
+        # builder. The rebuilt result is table-backed now, so the builder
+        # *could* do it - but it is handed ``declared_skips`` and would then
+        # double-report every column it could not cast.
         #
         # The cast itself is a no-op: the entry was reconciled before it was
         # written. What this recovers is the *skips* - the columns that could
         # not be cast are still at their engine type in the stored table, so
-        # re-examining it names them again.
+        # re-examining it names them again, and a hit reports the same warnings
+        # as the miss that filled it without the entry having to carry them.
         hit_table, hit_skips = reconcile_to_declared(
             cached.data_table, declared_arrow_types(model, query)
         )

--- a/src/orionbelt/cache/key.py
+++ b/src/orionbelt/cache/key.py
@@ -29,7 +29,12 @@ from typing import Any
 
 # v4: cache blobs hold only row data (no baked response envelope); entries
 # written under v3 recompute-miss and age out.
-KEY_VERSION = 4
+# v5: a blob holds the driver's Arrow table verbatim - native ``timestamp``,
+# ``date`` and ``binary`` - where v4 held whatever the writing surface's rows
+# looked like: ISO strings and base64 from REST and pgwire, native types from
+# Flight, in the same key. A v4 entry read as v5 would hand a string to a
+# column the sidecar calls a datetime, so the version moves and they age out.
+KEY_VERSION = 5
 
 # Separator for composite datasource keys; an ASCII unit separator that cannot
 # appear in a dialect name or a sanitized principal id.

--- a/src/orionbelt/cache/result_codec.py
+++ b/src/orionbelt/cache/result_codec.py
@@ -23,7 +23,6 @@ Two deliberate choices, both measured in the plan:
 
 from __future__ import annotations
 
-import contextlib
 import gzip
 from typing import Any
 
@@ -38,138 +37,24 @@ _GZIP_LEVEL = 6
 _MAX_CHUNKSIZE = 100_000
 
 
-# Substrings that mark an extension's ``type_name`` as numeric. Mirrors
-# ``service.value_formatting._NUMERIC_TYPE_TOKENS``, which the cache layer may
-# not import (``tests/architecture/test_dependencies.py`` forbids cache ->
-# service; Flight reaches this module through the cache). The two are pinned
-# equal by ``test_numeric_tokens_match_the_service_definition``.
-_NUMERIC_TYPE_TOKENS = ("number", "int", "float", "decimal", "numeric", "double", "real")
-
-# Type names a token matches without the type being numeric. The tokens are
-# substrings because the numeric names are a family rather than a list -
-# ``bigint``, ``smallint`` and ``integer`` all have to match ``int`` - and
-# ``interval`` is what that costs: it contains ``int`` and is a duration.
-_NOT_NUMERIC_TYPE_NAMES = ("interval",)
-
-
-def _is_string_backed_numeric(arrow_type: Any) -> bool:
-    """Whether the type is an Arrow extension wrapping a *number* as a string.
-
-    ADBC's PostgreSQL driver represents NUMERIC as
-    ``arrow.opaque[storage_type=string, type_name=numeric]`` to keep precision
-    Arrow's ``decimal128`` cannot hold, and the executor parses those cells back
-    to ``Decimal`` before they reach this module. Duck-typed on the
-    ``storage_type`` / ``type_name`` pair that plain Arrow types do not carry -
-    the same detection ``db_executor._is_string_stored_numeric_arrow_type``
-    makes.
-
-    The ``type_name`` test is what keeps this narrow, and it is load-bearing
-    rather than defensive. An opaque ``json``, ``uuid`` or ``interval`` is
-    string-backed too, and its cells stay strings all the way here, so
-    ``string`` is the right offer for it and refusing one would make *those*
-    columns value-dependent instead - inferred ``string`` when populated and
-    ``null`` when empty.
-
-    ``interval`` needs saying twice because the tokens are substrings: the
-    numeric names are a family, so ``int`` has to match ``bigint`` and
-    ``integer``, and it matches ``interval`` on the way past.
-    """
-    import pyarrow as pa
-
-    try:
-        storage = getattr(arrow_type, "storage_type", None)
-        type_name = getattr(arrow_type, "type_name", None)
-        if storage is None or type_name is None:
-            return False
-        if not pa.types.is_string(storage):
-            return False
-        if isinstance(type_name, bytes):
-            type_name = type_name.decode("utf-8", "ignore")
-        name = str(type_name).lower()
-        if any(excluded in name for excluded in _NOT_NUMERIC_TYPE_NAMES):
-            return False
-        return any(tok in name for tok in _NUMERIC_TYPE_TOKENS)
-    except (AttributeError, TypeError):
-        return False
-
-
-def _serialized_field_type(arrow_type: Any) -> Any:
-    """The Arrow type a column has *after* the executor serialises its cells,
-    or ``None`` where the declaration says nothing the blob can use.
-
-    ``encode_data`` is handed rows that already went through
-    ``_serialize_value``: temporals become ISO strings, binary becomes base64,
-    intervals become ``str(timedelta)``. Numerics, booleans, strings and
-    ``Decimal`` pass through untouched. This maps a driver's Arrow type onto
-    the type its *serialised* values carry, which is the type the blob can
-    actually hold - naming the driver's ``timestamp[us]`` here would be a
-    declaration no serialised row could satisfy.
-
-    A string-backed numeric is the one case with no usable answer, and
-    ``None`` rather than ``string`` is what keeps it honest. Its cells arrive as
-    ``Decimal``, so ``string`` is refused wherever there are values and accepted
-    wherever there are none - the same column typed ``decimal128`` for one
-    filter and ``string`` for another, which is the instability this schema
-    exists to remove. A width cannot be invented instead: ADBC's opaque type
-    carries none, PostgreSQL reports typmod ``-1`` for a computed expression,
-    and offering a fixed one would rescale the value - ``1.50`` stored under
-    ``decimal128(38, 9)`` reads back ``1.500000000``, which is what a cache hit
-    would then render. So the column is inferred where it has values and left
-    ``null`` where it has none, and the entry's column sidecar carries the
-    ``number`` type and its format either way.
-    """
-    import pyarrow as pa
-
-    if _is_string_backed_numeric(arrow_type):
-        return None
-    try:
-        if (
-            pa.types.is_integer(arrow_type)
-            or pa.types.is_floating(arrow_type)
-            or pa.types.is_boolean(arrow_type)
-            or pa.types.is_decimal(arrow_type)
-        ):
-            return arrow_type
-    except (AttributeError, TypeError):
-        return pa.string()
-    return pa.string()
-
-
-def build_result_table(column_names: list[str], rows: list[list[Any]], schema: Any = None) -> Any:
+def build_result_table(column_names: list[str], rows: list[list[Any]]) -> Any:
     """Build a pyarrow Table from result column names + list-of-lists rows.
 
-    Rows are padded to the column arity and transposed into columns.
+    Rows are padded to the column arity and transposed into columns, and the
+    types are **inferred from the values**, which is why this is the fallback
+    rather than the path.
 
-    ``schema`` is the *driver* Arrow schema (from ``ExecutionResult``), and
-    where it is given it **decides** each column's type rather than merely
-    rescuing the ones inference would type as ``null``. Inference reads the
-    values that happen to be present, so a ``decimal(18, 2)`` measure holding
-    1.50 and 2.25 came back ``decimal128(3, 2)``, and the same column came back
-    a different width for a different filter: a consumer that read the schema
-    once was wrong about the next result. That is the failure #393 fixed on
-    MySQL and #407 on Snowflake, arriving here by a third route, and the fix is
-    the same one - read the width from the declaration, not from the rows.
+    Inference reads what happens to be present: an empty or all-null column
+    comes back ``null``, and a ``decimal(18, 2)`` holding 1.50 and 2.25 comes
+    back ``decimal128(3, 2)`` - a different width for a different filter, so a
+    consumer that read the schema once was wrong about the next result. A
+    driver's own table has none of those problems, so a caller that holds one
+    uses :func:`encode_table`.
 
-    The declared type is only *offered*: rows have already been through
-    ``_serialize_value``, so a column whose values no longer fit what the driver
-    declared falls back to inference. pyarrow raises on every such mismatch
-    rather than coercing (measured: a Decimal into a string array, a value wider
-    than the declared precision, an integer too large for the declared width),
-    so the fallback cannot silently change a value.
-
-    One declaration is refused before it is offered. A string-backed numeric -
-    PostgreSQL NUMERIC under ADBC - carries no width to read and its cells
-    arrive as ``Decimal``, so ``_serialized_field_type`` answers ``None`` for it
-    and the column is inferred, exactly as it was before this. Offering
-    ``string`` there would have been accepted by an empty result and refused by
-    a populated one, which is the instability this schema exists to remove.
-
-    Without a schema, types are inferred as before. That is the PEP 249 path,
-    which has no Arrow schema to read, and the ``format_values`` arrow response,
-    where every cell is a display string by construction.
-
-    Types are matched by position, since the caller's ``column_names`` are the
-    model-decorated names for the same columns in the same order.
+    What is left here is the case with no table to hold: a PEP 249 result from
+    a driver with no Arrow, a process that never imported pyarrow, and the
+    ``format_values`` Arrow response, where every cell is a display string by
+    construction and there is no driver type left to preserve.
     """
     import pyarrow as pa
 
@@ -184,19 +69,7 @@ def build_result_table(column_names: list[str], rows: list[list[Any]], schema: A
     else:
         cols_data = [[] for _ in column_names]
 
-    hints: list[Any] = []
-    if schema is not None and len(schema) == width:
-        hints = [_serialized_field_type(f.type) for f in schema]
-
-    arrays = []
-    for i, col in enumerate(cols_data):
-        arr = None
-        if hints and hints[i] is not None and not pa.types.is_null(hints[i]):
-            with contextlib.suppress(pa.ArrowInvalid, pa.ArrowTypeError, TypeError, ValueError):
-                arr = pa.array(col, type=hints[i], from_pandas=False)
-        if arr is None:
-            arr = pa.array(col, from_pandas=False)
-        arrays.append(arr)
+    arrays = [pa.array(col, from_pandas=False) for col in cols_data]
     return pa.Table.from_arrays(arrays, names=list(column_names))
 
 
@@ -219,18 +92,15 @@ def to_ipc_stream(table: Any) -> bytes:
     return raw
 
 
-def encode_data(column_names: list[str], rows: list[list[Any]], schema: Any = None) -> bytes:
+def encode_data(column_names: list[str], rows: list[list[Any]]) -> bytes:
     """Serialize row data as a gzip'd Arrow IPC stream blob (data only).
 
-    No response envelope is baked in — the blob is a pure Arrow data stream. The
-    caller stores this in the cache; metadata is rebuilt fresh on every read.
-    ``schema`` is the executor's driver Arrow schema, and it decides the
-    column types (see :func:`build_result_table`); without one they are
-    inferred from the values. A caller that already holds a fully-typed table
-    should use :func:`encode_table` instead, which keeps the table's own schema
-    with no serialisation step in between.
+    No response envelope is baked in — the blob is a pure Arrow data stream.
+    Types are inferred from the values (see :func:`build_result_table`), so
+    this is the fallback for a result with no Arrow table. A caller that holds
+    one uses :func:`encode_table`, which keeps the warehouse's own types.
     """
-    table = build_result_table(column_names, rows, schema)
+    table = build_result_table(column_names, rows)
     return gzip.compress(to_ipc_stream(table), _GZIP_LEVEL)
 
 
@@ -263,12 +133,6 @@ def decode_data(payload: bytes) -> Any:
     raw = gzip.decompress(payload)
     with ipc.open_stream(pa.BufferReader(raw)) as reader:
         return reader.read_all()
-
-
-def table_to_rows(table: Any) -> list[list[Any]]:
-    """Return a decoded table's rows as list-of-lists in schema column order."""
-    names = table.column_names
-    return [[row.get(n) for n in names] for row in table.to_pylist()]
 
 
 def warm() -> None:

--- a/src/orionbelt/service/db_executor.py
+++ b/src/orionbelt/service/db_executor.py
@@ -90,18 +90,28 @@ class ExecutionResult:
         # before anything touches ``rows`` — an ordering hazard that would
         # otherwise be invisible at the call site.
         # ``arrow_schema`` lets a row-backed result still carry the types its
-        # rows came from. A cache hit is rebuilt from ``raw_rows`` - because
-        # ``table_to_rows`` keeps native dates where the Arrow row builder
-        # serialises them - and without the schema the re-encode infers types
-        # from values, so an empty or all-null ``int64`` column comes back
-        # ``null``. That is the exact preservation the schema sidecar exists
-        # for, and losing it on the way out would undo it.
+        # rows came from. That is the PEP 249 path - a driver with no Arrow at
+        # all - since a cache hit is table-backed like a fresh result. Without
+        # the schema a re-encode infers types from values, so an empty or
+        # all-null ``int64`` column comes back ``null``.
         self._arrow_schema = getattr(arrow_table, "schema", None) or arrow_schema
 
     @property
     def timezone(self) -> str | None:
         """IANA timezone name used to label naive timestamps, or None."""
         return str(self._tz) if self._tz is not None else None
+
+    @property
+    def arrow_table(self) -> Any | None:
+        """The driver's Arrow table, or ``None`` once :attr:`rows` freed it.
+
+        Read it *before* ``rows``. Callers that store or re-encode the result
+        want the table itself rather than its serialised rows: the cache and
+        the ``format=arrow`` response both hold the warehouse's own types this
+        way, instead of re-inferring them from values that have already been
+        through ``_serialize_value``.
+        """
+        return self._arrow_table
 
     @property
     def arrow_schema(self) -> Any | None:
@@ -703,7 +713,7 @@ def _interval_to_timedelta(val: Any) -> Any:
     )
 
 
-def _arrow_to_rows(table: Any, tz: ZoneInfo | None = None) -> list[list[Any]]:
+def arrow_to_rows(table: Any, tz: ZoneInfo | None = None) -> list[list[Any]]:
     """Convert an Arrow Table to a list of JSON-serializable rows.
 
     String-stored numeric extension types are parsed to ``Decimal`` before
@@ -736,6 +746,15 @@ def _arrow_to_rows(table: Any, tz: ZoneInfo | None = None) -> list[list[Any]]:
             row.append(_serialize_value(val, tz))
         result.append(row)
     return result
+
+
+#: The historical private name, used throughout this module.
+#:
+#: Public because a cached result and a fresh one must serialise identically,
+#: and the UI decodes the same Arrow the cache stores - so all three go
+#: through this one function rather than each having its own idea of what a
+#: ``timestamp`` cell looks like.
+_arrow_to_rows = arrow_to_rows
 
 
 # ---------------------------------------------------------------------------

--- a/src/orionbelt/ui/handlers.py
+++ b/src/orionbelt/ui/handlers.py
@@ -608,19 +608,33 @@ def _decode_arrow_execute_response(resp: Any) -> Any:
     envelope is rebuilt per request, ``execution_time_ms`` / ``cached`` are
     correct even on a cache hit.
     """
+    import contextlib
     import gzip
     import json
+    from zoneinfo import ZoneInfo
 
     import pyarrow as pa
+
+    from orionbelt.service.db_executor import arrow_to_rows
 
     body = resp.content
     meta_len = int.from_bytes(body[:4], "big")
     data: dict[str, Any] = json.loads(body[4 : 4 + meta_len].decode("utf-8"))
     table = pa.ipc.open_stream(gzip.decompress(body[4 + meta_len :])).read_all()
-    names = table.column_names
-    data["rows"] = [[row.get(n) for n in names] for row in table.to_pylist()]
+    # The Arrow data carries the warehouse's own types - ``timestamp``,
+    # ``date``, ``binary`` - so the cells are serialised here with the same
+    # function the JSON surface uses, which is what keeps the promise above
+    # that the two shapes are identical. Reading the table with a bare
+    # ``to_pylist()`` handed the renderer ``datetime`` objects where JSON gives
+    # ISO strings.
+    tz_name = data.get("timezone")
+    tz = None
+    if tz_name:
+        with contextlib.suppress(Exception):
+            tz = ZoneInfo(tz_name)
+    data["rows"] = arrow_to_rows(table, tz)
     if not data.get("columns"):
-        data["columns"] = [{"name": n} for n in names]
+        data["columns"] = [{"name": n} for n in table.column_names]
     return data
 
 

--- a/tests/architecture/test_cached_hits_reconcile.py
+++ b/tests/architecture/test_cached_hits_reconcile.py
@@ -1,16 +1,20 @@
-"""Every rebuild of a cached result must reconcile the table first.
+"""Every rebuild of a cached result must reconcile it.
 
 This rule was rediscovered four times, once per read path, because each site
 looks correct on its own: it calls ``execution_result_from_data`` and then a
-response builder that *does* reconcile. The trap is that the rebuilt result is
-row-backed - ``table_to_rows`` keeps native dates where the Arrow row builder
-serialises them, so a hit cannot simply hold the table - and
-``ExecutionResult.reconcile_to_declared`` needs an Arrow table. Reconciling the
-result is therefore a silent no-op, and the hit returns the engine's types
-while the miss that filled the entry returned the model's.
+response builder that *does* reconcile. The trap was that the rebuilt result
+used to be row-backed while ``reconcile_to_declared`` needs an Arrow table, so
+reconciling was a silent no-op and a hit returned the engine's types while the
+miss that filled the entry returned the model's.
 
-So the invariant is checked structurally rather than left to be remembered: a
-function that rebuilds a cached result must also name ``reconcile_to_declared``.
+A rebuilt hit holds its table now, so the call works wherever it is made - but
+it still has to be *made*, and a reader who does not know the history has no
+reason to think of it. The response builder cannot be relied on either: the
+read path hands it the skips, so it takes them rather than re-deriving them.
+
+So the invariant stays checked structurally rather than left to be remembered:
+a function that rebuilds a cached result must also name
+``reconcile_to_declared``.
 """
 
 from __future__ import annotations

--- a/tests/integration/test_duckdb_execution.py
+++ b/tests/integration/test_duckdb_execution.py
@@ -1383,6 +1383,119 @@ class TestAPIExecuteEndpoint:
         finally:
             reset_session_manager()
 
+    async def test_arrow_returns_warehouse_types_and_a_hit_returns_the_same(
+        self, api_duckdb: duckdb.DuckDBPyConnection
+    ) -> None:
+        """A date column arrives as ``date32``, and the cache does not change it.
+
+        ``format=arrow`` used to encode rows that had already been serialised,
+        so a temporal column shipped as an ISO ``string`` under an envelope
+        whose own column metadata called it a datetime. The cache stored that
+        same flattening - while Flight, sharing the key, stored the native
+        type - so the answer depended on which surface ran the query first.
+
+        This asserts both halves: the fresh response carries the warehouse's
+        type, and a second identical request carries it too, with rows the
+        JSON surface agrees with.
+        """
+        pytest.importorskip("pyarrow", reason="pyarrow required for arrow format")
+        import pyarrow as pa
+
+        # Its own table and model: the shared sample fixture has no temporal
+        # column, and adding one to it would reach every other test here.
+        api_duckdb.execute(
+            """
+            CREATE OR REPLACE TABLE PUBLIC.SHIPMENTS (
+                SHIPMENT_ID VARCHAR, SHIPPED_ON DATE, WEIGHT DOUBLE
+            );
+            INSERT INTO PUBLIC.SHIPMENTS VALUES
+                ('S1', DATE '2024-01-15', 10.0),
+                ('S2', DATE '2024-02-20', 25.0);
+            """
+        )
+        model_yaml = """
+version: 1.0
+dataObjects:
+  Shipments:
+    code: SHIPMENTS
+    schema: PUBLIC
+    columns:
+      Shipment ID:
+        code: SHIPMENT_ID
+        abstractType: string
+        primaryKey: true
+      Shipped On:
+        code: SHIPPED_ON
+        abstractType: date
+      Weight:
+        code: WEIGHT
+        abstractType: float
+dimensions:
+  Shipped On:
+    dataObject: Shipments
+    column: Shipped On
+    resultType: date
+measures:
+  Total Weight:
+    resultType: float
+    aggregation: sum
+    expression: "{[Shipments].[Weight]}"
+"""
+        settings = Settings(session_ttl_seconds=3600, session_cleanup_interval=9999)
+        app = create_app(settings=settings)
+        mgr = SessionManager(
+            ttl_seconds=settings.session_ttl_seconds,
+            cleanup_interval=settings.session_cleanup_interval,
+        )
+        init_session_manager(mgr, query_execute_enabled=True, db_vendor="duckdb")
+        try:
+            mock_exec = _make_execute_sql(api_duckdb)
+            body = {
+                "model_id": None,
+                "query": {
+                    "select": {"dimensions": ["Shipped On"], "measures": ["Total Weight"]},
+                    "orderBy": [{"field": "Shipped On"}],
+                },
+                "dialect": "duckdb",
+            }
+            with patch("orionbelt.api.query_cache.execute_sql", mock_exec):
+                transport = ASGITransport(app=app)
+                async with AsyncClient(transport=transport, base_url="http://test") as c:
+                    sid = (await c.post("/v1/sessions")).json()["session_id"]
+                    loaded = await c.post(
+                        f"/v1/sessions/{sid}/models", json={"model_yaml": model_yaml}
+                    )
+                    assert loaded.status_code == 201, loaded.text
+                    body["model_id"] = loaded.json()["model_id"]
+
+                    fresh = await c.post(
+                        f"/v1/sessions/{sid}/query/execute?format=arrow", json=body
+                    )
+                    again = await c.post(
+                        f"/v1/sessions/{sid}/query/execute?format=arrow", json=body
+                    )
+                    as_json = await c.post(f"/v1/sessions/{sid}/query/execute", json=body)
+
+            assert fresh.status_code == 200, fresh.text
+            _, fresh_table = _split_result_frame(fresh.content)
+            shipped = fresh_table.schema.field("Shipped On").type
+            assert pa.types.is_date(shipped) or pa.types.is_timestamp(shipped), (
+                f"Shipped On shipped as {shipped}"
+            )
+
+            # The second response has to agree, hit or miss - a cache that
+            # stores a different representation is exactly the defect, so this
+            # passes for the right reason either way.
+            _, again_table = _split_result_frame(again.content)
+            assert again_table.schema == fresh_table.schema
+            assert again_table.to_pylist() == fresh_table.to_pylist()
+
+            # And the JSON surface serialises the same data, as it always did.
+            json_rows = as_json.json()["rows"]
+            assert json_rows[0][0] == fresh_table.column("Shipped On")[0].as_py().isoformat()
+        finally:
+            reset_session_manager()
+
     async def test_execute_format_arrow_format_values_bakes_display_strings(
         self, api_duckdb: duckdb.DuckDBPyConnection
     ) -> None:

--- a/tests/integration/test_oneshot_batch.py
+++ b/tests/integration/test_oneshot_batch.py
@@ -424,12 +424,12 @@ class TestOneshotCacheSchemaPreservation:
     """The one-shot writer feeds the *shared* cache, so it must store types.
 
     Its envelope has already reduced the result to JSON rows, which cannot
-    type an empty or all-null column. Without the executor's Arrow schema the
+    type an empty or all-null column. Without the executor's Arrow table the
     blob stores ``null`` — and a later raw ``format=arrow`` hit serves that
     blob verbatim against numeric column metadata.
     """
 
-    async def test_schema_is_forwarded_to_the_encoder(self) -> None:
+    async def test_the_table_is_forwarded_to_the_encoder(self) -> None:
         pa = pytest.importorskip("pyarrow")
 
         from types import SimpleNamespace
@@ -445,9 +445,9 @@ class TestOneshotCacheSchemaPreservation:
             dialect="duckdb",
             row_count=0,
         )
-        schema = pa.schema([pa.field("n", pa.int64())])
+        table = pa.table({"n": pa.array([], pa.int64())})
 
-        async def _write(schema_arg: object) -> object:
+        async def _write(table_arg: object) -> object:
             cache = _CapturingCache()
             await _try_oneshot_cache_set(
                 cache=cache,
@@ -458,24 +458,24 @@ class TestOneshotCacheSchemaPreservation:
                 model_id="m",
                 dialect="duckdb",
                 physical_tables=[],
-                schema=schema_arg,
+                table=table_arg,
             )
             assert cache.payload is not None
             return decode_data(cache.payload).schema.field(0).type
 
-        assert str(await _write(schema)) == "int64"
-        # Guard the test itself: without the schema the defect reproduces.
+        assert str(await _write(table)) == "int64"
+        # Guard the test itself: without the table the defect reproduces.
         assert str(await _write(None)) == "null"
 
-    def test_try_cache_set_requires_schema(self) -> None:
-        """``schema`` has no default, so a new writer cannot silently omit it.
+    def test_try_cache_set_requires_the_table(self) -> None:
+        """``table`` has no default, so a new writer cannot silently omit it.
 
-        Every cache writer must decide what to pass. Defaulting it to None is
-        what let the one-shot path store null-typed payloads unnoticed.
+        Every cache writer must decide what to pass. Defaulting it is what let
+        the one-shot path store null-typed payloads unnoticed.
         """
         import inspect
 
         from orionbelt.api.query_cache import try_cache_set
 
-        param = inspect.signature(try_cache_set).parameters["schema"]
+        param = inspect.signature(try_cache_set).parameters["table"]
         assert param.default is inspect.Parameter.empty

--- a/tests/unit/test_cache_one_representation.py
+++ b/tests/unit/test_cache_one_representation.py
@@ -1,0 +1,126 @@
+"""One cache entry means the same thing to every surface that reads it.
+
+REST, pgwire and Flight share a cache: same key, same blob (KEY_VERSION). They
+did not share a *representation*. REST and pgwire encoded their already
+serialised rows, so a timestamp column was stored as an ISO ``string``, a date
+as a ``string`` and binary as base64; Flight stored its Arrow table verbatim,
+so the same three columns were ``timestamp[us]``, ``date32`` and ``binary``.
+Whichever surface executed the query first decided what the others read, and
+each read path only understood its own writer's convention.
+
+These pin the fix: the driver's table is what gets stored, and a hit is
+serialised by the same function a miss is.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+from typing import Any
+
+import pytest
+
+pa = pytest.importorskip("pyarrow", reason="pyarrow required for the result cache")
+
+from orionbelt.api.query_cache import execution_result_from_data  # noqa: E402
+from orionbelt.cache.result_codec import decode_data, encode_table  # noqa: E402
+from orionbelt.service.db_executor import ColumnMeta, ExecutionResult  # noqa: E402
+
+
+def _warehouse_table() -> Any:
+    """A result with one column of every type the two writers disagreed about."""
+    return pa.table(
+        {
+            "Orders": pa.array([1, None], pa.int64()),
+            "Amount": pa.array([Decimal("1.50"), None], pa.decimal128(18, 2)),
+            "Ordered At": pa.array([dt.datetime(2024, 1, 2, 3, 4, 5), None], pa.timestamp("us")),
+            "Shipped On": pa.array([dt.date(2024, 1, 2), None], pa.date32()),
+            "Payload": pa.array([b"\x00\x01", None], pa.binary()),
+            "Unsold": pa.array([None, None], pa.int64()),
+        }
+    )
+
+
+def _miss(table: Any) -> ExecutionResult:
+    """What the executor hands the response builder on a cache miss."""
+    return ExecutionResult(
+        columns=[ColumnMeta(name=f.name, type_hint="string") for f in table.schema],
+        arrow_table=table,
+        row_count=table.num_rows,
+    )
+
+
+def _hit(table: Any) -> ExecutionResult:
+    """The same result, written to the cache and read back."""
+    return execution_result_from_data(decode_data(encode_table(table)), execution_time_ms=1.0)
+
+
+class TestTheStoredEntry:
+    def test_the_blob_holds_the_warehouse_types(self) -> None:
+        stored = decode_data(encode_table(_warehouse_table()))
+        assert stored.schema.field("Ordered At").type == pa.timestamp("us")
+        assert stored.schema.field("Shipped On").type == pa.date32()
+        assert stored.schema.field("Payload").type == pa.binary()
+        assert stored.schema.field("Amount").type == pa.decimal128(18, 2)
+        assert stored.schema.field("Unsold").type == pa.int64()
+
+    def test_flight_reads_what_rest_wrote(self) -> None:
+        """Flight streams the decoded table straight to the client, so the
+        stored types *are* the wire types. A REST-written entry used to hand
+        it ``string`` where its own advertised schema said ``timestamp``.
+        """
+        original = _warehouse_table()
+        streamed = decode_data(encode_table(original))
+        assert streamed.schema == original.schema
+
+
+class TestAHitEqualsItsMiss:
+    """The invariant worth the KEY_VERSION bump."""
+
+    def test_every_cell_matches(self) -> None:
+        table = _warehouse_table()
+        assert _hit(table).rows == _miss(table).rows
+
+    def test_and_the_values_are_the_serialised_ones(self) -> None:
+        """Not an accident of both paths being equally wrong."""
+        rows = _hit(_warehouse_table()).rows
+        assert rows[0] == [1, Decimal("1.50"), "2024-01-02T03:04:05", "2024-01-02", "AAE=", None]
+
+    def test_an_adbc_opaque_numeric_matches_too(self) -> None:
+        """PostgreSQL NUMERIC under ADBC: a string in Arrow, a Decimal in a row.
+
+        The executor parses it on the way out, so a hit only agrees with its
+        miss if the hit goes through the executor - which is what holding the
+        table, rather than pre-serialising it, buys.
+        """
+        opaque = pa.opaque(pa.string(), "numeric", "PostgreSQL")
+        table = pa.table({"Amount": pa.array(["1.50", None], pa.string()).cast(opaque)})
+        assert _hit(table).rows == _miss(table).rows == [[Decimal("1.50")], [None]]
+
+    def test_an_interval_matches_too(self) -> None:
+        """The normalisation that used to live on one side only.
+
+        ``_arrow_to_rows`` turns a duration into ``str(timedelta)``. That was
+        correct for a miss and irrelevant for a hit, because the stored cell
+        was already a string. Now both go through it.
+        """
+        table = pa.table({"Age": pa.array([dt.timedelta(days=1), None], pa.duration("us"))})
+        assert _hit(table).rows == _miss(table).rows == [["1 day, 0:00:00"], [None]]
+
+
+class TestReconciliationOnAHit:
+    def test_a_hit_can_be_reconciled(self) -> None:
+        """It is table-backed, so the cast has something to work on.
+
+        A row-backed hit made ``reconcile_to_declared`` a silent no-op, which
+        is the trap four read paths rediscovered one at a time.
+        """
+        table = pa.table({"flag": pa.array([0, 1], pa.int64())})
+        hit = _hit(table)
+        assert hit.reconcile_to_declared({"flag": pa.bool_()}) == []
+        assert hit.arrow_table.schema.field("flag").type == pa.bool_()
+
+    def test_and_it_names_what_it_could_not_cast(self) -> None:
+        table = pa.table({"flag": pa.array([0, 1, 7], pa.int64())})
+        skips = _hit(table).reconcile_to_declared({"flag": pa.bool_()})
+        assert [name for name, _ in skips] == ["flag"]

--- a/tests/unit/test_ensure_arrow.py
+++ b/tests/unit/test_ensure_arrow.py
@@ -87,15 +87,17 @@ class TestTheTypeThisProtects:
     def test_a_wide_declaration_survives_narrow_values(self) -> None:
         import pyarrow as pa
 
-        from orionbelt.cache.result_codec import build_result_table
+        from orionbelt.cache.result_codec import build_result_table, decode_data, encode_table
 
         rows = [[Decimal("1.50")], [Decimal("2.25")]]
-        schema = pa.schema([pa.field("amount", pa.decimal128(18, 2))])
+        table = pa.table({"amount": pa.array([r[0] for r in rows], pa.decimal128(18, 2))})
 
-        inferred = build_result_table(["amount"], rows, None)
-        carried = build_result_table(["amount"], rows, schema)
+        inferred = build_result_table(["amount"], rows)
+        stored = decode_data(encode_table(table))
 
         # Inference reads only the values present, so the same column comes
-        # back a different width for a different filter.
+        # back a different width for a different filter. Which is why the
+        # driver's table is what gets stored, rather than its rows plus a
+        # schema offered to them.
         assert inferred.schema.field(0).type == pa.decimal128(3, 2)
-        assert carried.schema.field(0).type == pa.decimal128(18, 2)
+        assert stored.schema.field(0).type == pa.decimal128(18, 2)

--- a/tests/unit/test_result_codec.py
+++ b/tests/unit/test_result_codec.py
@@ -8,7 +8,6 @@ baked in — metadata is rebuilt fresh on every read.
 from __future__ import annotations
 
 import gzip
-from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -21,13 +20,25 @@ _COLUMN_NAMES = ["Country", "Revenue"]
 _ROWS = [["US", 1234.5], ["UK", 6789.0]]
 
 
+def _rows(table: Any) -> list[list[Any]]:
+    """A decoded table as list-of-lists.
+
+    Local because production no longer has one: a cache hit is table-backed
+    and materialises through ``ExecutionResult.rows``, the same serialiser a
+    miss runs. ``result_codec.table_to_rows`` existed only to read the rows a
+    cache entry stored *pre-serialised*, and nothing stores those any more.
+    """
+    names = table.column_names
+    return [[row.get(n) for n in names] for row in table.to_pylist()]
+
+
 def test_encode_decode_round_trip() -> None:
     payload = result_codec.encode_data(_COLUMN_NAMES, _ROWS)
     table = result_codec.decode_data(payload)
 
     assert table.column_names == _COLUMN_NAMES
     assert table.num_rows == 2
-    assert result_codec.table_to_rows(table) == _ROWS
+    assert _rows(table) == _ROWS
 
 
 def test_encode_table_preserves_schema() -> None:
@@ -61,7 +72,7 @@ def test_encode_table_shares_byte_format_with_encode_data() -> None:
     assert payload[:2] == b"\x1f\x8b"  # gzip magic, same container as encode_data
     decoded = result_codec.decode_data(payload)
     assert decoded.column_names == _COLUMN_NAMES
-    assert result_codec.table_to_rows(decoded) == _ROWS
+    assert _rows(decoded) == _ROWS
 
 
 def test_payload_is_gzip() -> None:
@@ -96,14 +107,14 @@ def test_empty_rows_round_trips() -> None:
     table = result_codec.decode_data(payload)
     assert table.num_rows == 0
     assert table.column_names == ["Country", "Revenue"]
-    assert result_codec.table_to_rows(table) == []
+    assert _rows(table) == []
 
 
 def test_zero_columns_round_trips() -> None:
     payload = result_codec.encode_data([], [])
     table = result_codec.decode_data(payload)
     assert table.column_names == []
-    assert result_codec.table_to_rows(table) == []
+    assert _rows(table) == []
 
 
 def test_build_result_table_pads_short_rows() -> None:
@@ -135,230 +146,97 @@ def test_decode_data_is_shared_across_surfaces() -> None:
     ]
 
 
-def test_table_to_rows_preserves_schema_order() -> None:
+def test_decoded_rows_keep_schema_order() -> None:
     table = result_codec.build_result_table(["x", "y"], [[1, 2], [3, 4]])
-    assert result_codec.table_to_rows(table) == [[1, 2], [3, 4]]
+    assert _rows(table) == [[1, 2], [3, 4]]
 
 
 # ---------------------------------------------------------------------------
-# The driver schema decides the column types
+# The driver's table is what gets stored
 # ---------------------------------------------------------------------------
-
-_DECIMAL_SCHEMA = pa.schema(
-    [
-        pa.field("Amount", pa.decimal128(18, 2)),
-        pa.field("Orders", pa.int64()),
-        pa.field("Ordered At", pa.timestamp("us")),
-        pa.field("Shipped", pa.bool_()),
-    ]
-)
-_DECIMAL_NAMES = ["Amount", "Orders", "Ordered At", "Shipped"]
+#
+# These replace a block that tested a schema *hint*: ``build_result_table``
+# used to take the driver's Arrow schema and offer each column's type to
+# values that had already been serialised, falling back to inference when the
+# offer was refused. That existed because the writer only had rows. It now has
+# the table, so the width is not offered - it is what is stored.
 
 
-def test_declared_decimal_width_survives_narrow_values() -> None:
-    """A ``decimal(18, 2)`` measure holding 1.50 stays ``decimal128(18, 2)``.
-
-    Inference reads the digits that happen to be present and answered
-    ``decimal128(3, 2)``, so the blob advertised a narrower column than the
-    model declares.
-    """
+def _driver_table() -> Any:
+    """One column of every type the two encoders used to disagree about."""
+    import datetime as dt
     from decimal import Decimal
 
-    rows = [[Decimal("1.50"), 3, "2026-08-15T13:45:00", True]]
-    table = result_codec.build_result_table(_DECIMAL_NAMES, rows, _DECIMAL_SCHEMA)
-
-    assert table.schema.field("Amount").type == pa.decimal128(18, 2)
-    assert table.to_pylist()[0]["Amount"] == Decimal("1.50")
-
-
-def test_declared_width_is_stable_across_result_sets() -> None:
-    """The same column answers the same Arrow type whatever rows it returns.
-
-    This is the property, not the width itself: a consumer that read the schema
-    from one result was wrong about the next, which is the failure #393 fixed on
-    MySQL and #407 on Snowflake.
-    """
-    from decimal import Decimal
-
-    narrow = result_codec.build_result_table(
-        _DECIMAL_NAMES, [[Decimal("1.50"), 3, "2026-08-15T13:45:00", True]], _DECIMAL_SCHEMA
+    return pa.table(
+        {
+            "Amount": pa.array([Decimal("1.50"), None], pa.decimal128(18, 2)),
+            "Orders": pa.array([1, None], pa.int64()),
+            "Ordered At": pa.array([dt.datetime(2024, 1, 2, 3, 4, 5), None], pa.timestamp("us")),
+            "Shipped On": pa.array([dt.date(2024, 1, 2), None], pa.date32()),
+            "Blob": pa.array([b"\x00\x01", None], pa.binary()),
+            "Empty": pa.array([None, None], pa.int64()),
+        }
     )
-    wide = result_codec.build_result_table(
-        _DECIMAL_NAMES, [[Decimal("123456.78"), 4, "2026-08-15T14:45:00", False]], _DECIMAL_SCHEMA
-    )
-    empty = result_codec.build_result_table(_DECIMAL_NAMES, [], _DECIMAL_SCHEMA)
-
-    assert narrow.schema == wide.schema == empty.schema
 
 
-def test_temporals_still_serialize_as_strings() -> None:
-    """The declared type is mapped through serialisation first, so a
-    ``timestamp[us]`` column keeps the ISO string the executor produced rather
-    than a declaration no serialised row could satisfy."""
-    rows = [[None, None, "2026-08-15T13:45:00", None]]
-    table = result_codec.build_result_table(_DECIMAL_NAMES, rows, _DECIMAL_SCHEMA)
+def test_the_stored_blob_is_the_drivers_table() -> None:
+    """Every type survives, including the three that used to be flattened.
 
-    assert table.schema.field("Ordered At").type == pa.string()
-    assert table.to_pylist()[0]["Ordered At"] == "2026-08-15T13:45:00"
-
-
-def test_values_that_outgrow_the_declaration_fall_back_to_inference() -> None:
-    """A declared type is offered, never forced: pyarrow raises rather than
-    coercing, and the column is inferred instead of failing the encode."""
-    from decimal import Decimal
-
-    schema = pa.schema([pa.field("Amount", pa.decimal128(18, 2))])
-    table = result_codec.build_result_table(["Amount"], [[Decimal("1.5678")]], schema)
-
-    assert table.to_pylist() == [{"Amount": Decimal("1.5678")}]
-
-
-class _StringBackedField:
-    """A schema field whose type is a string-backed Arrow extension.
-
-    ``pa.opaque`` is used where the installed pyarrow has it and stood in for
-    otherwise, since the floor is ``pyarrow>=16`` and the constructor arrived in
-    18. ``build_result_table`` reads a schema for its length and each field's
-    ``type``, which is all either shape has to provide.
+    ``timestamp`` and ``date`` were stored as ISO ``string`` and ``binary`` as
+    base64 ``string``, because the writer encoded already-serialised rows.
+    Flight, which stored its table verbatim, wrote native types into the same
+    key - so whoever wrote first decided what the other read.
     """
-
-    def __init__(self, name: str, type_name: str = "numeric") -> None:
-        self.name = name
-        opaque = getattr(pa, "opaque", None)
-        if opaque is not None:
-            self.type: Any = opaque(pa.string(), type_name, "postgresql")
-        else:
-            self.type = SimpleNamespace(storage_type=pa.string(), type_name=type_name)
-
-
-def test_string_backed_numeric_is_never_typed_as_text() -> None:
-    """PostgreSQL NUMERIC under ADBC arrives as a string-backed extension type
-    whose cells reach the codec as ``Decimal``.
-
-    Offering ``string`` for it would be refused by a populated result and
-    accepted by an empty one, so the same column would be cached as
-    ``decimal128`` for one filter and ``string`` for another - the instability
-    the driver schema is here to remove. It carries no width to offer instead,
-    so the column is inferred where it has values and left ``null`` where it has
-    none, with the entry's column sidecar carrying ``number`` either way.
-    """
-    from decimal import Decimal
-
-    schema = [_StringBackedField("Amount")]
-
-    populated = result_codec.build_result_table(["Amount"], [[Decimal("1.50")]], schema)
-    all_null = result_codec.build_result_table(["Amount"], [[None], [None]], schema)
-    empty = result_codec.build_result_table(["Amount"], [], schema)
-
-    for table in (populated, all_null, empty):
-        assert not pa.types.is_string(table.schema.field("Amount").type)
-
-    assert pa.types.is_decimal(populated.schema.field("Amount").type)
-    assert populated.to_pylist() == [{"Amount": Decimal("1.50")}]
-    assert pa.types.is_null(all_null.schema.field("Amount").type)
-    assert pa.types.is_null(empty.schema.field("Amount").type)
-
-
-def test_string_backed_numeric_keeps_its_scale_through_the_cache() -> None:
-    """The reason no fixed width is invented for it: a value stored under a
-    wider scale reads back rescaled, and that is what a cache hit renders.
-    ``1.50`` has to come back ``1.50``."""
-    from decimal import Decimal
-
-    schema = [_StringBackedField("Amount")]
-    payload = result_codec.encode_data(["Amount"], [[Decimal("1.50")]], schema)
-
-    assert result_codec.table_to_rows(result_codec.decode_data(payload)) == [[Decimal("1.50")]]
-
-
-def test_declared_string_column_receiving_decimals_falls_back() -> None:
-    """The generic form of the same refusal: pyarrow will not put a ``Decimal``
-    in a string array, so the column is inferred rather than the encode failing.
-    """
-    from decimal import Decimal
-
-    schema = pa.schema([pa.field("Amount", pa.string())])
-    table = result_codec.build_result_table(["Amount"], [[Decimal("1.50")]], schema)
-
-    assert pa.types.is_decimal(table.schema.field("Amount").type)
-    assert table.to_pylist() == [{"Amount": Decimal("1.50")}]
-
-
-def test_types_are_inferred_without_a_schema() -> None:
-    """The PEP 249 path has no Arrow schema, and the ``format_values`` arrow
-    response deliberately passes none. Both keep value inference."""
-    from decimal import Decimal
-
-    table = result_codec.build_result_table(["Amount"], [[Decimal("1.50")]])
-
-    assert table.schema.field("Amount").type == pa.decimal128(3, 2)
-
-
-def test_declared_types_survive_the_cache_round_trip() -> None:
-    """What the schema decided is what a cache hit reads back."""
-    from decimal import Decimal
-
-    rows = [[Decimal("1.50"), 3, "2026-08-15T13:45:00", True]]
-    decoded = result_codec.decode_data(
-        result_codec.encode_data(_DECIMAL_NAMES, rows, _DECIMAL_SCHEMA)
-    )
+    decoded = result_codec.decode_data(result_codec.encode_table(_driver_table()))
 
     assert decoded.schema.field("Amount").type == pa.decimal128(18, 2)
     assert decoded.schema.field("Orders").type == pa.int64()
-    assert result_codec.table_to_rows(decoded) == rows
+    assert decoded.schema.field("Ordered At").type == pa.timestamp("us")
+    assert decoded.schema.field("Shipped On").type == pa.date32()
+    assert decoded.schema.field("Blob").type == pa.binary()
+    assert decoded.schema.field("Empty").type == pa.int64(), "an empty column kept its type"
 
 
-@pytest.mark.parametrize(
-    ("type_name", "value"),
-    [
-        ("json", '{"a": 1}'),
-        ("uuid", "0b3d1f8e-6a1a-4c2a-9f3a-2b8b6f5a1c77"),
-        # ``interval`` contains ``int``, so a substring match calls it numeric.
-        ("interval", "1 day 02:00:00"),
-    ],
-)
-def test_non_numeric_string_backed_extension_keeps_its_string_hint(
-    type_name: str, value: str
-) -> None:
-    """An opaque ``json``, ``uuid`` or ``interval`` is string-backed too, and
-    its cells stay strings all the way to the codec.
+def test_a_declared_width_is_stable_across_result_sets() -> None:
+    """The failure the old schema hint existed to prevent, now structural.
 
-    So ``string`` is the right offer for it, and the numeric refusal must not
-    reach it: these columns would otherwise be the value-dependent ones
-    instead, inferred ``string`` when populated and ``null`` when empty.
+    Inference reads the values present, so the same ``decimal(18, 2)`` column
+    came back a different width for a different filter and a consumer that
+    read the schema once was wrong about the next result.
     """
-    schema = [_StringBackedField("Payload", type_name=type_name)]
-
-    populated = result_codec.build_result_table(["Payload"], [[value]], schema)
-    all_null = result_codec.build_result_table(["Payload"], [[None], [None]], schema)
-    empty = result_codec.build_result_table(["Payload"], [], schema)
-
-    assert populated.schema == all_null.schema == empty.schema
-    assert pa.types.is_string(empty.schema.field("Payload").type)
-    assert populated.to_pylist() == [{"Payload": value}]
-
-
-@pytest.mark.parametrize("type_name", ["numeric", "decimal", "bigint", "smallint", "integer"])
-def test_numeric_string_backed_names_still_refuse_the_string_hint(type_name: str) -> None:
-    """The exclusion must not cost the family it sits inside: every numeric name
-    still reaches the refusal, which is why the tokens are substrings."""
     from decimal import Decimal
 
-    schema = [_StringBackedField("Amount", type_name=type_name)]
-    table = result_codec.build_result_table(["Amount"], [[Decimal("1.50")]], schema)
+    schema = pa.schema([pa.field("Amount", pa.decimal128(18, 2))])
+    narrow = pa.table({"Amount": pa.array([Decimal("1.50")], pa.decimal128(18, 2))})
+    wide = pa.table({"Amount": pa.array([Decimal("12345.67")], pa.decimal128(18, 2))})
+    empty = pa.table({"Amount": pa.array([], pa.decimal128(18, 2))})
 
-    assert pa.types.is_decimal(table.schema.field("Amount").type)
+    for table in (narrow, wide, empty):
+        decoded = result_codec.decode_data(result_codec.encode_table(table))
+        assert decoded.schema.field("Amount").type == schema.field("Amount").type
 
 
-def test_numeric_tokens_match_the_service_definition() -> None:
-    """The cache may not import the service layer
-    (``tests/architecture/test_dependencies.py``), so the numeric ``type_name``
-    tokens are spelled twice. A test is what keeps the copies equal.
+def test_an_adbc_opaque_numeric_survives_the_round_trip() -> None:
+    """PostgreSQL NUMERIC under ADBC, which carries no width to read.
 
-    The codec's exclusion list is its own: ``is_numeric_type_hint`` reads a
-    column's *declared* type, where ``interval`` never appears, while this reads
-    an extension's ``type_name``, where it does.
+    It used to be inferred - ``decimal128`` where the column had values and
+    ``null`` where it did not - because the extension type never reached the
+    blob. It does now, and the executor parses its cells back to ``Decimal``
+    on the way out exactly as it does on a miss.
     """
-    from orionbelt.service.value_formatting import _NUMERIC_TYPE_TOKENS
+    opaque = pa.opaque(pa.string(), "numeric", "PostgreSQL")
+    table = pa.table({"Amount": pa.array(["1.50", None], pa.string()).cast(opaque)})
 
-    assert result_codec._NUMERIC_TYPE_TOKENS == _NUMERIC_TYPE_TOKENS
+    decoded = result_codec.decode_data(result_codec.encode_table(table))
+    assert decoded.schema.field("Amount").type == opaque
+    assert decoded.column("Amount").to_pylist() == ["1.50", None]
+
+
+def test_the_fallback_still_infers_from_values() -> None:
+    """``encode_data`` is what a result with no Arrow table gets, and it is
+    honest about being inference: no schema is offered because none exists."""
+    from decimal import Decimal
+
+    table = result_codec.build_result_table(["Amount"], [[Decimal("1.50")]])
+    assert pa.types.is_decimal(table.schema.field("Amount").type)
+    assert _rows(result_codec.decode_data(result_codec.encode_data(["x"], [[1]]))) == [[1]]

--- a/tests/unit/test_result_schema.py
+++ b/tests/unit/test_result_schema.py
@@ -291,25 +291,25 @@ class TestCoalesceAliases:
 class TestCacheHitWarnings:
     """A hit has to report the warnings its miss did.
 
-    ``execution_result_from_data`` rebuilds a hit with ``raw_rows`` rather than
-    an Arrow table - deliberately, because ``table_to_rows`` keeps native dates
-    where the executor's row builder serialises them to ISO strings, so
-    swapping it changes what a hit returns. It also leaves ``arrow_schema``
-    None, so reconciling the *result* is a no-op. The table is reconciled
-    instead, before the result is built.
+    A rebuilt hit is table-backed, like a fresh result, so reconciling it
+    works rather than silently finding nothing for want of a table. The read
+    path still reconciles the table before building the result, because the
+    response builder is handed the skips and would otherwise report each
+    uncastable column twice.
     """
 
-    def test_reconciling_the_rebuilt_result_finds_nothing(self) -> None:
-        """The failure mode, pinned so the ordering requirement is explicit."""
+    def test_reconciling_the_rebuilt_result_now_finds_the_skip(self) -> None:
+        """The trap that four read paths rediscovered, closed.
+
+        The rebuild used to hand back rows, so ``reconcile_to_declared`` had
+        no table to work on and quietly returned nothing - a hit reported none
+        of the warnings its miss did.
+        """
         from orionbelt.api.query_cache import execution_result_from_data
 
         stored = pa.table({"flag": pa.array([0, 1, 7], type=pa.int64())})
         result = execution_result_from_data(stored, execution_time_ms=1.0)
-        # The schema travels with it, so a re-encode keeps the types - but the
-        # *table* does not, and that is what reconciliation needs.
-        assert result.arrow_schema is not None
-        assert result.reconcile_to_declared({"flag": pa.bool_()}) == []
-        assert result.arrow_schema.field("flag").type == pa.int64()
+        assert [name for name, _ in result.reconcile_to_declared({"flag": pa.bool_()})] == ["flag"]
 
     def test_reconciling_the_table_recovers_the_skip(self) -> None:
         stored = pa.table({"flag": pa.array([0, 1, 7], type=pa.int64())})
@@ -322,17 +322,27 @@ class TestCacheHitWarnings:
         assert skips == []
         assert table.schema.field("flag").type == pa.bool_()
 
-    def test_the_hit_keeps_its_native_row_shape(self) -> None:
-        """``table_to_rows`` semantics must survive the reconciliation."""
+    def test_the_hit_serialises_its_rows_like_a_miss(self) -> None:
+        """The point of the change: one serialiser, so one answer.
+
+        A hit used to return whatever the stored cells happened to be, which
+        was an ISO string when REST wrote the entry and a ``date`` when Flight
+        did. Now the stored table is native either way and the executor
+        serialises it on the way out, exactly as it does for a fresh result.
+        """
         import datetime
 
         from orionbelt.api.query_cache import execution_result_from_data
+        from orionbelt.service.db_executor import ColumnMeta, ExecutionResult
 
         stored = pa.table({"d": pa.array([datetime.date(2026, 8, 15)], type=pa.date32())})
         table, _ = reconcile_to_declared(stored, {"d": pa.date32()})
-        assert execution_result_from_data(table, execution_time_ms=1.0).rows == [
-            [datetime.date(2026, 8, 15)]
-        ]
+
+        hit = execution_result_from_data(table, execution_time_ms=1.0)
+        miss = ExecutionResult(
+            columns=[ColumnMeta(name="d", type_hint="datetime")], arrow_table=stored, row_count=1
+        )
+        assert hit.rows == miss.rows == [["2026-08-15"]]
 
 
 class TestCoalesceAliasMetadata:
@@ -591,15 +601,13 @@ class TestSkippedColumnsReportWhatTheyAre:
         assert columns[0].type == "number"
 
 
-class TestARowBackedHitKeepsItsTypes:
-    """A decoded hit is rebuilt from rows, and must still carry the schema.
+class TestARebuiltHitKeepsItsTypes:
+    """A decoded hit holds its table, so the types are the table's.
 
-    The raw-arrow path decodes when reconciliation is possible, and the rebuilt
-    result is row-backed - ``table_to_rows`` keeps native dates where the Arrow
-    row builder serialises them, so it cannot simply hold the table. Without
-    the schema travelling alongside, the re-encode on the way out infers types
-    from values and an empty or all-null ``int64`` column comes back ``null``,
-    undoing exactly what the schema sidecar exists to preserve.
+    This used to be delicate: the rebuild handed back rows and carried the
+    schema separately, so a re-encode on the way out could infer types from
+    values and collapse an empty or all-null ``int64`` column to ``null``.
+    Holding the table removes the step that could go wrong.
     """
 
     def test_an_empty_typed_column_keeps_its_type(self) -> None:
@@ -618,15 +626,16 @@ class TestARowBackedHitKeepsItsTypes:
         assert result.arrow_schema is not None
         assert result.arrow_schema.field("Amount").type == pa.int64()
 
-    def test_the_rows_are_still_the_table_to_rows_shape(self) -> None:
-        """Carrying the schema must not change what a hit returns."""
+    def test_the_table_is_held_rather_than_pre_serialised(self) -> None:
+        """What makes reconciliation and the shared serialiser possible."""
         import datetime
 
         from orionbelt.api.query_cache import execution_result_from_data
 
         table = pa.table({"d": pa.array([datetime.date(2026, 8, 15)], type=pa.date32())})
         result = execution_result_from_data(table, execution_time_ms=1.0)
-        assert result.rows == [[datetime.date(2026, 8, 15)]]
+        assert result.arrow_table is not None
+        assert result.arrow_table.schema.field("d").type == pa.date32()
 
     def test_a_real_arrow_table_still_wins(self) -> None:
         """The explicit schema is a fallback, not an override."""


### PR DESCRIPTION
Track I-5 of the ADBC plan, and the part of it that turned out to be a live defect rather than a cleanup.

## The defect

REST, pgwire and Flight share a result cache - same key, same blob (`KEY_VERSION`). They did not share a *representation*.

| column | written by REST / pgwire | written by Flight |
|---|---|---|
| `timestamp` | `string` (ISO) | `timestamp[us]` |
| `date` | `string` | `date32` |
| `binary` | `string` (base64) | `binary` |

REST and pgwire encoded rows that had already been through the executor's serialiser; Flight stored its Arrow table verbatim. So whichever surface ran a query first decided what the others read, and each read path only understood its own writer's convention: the REST reader took the stored cells as-is (correct only for REST-written entries), while Flight streams the decoded table straight to the client against a schema it advertised in `FlightInfo`.

## The fix

The driver's table is what gets stored, and a hit is materialised through the same serialiser a miss is. A hit then returns what its miss returned, cell for cell:

```
miss: [1, Decimal('1.50'), '2024-01-02T03:04:05', '2024-01-02', 'AAE=', None]
hit : [1, Decimal('1.50'), '2024-01-02T03:04:05', '2024-01-02', 'AAE=', None]
```

That includes two cases which only worked by accident before: the ADBC opaque NUMERIC, which is a `string` in Arrow and a `Decimal` in a row (the executor parses it, and now a hit goes through the executor); and the interval normalisation, which lived only on the fresh path because the stored cell was already a string.

## Two visible consequences

- **`format=arrow` returns the warehouse's types.** It previously shipped ISO strings under an envelope whose own column metadata called them datetimes. A raw-arrow hit and the miss that filled it now ship the same bytes, which they did not before.
- **`reconcile_to_declared` works on a cache hit.** The rebuilt result holds its table instead of pre-serialised rows, so the cast has something to work on. A row-backed rebuild made it a silent no-op - the trap four read paths rediscovered one at a time, and the reason `tests/architecture/test_cached_hits_reconcile.py` exists.

## What this removes

`encode_data` stays, as the fallback for a result with no Arrow table at all (a driver with no Arrow, a process without pyarrow, and the `format_values` arrow response where every cell is a display string). What goes is the machinery it needed to approximate types from serialised rows: the offered-type hint, the string-backed-numeric probe that had to refuse the hint, and `table_to_rows`, whose only job was reading cells that had been serialised before they were stored. `result_codec` drops from 286 to 150 lines.

## Compatibility

`KEY_VERSION` moves 4 -> 5. Entries written under v4 hold serialised values, so they miss once and age out.

The UI decodes the same Arrow and its decoder promises rows "identical to the JSON shape", so it now serialises with the same function rather than handing the renderer `datetime` objects.

## Verification

`uv run pytest` 5107 passed / 1065 skipped, `pytest -m adbc_flight` 97 passed / 1 skipped, ruff and mypy clean.

New: `tests/unit/test_cache_one_representation.py` pins the invariant directly (a hit equals its miss, per type, including the opaque NUMERIC and the interval), and an end-to-end test in `test_duckdb_execution.py` asserts a date column arrives as `date32` over `format=arrow` and that a second request agrees.

Rewritten rather than deleted: the tests that pinned the old asymmetry now pin the new guarantee - a declared decimal width is stable across result sets because the table is stored, not because a schema is offered to rows that might refuse it.