### PR TITLE
fix(flight): honour include_schema on CommandGetTables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to OrionBelt Semantic Layer are documented here.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`CommandGetTables` ignored `include_schema`, so DuckDB could not list tables (#432).** Flight
+  SQL defines two response shapes for that command: four columns, or five with the serialised table
+  schema appended, chosen by a flag on the request. OBSL always answered with five. Every client
+  tested until now happened to ask for the five-column form, so it went unnoticed; DuckDB's
+  `adbc_scanner` extension asks for four and the driver rejects the endpoint outright -
+  `Invalid schema returned for: expected schema: fields: 4 ... got schema: fields: 5`.
+
+  The flag is parsed now and both the streamed table and the schema advertised in `FlightInfo`
+  follow it. With that, a plain DuckDB shell can list, describe and query a model over Flight SQL,
+  join the result to local tables and materialise it with `CREATE TABLE AS`.
+
+  Same class as the two catalog defects the ADBC conformance harness found in #382, and caught the
+  same way: by driving the server with a client nobody had pointed at it before.
+
 ## [2.27.0] - 2026-09-09
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to OrionBelt Semantic Layer are documented here.
 
 ### Fixed
 
-- **`CommandGetTables` ignored `include_schema`, so DuckDB could not list tables (#432).** Flight
+- **`CommandGetTables` ignored `include_schema`, so DuckDB could not list tables (#433).** Flight
   SQL defines two response shapes for that command: four columns, or five with the serialised table
   schema appended, chosen by a flag on the request. OBSL always answered with five. Every client
   tested until now happened to ask for the five-column form, so it went unnoticed; DuckDB's

--- a/drivers/ob-flight-extension/src/ob_flight/flight_sql.py
+++ b/drivers/ob-flight-extension/src/ob_flight/flight_sql.py
@@ -50,15 +50,31 @@ DB_SCHEMA_SCHEMA = pa.schema(
     ]
 )
 
+# ``CommandGetTables`` has two response shapes, chosen by the request's
+# ``include_schema`` flag: four columns without it, five with the serialised
+# table schema appended. It is not optional decoration - a client that asked
+# for four columns and is handed five refuses the stream, which is how DuckDB's
+# adbc_scanner failed to list tables while every other client worked.
+TABLE_SCHEMA_FIELDS = [
+    pa.field("catalog_name", pa.utf8()),
+    pa.field("db_schema_name", pa.utf8()),
+    pa.field("table_name", pa.utf8(), nullable=False),
+    pa.field("table_type", pa.utf8(), nullable=False),
+]
+
+#: ``include_schema = false``, the Flight SQL default.
+TABLE_SCHEMA_NO_SCHEMA = pa.schema(TABLE_SCHEMA_FIELDS)
+
+#: ``include_schema = true``.
 TABLE_SCHEMA = pa.schema(
-    [
-        pa.field("catalog_name", pa.utf8()),
-        pa.field("db_schema_name", pa.utf8()),
-        pa.field("table_name", pa.utf8(), nullable=False),
-        pa.field("table_type", pa.utf8(), nullable=False),
-        pa.field("table_schema", pa.binary(), nullable=False),
-    ]
+    [*TABLE_SCHEMA_FIELDS, pa.field("table_schema", pa.binary(), nullable=False)]
 )
+
+
+def tables_response_schema(include_schema: bool) -> pa.Schema:
+    """The ``CommandGetTables`` response schema for a request's flag."""
+    return TABLE_SCHEMA if include_schema else TABLE_SCHEMA_NO_SCHEMA
+
 
 TABLE_TYPES_SCHEMA = pa.schema([pa.field("table_type", pa.utf8(), nullable=False)])
 
@@ -318,6 +334,34 @@ def parse_db_schema_filter(value: bytes) -> str | None:
     return _parse_filter_field(value, target_field=2)
 
 
+def parse_include_schema(value: bytes) -> bool:
+    """Extract ``include_schema`` (field 5, a bool) from a ``CommandGetTables``.
+
+    Absent means false, which is the protobuf default and what most clients
+    send. Answering with the five-column shape regardless is what made
+    ``adbc_tables`` fail on DuckDB: the driver compares the streamed schema
+    against the four columns it asked for and rejects the endpoint.
+    """
+    try:
+        offset = 0
+        while offset < len(value):
+            tag, offset = _read_varint(value, offset)
+            field_number = tag >> 3
+            wire_type = tag & 0x07
+            if wire_type == 0:  # varint (bool / int)
+                parsed, offset = _read_varint(value, offset)
+                if field_number == 5:
+                    return bool(parsed)
+            elif wire_type == 2:  # length-delimited (string / bytes)
+                length, offset = _read_varint(value, offset)
+                offset += length
+            else:
+                break
+    except Exception:
+        pass
+    return False
+
+
 def _parse_filter_field(value: bytes, *, target_field: int) -> str | None:
     """Scan a Flight SQL command body for one length-delimited string field."""
     try:
@@ -415,6 +459,7 @@ def build_tables_table(
     *,
     expose_data_objects: bool = False,
     table_filter: str | None = None,
+    include_schema: bool = True,
 ) -> pa.Table:
     """Build response for CommandGetTables from the semantic model.
 
@@ -487,16 +532,15 @@ def build_tables_table(
     for vt_name in METADATA_VIEW_NAMES:
         _emit(vt_name, "VIEW", virtual_view_schema(model, vt_name))
 
-    return pa.table(
-        {
-            "catalog_name": catalogs,
-            "db_schema_name": schemas,
-            "table_name": names,
-            "table_type": types,
-            "table_schema": table_schemas,
-        },
-        schema=TABLE_SCHEMA,
-    )
+    columns: dict[str, Any] = {
+        "catalog_name": catalogs,
+        "db_schema_name": schemas,
+        "table_name": names,
+        "table_type": types,
+    }
+    if include_schema:
+        columns["table_schema"] = table_schemas
+    return pa.table(columns, schema=tables_response_schema(include_schema))
 
 
 def build_table_types_table() -> pa.Table:

--- a/drivers/ob-flight-extension/src/ob_flight/server.py
+++ b/drivers/ob-flight-extension/src/ob_flight/server.py
@@ -42,14 +42,16 @@ from ob_flight.flight_sql import (
     FOREIGN_KEYS_SCHEMA,
     PRIMARY_KEYS_SCHEMA,
     SQL_INFO_SCHEMA,
-    TABLE_SCHEMA,
+    TABLE_SCHEMA_NO_SCHEMA,
     TABLE_TYPES_SCHEMA,
     build_prepared_statement_result,
     is_flight_sql_command,
     parse_any,
     parse_create_prepared_statement,
+    parse_include_schema,
     parse_prepared_statement_handle,
     parse_statement_query,
+    tables_response_schema,
 )
 from ob_flight.server_routing import (
     _ROUTING_MIDDLEWARE_KEY,
@@ -84,7 +86,10 @@ __all__ = [
 _CATALOG_COMMAND_SCHEMAS = {
     CMD_GET_CATALOGS: CATALOG_SCHEMA,
     CMD_GET_DB_SCHEMAS: DB_SCHEMA_SCHEMA,
-    CMD_GET_TABLES: TABLE_SCHEMA,
+    # ``CommandGetTables`` alone has two shapes. The map holds the default
+    # (``include_schema`` absent, so false); ``get_flight_info`` overrides it
+    # per request via ``tables_response_schema``.
+    CMD_GET_TABLES: TABLE_SCHEMA_NO_SCHEMA,
     CMD_GET_TABLE_TYPES: TABLE_TYPES_SCHEMA,
     CMD_GET_SQL_INFO: SQL_INFO_SCHEMA,
     CMD_GET_XDBC_TYPE_INFO: pa.schema([pa.field("info", pa.utf8())]),
@@ -372,6 +377,7 @@ class OBFlightServer(flight.FlightServerBase):  # type: ignore[misc]
         table_filter: str | None = None,
         catalog_filter: str | None = None,
         db_schema_filter: str | None = None,
+        include_schema: bool = True,
     ) -> pa.Table:
         return server_catalog.build_tables_from_model(
             self,
@@ -379,6 +385,7 @@ class OBFlightServer(flight.FlightServerBase):  # type: ignore[misc]
             table_filter=table_filter,
             catalog_filter=catalog_filter,
             db_schema_filter=db_schema_filter,
+            include_schema=include_schema,
         )
 
     def _build_columns_from_model(
@@ -505,6 +512,11 @@ class OBFlightServer(flight.FlightServerBase):  # type: ignore[misc]
                 # already has its spec schema as a constant, so there is no
                 # reason to guess.
                 schema = _CATALOG_COMMAND_SCHEMAS.get(type_url)
+                if type_url == CMD_GET_TABLES:
+                    # Two shapes, chosen by the request. Advertising the
+                    # five-column one for a four-column request is the same
+                    # inconsistency this block exists to avoid, one level in.
+                    schema = tables_response_schema(parse_include_schema(value))
                 if schema is None:
                     raise flight.FlightServerError(
                         f"No advertised schema for catalog command: {type_url}"

--- a/drivers/ob-flight-extension/src/ob_flight/server_catalog.py
+++ b/drivers/ob-flight-extension/src/ob_flight/server_catalog.py
@@ -42,6 +42,7 @@ from ob_flight.flight_sql import (
     build_sql_info_table,
     build_table_types_table,
     build_tables_table,
+    parse_include_schema,
 )
 
 if TYPE_CHECKING:
@@ -415,6 +416,7 @@ def build_tables_from_model(
     table_filter: str | None = None,
     catalog_filter: str | None = None,
     db_schema_filter: str | None = None,
+    include_schema: bool = True,
 ) -> pa.Table:
     """Build the CommandGetTables response.
 
@@ -430,7 +432,7 @@ def build_tables_from_model(
     model = resolve_model_for_catalog(
         server, catalog_filter, context, db_schema_filter=db_schema_filter
     )
-    return build_tables_table(model, table_filter=table_filter)
+    return build_tables_table(model, table_filter=table_filter, include_schema=include_schema)
 
 
 def build_columns_from_model(
@@ -516,6 +518,7 @@ def build_catalog_table(
             table_filter=table_filter,
             catalog_filter=catalog_filter,
             db_schema_filter=db_schema_filter,
+            include_schema=parse_include_schema(cmd_value),
         )
     elif type_url == CMD_GET_COLUMNS:
         table = server._build_columns_from_model(

--- a/drivers/ob-flight-extension/tests/test_catalog.py
+++ b/drivers/ob-flight-extension/tests/test_catalog.py
@@ -430,6 +430,68 @@ class TestAdvertisedSchemaMatchesStream:
                 )
         assert not mismatches, "\n".join(mismatches)
 
+    def test_get_tables_streams_the_shape_the_request_asked_for(self) -> None:
+        """``CommandGetTables`` has two, chosen by ``include_schema``.
+
+        Answering with the five-column shape regardless is how DuckDB's
+        ``adbc_scanner`` failed to list tables: the driver compares the stream
+        against the four columns it asked for and rejects the endpoint. Every
+        other client we test with happened to ask for five.
+        """
+        import threading
+
+        from ob_flight.flight_sql import (
+            CMD_GET_TABLES,
+            TABLE_SCHEMA,
+            TABLE_SCHEMA_NO_SCHEMA,
+        )
+        from ob_flight.server import OBFlightServer
+        from ob_flight.server_catalog import build_catalog_table
+
+        server = OBFlightServer.__new__(OBFlightServer)
+        server._session_manager = None
+        server._default_dialect = "duckdb"
+        server._lock = threading.Lock()
+        server._pending = {}
+        server._prepared = {}
+        server._pending_ttl = 300
+        server._batch_size = 1024
+        server._cache = None
+        server._cache_config = None
+
+        # field 5 (include_schema), varint: tag 0x28 then the value.
+        without = build_catalog_table(server, CMD_GET_TABLES, b"")
+        explicit_false = build_catalog_table(server, CMD_GET_TABLES, b"\x28\x00")
+        with_schema = build_catalog_table(server, CMD_GET_TABLES, b"\x28\x01")
+
+        assert without.schema == TABLE_SCHEMA_NO_SCHEMA, "absent must mean false"
+        assert explicit_false.schema == TABLE_SCHEMA_NO_SCHEMA
+        assert with_schema.schema == TABLE_SCHEMA
+        assert "table_schema" not in without.column_names
+
+    def test_get_tables_advertises_the_shape_it_will_stream(self) -> None:
+        """The two halves have to agree per request, not just per command."""
+        from ob_flight.flight_sql import (
+            TABLE_SCHEMA,
+            TABLE_SCHEMA_NO_SCHEMA,
+            parse_include_schema,
+            tables_response_schema,
+        )
+
+        assert parse_include_schema(b"") is False
+        assert parse_include_schema(b"\x28\x01") is True
+        assert tables_response_schema(False) == TABLE_SCHEMA_NO_SCHEMA
+        assert tables_response_schema(True) == TABLE_SCHEMA
+
+    def test_a_table_name_filter_survives_the_include_schema_flag(self) -> None:
+        """Both live in the same body; parsing one must not consume the other."""
+        from ob_flight.flight_sql import parse_include_schema, parse_table_filter
+
+        # field 3 (table_name_filter_pattern) = "model", then field 5 = true.
+        body = b"\x1a\x05model\x28\x01"
+        assert parse_table_filter(body) == "model"
+        assert parse_include_schema(body) is True
+
     def test_foreign_key_commands_share_one_schema(self) -> None:
         """FlightSql.proto gives all three the same thirteen columns.
 


### PR DESCRIPTION
Found by pointing a client at OBSL that nobody had pointed at it before: a plain DuckDB, using the `adbc_scanner` community extension.

## The defect

Flight SQL's `CommandGetTables` has two response shapes, chosen by an `include_schema` flag on the request:

| flag | columns |
|---|---|
| false (the protobuf default) | `catalog_name`, `db_schema_name`, `table_name`, `table_type` |
| true | the same four plus `table_schema: binary` |

OBSL always answered with five. Every client tested until now happened to ask for the five-column form, so it went unnoticed. DuckDB asks for four, and the driver refuses the endpoint:

```
[flightsql] Failed to get database objects: Invalid schema returned for:
  expected schema: fields: 4 ... got schema: fields: 5
    - table_schema: type=binary
```

The flag was documented in a comment in `parse_table_filter` and never parsed.

## The fix

`parse_include_schema` reads field 5, and both halves follow it: the table `do_get` streams, and the schema `get_flight_info` advertises. The advertised-schema map holds the default and `get_flight_info` overrides it per request, because this is the one catalog command whose shape depends on the body.

Same class as the two catalog defects the ADBC conformance harness found in #382 - a mismatch between what is advertised and what is streamed - and the existing `TestAdvertisedSchemaMatchesStream` invariant caught the change the moment the default shape moved, which is what it was written for.

## What it unlocks

A plain DuckDB shell is now a working client of the semantic layer over Flight SQL. Verified end to end against a real `OBFlightServer`:

```sql
LOAD adbc_scanner;
SELECT adbc_connect(MAP {'driver': '<libadbc_driver_flightsql>', 'uri': 'grpc://host:port'});

SELECT * FROM adbc_scan(handle, 'SELECT "Customer Country", "Total Revenue" FROM sales');
-- ('US', 150.0), ('UK', 75.0)
```

`adbc_tables` (was failing, now lists `model` / `dimensions` / `measures` / `metrics`), `adbc_schema`, filtering, aggregating on top, joining to local DuckDB tables and `CREATE TABLE AS` all work.

Worth noting for `design/PLAN-duckdb-airport.md`: that plan assumed DuckDB access required building an Airport action surface, because Airport is not Flight SQL. It is right about Airport and wrong about the conclusion - the ADBC route needs no new server surface at all.

## Verification

`uv run pytest` 5112 passed, `pytest -m adbc_flight` 97 passed, `pytest drivers/ob-flight-extension/tests` 290 passed (3 new), ruff and mypy clean in the package and at the root.

The three new tests cover the two shapes, the advertised/streamed agreement per request, and that parsing the flag does not consume the table-name filter that shares the body.