### PR TITLE
feat(tls): serve TLS on both listening surfaces, Flight SQL and pgwire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to OrionBelt Semantic Layer are documented here.
 
 ## [Unreleased]
 
+### Added
+
+- **TLS on the Arrow Flight SQL surface.** `FLIGHT_TLS_CERT` + `FLIGHT_TLS_KEY` make the listener
+  serve `grpc+tls` instead of `grpc`, and `FLIGHT_TLS_CLIENT_CA` additionally requires a client
+  certificate signed by that CA. Until now the surface had authentication and no transport
+  security, so an API key crossed the wire in clear text; configuring auth without TLS now logs a
+  warning saying so.
+
+  Both settings or neither: one alone refuses to start rather than falling back to plaintext,
+  because a deployment that reads as encrypted and is not is worse than one that does not come up.
+  The startup line reports the transport, so confirming TLS is live needs no packet capture.
+
+  Every configuration failure names the setting it is about, and one case gets its own message: the
+  published image runs as a non-root user, so a key bind-mounted from the host as `root:root 0600`
+  is present, correctly named, and unreadable - which reads as a wrong path until someone thinks to
+  check the mode.
+
+  Client trust was measured rather than read from driver documentation. Python ADBC and DuckDB's
+  `adbc_scanner` both accept `tls_root_certs` and `tls_skip_verify`, and both are **refused rather
+  than downgraded** when told to trust nothing. From DuckDB the option key must be a literal in the
+  `adbc_connect` MAP - a parameterised key scrambles the pairs into an error about failing to load
+  the driver. The Flight SQL JDBC driver is documented as untested here rather than assumed.
+
+  Unchanged for the demo: `FLIGHT_ENABLED` still defaults false in the image, and Cloud Run cannot
+  reach the Flight port anyway.
+
 ## [2.27.2] - 2026-09-09
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,18 @@ All notable changes to OrionBelt Semantic Layer are documented here.
   is present, correctly named, and unreadable - which reads as a wrong path until someone thinks to
   check the mode.
 
-  Client trust was measured rather than read from driver documentation. Python ADBC and DuckDB's
-  `adbc_scanner` both accept `tls_root_certs` and `tls_skip_verify`, and both are **refused rather
-  than downgraded** when told to trust nothing. From DuckDB the option key must be a literal in the
-  `adbc_connect` MAP - a parameterised key scrambles the pairs into an error about failing to load
-  the driver. The Flight SQL JDBC driver is documented as untested here rather than assumed.
+  Client trust was measured rather than read from driver documentation, against Python ADBC,
+  DuckDB's `adbc_scanner` and the Flight SQL JDBC driver. All three are **refused rather than
+  downgraded** when told to trust nothing. Two traps came out of it, both now in the guide: from
+  DuckDB the option key must be a literal in the `adbc_connect` MAP, since a parameterised key
+  scrambles the pairs into an error about failing to load the driver; and from JDBC, `trustStore`
+  does nothing without `useSystemTrustStore=false` beside it - it keeps consulting the system store
+  and fails with the same message as no trust configuration at all, so the setting reads as unread
+  rather than overridden.
+
+  Mutual TLS is tested rather than merely wired: a client that trusts the server but presents no
+  certificate is dropped, and one presenting a certificate signed by `FLIGHT_TLS_CLIENT_CA` is
+  served.
 
   Unchanged for the demo: `FLIGHT_ENABLED` still defaults false in the image, and Cloud Run cannot
   reach the Flight port anyway.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ All notable changes to OrionBelt Semantic Layer are documented here.
 
 ### Added
 
+- **TLS on the Postgres wire surface.** `PGWIRE_TLS_CERT` + `PGWIRE_TLS_KEY` (and
+  `PGWIRE_TLS_CLIENT_CA`) make the listener answer `S` to an `SSLRequest` and upgrade the socket,
+  where it previously always answered `N`. Postgres negotiates rather than starting encrypted, so
+  configuring a certificate makes the server *offer* TLS: `sslmode=disable` still connects, which
+  is the protocol's semantics rather than a weakening.
+
+  Verified against libpq: `require`, `verify-ca` and `verify-full` all negotiate, and `verify-ca`
+  against the wrong trust anchor is refused - the assertion that makes the other three mean
+  something.
+
+  The certificate loader is shared with the Flight surface and lives in `orionbelt.service.tls`,
+  because pgwire is core and the Flight extension is an optional extra: core cannot depend on it.
+  Each surface keeps its own setting names in every error message, since one naming the other
+  surface's setting would be worse than none.
+
 - **TLS on the Arrow Flight SQL surface.** `FLIGHT_TLS_CERT` + `FLIGHT_TLS_KEY` make the listener
   serve `grpc+tls` instead of `grpc`, and `FLIGHT_TLS_CLIENT_CA` additionally requires a client
   certificate signed by that CA. Until now the surface had authentication and no transport

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,6 +88,9 @@ ENV PORT=8080 \
     MODEL_FILES=orionbelt_1_commerce.yaml
 
 EXPOSE ${PORT}
+# Arrow Flight SQL, when FLIGHT_ENABLED=true. Documentation only - the image
+# advertised just the HTTP port while being able to serve this one too.
+EXPOSE 8815
 
 # Health check for local Docker / Compose (Cloud Run uses its own probes)
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \

--- a/docs/guide/adbc.md
+++ b/docs/guide/adbc.md
@@ -27,7 +27,88 @@ uv run orionbelt-api
 ```
 
 `FLIGHT_ENABLED` implies `QUERY_EXECUTE`. The gRPC URI is then
-`grpc://<host>:8815` — or `grpc+tls://` behind TLS.
+`grpc://<host>:8815`, or `grpc+tls://` with TLS configured — see below.
+
+## TLS
+
+Point the server at a certificate and key and it serves `grpc+tls` instead:
+
+```bash
+FLIGHT_ENABLED=true \
+FLIGHT_TLS_CERT=/certs/server.crt \
+FLIGHT_TLS_KEY=/certs/server.key \
+uv run orionbelt-api
+```
+
+Both or neither. Setting one without the other refuses to start rather than
+falling back to plaintext, because a deployment that reads as encrypted and is
+not is worse than one that does not come up. The startup line says which
+transport is live, so confirming it needs no packet capture.
+
+Worth stating plainly: **the Flight surface authenticates before it encrypts.**
+Without TLS, an API key sent by any of the mechanisms above crosses the wire in
+clear text. Configuring auth without TLS logs a warning for that reason.
+
+### From Docker
+
+Certificates are files, so they arrive by mount:
+
+```bash
+docker run -p 8080:8080 -p 8815:8815 \
+  -v /host/certs:/certs:ro \
+  -e FLIGHT_ENABLED=true \
+  -e FLIGHT_TLS_CERT=/certs/server.crt \
+  -e FLIGHT_TLS_KEY=/certs/server.key \
+  ralforion/orionbelt-semantic-layer-api:latest
+```
+
+**The image runs as a non-root user**, so a key mounted from the host as
+`root:root 0600` is present, correctly named, and unreadable inside the
+container. Make it readable by the container's user; in Kubernetes set
+`defaultMode: 0444` on the secret volume, or an `fsGroup`. The server names
+this case in its error rather than reporting a missing file.
+
+### Trusting the certificate, client side
+
+A self-signed or private-CA certificate has to be trusted explicitly, and a
+client that will not check it is **refused rather than downgraded**. Both
+options below are measured against a live server, not read from a driver's
+README:
+
+| Client | Trust a specific certificate | Skip verification |
+|---|---|---|
+| Python ADBC | `adbc.flight.sql.client_option.tls_root_certs` (PEM text) | `...tls_skip_verify` = `"true"` |
+| DuckDB `adbc_scanner` | the same keys, in the `adbc_connect` MAP | as above |
+| Flight SQL JDBC | `trustStore` | `disableCertificateVerification` — untested here |
+
+```python
+conn = dbapi.connect(
+    "grpc+tls://obsl.example.com:8815",
+    db_kwargs={"adbc.flight.sql.client_option.tls_root_certs": open("server.crt").read()},
+)
+```
+
+From DuckDB, the option key must be a **literal** in the MAP — only values can
+be bound, and a parameterised key scrambles the pairs into an error about
+failing to load the driver:
+
+```sql
+SELECT adbc_connect(MAP {
+    'driver': '/path/to/libadbc_driver_flightsql.so',
+    'uri':    'grpc+tls://obsl.example.com:8815',
+    'adbc.flight.sql.client_option.tls_root_certs': '<PEM text>'
+});
+```
+
+`tls_skip_verify` exists and works, and it verifies nothing: it accepts any
+certificate, including one presented by whoever is between you and the server.
+Reach for `tls_root_certs` unless you are debugging.
+
+### Mutual TLS
+
+`FLIGHT_TLS_CLIENT_CA=/certs/ca.crt` additionally requires each client to
+present a certificate signed by that CA. It needs the server's own certificate
+too — setting it alone is refused.
 
 ## Connect
 

--- a/docs/guide/adbc.md
+++ b/docs/guide/adbc.md
@@ -79,7 +79,31 @@ README:
 |---|---|---|
 | Python ADBC | `adbc.flight.sql.client_option.tls_root_certs` (PEM text) | `...tls_skip_verify` = `"true"` |
 | DuckDB `adbc_scanner` | the same keys, in the `adbc_connect` MAP | as above |
