### PR TITLE
Drop the backdrop blur from the cookie consent overlay

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -105,3 +105,13 @@ td code {
   opacity: 0.7;
   line-height: 1.6;
 }
+
+/* Cookie consent overlay: drop Material's backdrop blur. The overlay is a
+   fixed, full-viewport layer that stays up until the visitor answers the
+   banner, so the blur makes the browser re-filter the whole viewport on
+   every scroll and repaint underneath it. The dark background already
+   separates the banner from the page, so only the filter goes. */
+.md-consent__overlay {
+  -webkit-backdrop-filter: none;
+  backdrop-filter: none;
+}


### PR DESCRIPTION
## Why

Material's `.md-consent__overlay` is a **fixed, full-viewport** layer carrying `backdrop-filter: blur(.1rem)`, and it stays up on every docs page until the visitor answers the banner:

```css
.md-consent__overlay {
  position: fixed; width: 100%; height: 100%;
  backdrop-filter: blur(.1rem);
  background-color: #0000008a;
  z-index: 5;
}
```

Measured on `/orionbelt-semantic-layer/`, the element is 2056 x 1198 (the whole viewport) with `backdrop-filter: blur(2.4px)` computed. A full-screen backdrop filter keeps a dedicated composited layer alive and makes the browser re-blur the entire viewport on every scroll and repaint underneath it. It is a lot of GPU for a banner backdrop, and it is live on all 57 docs pages for anyone without the `__md_consent` cookie.

The banner's own animation is one-shot (`iterations: 1`, 250ms), so nothing is actually animating. That is why this never looked like an animation problem.

## What

Override the overlay in `docs/stylesheets/extra.css` to drop the filter. The banner stays, and `background-color: #0000008a` already separates it from the page, so only the blur goes.

## Verification

Built locally with `mkdocs build` and checked in Chrome:

- Computed `backdropFilter: "none"`, and **zero** backdrop-filter elements left on the page.
- `extra.css` loads after `main.*.min.css` at equal specificity, so the override wins.
- Side by side against the current build: before is dimmed **and blurry**, after is dimmed and **crisp**. The dim is fully intact.

One note for reviewers: after the change, screenshots of the page can come back undimmed even though computed style still reads `opacity: 1` / `rgba(0, 0, 0, 0.54)` and `elementFromPoint` still returns the overlay. That is a stale-composite artifact in the capture, not a paint bug. A control pair of fixed strips differing only in `backdrop-filter` both captured fine, and forcing a repaint brings the dim straight back. The overlay going stale in captures is itself a sign it no longer holds its own GPU layer.

No version bump needed: `docs/**` is in the `deploy-docs.yml` path filter, and `project_version` is only used for the deploy commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)