### PR TITLE
docs(adbc): DuckDB as a client, with an asserted example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to OrionBelt Semantic Layer are documented here.
 
 ## [Unreleased]
 
+### Added
+
+- **Documented DuckDB as a client of the layer.** `docs/guide/adbc.md` gains a `From DuckDB`
+  section: with the `adbc_scanner` community extension, a plain DuckDB shell connects to the Flight
+  SQL surface and `adbc_scan` turns a governed query into a relation, so it joins to local tables,
+  aggregates, and materialises with `CREATE TABLE AS`. The recipe is asserted like every other
+  sample on that page - `tests/integration/test_adbc_docs_claims.py` runs it against a live server,
+  skipping only where the community extension cannot be fetched.
+
+  Two caveats the page states plainly: `adbc_scanner` is a community extension, not a bundled one,
+  and `adbc_connect` needs a filesystem path to the Flight SQL driver library rather than a package
+  name. It also names the division of labour - predicates inside the OBSQL string are compiled into
+  the warehouse query, predicates outside the scan are DuckDB's and run after the rows arrive.
+
 ### Fixed
 
 - **`CommandGetTables` ignored `include_schema`, so DuckDB could not list tables (#433).** Flight

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ The same model serves every surface you already use:
 - **Your BI tool**, over the PostgreSQL wire protocol on `:5432`. Tableau, Power BI, Superset, DBeaver, and `psql` connect with the Postgres driver they already ship. Dremio federates it as a Postgres source.
 - **Your [AI agents](https://ralforion.com/agentic-ai-data-access.html)**, over MCP. Works with Claude, Cursor, Copilot, and Windsurf.
 - **Your code**, over REST, Arrow Flight SQL, or PEP 249 drivers.
+- **Your DuckDB**, over Arrow Flight SQL. `LOAD adbc_scanner`, connect, and `adbc_scan` a governed query into a DuckDB relation you can join, filter, and materialise locally. See [Connecting via ADBC](https://ralforion.com/orionbelt-semantic-layer/guide/adbc/#from-duckdb).
 
 Compiles to BigQuery, ClickHouse, Databricks, Dremio, DuckDB/MotherDuck, MySQL, PostgreSQL, and Snowflake.
 
@@ -401,6 +402,7 @@ Also works with Copilot, Cursor, and Windsurf. See the [MCP repo](https://github
 - **AI Integrations** — LangChain, OpenAI Agents SDK, CrewAI, Google ADK, Vercel AI SDK, n8n, ChatGPT
 - **Gradio UI** — interactive web interface for model editing, query testing, and ER diagrams
 - **DB-API 2.0 + Flight SQL** — PEP 249 drivers and Arrow Flight SQL server for DBeaver, Tableau, Power BI; ships with `examples/obsql.py`, a tiny terminal CLI for testing the Flight surface without a BI tool
+- **DuckDB as a client** (v2.27.1+) — with the `adbc_scanner` community extension, a plain DuckDB shell queries the layer over Flight SQL: `adbc_scan` returns a relation, so governed measures join to local tables and land in `CREATE TABLE AS`. Arrow the whole way, no conversion at either end
 - **PostgreSQL Wire Protocol** (v2.5.0+) — native Postgres-protocol surface on `:5432`. Every BI tool already ships a Postgres ODBC/JDBC driver, so the user side is "point your existing connection at OBSL and go" — Tableau, DBeaver, Superset, Power BI, plain `psql`, and **Dremio as a federated Postgres source** (Dremio → OBSL → optionally back to Dremio's lakehouse, full circle)
 
 ### Agent-Facing API

--- a/docs/guide/adbc.md
+++ b/docs/guide/adbc.md
@@ -88,6 +88,53 @@ to send — it never returns an empty result instead.
 Flight's older `Handshake` — where the key travels on the stream rather than in
 a header — keeps working alongside these, for clients that still speak it.
 
+## From DuckDB
+
+DuckDB can be the client. The `adbc_scanner` community extension makes it an
+ADBC client, and the semantic layer is an ADBC server, so a plain DuckDB shell
+queries governed measures and joins the result to local tables:
+
+```sql
+INSTALL adbc_scanner FROM community;
+LOAD adbc_scanner;
+
+CREATE OR REPLACE TABLE h AS
+SELECT adbc_connect(MAP {
+    'driver': '/path/to/libadbc_driver_flightsql.so',
+    'uri':    'grpc://127.0.0.1:8815'
+}) AS handle;
+
+SELECT * FROM adbc_scan(
+    (SELECT handle FROM h),
+    'SELECT "Customer Country", "Total Revenue" FROM sales'
+);
+```
+
+Two things it needs that the Python recipe does not: `adbc_scanner` is a
+**community** extension rather than a bundled one, and `adbc_connect` wants a
+filesystem path to the Flight SQL driver library. Any ADBC install has one —
+`python -c "import adbc_driver_flightsql as d; print(d._driver_path())"` prints
+it — but it is a path, not a package name.
+
+What works from there:
+
+| | |
+|---|---|
+| `adbc_scan(handle, '<OBSQL>')` | The point. Governed measures, resolved joins, typed columns. |
+| `adbc_tables(handle)` | Lists `model` and the `dimensions` / `measures` / `metrics` views. |
+| `adbc_schema(handle, 'model', schema := 'sales')` | Column names and types without executing anything. |
+| Filtering, grouping, joining to local tables | Ordinary DuckDB SQL over the scan. |
+| `CREATE TABLE local AS SELECT * FROM adbc_scan(…)` | Materialises the result locally. |
+
+The scan is a table function, so DuckDB treats its output as any other
+relation: the semantic layer resolves the model and returns Arrow, and DuckDB
+does whatever you ask on top.
+
+Note the division of labour. Predicates written *outside* `adbc_scan` are
+DuckDB's, applied after the rows arrive; predicates inside the OBSQL string are
+the semantic layer's, compiled into the warehouse query. For anything
+selective, put them in the OBSQL.
+
 ## What you can send
 
 The Flight surface takes **OBSQL** — `SELECT <dimension|measure> FROM <model>`,

--- a/tests/integration/test_adbc_docs_claims.py
+++ b/tests/integration/test_adbc_docs_claims.py
@@ -132,6 +132,71 @@ class TestTheCatalogSamples:
             assert cur.fetch_arrow_table().num_rows > 0
 
 
+class TestTheDuckDBRecipe:
+    """The `From DuckDB` section, run as written.
+
+    Skipped where the community extension cannot be installed - it is fetched
+    over the network, unlike everything else this suite needs. The recipe is
+    the one claim on the page that depends on a third-party extension, so it
+    gets a skip rather than a hard requirement.
+    """
+
+    @staticmethod
+    def _duckdb_with_adbc() -> Any:
+        duckdb = pytest.importorskip("duckdb", reason="duckdb required")
+        connection = duckdb.connect()
+        try:
+            connection.execute("INSTALL adbc_scanner FROM community")
+            connection.execute("LOAD adbc_scanner")
+        except Exception as exc:  # noqa: BLE001 - network or unavailable build
+            pytest.skip(f"adbc_scanner community extension unavailable: {exc}")
+        return connection
+
+    @staticmethod
+    def _handle(connection: Any, uri: str) -> Any:
+        driver = pytest.importorskip("adbc_driver_flightsql")._driver_path()
+        return connection.execute(
+            "SELECT adbc_connect(MAP {'driver': ?, 'uri': ?})", [driver, uri]
+        ).fetchone()[0]
+
+    def test_a_duckdb_shell_queries_the_model(self, flight_uri: str) -> None:
+        connection = self._duckdb_with_adbc()
+        handle = self._handle(connection, flight_uri)
+        rows = connection.execute(
+            "SELECT * FROM adbc_scan(?, ?)",
+            [handle, f'SELECT "Customer Country", "Total Revenue" FROM {MODEL_NAME}'],
+        ).fetchall()
+        assert {r[0] for r in rows} == {"US", "UK"}
+        assert all(isinstance(r[1], float) for r in rows)
+
+    def test_the_catalog_functions_answer(self, flight_uri: str) -> None:
+        """``adbc_tables`` is the one that failed before #433: DuckDB asks for
+        the four-column ``CommandGetTables`` shape and OBSL always sent five."""
+        connection = self._duckdb_with_adbc()
+        handle = self._handle(connection, flight_uri)
+        tables = connection.execute("SELECT * FROM adbc_tables(?)", [handle]).fetchall()
+        assert "model" in {r[2] for r in tables}
+
+        columns = connection.execute(
+            "SELECT * FROM adbc_schema(?, 'model', schema := ?) LIMIT 20",
+            [handle, MODEL_NAME],
+        ).fetchall()
+        assert "Customer Country" in {r[0] for r in columns}
+
+    def test_the_result_composes_with_local_sql(self, flight_uri: str) -> None:
+        """The page claims filtering, aggregating and CREATE TABLE AS."""
+        connection = self._duckdb_with_adbc()
+        handle = self._handle(connection, flight_uri)
+        query = f'SELECT "Customer Country", "Total Revenue" FROM {MODEL_NAME}'
+
+        total = connection.execute(
+            'SELECT sum("Total Revenue") FROM adbc_scan(?, ?)', [handle, query]
+        ).fetchone()[0]
+        connection.execute("CREATE TABLE local AS SELECT * FROM adbc_scan(?, ?)", [handle, query])
+        materialised = connection.execute('SELECT sum("Total Revenue") FROM local').fetchone()[0]
+        assert materialised == total
+
+
 class TestThePageItselfRuns:
     """Executes the guide's code blocks verbatim, rather than transcribing them.
 


### PR DESCRIPTION
#433 made a plain DuckDB shell a working client of the Flight SQL surface. Nothing said so.

## The guide

`docs/guide/adbc.md` gains a `From DuckDB` section with the full recipe:

```sql
INSTALL adbc_scanner FROM community;
LOAD adbc_scanner;

CREATE OR REPLACE TABLE h AS
SELECT adbc_connect(MAP {
    'driver': '/path/to/libadbc_driver_flightsql.so',
    'uri':    'grpc://127.0.0.1:8815'
}) AS handle;

SELECT * FROM adbc_scan(
    (SELECT handle FROM h),
    'SELECT "Customer Country", "Total Revenue" FROM sales'
);
```

Plus a table of what works from there (`adbc_tables`, `adbc_schema`, filtering, joining to local tables, `CREATE TABLE AS`), and two caveats stated plainly rather than buried: `adbc_scanner` is a **community** extension, and `adbc_connect` wants a filesystem path to the driver library, not a package name.

It also names the division of labour, which is the thing a reader will get wrong first: predicates inside the OBSQL string are compiled into the warehouse query; predicates outside `adbc_scan` are DuckDB's and run after the rows arrive.

## Asserted, like the rest of that page

`tests/integration/test_adbc_docs_claims.py` gains three tests that run the recipe against a live `OBFlightServer`: the query, the catalog functions (`adbc_tables` is the one that failed before #433), and the compose-with-local-SQL claims. They skip only where the community extension cannot be fetched, since it is the one claim on the page that depends on a third party.

`pytest -m adbc_flight`: 100 passed, 1 skipped - up from 97, and the three new ones ran rather than skipped.

## README

Two bullets. One in the "same model serves every surface you already use" list at the top, one in the integration-surface features. Both link to the guide rather than repeating the recipe, so the caveats live in one place.