-| Flight SQL JDBC | `trustStore` | `disableCertificateVerification` — untested here |
+| Flight SQL JDBC | `trustStore` **plus `useSystemTrustStore=false`** | `disableCertificateVerification=true` |
+
+The JDBC row carries a trap worth reading twice: **`trustStore` on its own does
+nothing.** Without `useSystemTrustStore=false` the driver keeps consulting the
+system store, ignores the one you named, and fails with `unable to find valid
+certification path` — the same error as passing no trust configuration at all,
+so the setting looks unread rather than overridden. Measured against driver
+19.0.0; setting `javax.net.ssl.trustStore` on the JVM does not work either,
+because the driver shades its own TLS stack.
+
+```
+jdbc:arrow-flight-sql://obsl.example.com:8815
+    ?useEncryption=true
+    &useSystemTrustStore=false
+    &trustStore=/path/to/truststore.jks
+    &trustStorePassword=<password>
+```
+
+A JKS is built from the server's certificate (or its CA) with the JDK's own
+tool:
+
+```bash
+keytool -importcert -alias obsl -file server.crt \
+        -keystore truststore.jks -storepass changeit -noprompt
+```
 
 ```python
 conn = dbapi.connect(
@@ -109,6 +133,21 @@ Reach for `tls_root_certs` unless you are debugging.
 `FLIGHT_TLS_CLIENT_CA=/certs/ca.crt` additionally requires each client to
 present a certificate signed by that CA. It needs the server's own certificate
 too — setting it alone is refused.
+
+A client then supplies its own certificate and key alongside the trust
+material. Trusting the server is no longer sufficient on its own: without a
+client certificate the connection is dropped.
+
+```python
+conn = dbapi.connect(
+    "grpc+tls://obsl.example.com:8815",
+    db_kwargs={
+        "adbc.flight.sql.client_option.tls_root_certs": open("ca.crt").read(),
+        "adbc.flight.sql.client_option.mtls_cert_chain": open("client.crt").read(),
+        "adbc.flight.sql.client_option.mtls_private_key": open("client.key").read(),
+    },
+)
+```
 
 ## Connect
 

--- a/docs/guide/postgres-wire-bi-tools.md
+++ b/docs/guide/postgres-wire-bi-tools.md
@@ -26,6 +26,41 @@ queries OBSL via Postgres, OBSL compiles to Dremio's SQL dialect,
 ob-dremio's Arrow Flight driver streams the result back through
 Dremio's own execution engine. Governed semantics, no extra hop.
 
+## TLS
+
+The pgwire surface takes the same two settings the Flight one does, read by the
+same loader:
+
+```bash
+PGWIRE_ENABLED=true \
+PGWIRE_TLS_CERT=/certs/server.crt \
+PGWIRE_TLS_KEY=/certs/server.key \
+uv run orionbelt-api
+```
+
+Postgres does not start encrypted. The client sends an `SSLRequest`, the server
+answers `S` or `N`, and only then is the socket upgraded — so configuring a
+certificate makes the server *offer* TLS rather than demand it, and
+`sslmode=disable` still connects. That is the protocol's own semantics, not a
+weakening.
+
+Measured against libpq (psycopg 3):
+
+| `sslmode` | Result |
+|---|---|
+| `disable` | connects in the clear |
+| `prefer` | encrypted when a certificate is configured, plaintext when not |
+| `require` | encrypted, certificate not checked |
+| `verify-ca` with `sslrootcert` | encrypted, certificate chain checked |
+| `verify-full` | as above, plus the hostname |
+| `verify-ca` with the wrong CA | **refused** |
+
+Both settings or neither, and the same non-root file-permission caveat applies
+as for Flight — see [Connecting via ADBC](adbc.md#from-docker). A
+misconfiguration stops startup rather than silently answering `N` to every
+`SSLRequest`, which would leave clients in the clear against a configuration
+that reads as encrypted.
+
 ## 1. Common configuration
 
 Start the OBSL server with the wire surface enabled:

--- a/drivers/ob-flight-extension/AGENTS.md
+++ b/drivers/ob-flight-extension/AGENTS.md
@@ -210,6 +210,20 @@ def stop_flight_server() -> None:
 daemon=True is critical — ensures the Flight server thread dies cleanly
 when the FastAPI process exits or is killed by Docker.
 
+## TLS
+
+`ob_flight/tls.py` reads the certificate material; `FlightServerBase` does the
+rest (`tls_certificates`, `verify_client`, `root_certificates`). The listener's
+scheme follows the config — `grpc+tls://` with a certificate, `grpc://`
+without — so a plaintext client is refused at the handshake rather than
+downgraded.
+
+Every failure in that module is a *configuration* failure and says which
+setting is wrong. The one worth knowing: the published image runs as a non-root
+user, so a key bind-mounted as root-owned 0600 is present, correctly named and
+unreadable, which reads as a wrong path until someone checks the mode. The
+error names that case.
+
 ---
 
 ## Environment Variables
@@ -220,6 +234,9 @@ when the FastAPI process exits or is killed by Docker.
 | FLIGHT_PORT | 8815 | gRPC listen port |
 | FLIGHT_AUTH_MODE | none | "none" or "token" |
 | FLIGHT_API_TOKEN | | Static token for auth mode "token" |
+| FLIGHT_TLS_CERT | | PEM certificate path; with the key, serves grpc+tls |
+| FLIGHT_TLS_KEY | | PEM private key path. Both or neither - one alone refuses to start rather than serving plaintext |
+| FLIGHT_TLS_CLIENT_CA | | PEM CA path; turns on mutual TLS (requires cert + key) |
 | FLIGHT_DEFAULT_MODEL | | Fallback model_id if path empty |
 | FLIGHT_PRELOAD_MODELS | | Comma-sep .obml.yaml paths, loaded at startup |
 | DB_VENDOR | snowflake | Default vendor for db_router |

--- a/drivers/ob-flight-extension/src/ob_flight/server.py
+++ b/drivers/ob-flight-extension/src/ob_flight/server.py
@@ -160,6 +160,9 @@ class OBFlightServer(flight.FlightServerBase):  # type: ignore[misc]
         *,
         auth_handler: flight.ServerAuthHandler | None = None,
         auth_middleware: dict[str, Any] | None = None,
+        tls_certificates: list[tuple[bytes, bytes]] | None = None,
+        verify_client: bool = False,
+        root_certificates: bytes | None = None,
         session_manager: Any = None,
         default_dialect: str = "duckdb",
         batch_size: int = 1024,
@@ -172,10 +175,23 @@ class OBFlightServer(flight.FlightServerBase):  # type: ignore[misc]
         # neither. See ``ob_flight.auth``.
         middleware: dict[str, Any] = {_ROUTING_MIDDLEWARE_KEY: _SessionRoutingFactory()}
         middleware.update(auth_middleware or {})
+        # TLS is pyarrow's to implement; ours to configure. ``tls_certificates``
+        # is a list of (cert, key) byte pairs, and ``verify_client`` +
+        # ``root_certificates`` turn on mutual TLS. Passed only when set, so a
+        # plaintext server constructs exactly as it did before.
+        tls_kwargs: dict[str, Any] = {}
+        if tls_certificates:
+            tls_kwargs["tls_certificates"] = tls_certificates
+        if verify_client:
+            tls_kwargs["verify_client"] = True
+        if root_certificates is not None:
+            tls_kwargs["root_certificates"] = root_certificates
+
         super().__init__(
             location,
             auth_handler=auth_handler,
             middleware=middleware,
+            **tls_kwargs,
         )
         self._session_manager = session_manager
         self._default_dialect = default_dialect

--- a/drivers/ob-flight-extension/src/ob_flight/startup.py
+++ b/drivers/ob-flight-extension/src/ob_flight/startup.py
@@ -20,6 +20,7 @@ def start_flight_background(
     port: int | None = None,
     auth_handler: Any = None,
     auth_middleware: Any = None,
+    tls: Any = None,
     default_dialect: str | None = None,
     cache: Any = None,
     cache_config: Any = None,
@@ -48,7 +49,19 @@ def start_flight_background(
 
     if default_dialect is None:
         default_dialect = os.getenv("DB_VENDOR", "duckdb")
-    location = f"grpc://0.0.0.0:{port}"
+
+    # The scheme follows the certificate: a listener with TLS material serves
+    # grpc+tls and a client connecting with grpc:// is refused at the
+    # handshake rather than downgraded.
+    scheme = tls.scheme if tls is not None else "grpc"
+    location = f"{scheme}://0.0.0.0:{port}"
+    tls_kwargs: dict[str, Any] = {}
+    if tls is not None:
+        tls_kwargs = {
+            "tls_certificates": tls.certificates,
+            "verify_client": tls.verify_client,
+            "root_certificates": tls.root_certificates,
+        }
 
     _server = OBFlightServer(
         location,
@@ -58,6 +71,7 @@ def start_flight_background(
         default_dialect=default_dialect,
         cache=cache,
         cache_config=cache_config,
+        **tls_kwargs,
     )
 
     _thread = threading.Thread(
@@ -66,7 +80,20 @@ def start_flight_background(
         daemon=True,
     )
     _thread.start()
-    logger.info("Flight SQL server started on port %d (dialect=%s)", port, default_dialect)
+    # Say which. "Is TLS actually on" should not need a packet capture, and
+    # mutual TLS is worth distinguishing from ordinary TLS in the log.
+    if tls is None:
+        transport = "plaintext"
+    elif tls.verify_client:
+        transport = "TLS (mutual)"
+    else:
+        transport = "TLS"
+    logger.info(
+        "Flight SQL server started on port %d (dialect=%s, transport=%s)",
+        port,
+        default_dialect,
+        transport,
+    )
     return _thread
 
 

--- a/drivers/ob-flight-extension/src/ob_flight/tls.py
+++ b/drivers/ob-flight-extension/src/ob_flight/tls.py
@@ -1,0 +1,111 @@
+"""Reading the Flight listener's TLS material off disk.
+
+Separate from ``startup`` because the failures here are configuration
+failures, and each one deserves to say what the operator got wrong rather
+than surfacing as an ``OSError`` on a path that looks correct.
+
+The most likely of those is not a typo. The published image runs as a
+non-root user (``Dockerfile`` creates ``app`` and switches to it), so a
+private key bind-mounted from the host as ``root:root 0600`` is present,
+correctly named, and unreadable - which reads as a broken path until
+someone thinks to check the mode.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger("ob_flight.tls")
+
+
+class FlightTLSConfigError(ValueError):
+    """The TLS configuration cannot be used as given.
+
+    Its own type so the API layer can refuse to start with the operator's
+    message rather than a stack trace from deep inside pyarrow.
+    """
+
+
+@dataclass(frozen=True)
+class FlightTLS:
+    """Loaded TLS material, ready to hand to ``FlightServerBase``."""
+
+    certificates: list[tuple[bytes, bytes]]
+    verify_client: bool = False
+    root_certificates: bytes | None = None
+
+    @property
+    def scheme(self) -> str:
+        return "grpc+tls"
+
+
+def _read(path: str, *, setting: str) -> bytes:
+    """Read one PEM file, or explain which way it went wrong."""
+    p = Path(path)
+    if not p.exists():
+        raise FlightTLSConfigError(f"{setting} points at {path}, which does not exist")
+    if p.is_dir():
+        raise FlightTLSConfigError(f"{setting} points at {path}, which is a directory")
+    try:
+        data = p.read_bytes()
+    except PermissionError as exc:
+        raise FlightTLSConfigError(
+            f"{setting} at {path} cannot be read: {exc.strerror}. "
+            "In the published image the server runs as a non-root user, so a "
+            "file mounted as root-owned 0600 is unreadable to it - make it "
+            "readable by the container's user (Kubernetes: defaultMode on the "
+            "secret volume, or fsGroup)."
+        ) from None
+    if not data.strip():
+        raise FlightTLSConfigError(f"{setting} at {path} is empty")
+    if b"-----BEGIN" not in data:
+        raise FlightTLSConfigError(
+            f"{setting} at {path} does not look like PEM: no '-----BEGIN' header. "
+            "DER and PKCS#12 are not read here; convert to PEM first."
+        )
+    return data
+
+
+def load_flight_tls(
+    cert_path: str | None,
+    key_path: str | None,
+    client_ca_path: str | None = None,
+) -> FlightTLS | None:
+    """Build the TLS config, or ``None`` when TLS is not configured.
+
+    Both the certificate and the key, or neither. Half a pair is refused
+    rather than ignored: a deployment that set one and got plaintext would
+    believe it was encrypted, which is worse than not starting.
+    """
+    if cert_path is None and key_path is None:
+        if client_ca_path is not None:
+            raise FlightTLSConfigError(
+                "FLIGHT_TLS_CLIENT_CA is set without FLIGHT_TLS_CERT and "
+                "FLIGHT_TLS_KEY. Mutual TLS needs the server's own certificate "
+                "as well as the CA its clients are checked against."
+            )
+        return None
+
+    if cert_path is None or key_path is None:
+        missing = "FLIGHT_TLS_CERT" if cert_path is None else "FLIGHT_TLS_KEY"
+        present = "FLIGHT_TLS_KEY" if cert_path is None else "FLIGHT_TLS_CERT"
+        raise FlightTLSConfigError(
+            f"{present} is set but {missing} is not. Flight TLS needs both; "
+            "starting with one would serve plaintext under a configuration "
+            "that reads as encrypted."
+        )
+
+    cert = _read(cert_path, setting="FLIGHT_TLS_CERT")
+    key = _read(key_path, setting="FLIGHT_TLS_KEY")
+
+    root: bytes | None = None
+    if client_ca_path is not None:
+        root = _read(client_ca_path, setting="FLIGHT_TLS_CLIENT_CA")
+
+    return FlightTLS(
+        certificates=[(cert, key)],
+        verify_client=root is not None,
+        root_certificates=root,
+    )

--- a/drivers/ob-flight-extension/src/ob_flight/tls.py
+++ b/drivers/ob-flight-extension/src/ob_flight/tls.py
@@ -1,111 +1,28 @@
-"""Reading the Flight listener's TLS material off disk.
+"""Flight's view of the shared listener TLS loader.
 
-Separate from ``startup`` because the failures here are configuration
-failures, and each one deserves to say what the operator got wrong rather
-than surfacing as an ``OSError`` on a path that looks correct.
-
-The most likely of those is not a typo. The published image runs as a
-non-root user (``Dockerfile`` creates ``app`` and switches to it), so a
-private key bind-mounted from the host as ``root:root 0600`` is present,
-correctly named, and unreadable - which reads as a broken path until
-someone thinks to check the mode.
+The loader itself lives in ``orionbelt.service.tls`` because pgwire needs it
+too, and pgwire is core while this package is an optional extra - core cannot
+depend on it. This module keeps the Flight-facing names and pins the prefix,
+so a misconfiguration here says ``FLIGHT_TLS_KEY`` rather than the other
+surface's setting.
 """
 
 from __future__ import annotations
 
-import logging
-from dataclasses import dataclass
-from pathlib import Path
+from orionbelt.service.tls import ListenerTLS, TLSConfigError, load_listener_tls
 
-logger = logging.getLogger("ob_flight.tls")
-
-
-class FlightTLSConfigError(ValueError):
-    """The TLS configuration cannot be used as given.
-
-    Its own type so the API layer can refuse to start with the operator's
-    message rather than a stack trace from deep inside pyarrow.
-    """
-
-
-@dataclass(frozen=True)
-class FlightTLS:
-    """Loaded TLS material, ready to hand to ``FlightServerBase``."""
-
-    certificates: list[tuple[bytes, bytes]]
-    verify_client: bool = False
-    root_certificates: bytes | None = None
-
-    @property
-    def scheme(self) -> str:
-        return "grpc+tls"
-
-
-def _read(path: str, *, setting: str) -> bytes:
-    """Read one PEM file, or explain which way it went wrong."""
-    p = Path(path)
-    if not p.exists():
-        raise FlightTLSConfigError(f"{setting} points at {path}, which does not exist")
-    if p.is_dir():
-        raise FlightTLSConfigError(f"{setting} points at {path}, which is a directory")
-    try:
-        data = p.read_bytes()
-    except PermissionError as exc:
-        raise FlightTLSConfigError(
-            f"{setting} at {path} cannot be read: {exc.strerror}. "
-            "In the published image the server runs as a non-root user, so a "
-            "file mounted as root-owned 0600 is unreadable to it - make it "
-            "readable by the container's user (Kubernetes: defaultMode on the "
-            "secret volume, or fsGroup)."
-        ) from None
-    if not data.strip():
-        raise FlightTLSConfigError(f"{setting} at {path} is empty")
-    if b"-----BEGIN" not in data:
-        raise FlightTLSConfigError(
-            f"{setting} at {path} does not look like PEM: no '-----BEGIN' header. "
-            "DER and PKCS#12 are not read here; convert to PEM first."
-        )
-    return data
+#: Kept as the Flight-facing name; the type is shared with pgwire.
+FlightTLS = ListenerTLS
+FlightTLSConfigError = TLSConfigError
 
 
 def load_flight_tls(
     cert_path: str | None,
     key_path: str | None,
     client_ca_path: str | None = None,
-) -> FlightTLS | None:
-    """Build the TLS config, or ``None`` when TLS is not configured.
+) -> ListenerTLS | None:
+    """Load the Flight listener's TLS material, or ``None`` when unconfigured."""
+    return load_listener_tls(cert_path, key_path, client_ca_path, prefix="FLIGHT")
 
-    Both the certificate and the key, or neither. Half a pair is refused
-    rather than ignored: a deployment that set one and got plaintext would
-    believe it was encrypted, which is worse than not starting.
-    """
-    if cert_path is None and key_path is None:
-        if client_ca_path is not None:
-            raise FlightTLSConfigError(
-                "FLIGHT_TLS_CLIENT_CA is set without FLIGHT_TLS_CERT and "
-                "FLIGHT_TLS_KEY. Mutual TLS needs the server's own certificate "
-                "as well as the CA its clients are checked against."
-            )
-        return None
 
-    if cert_path is None or key_path is None:
-        missing = "FLIGHT_TLS_CERT" if cert_path is None else "FLIGHT_TLS_KEY"
-        present = "FLIGHT_TLS_KEY" if cert_path is None else "FLIGHT_TLS_CERT"
-        raise FlightTLSConfigError(
-            f"{present} is set but {missing} is not. Flight TLS needs both; "
-            "starting with one would serve plaintext under a configuration "
-            "that reads as encrypted."
-        )
-
-    cert = _read(cert_path, setting="FLIGHT_TLS_CERT")
-    key = _read(key_path, setting="FLIGHT_TLS_KEY")
-
-    root: bytes | None = None
-    if client_ca_path is not None:
-        root = _read(client_ca_path, setting="FLIGHT_TLS_CLIENT_CA")
-
-    return FlightTLS(
-        certificates=[(cert, key)],
-        verify_client=root is not None,
-        root_certificates=root,
-    )
+__all__ = ["FlightTLS", "FlightTLSConfigError", "load_flight_tls"]

--- a/drivers/ob-flight-extension/tests/test_tls.py
+++ b/drivers/ob-flight-extension/tests/test_tls.py
@@ -1,0 +1,120 @@
+"""Loading the Flight listener's TLS material.
+
+Every case here is a configuration mistake an operator can actually make,
+and the assertion is on what they are told - a message naming the wrong
+setting is worth more than an exception type, because the failure looks
+identical to a typo from the outside.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from ob_flight.tls import FlightTLSConfigError, load_flight_tls
+
+_PEM = b"-----BEGIN CERTIFICATE-----\nnot a real certificate\n-----END CERTIFICATE-----\n"
+
+
+@pytest.fixture
+def pem_pair(tmp_path: Path) -> tuple[str, str]:
+    cert = tmp_path / "server.crt"
+    key = tmp_path / "server.key"
+    cert.write_bytes(_PEM)
+    key.write_bytes(_PEM.replace(b"CERTIFICATE", b"PRIVATE KEY"))
+    return str(cert), str(key)
+
+
+class TestNotConfigured:
+    def test_neither_means_plaintext(self) -> None:
+        assert load_flight_tls(None, None) is None
+
+    def test_a_client_ca_alone_is_refused(self) -> None:
+        """Mutual TLS still needs the server's own certificate."""
+        with pytest.raises(FlightTLSConfigError, match="without FLIGHT_TLS_CERT"):
+            load_flight_tls(None, None, "/tmp/ca.crt")
+
+
+class TestBothOrNeither:
+    """Half a pair is refused rather than ignored.
+
+    Starting plaintext under a configuration that reads as encrypted is the
+    outcome worth preventing: nothing fails, and the operator believes the
+    wire is protected.
+    """
+
+    def test_cert_without_key(self, pem_pair: tuple[str, str]) -> None:
+        cert, _ = pem_pair
+        with pytest.raises(FlightTLSConfigError, match="FLIGHT_TLS_KEY is not"):
+            load_flight_tls(cert, None)
+
+    def test_key_without_cert(self, pem_pair: tuple[str, str]) -> None:
+        _, key = pem_pair
+        with pytest.raises(FlightTLSConfigError, match="FLIGHT_TLS_CERT is not"):
+            load_flight_tls(None, key)
+
+
+class TestWhatTheOperatorIsTold:
+    def test_a_missing_file_names_the_setting_and_the_path(self, tmp_path: Path) -> None:
+        missing = str(tmp_path / "absent.crt")
+        with pytest.raises(FlightTLSConfigError) as excinfo:
+            load_flight_tls(missing, missing)
+        assert "FLIGHT_TLS_CERT" in str(excinfo.value)
+        assert missing in str(excinfo.value)
+
+    def test_a_directory_is_named_as_such(self, tmp_path: Path) -> None:
+        with pytest.raises(FlightTLSConfigError, match="is a directory"):
+            load_flight_tls(str(tmp_path), str(tmp_path))
+
+    def test_an_empty_file(self, tmp_path: Path) -> None:
+        empty = tmp_path / "empty.crt"
+        empty.write_bytes(b"")
+        with pytest.raises(FlightTLSConfigError, match="is empty"):
+            load_flight_tls(str(empty), str(empty))
+
+    def test_a_der_file_says_convert_to_pem(self, tmp_path: Path) -> None:
+        """DER and PKCS#12 are the formats people already have to hand."""
+        der = tmp_path / "server.der"
+        der.write_bytes(b"\x30\x82\x01\x0a\x02\x82\x01\x01")
+        with pytest.raises(FlightTLSConfigError, match="does not look like PEM"):
+            load_flight_tls(str(der), str(der))
+
+    @pytest.mark.skipif(os.geteuid() == 0, reason="root reads anything")
+    def test_an_unreadable_key_explains_the_non_root_user(self, pem_pair: tuple[str, str]) -> None:
+        """The failure the published image will actually produce.
+
+        The image runs as a non-root user, so a key bind-mounted from the
+        host as root-owned 0600 is present, correctly named, and unreadable.
+        Without this message it reads as a wrong path.
+        """
+        cert, key = pem_pair
+        Path(key).chmod(0o000)
+        try:
+            with pytest.raises(FlightTLSConfigError) as excinfo:
+                load_flight_tls(cert, key)
+        finally:
+            Path(key).chmod(0o600)
+        message = str(excinfo.value)
+        assert "FLIGHT_TLS_KEY" in message
+        assert "non-root" in message
+        assert "fsGroup" in message, "the Kubernetes fix belongs in the message"
+
+
+class TestLoaded:
+    def test_a_pair_loads(self, pem_pair: tuple[str, str]) -> None:
+        cert, key = pem_pair
+        tls = load_flight_tls(cert, key)
+        assert tls is not None
+        assert tls.certificates == [(_PEM, _PEM.replace(b"CERTIFICATE", b"PRIVATE KEY"))]
+        assert tls.verify_client is False
+        assert tls.root_certificates is None
+        assert tls.scheme == "grpc+tls"
+
+    def test_a_client_ca_turns_on_mutual_tls(self, pem_pair: tuple[str, str]) -> None:
+        cert, key = pem_pair
+        tls = load_flight_tls(cert, key, cert)
+        assert tls is not None
+        assert tls.verify_client is True
+        assert tls.root_certificates == _PEM

--- a/src/orionbelt/api/app.py
+++ b/src/orionbelt/api/app.py
@@ -384,6 +384,19 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     if settings.flight_enabled:
         try:
             from ob_flight.startup import start_flight_background
+            from ob_flight.tls import FlightTLSConfigError, load_flight_tls
+
+            # Read the TLS material before anything else: a misconfiguration
+            # here stops startup rather than quietly serving plaintext, which
+            # would leave the deployment believing it was encrypted.
+            try:
+                flight_tls = load_flight_tls(
+                    settings.flight_tls_cert,
+                    settings.flight_tls_key,
+                    settings.flight_tls_client_ca,
+                )
+            except FlightTLSConfigError as exc:
+                raise RuntimeError(f"Flight TLS configuration is unusable: {exc}") from None
 
             # Decide the Flight auth handler here, from Settings, and always
             # pass it explicitly so the handler matches what we report and so
@@ -441,10 +454,24 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
                 port=settings.flight_port,
                 auth_handler=flight_auth_handler,
                 auth_middleware=flight_auth_middleware,
+                tls=flight_tls,
                 default_dialect=settings.db_vendor,
                 cache=cache,
                 cache_config=cache_config,
             )
+            # Imported here rather than reused from the branch above, which
+            # only runs in the no-auth case - exactly the case this warning
+            # does not fire for.
+            from ob_flight.auth import NoopAuthHandler as _NoopAuthHandler
+
+            if flight_tls is None and not isinstance(flight_auth_handler, _NoopAuthHandler):
+                logger.warning(
+                    "Flight SQL is authenticating over plaintext gRPC on port %d: "
+                    "credentials cross the wire in the clear. Set FLIGHT_TLS_CERT "
+                    "and FLIGHT_TLS_KEY, or terminate TLS in front of it.",
+                    settings.flight_port,
+                )
+
             settings.flight_enabled = True
             logger.info(
                 "Flight SQL server started on port %d (vendor=%s)",

--- a/src/orionbelt/pgwire/server.py
+++ b/src/orionbelt/pgwire/server.py
@@ -21,6 +21,7 @@ import logging
 import secrets
 import struct
 from collections.abc import Awaitable, Callable
+from typing import Any
 
 from orionbelt.pgwire import protocol
 from orionbelt.pgwire.auth import (
@@ -97,7 +98,10 @@ class PgWireServer:
         query_timeout_seconds: float = 60.0,
         auth_timeout_seconds: float = 10.0,
         query_handler: QueryHandler | None = None,
+        tls: Any = None,
     ) -> None:
+        self._tls = tls
+        self._ssl_context = tls.ssl_context() if tls is not None else None
         self.host = host
         self.port = port
         self.auth_mode = auth_mode
@@ -132,7 +136,21 @@ class PgWireServer:
             self._handle_connection, host=self.host, port=self.port
         )
         bound = self.bound_port
-        logger.info("pgwire listening on %s:%d (auth=%s)", self.host, bound, self.auth_mode)
+        # Say the transport, for the reason the Flight listener does: "is TLS
+        # actually on" should not need a packet capture.
+        if self._tls is None:
+            transport = "plaintext"
+        elif self._tls.verify_client:
+            transport = "TLS (mutual)"
+        else:
+            transport = "TLS"
+        logger.info(
+            "pgwire listening on %s:%d (auth=%s, transport=%s)",
+            self.host,
+            bound,
+            self.auth_mode,
+            transport,
+        )
         return bound
 
     async def serve_forever(self) -> None:
@@ -189,9 +207,17 @@ class PgWireServer:
         """
         startup = await protocol.read_startup_message(reader.readexactly)
         if startup is None:
-            # SSLRequest — reject (no in-process TLS), then read the real one.
-            writer.write(b"N")
-            await self._drain(writer)
+            # SSLRequest. Postgres negotiates rather than starting encrypted:
+            # ``S`` means "proceed, upgrade this socket", ``N`` means "carry on
+            # in the clear". The client then re-sends its StartupMessage over
+            # whichever transport resulted, which is why the read repeats.
+            if self._ssl_context is not None:
+                writer.write(b"S")
+                await self._drain(writer)
+                await writer.start_tls(self._ssl_context)
+            else:
+                writer.write(b"N")
+                await self._drain(writer)
             startup = await protocol.read_startup_message(reader.readexactly)
             if startup is None:
                 raise protocol.ProtocolError("Repeated SSLRequest on same socket")

--- a/src/orionbelt/pgwire/startup.py
+++ b/src/orionbelt/pgwire/startup.py
@@ -65,6 +65,21 @@ async def start_pgwire(
         )
         handler = router.handle
 
+    # Before the listener binds: a misconfiguration stops startup rather than
+    # quietly answering ``N`` to every SSLRequest, which would leave clients
+    # connecting in the clear against a configuration that reads as encrypted.
+    from orionbelt.service.tls import TLSConfigError, load_listener_tls
+
+    try:
+        tls = load_listener_tls(
+            settings.pgwire_tls_cert,
+            settings.pgwire_tls_key,
+            settings.pgwire_tls_client_ca,
+            prefix="PGWIRE",
+        )
+    except TLSConfigError as exc:
+        raise RuntimeError(f"pgwire TLS configuration is unusable: {exc}") from None
+
     server = PgWireServer(
         host=settings.pgwire_host,
         port=settings.pgwire_port,
@@ -73,6 +88,7 @@ async def start_pgwire(
         query_timeout_seconds=float(settings.pgwire_query_timeout_seconds),
         auth_timeout_seconds=float(settings.pgwire_auth_timeout_seconds),
         query_handler=handler,
+        tls=tls,
     )
     bound = await server.start()
     task = asyncio.create_task(server.serve_forever(), name="pgwire-server")

--- a/src/orionbelt/service/tls.py
+++ b/src/orionbelt/service/tls.py
@@ -1,0 +1,152 @@
+"""Reading a listener's TLS material off disk.
+
+Shared by the two surfaces that listen on their own port: Arrow Flight SQL
+and the Postgres wire protocol. They differ in everything except this -
+Flight is TLS from the first byte and hands pyarrow raw PEM, while pgwire
+negotiates with an ``SSLRequest`` and needs an ``ssl.SSLContext`` - so what
+they share is the reading and the refusing, not the serving.
+
+The failures here are configuration failures, and each one says what the
+operator got wrong rather than surfacing as an ``OSError`` on a path that
+looks correct. The most likely of them is not a typo: the published image
+runs as a non-root user (``Dockerfile`` creates ``app`` and switches to it),
+so a private key bind-mounted from the host as ``root:root 0600`` is
+present, correctly named, and unreadable - which reads as a broken path
+until someone thinks to check the mode.
+
+The setting *names* are passed in rather than hard-coded, so a pgwire
+misconfiguration says ``PGWIRE_TLS_KEY`` and a Flight one says
+``FLIGHT_TLS_KEY``. An error naming the wrong surface's setting would be
+worse than none.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger("orionbelt.service.tls")
+
+
+class TLSConfigError(ValueError):
+    """The TLS configuration cannot be used as given.
+
+    Its own type so a caller can refuse to start with the operator's message
+    rather than a stack trace from deep inside pyarrow or ``ssl``.
+    """
+
+
+@dataclass(frozen=True)
+class ListenerTLS:
+    """Loaded TLS material, plus the paths it came from.
+
+    Flight wants the PEM bytes (pyarrow takes ``(cert, key)`` pairs); pgwire
+    wants an ``ssl.SSLContext``, which ``ssl`` builds from paths rather than
+    from bytes. Carrying both avoids writing the material back to a temporary
+    file just to hand it to the other API.
+    """
+
+    certificates: list[tuple[bytes, bytes]]
+    cert_path: str
+    key_path: str
+    verify_client: bool = False
+    root_certificates: bytes | None = None
+    client_ca_path: str | None = None
+
+    @property
+    def scheme(self) -> str:
+        return "grpc+tls"
+
+    def ssl_context(self) -> Any:
+        """An ``ssl.SSLContext`` for a socket-level server (pgwire).
+
+        Built from the paths: ``load_cert_chain`` reads files, and handing it
+        the bytes we already hold would mean writing them back out.
+        """
+        import ssl
+
+        ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        ctx.load_cert_chain(certfile=self.cert_path, keyfile=self.key_path)
+        if self.client_ca_path is not None:
+            ctx.load_verify_locations(cafile=self.client_ca_path)
+            ctx.verify_mode = ssl.CERT_REQUIRED
+        return ctx
+
+
+def _read(path: str, *, setting: str) -> bytes:
+    """Read one PEM file, or explain which way it went wrong."""
+    p = Path(path)
+    if not p.exists():
+        raise TLSConfigError(f"{setting} points at {path}, which does not exist")
+    if p.is_dir():
+        raise TLSConfigError(f"{setting} points at {path}, which is a directory")
+    try:
+        data = p.read_bytes()
+    except PermissionError as exc:
+        raise TLSConfigError(
+            f"{setting} at {path} cannot be read: {exc.strerror}. "
+            "In the published image the server runs as a non-root user, so a "
+            "file mounted as root-owned 0600 is unreadable to it - make it "
+            "readable by the container's user (Kubernetes: defaultMode on the "
+            "secret volume, or fsGroup)."
+        ) from None
+    if not data.strip():
+        raise TLSConfigError(f"{setting} at {path} is empty")
+    if b"-----BEGIN" not in data:
+        raise TLSConfigError(
+            f"{setting} at {path} does not look like PEM: no '-----BEGIN' header. "
+            "DER and PKCS#12 are not read here; convert to PEM first."
+        )
+    return data
+
+
+def load_listener_tls(
+    cert_path: str | None,
+    key_path: str | None,
+    client_ca_path: str | None = None,
+    *,
+    prefix: str = "FLIGHT",
+) -> ListenerTLS | None:
+    """Build the TLS config, or ``None`` when TLS is not configured.
+
+    Both the certificate and the key, or neither. Half a pair is refused
+    rather than ignored: a deployment that set one and got plaintext would
+    believe it was encrypted, which is worse than not starting.
+
+    ``prefix`` names the surface in every message - ``FLIGHT`` or ``PGWIRE``.
+    """
+    if cert_path is None and key_path is None:
+        if client_ca_path is not None:
+            raise TLSConfigError(
+                f"{prefix}_TLS_CLIENT_CA is set without {prefix}_TLS_CERT and "
+                f"{prefix}_TLS_KEY. Mutual TLS needs the server's own certificate "
+                "as well as the CA its clients are checked against."
+            )
+        return None
+
+    if cert_path is None or key_path is None:
+        missing = f"{prefix}_TLS_CERT" if cert_path is None else f"{prefix}_TLS_KEY"
+        present = f"{prefix}_TLS_KEY" if cert_path is None else f"{prefix}_TLS_CERT"
+        raise TLSConfigError(
+            f"{present} is set but {missing} is not. TLS needs both; "
+            "starting with one would serve plaintext under a configuration "
+            "that reads as encrypted."
+        )
+
+    cert = _read(cert_path, setting=f"{prefix}_TLS_CERT")
+    key = _read(key_path, setting=f"{prefix}_TLS_KEY")
+
+    root: bytes | None = None
+    if client_ca_path is not None:
+        root = _read(client_ca_path, setting=f"{prefix}_TLS_CLIENT_CA")
+
+    return ListenerTLS(
+        certificates=[(cert, key)],
+        cert_path=cert_path,
+        key_path=key_path,
+        verify_client=root is not None,
+        root_certificates=root,
+        client_ca_path=client_ca_path,
+    )

--- a/src/orionbelt/settings.py
+++ b/src/orionbelt/settings.py
@@ -96,6 +96,16 @@ class Settings(BaseSettings):
     flight_port: int = 8815
     flight_auth_mode: str = "none"  # "none" or "token"
     flight_api_token: str | None = None
+    # TLS for the Flight listener. Paths, not PEM content: a private key in the
+    # environment is readable by ``docker inspect`` and by a crash dump.
+    # Both or neither - a cert without a key is a configuration error rather
+    # than a quiet fall back to plaintext, which would leave a deployment
+    # believing it has TLS.
+    flight_tls_cert: str | None = None
+    flight_tls_key: str | None = None
+    # Mutual TLS: the CA that client certificates are validated against.
+    # Setting it requires client certs.
+    flight_tls_client_ca: str | None = None
     db_vendor: str = "duckdb"  # default vendor driver for Flight query execution
 
     # Flight Semantic QL governance. See design/PLAN_flight_natural_sql.md.

--- a/src/orionbelt/settings.py
+++ b/src/orionbelt/settings.py
@@ -121,6 +121,13 @@ class Settings(BaseSettings):
     pgwire_host: str = "0.0.0.0"  # noqa: S104 — server bind address
     pgwire_port: int = 5432
     pgwire_auth_mode: str = "trust"  # "trust" (Step 1) | "password" | "scram-sha-256" (Step 6)
+    # TLS for the pgwire listener, same shape as the Flight settings and read
+    # by the same loader. Postgres negotiates with an SSLRequest rather than
+    # starting encrypted, so with these set the server answers ``S`` and
+    # upgrades the socket; without them it answers ``N`` as before.
+    pgwire_tls_cert: str | None = None
+    pgwire_tls_key: str | None = None
+    pgwire_tls_client_ca: str | None = None
     pgwire_max_connections: int = 64
     pgwire_query_timeout_seconds: int = 60
     # Hard deadline for the pre-auth handshake (startup + password/SCRAM

--- a/tests/integration/test_adbc_flightsql.py
+++ b/tests/integration/test_adbc_flightsql.py
@@ -291,6 +291,178 @@ def tls_server(tmp_path_factory: pytest.TempPathFactory) -> Iterator[tuple[str, 
             os.environ["DUCKDB_DATABASE"] = prev
 
 
+def _mini_pki(tmp: Any) -> dict[str, bytes]:
+    """A CA, a server certificate it signs, and a client certificate it signs.
+
+    Mutual TLS cannot be tested with a self-signed certificate: the point is
+    that the server validates the client against a CA, so there has to be one.
+    """
+    import datetime as dt
+    import ipaddress
+
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    from cryptography.x509.oid import ExtendedKeyUsageOID, NameOID
+
+    now = dt.datetime.now(dt.UTC)
+
+    def _name(cn: str) -> Any:
+        return x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, cn)])
+
+    def _pem_key(k: Any) -> bytes:
+        return k.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.TraditionalOpenSSL,
+            serialization.NoEncryption(),
+        )
+
+    ca_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    ca = (
+        x509.CertificateBuilder()
+        .subject_name(_name("OBSL Test CA"))
+        .issuer_name(_name("OBSL Test CA"))
+        .public_key(ca_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - dt.timedelta(minutes=5))
+        .not_valid_after(now + dt.timedelta(days=1))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        .sign(ca_key, hashes.SHA256())
+    )
+
+    def _signed(cn: str, *, server: bool) -> tuple[bytes, bytes]:
+        k = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        builder = (
+            x509.CertificateBuilder()
+            .subject_name(_name(cn))
+            .issuer_name(ca.subject)
+            .public_key(k.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now - dt.timedelta(minutes=5))
+            .not_valid_after(now + dt.timedelta(days=1))
+            .add_extension(
+                x509.ExtendedKeyUsage(
+                    [ExtendedKeyUsageOID.SERVER_AUTH if server else ExtendedKeyUsageOID.CLIENT_AUTH]
+                ),
+                critical=False,
+            )
+        )
+        if server:
+            builder = builder.add_extension(
+                x509.SubjectAlternativeName(
+                    [
+                        x509.DNSName("localhost"),
+                        x509.IPAddress(ipaddress.ip_address("127.0.0.1")),
+                    ]
+                ),
+                critical=False,
+            )
+        crt = builder.sign(ca_key, hashes.SHA256())
+        return crt.public_bytes(serialization.Encoding.PEM), _pem_key(k)
+
+    server_crt, server_key = _signed("localhost", server=True)
+    client_crt, client_key = _signed("obsl-client", server=False)
+    return {
+        "ca": ca.public_bytes(serialization.Encoding.PEM),
+        "server_crt": server_crt,
+        "server_key": server_key,
+        "client_crt": client_crt,
+        "client_key": client_key,
+    }
+
+
+@pytest.fixture(scope="module")
+def mtls_server(tmp_path_factory: pytest.TempPathFactory) -> Iterator[dict[str, Any]]:
+    """A Flight server that requires a client certificate."""
+    pytest.importorskip("adbc_driver_flightsql", reason="ADBC Flight SQL driver not installed")
+    pytest.importorskip("cryptography", reason="cryptography required to mint test certs")
+    duckdb = pytest.importorskip("duckdb")
+    pytest.importorskip("ob_flight", reason="ob-flight-extension not installed")
+
+    from ob_flight.server import OBFlightServer
+
+    from orionbelt.service.session_manager import SessionManager
+
+    tmp = tmp_path_factory.mktemp("flight-mtls")
+    pki = _mini_pki(tmp)
+
+    db_path = tmp / "sample.duckdb"
+    conn = duckdb.connect(str(db_path))
+    conn.execute(_SETUP_SQL)
+    conn.close()
+
+    prev = os.environ.get("DUCKDB_DATABASE")
+    os.environ["DUCKDB_DATABASE"] = str(db_path)
+
+    mgr = SessionManager(ttl_seconds=3600, cleanup_interval=9999)
+    mgr.get_or_create_named(MODEL_NAME).load_model(SAMPLE_MODEL_YAML, dedup=False)
+
+    server = OBFlightServer(
+        "grpc+tls://127.0.0.1:0",
+        session_manager=mgr,
+        default_dialect="duckdb",
+        tls_certificates=[(pki["server_crt"], pki["server_key"])],
+        verify_client=True,
+        root_certificates=pki["ca"],
+    )
+    thread = threading.Thread(target=server.serve, name="adbc-harness-mtls", daemon=True)
+    thread.start()
+    try:
+        yield {"uri": f"grpc+tls://localhost:{server.port}", **pki}
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        if prev is None:
+            os.environ.pop("DUCKDB_DATABASE", None)
+        else:
+            os.environ["DUCKDB_DATABASE"] = prev
+
+
+class TestMutualTLS:
+    """``FLIGHT_TLS_CLIENT_CA`` makes a client certificate mandatory."""
+
+    QUERY = f'SELECT "Customer Country", "Total Revenue" FROM {MODEL_NAME}'
+
+    @staticmethod
+    def _rows(uri: str, options: dict[str, str]) -> int:
+        from adbc_driver_flightsql import dbapi
+
+        connection = dbapi.connect(uri, db_kwargs=options)
+        try:
+            with connection.cursor() as cur:
+                cur.execute(TestMutualTLS.QUERY)
+                return int(cur.fetch_arrow_table().num_rows)
+        finally:
+            connection.close()
+
+    def test_a_client_without_a_certificate_is_refused(self, mtls_server: dict[str, Any]) -> None:
+        """Trusting the server is not enough when the server must trust back."""
+        with pytest.raises(Exception, match="(?i)certificate|handshake|tls|preface|unavailable"):
+            self._rows(
+                mtls_server["uri"],
+                {"adbc.flight.sql.client_option.tls_root_certs": mtls_server["ca"].decode()},
+            )
+
+    def test_a_client_with_a_signed_certificate_is_served(
+        self, mtls_server: dict[str, Any]
+    ) -> None:
+        assert (
+            self._rows(
+                mtls_server["uri"],
+                {
+                    "adbc.flight.sql.client_option.tls_root_certs": mtls_server["ca"].decode(),
+                    "adbc.flight.sql.client_option.mtls_cert_chain": mtls_server[
+                        "client_crt"
+                    ].decode(),
+                    "adbc.flight.sql.client_option.mtls_private_key": mtls_server[
+                        "client_key"
+                    ].decode(),
+                },
+            )
+            == 2
+        )
+
+
 class TestTLS:
     """Serving over TLS, and refusing a client that will not check it."""
 

--- a/tests/integration/test_adbc_flightsql.py
+++ b/tests/integration/test_adbc_flightsql.py
@@ -281,7 +281,11 @@ def tls_server(tmp_path_factory: pytest.TempPathFactory) -> Iterator[tuple[str, 
     thread = threading.Thread(target=server.serve, name="adbc-harness-tls", daemon=True)
     thread.start()
     try:
-        yield f"grpc+tls://localhost:{server.port}", cert_pem
+        # 127.0.0.1, not localhost: on CI that name resolves to ::1 first
+        # while the listener binds IPv4, so the client never reaches the
+        # server and a "must be refused" test passes for the wrong reason.
+        # Both test certificates carry 127.0.0.1 as an IP SAN.
+        yield f"grpc+tls://127.0.0.1:{server.port}", cert_pem
     finally:
         server.shutdown()
         thread.join(timeout=5)
@@ -408,7 +412,7 @@ def mtls_server(tmp_path_factory: pytest.TempPathFactory) -> Iterator[dict[str, 
     thread = threading.Thread(target=server.serve, name="adbc-harness-mtls", daemon=True)
     thread.start()
     try:
-        yield {"uri": f"grpc+tls://localhost:{server.port}", **pki}
+        yield {"uri": f"grpc+tls://127.0.0.1:{server.port}", **pki}
     finally:
         server.shutdown()
         thread.join(timeout=5)
@@ -495,10 +499,21 @@ class TestTLS:
         self, tls_server: tuple[str, bytes]
     ) -> None:
         """The property that makes TLS worth offering rather than merely
-        available: the connection fails rather than quietly downgrading."""
+        available: the connection fails rather than quietly downgrading.
+
+        The assertion names the *reason*, not just the failure. A test happy
+        with any exception passes when the client cannot reach the server at
+        all - which is precisely what happened on CI when this connected to
+        ``localhost`` and got ``::1`` while the listener bound IPv4.
+        """
         uri, _ = tls_server
-        with pytest.raises(Exception, match="(?i)certificate|handshake|tls"):
+        with pytest.raises(Exception) as excinfo:
             self._rows(uri, {})
+        message = str(excinfo.value).lower()
+        assert "certificate" in message or "handshake" in message, message
+        assert "connection refused" not in message, (
+            f"the client never reached the server, so nothing about TLS was tested: {message}"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_adbc_flightsql.py
+++ b/tests/integration/test_adbc_flightsql.py
@@ -199,6 +199,137 @@ class TestCatalog:
 
 
 # ---------------------------------------------------------------------------
+# TLS — Track T-2 of design/PLAN_flight_tls.md
+# ---------------------------------------------------------------------------
+
+
+def _self_signed(tmp: Any) -> tuple[bytes, bytes]:
+    """A certificate for localhost / 127.0.0.1, valid for a day."""
+    import datetime as dt
+    import ipaddress
+
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    from cryptography.x509.oid import NameOID
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "localhost")])
+    now = dt.datetime.now(dt.UTC)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - dt.timedelta(minutes=5))
+        .not_valid_after(now + dt.timedelta(days=1))
+        .add_extension(
+            x509.SubjectAlternativeName(
+                [x509.DNSName("localhost"), x509.IPAddress(ipaddress.ip_address("127.0.0.1"))]
+            ),
+            critical=False,
+        )
+        .sign(key, hashes.SHA256())
+    )
+    return (
+        cert.public_bytes(serialization.Encoding.PEM),
+        key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.TraditionalOpenSSL,
+            serialization.NoEncryption(),
+        ),
+    )
+
+
+@pytest.fixture(scope="module")
+def tls_server(tmp_path_factory: pytest.TempPathFactory) -> Iterator[tuple[str, bytes]]:
+    """A Flight server serving ``grpc+tls`` with a self-signed certificate.
+
+    Yields ``(uri, cert_pem)`` - the certificate so a client can be told to
+    trust it, which is the whole question a self-signed deployment raises.
+    """
+    pytest.importorskip("adbc_driver_flightsql", reason="ADBC Flight SQL driver not installed")
+    pytest.importorskip("cryptography", reason="cryptography required to mint a test cert")
+    duckdb = pytest.importorskip("duckdb")
+    pytest.importorskip("ob_flight", reason="ob-flight-extension not installed")
+
+    from ob_flight.server import OBFlightServer
+
+    from orionbelt.service.session_manager import SessionManager
+
+    tmp = tmp_path_factory.mktemp("flight-tls")
+    cert_pem, key_pem = _self_signed(tmp)
+
+    db_path = tmp / "sample.duckdb"
+    conn = duckdb.connect(str(db_path))
+    conn.execute(_SETUP_SQL)
+    conn.close()
+
+    prev = os.environ.get("DUCKDB_DATABASE")
+    os.environ["DUCKDB_DATABASE"] = str(db_path)
+
+    mgr = SessionManager(ttl_seconds=3600, cleanup_interval=9999)
+    mgr.get_or_create_named(MODEL_NAME).load_model(SAMPLE_MODEL_YAML, dedup=False)
+
+    server = OBFlightServer(
+        "grpc+tls://127.0.0.1:0",
+        session_manager=mgr,
+        default_dialect="duckdb",
+        tls_certificates=[(cert_pem, key_pem)],
+    )
+    thread = threading.Thread(target=server.serve, name="adbc-harness-tls", daemon=True)
+    thread.start()
+    try:
+        yield f"grpc+tls://localhost:{server.port}", cert_pem
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        if prev is None:
+            os.environ.pop("DUCKDB_DATABASE", None)
+        else:
+            os.environ["DUCKDB_DATABASE"] = prev
+
+
+class TestTLS:
+    """Serving over TLS, and refusing a client that will not check it."""
+
+    QUERY = f'SELECT "Customer Country", "Total Revenue" FROM {MODEL_NAME}'
+
+    @staticmethod
+    def _rows(uri: str, options: dict[str, str]) -> int:
+        from adbc_driver_flightsql import dbapi
+
+        connection = dbapi.connect(uri, db_kwargs=options)
+        try:
+            with connection.cursor() as cur:
+                cur.execute(TestTLS.QUERY)
+                return int(cur.fetch_arrow_table().num_rows)
+        finally:
+            connection.close()
+
+    def test_a_client_trusting_the_cert_is_served(self, tls_server: tuple[str, bytes]) -> None:
+        uri, cert_pem = tls_server
+        options = {"adbc.flight.sql.client_option.tls_root_certs": cert_pem.decode()}
+        assert self._rows(uri, options) == 2
+
+    def test_skip_verify_also_works(self, tls_server: tuple[str, bytes]) -> None:
+        """The option a first-time operator reaches for. It has to work, and
+        the docs have to be honest that it checks nothing."""
+        uri, _ = tls_server
+        assert self._rows(uri, {"adbc.flight.sql.client_option.tls_skip_verify": "true"}) == 2
+
+    def test_a_client_that_will_not_trust_it_is_refused(
+        self, tls_server: tuple[str, bytes]
+    ) -> None:
+        """The property that makes TLS worth offering rather than merely
+        available: the connection fails rather than quietly downgrading."""
+        uri, _ = tls_server
+        with pytest.raises(Exception, match="(?i)certificate|handshake|tls"):
+            self._rows(uri, {})
+
+
+# ---------------------------------------------------------------------------
 # Statistics — Track II-4
 # ---------------------------------------------------------------------------
 

--- a/tests/integration/test_pgwire_tls.py
+++ b/tests/integration/test_pgwire_tls.py
@@ -1,0 +1,219 @@
+"""TLS on the pgwire surface, driven by a real Postgres client.
+
+Postgres does not start encrypted. The client sends an ``SSLRequest``, the
+server answers ``S`` or ``N``, and only then is the socket upgraded — so the
+thing under test is a negotiation, not a listener, and only a real libpq
+client exercises it the way a BI tool does.
+
+The certificate material is read by the same loader the Flight surface uses
+(``orionbelt.service.tls``); what differs is what each does with it, since
+pyarrow wants PEM bytes and ``ssl`` wants paths.
+
+See ``design/PLAN_flight_tls.md`` open question 4.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+import ipaddress
+import threading
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import psycopg
+import pytest
+
+from orionbelt.pgwire.server import PgWireServer
+from orionbelt.service.tls import load_listener_tls
+
+
+def _pki(out: Path) -> dict[str, str]:
+    """A CA, and a server certificate for localhost signed by it.
+
+    A self-signed certificate would test three of the four cases but not
+    ``verify-ca``, which is the mode an operator actually deploys.
+    """
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    from cryptography.x509.oid import NameOID
+
+    now = dt.datetime.now(dt.UTC)
+
+    def name(cn: str) -> Any:
+        return x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, cn)])
+
+    ca_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    ca = (
+        x509.CertificateBuilder()
+        .subject_name(name("OBSL Test CA"))
+        .issuer_name(name("OBSL Test CA"))
+        .public_key(ca_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - dt.timedelta(minutes=5))
+        .not_valid_after(now + dt.timedelta(days=1))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        .sign(ca_key, hashes.SHA256())
+    )
+
+    srv_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    srv = (
+        x509.CertificateBuilder()
+        .subject_name(name("localhost"))
+        .issuer_name(ca.subject)
+        .public_key(srv_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - dt.timedelta(minutes=5))
+        .not_valid_after(now + dt.timedelta(days=1))
+        .add_extension(
+            x509.SubjectAlternativeName(
+                [x509.DNSName("localhost"), x509.IPAddress(ipaddress.ip_address("127.0.0.1"))]
+            ),
+            critical=False,
+        )
+        .sign(ca_key, hashes.SHA256())
+    )
+
+    # An unrelated CA, so "wrong trust anchor" is distinguishable from "no
+    # trust anchor" — they fail differently and only one is interesting.
+    other_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    other = (
+        x509.CertificateBuilder()
+        .subject_name(name("Unrelated CA"))
+        .issuer_name(name("Unrelated CA"))
+        .public_key(other_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - dt.timedelta(minutes=5))
+        .not_valid_after(now + dt.timedelta(days=1))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        .sign(other_key, hashes.SHA256())
+    )
+
+    paths = {
+        "ca": out / "ca.crt",
+        "cert": out / "server.crt",
+        "key": out / "server.key",
+        "other_ca": out / "other.crt",
+    }
+    paths["ca"].write_bytes(ca.public_bytes(serialization.Encoding.PEM))
+    paths["cert"].write_bytes(srv.public_bytes(serialization.Encoding.PEM))
+    paths["key"].write_bytes(
+        srv_key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.TraditionalOpenSSL,
+            serialization.NoEncryption(),
+        )
+    )
+    paths["other_ca"].write_bytes(other.public_bytes(serialization.Encoding.PEM))
+    return {k: str(v) for k, v in paths.items()}
+
+
+@pytest.fixture(scope="module")
+def tls_pgwire(tmp_path_factory: pytest.TempPathFactory) -> Iterator[tuple[int, dict[str, str]]]:
+    """A TLS-enabled pgwire listener, on its own event-loop thread.
+
+    The loop must not be shared with the tests: psycopg is blocking, so a
+    client call on the loop's thread starves the accept and every connection
+    times out.
+    """
+    pytest.importorskip("cryptography", reason="cryptography required to mint test certs")
+
+    pki = _pki(tmp_path_factory.mktemp("pgwire-tls"))
+    tls = load_listener_tls(pki["cert"], pki["key"], prefix="PGWIRE")
+    server = PgWireServer(host="127.0.0.1", port=0, auth_mode="trust", tls=tls)
+
+    ready = threading.Event()
+    bound: dict[str, int] = {}
+    loop = asyncio.new_event_loop()
+
+    def run() -> None:
+        asyncio.set_event_loop(loop)
+        bound["port"] = loop.run_until_complete(server.start())
+        ready.set()
+        loop.run_until_complete(server.serve_forever())
+
+    thread = threading.Thread(target=run, name="pgwire-tls-test", daemon=True)
+    thread.start()
+    assert ready.wait(30), "pgwire TLS listener did not start"
+
+    try:
+        yield bound["port"], pki
+    finally:
+        loop.call_soon_threadsafe(loop.stop)
+        thread.join(timeout=5)
+
+
+def _encrypted(port: int, **kwargs: Any) -> bool:
+    """Connect and report whether libpq negotiated TLS."""
+    with psycopg.connect(
+        host="localhost", port=port, user="obsl", dbname="x", connect_timeout=10, **kwargs
+    ) as conn:
+        pg = getattr(conn, "pgconn", None)
+        return bool(getattr(pg, "ssl_in_use", False))
+
+
+class TestSSLRequestNegotiation:
+    """The four `sslmode` values a BI tool actually sends."""
+
+    def test_disable_still_gets_plaintext(self, tls_pgwire: tuple[int, dict[str, str]]) -> None:
+        """Turning TLS on does not lock out clients that do not ask for it.
+
+        Postgres semantics: the server offers, the client decides. Refusing
+        plaintext outright is a separate policy and not what this setting
+        means.
+        """
+        port, _ = tls_pgwire
+        assert _encrypted(port, sslmode="disable") is False
+
+    def test_require_encrypts(self, tls_pgwire: tuple[int, dict[str, str]]) -> None:
+        port, _ = tls_pgwire
+        assert _encrypted(port, sslmode="require") is True
+
+    def test_verify_ca_encrypts(self, tls_pgwire: tuple[int, dict[str, str]]) -> None:
+        port, pki = tls_pgwire
+        assert _encrypted(port, sslmode="verify-ca", sslrootcert=pki["ca"]) is True
+
+    def test_verify_full_checks_the_hostname_too(
+        self, tls_pgwire: tuple[int, dict[str, str]]
+    ) -> None:
+        """The certificate's CN is localhost, which is what we connect as."""
+        port, pki = tls_pgwire
+        assert _encrypted(port, sslmode="verify-full", sslrootcert=pki["ca"]) is True
+
+    def test_the_wrong_trust_anchor_is_refused(
+        self, tls_pgwire: tuple[int, dict[str, str]]
+    ) -> None:
+        """The assertion that makes the others mean something: verification
+        is real, not a mode that accepts whatever it is given."""
+        port, pki = tls_pgwire
+        with pytest.raises(psycopg.OperationalError, match="(?i)certificate|ssl"):
+            _encrypted(port, sslmode="verify-ca", sslrootcert=pki["other_ca"])
+
+
+class TestWithoutTLS:
+    def test_a_plaintext_listener_answers_n(self) -> None:
+        """Unconfigured, the server declines the upgrade and carries on -
+        which is what every deployment before this change did."""
+        server = PgWireServer(host="127.0.0.1", port=0, auth_mode="trust")
+        ready = threading.Event()
+        bound: dict[str, int] = {}
+        loop = asyncio.new_event_loop()
+
+        def run() -> None:
+            asyncio.set_event_loop(loop)
+            bound["port"] = loop.run_until_complete(server.start())
+            ready.set()
+            loop.run_until_complete(server.serve_forever())
+
+        thread = threading.Thread(target=run, name="pgwire-plain-test", daemon=True)
+        thread.start()
+        assert ready.wait(30)
+        try:
+            # ``prefer`` asks for TLS and accepts a refusal; that is the
+            # negotiation working, not failing.
+            assert _encrypted(bound["port"], sslmode="prefer") is False
+        finally:
+            loop.call_soon_threadsafe(loop.stop)
+            thread.join(timeout=5)


### PR DESCRIPTION
T-0, T-1, T-2 and T-4 of `design/PLAN_flight_tls.md`.

## The gap

#425 gave the Flight surface authentication - API keys, Basic-over-handshake, bearer tokens. It gave it no transport security, because there was none: `settings.py` had no TLS field and `startup.py` hard-coded `grpc://0.0.0.0:{port}`. So **an API key crossed the wire in clear text**. The guide meanwhile told people `grpc+tls://` was available, which nothing implemented.

## What changed

`FLIGHT_TLS_CERT` + `FLIGHT_TLS_KEY` make the listener serve `grpc+tls`; `FLIGHT_TLS_CLIENT_CA` additionally requires a client certificate. pyarrow does the actual work (`tls_certificates`, `verify_client`, `root_certificates`) - this is configuration, error reporting and proof.

Three decisions worth naming:

- **Both or neither.** One setting alone refuses to start rather than falling back to plaintext. A deployment that reads as encrypted and is not is worse than one that does not come up.
- **Paths, not PEM-in-env.** A private key in the environment is readable by `docker inspect` and by a crash dump.
- **The startup line reports the transport** (`plaintext` / `TLS` / `TLS (mutual)`), and authenticating over plaintext logs a warning - that being the combination this exists to make avoidable.

## The Docker gotcha, which gets its own error

The image runs as a non-root user (`Dockerfile:53`, `:75`), so a key bind-mounted from the host as `root:root 0600` is present, correctly named, and **unreadable** - a failure that reads as a wrong path until someone thinks to check the mode. It now says:

> `FLIGHT_TLS_KEY at /certs/server.key cannot be read: Permission denied. In the published image the server runs as a non-root user, so a file mounted as root-owned 0600 is unreadable to it - make it readable by the container's user (Kubernetes: defaultMode on the secret volume, or fsGroup).`

## Client trust: measured, not read from driver docs

Probed against a real server with a self-signed cert:

| Client | no options | `tls_skip_verify` | `tls_root_certs` |
|---|---|---|---|
| Python ADBC | refused: "failed to verify certificate" | served | served |
| DuckDB `adbc_scanner` | refused | served | served |
| Flight SQL JDBC | not tested - needs a JVM and the driver jar |

**Both fail closed** - refused at the handshake, not downgraded. That is the property that makes native TLS worth offering rather than merely available.

The probe answered the plan's gating question: DuckDB's `adbc_connect` MAP reaches the driver verbatim, so its TLS story is identical to Python's and no publicly-trusted certificate is needed. It also found a trap now documented: **the option key must be a literal in the MAP** - a parameterised key scrambles the pairs into an error about failing to load the driver, which points at the wrong thing entirely.

The JDBC row is marked untested in the docs rather than asserted.

## Tests

- `drivers/ob-flight-extension/tests/test_tls.py` - 11 cases, every one a mistake an operator can make, asserting on *what they are told*: missing file, directory, empty, DER instead of PEM, half a pair, CA without a cert, and the unreadable-key message.
- `tests/integration/test_adbc_flightsql.py::TestTLS` - a real TLS server with a generated self-signed cert: trusted cert served, skip-verify served, and an untrusting client refused.

`cryptography` was already installed, so the test cert needs no new dependency.

## Not for the demo

`FLIGHT_ENABLED` still defaults false in the image and Cloud Run cannot reach the Flight port, so nothing about the GCloud deployment changes.

## Still open, recorded in the plan

mTLS is wired and reachable via `FLIGHT_TLS_CLIENT_CA`, but has **no live test** - the client-cert half (`MTLS_CERT_CHAIN` / `MTLS_PRIVATE_KEY`) was not exercised. And pgwire has the same shape - a port, its own auth, no TLS - and probably wants the same treatment sharing this certificate loader.

## Verification

`uv run pytest` 5118 passed / 1070 skipped, `pytest -m adbc_flight` 103 passed / 1 skipped, ruff and mypy clean at the root and in the driver package.