### PR TITLE
feat(pgwire): let DuckDB attach the semantic layer as a catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ All notable changes to OrionBelt Semantic Layer are documented here.
 
 ### Added
 
+- **DuckDB queries the semantic layer as an attached catalog.** `ATTACH 'host=... dbname=<model>'
+  AS obsl (TYPE postgres)` in a plain DuckDB shell mounts the model as `obsl.<model>.model`, so
+  governed measures join to local Parquet and CSV and land in `CREATE TABLE AS` with no
+  OBSL-specific client. This is the same capability the `adbc_scanner` route already offered over
+  Flight SQL, addressed as a table rather than a string in a table function.
+
+  Four gaps had to close for it, none of which raised an error. The extension enumerates a catalog
+  with a single batch of statements in one simple-query message, and the surface answered only the
+  first; it joins `pg_type.typnamespace` to `pg_namespace.oid`, and there was neither the column
+  nor a `pg_catalog` row to land on, so the whole enumeration matched nothing; it probes with
+  table-less `SELECT`s that the semantic translator has no model to resolve; and it asks for a row
+  count by projecting `SELECT NULL FROM t`, which read as a literal projection and was rejected.
+  Each returned an empty catalog or a message about something else.
+
+  One client setting is required: `SET pg_use_text_protocol = true`, because the default reads data
+  with `COPY ... TO STDOUT (FORMAT binary)`. See
+  [the guide](https://ralforion.com/orionbelt-semantic-layer/guide/postgres-wire-bi-tools/#7-duckdb).
+
+- **Multi-statement simple queries.** One `Query` message carrying several statements separated by
+  semicolons now runs each in order and replies with one result set per statement, as Postgres
+  does. The splitter is a scanner rather than `sql.split(";")`: a semicolon inside a string, an
+  escape string, a quoted identifier, a dollar-quoted body, a line comment or a nested block
+  comment is data, not a boundary. Execution stops at the first statement that errors.
+
 - **TLS on the Postgres wire surface.** `PGWIRE_TLS_CERT` + `PGWIRE_TLS_KEY` (and
   `PGWIRE_TLS_CLIENT_CA`) make the listener answer `S` to an `SSLRequest` and upgrade the socket,
   where it previously always answered `N`. Postgres negotiates rather than starting encrypted, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,10 @@ All notable changes to OrionBelt Semantic Layer are documented here.
   escape string, a quoted identifier, a dollar-quoted body, a line comment or a nested block
   comment is data, not a boundary. A fragment that is only comments is dropped rather than
   dispatched, so `SELECT 1; -- done` is one statement with a trailing remark and not a result
-  followed by an error. Execution stops at the first statement that errors.
+  followed by an error, and a message of nothing but comments is an empty query rather than a
+  parse failure. Routing sees the cleaned statement, since a word inside a discarded comment
+  (`-- from the dashboard`) would otherwise steer it. Execution stops at the first statement that
+  errors.
 
 - **TLS on the Postgres wire surface.** `PGWIRE_TLS_CERT` + `PGWIRE_TLS_KEY` (and
   `PGWIRE_TLS_CLIENT_CA`) make the listener answer `S` to an `SSLRequest` and upgrade the socket,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ All notable changes to OrionBelt Semantic Layer are documented here.
   count by projecting `SELECT NULL FROM t`, which read as a literal projection and was rejected.
   Each returned an empty catalog or a message about something else.
 
+  The row count is answered by projecting every column of the model, not just its dimensions.
+  Dimensions alone need no fact table, so the compiler picks a different base object and a
+  dimension value with no facts behind it (a customer who has never ordered) becomes a row:
+  `count(*)` then exceeded what `SELECT *` returned, which is the one number it has to agree with.
+
   One client setting is required: `SET pg_use_text_protocol = true`, because the default reads data
   with `COPY ... TO STDOUT (FORMAT binary)`.
 
@@ -33,7 +38,9 @@ All notable changes to OrionBelt Semantic Layer are documented here.
   semicolons now runs each in order and replies with one result set per statement, as Postgres
   does. The splitter is a scanner rather than `sql.split(";")`: a semicolon inside a string, an
   escape string, a quoted identifier, a dollar-quoted body, a line comment or a nested block
-  comment is data, not a boundary. Execution stops at the first statement that errors.
+  comment is data, not a boundary. A fragment that is only comments is dropped rather than
+  dispatched, so `SELECT 1; -- done` is one statement with a trailing remark and not a result
+  followed by an error. Execution stops at the first statement that errors.
 
 - **TLS on the Postgres wire surface.** `PGWIRE_TLS_CERT` + `PGWIRE_TLS_KEY` (and
   `PGWIRE_TLS_CLIENT_CA`) make the listener answer `S` to an `SSLRequest` and upgrade the socket,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,13 @@ All notable changes to OrionBelt Semantic Layer are documented here.
   (`-- from the dashboard`) would otherwise steer it. Execution stops at the first statement that
   errors.
 
+- **The TLS suites are pinned to a declared dependency.** They mint their certificates with
+  `cryptography` and guard themselves with `importorskip`, but nothing declared it: it arrived
+  transitively through `google-auth` / `pymysql` / `pyopenssl` / `snowflake-connector-python`. Any
+  of those dropping it would not have failed anything, it would have skipped every TLS test green -
+  on both surfaces and for the DuckDB client. It is a dev dependency now, so the lock file pins it
+  directly.
+
 - **TLS on the Postgres wire surface.** `PGWIRE_TLS_CERT` + `PGWIRE_TLS_KEY` (and
   `PGWIRE_TLS_CLIENT_CA`) make the listener answer `S` to an `SSLRequest` and upgrade the socket,
   where it previously always answered `N`. Postgres negotiates rather than starting encrypted, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,13 @@ All notable changes to OrionBelt Semantic Layer are documented here.
   Each returned an empty catalog or a message about something else.
 
   One client setting is required: `SET pg_use_text_protocol = true`, because the default reads data
-  with `COPY ... TO STDOUT (FORMAT binary)`. See
-  [the guide](https://ralforion.com/orionbelt-semantic-layer/guide/postgres-wire-bi-tools/#7-duckdb).
+  with `COPY ... TO STDOUT (FORMAT binary)`.
+
+  TLS and authentication need nothing added on either side. The extension is libpq underneath, so
+  `sslmode` / `sslrootcert` / `password` reach it verbatim: all five `sslmode` values negotiate
+  against a `PGWIRE_TLS_CERT` listener and the wrong trust anchor is refused, and under
+  `AUTH_MODE=api_key` the API key is the password over SCRAM-SHA-256 (libpq performs the exchange).
+  See [the guide](https://ralforion.com/orionbelt-semantic-layer/guide/postgres-wire-bi-tools/#7-duckdb).
 
 - **Multi-statement simple queries.** One `Query` message carrying several statements separated by
   semicolons now runs each in order and replies with one result set per statement, as Postgres

--- a/README.md
+++ b/README.md
@@ -28,6 +28,23 @@ OrionBelt is a **[semantic sidecar](https://ralforion.com/semantic-sidecar.html)
 
 No BI tool in the middle. No runtime lock-in. Point it at what you already have.
 
+## Four ways in
+
+The same model serves every surface you already use. Four of them, and one model behind all four:
+
+| Surface | Port | Speaks | Connect with |
+|---|---|---|---|
+| **PostgreSQL wire** | `5432` | Postgres protocol | [DuckDB](https://ralforion.com/orionbelt-semantic-layer/guide/duckdb/) via `ATTACH`, Tableau, [Dremio](https://ralforion.com/orionbelt-semantic-layer/guide/postgres-wire-bi-tools/#6-dremio-sql-runner-catalog-flip-calcite-quirks) as a federated source, Power BI, Superset, DBeaver, Metabase, `psql` |
+| **Arrow Flight SQL** | `8815` | gRPC + Arrow | [DuckDB](https://ralforion.com/orionbelt-semantic-layer/guide/duckdb/) via `adbc_scanner`, Tableau and Power BI through the Flight SQL JDBC/ODBC drivers, [ADBC](https://ralforion.com/orionbelt-semantic-layer/guide/adbc/) clients (Python, Go, Java) |
+| **REST** | `8000` | HTTP + JSON | your code, notebooks, `curl`, and the [8 PEP 249 drivers](https://ralforion.com/orionbelt-semantic-layer/drivers/) (which compile here, then execute on the warehouse directly) |
+| **MCP** | stdio / HTTP | Model Context Protocol | [AI agents](https://ralforion.com/agentic-ai-data-access.html): Claude, Cursor, Copilot, Windsurf |
+
+Both SQL surfaces speak [OBSQL](https://ralforion.com/orionbelt-semantic-layer/guide/semantic-ql/), so `SELECT "Region", "Total Sales" FROM sales_model` is the same query whichever one you came in through. ADBC is how you *use* the Flight SQL surface rather than a fifth surface of its own, and DuckDB is a client that can take either SQL surface.
+
+## Eight ways out
+
+Compiles to **BigQuery, ClickHouse, Databricks, Dremio, DuckDB/MotherDuck, MySQL, PostgreSQL, and Snowflake.** The warehouse behind the model is independent of the surface in front of it: any of the four surfaces, against any of the eight dialects.
+
 Here is TPC-DS query 98. Two measures over the same column, identical but for one line: `Class Revenue` is pinned to a coarser grain than the query asks for.
 
 ```yaml
@@ -105,24 +122,6 @@ You did not write the join path, the window function over an aggregate, the `NUL
 
 **This is checked, not asserted.** 40 TPC-DS queries are built against a single OBML model and compared row by row against each engine's own reference SQL: 39 of 40 match on DuckDB at sf=1, 37 of 40 on ClickHouse at sf=10. Every one of the remaining differences traces to a reference variant rather than a compilation error, and each is documented. See [the sweep](https://ralforion.com/orionbelt-semantic-layer/examples/tpcds-sweep/), or the queries in [`examples/tpcds_queries/`](examples/tpcds_queries/).
 
-### Four ways in
-
-The same model serves every surface you already use. Four of them, and one
-model behind all four:
-
-| Surface | Port | Speaks | Connect with |
-|---|---|---|---|
-| **REST** | `8000` | HTTP + JSON | your code, notebooks, `curl`, and the [8 PEP 249 drivers](https://ralforion.com/orionbelt-semantic-layer/drivers/) (which compile here, then execute on the warehouse directly) |
-| **PostgreSQL wire** | `5432` | Postgres protocol | Tableau, Power BI, Superset, DBeaver, Metabase, `psql`, [Dremio](https://ralforion.com/orionbelt-semantic-layer/guide/postgres-wire-bi-tools/#6-dremio-sql-runner-catalog-flip-calcite-quirks) as a federated source, [DuckDB](https://ralforion.com/orionbelt-semantic-layer/guide/duckdb/) via `ATTACH` |
-| **Arrow Flight SQL** | `8815` | gRPC + Arrow | [ADBC](https://ralforion.com/orionbelt-semantic-layer/guide/adbc/) clients (Python, Go, Java), the Flight SQL JDBC/ODBC drivers, [DuckDB](https://ralforion.com/orionbelt-semantic-layer/guide/duckdb/) via `adbc_scanner` |
-| **MCP** | stdio / HTTP | Model Context Protocol | [AI agents](https://ralforion.com/agentic-ai-data-access.html): Claude, Cursor, Copilot, Windsurf |
-
-Both SQL surfaces speak [OBSQL](https://ralforion.com/orionbelt-semantic-layer/guide/semantic-ql/), so `SELECT "Region", "Total Sales" FROM sales_model` is the same query whichever one you came in through. ADBC is how you *use* the Flight SQL surface rather than a fifth surface of its own, and DuckDB is a client that can take either SQL surface.
-
-### Eight ways out
-
-Compiles to **BigQuery, ClickHouse, Databricks, Dremio, DuckDB/MotherDuck, MySQL, PostgreSQL, and Snowflake.** The warehouse behind the model is independent of the surface in front of it: any of the four above, against any of the eight below.
-
 ## Where OrionBelt fits
 
 OrionBelt is a sidecar, not a platform. It compiles a YAML model into correct SQL and exposes it over the protocols you already use. It does not run a cluster, own your cache, or ask you to adopt a cloud.
@@ -144,7 +143,7 @@ OrionBelt is a sidecar, not a platform. It compiles a YAML model into correct SQ
 
 ## Contents
 
-[Try it in 30 seconds](#try-it-in-30-seconds) · [Claude Desktop / MCP](#claude-desktop--mcp) · [Why OrionBelt?](#why-orionbelt) · [Features](#features) · [Example](#example) · [Documentation](#documentation) · [Roadmap](#status--roadmap) · [Commercial](#commercial-offerings) · [Development](#development)
+[Four ways in](#four-ways-in) · [Try it in 30 seconds](#try-it-in-30-seconds) · [Claude Desktop / MCP](#claude-desktop--mcp) · [Why OrionBelt?](#why-orionbelt) · [Features](#features) · [Example](#example) · [Documentation](#documentation) · [Roadmap](#status--roadmap) · [Commercial](#commercial-offerings) · [Development](#development)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ The same model serves every surface you already use:
 - **Your BI tool**, over the PostgreSQL wire protocol on `:5432`. Tableau, Power BI, Superset, DBeaver, and `psql` connect with the Postgres driver they already ship. Dremio federates it as a Postgres source.
 - **Your [AI agents](https://ralforion.com/agentic-ai-data-access.html)**, over MCP. Works with Claude, Cursor, Copilot, and Windsurf.
 - **Your code**, over REST, Arrow Flight SQL, or PEP 249 drivers.
-- **Your DuckDB**, over Arrow Flight SQL. `LOAD adbc_scanner`, connect, and `adbc_scan` a governed query into a DuckDB relation you can join, filter, and materialise locally. See [Connecting via ADBC](https://ralforion.com/orionbelt-semantic-layer/guide/adbc/#from-duckdb).
+- **Your DuckDB**, two ways. `ATTACH 'host=... dbname=...' AS obsl (TYPE postgres)` makes the model a table you query as `obsl.<model>.model` ([guide](https://ralforion.com/orionbelt-semantic-layer/guide/postgres-wire-bi-tools/#7-duckdb)); `adbc_scanner` does the same over Arrow Flight SQL and keeps Arrow end to end ([guide](https://ralforion.com/orionbelt-semantic-layer/guide/adbc/#from-duckdb)). Either way it joins to local files and lands in `CREATE TABLE AS`.
 
 Compiles to BigQuery, ClickHouse, Databricks, Dremio, DuckDB/MotherDuck, MySQL, PostgreSQL, and Snowflake.
 
@@ -402,7 +402,7 @@ Also works with Copilot, Cursor, and Windsurf. See the [MCP repo](https://github
 - **AI Integrations** — LangChain, OpenAI Agents SDK, CrewAI, Google ADK, Vercel AI SDK, n8n, ChatGPT
 - **Gradio UI** — interactive web interface for model editing, query testing, and ER diagrams
 - **DB-API 2.0 + Flight SQL** — PEP 249 drivers and Arrow Flight SQL server for DBeaver, Tableau, Power BI; ships with `examples/obsql.py`, a tiny terminal CLI for testing the Flight surface without a BI tool
-- **DuckDB as a client** (v2.27.1+) — with the `adbc_scanner` community extension, a plain DuckDB shell queries the layer over Flight SQL: `adbc_scan` returns a relation, so governed measures join to local tables and land in `CREATE TABLE AS`. Arrow the whole way, no conversion at either end
+- **DuckDB as a client** (v2.27.1+) - a plain DuckDB shell queries the layer, over either surface. `ATTACH ... (TYPE postgres)` mounts the model as a table (`SELECT ... FROM obsl.sales.model`, one `SET pg_use_text_protocol = true` first); the `adbc_scanner` community extension does it over Flight SQL with Arrow the whole way. Governed measures join to local tables and land in `CREATE TABLE AS`
 - **PostgreSQL Wire Protocol** (v2.5.0+) — native Postgres-protocol surface on `:5432`. Every BI tool already ships a Postgres ODBC/JDBC driver, so the user side is "point your existing connection at OBSL and go" — Tableau, DBeaver, Superset, Power BI, plain `psql`, and **Dremio as a federated Postgres source** (Dremio → OBSL → optionally back to Dremio's lakehouse, full circle)
 
 ### Agent-Facing API

--- a/README.md
+++ b/README.md
@@ -105,14 +105,23 @@ You did not write the join path, the window function over an aggregate, the `NUL
 
 **This is checked, not asserted.** 40 TPC-DS queries are built against a single OBML model and compared row by row against each engine's own reference SQL: 39 of 40 match on DuckDB at sf=1, 37 of 40 on ClickHouse at sf=10. Every one of the remaining differences traces to a reference variant rather than a compilation error, and each is documented. See [the sweep](https://ralforion.com/orionbelt-semantic-layer/examples/tpcds-sweep/), or the queries in [`examples/tpcds_queries/`](examples/tpcds_queries/).
 
-The same model serves every surface you already use:
+### Four ways in
 
-- **Your BI tool**, over the PostgreSQL wire protocol on `:5432`. Tableau, Power BI, Superset, DBeaver, and `psql` connect with the Postgres driver they already ship. Dremio federates it as a Postgres source.
-- **Your [AI agents](https://ralforion.com/agentic-ai-data-access.html)**, over MCP. Works with Claude, Cursor, Copilot, and Windsurf.
-- **Your code**, over REST, Arrow Flight SQL, or PEP 249 drivers.
-- **Your DuckDB**, two ways. `ATTACH 'host=... dbname=...' AS obsl (TYPE postgres)` makes the model a table you query as `obsl.<model>.model` ([guide](https://ralforion.com/orionbelt-semantic-layer/guide/postgres-wire-bi-tools/#7-duckdb)); `adbc_scanner` does the same over Arrow Flight SQL and keeps Arrow end to end ([guide](https://ralforion.com/orionbelt-semantic-layer/guide/adbc/#from-duckdb)). Either way it joins to local files and lands in `CREATE TABLE AS`.
+The same model serves every surface you already use. Four of them, and one
+model behind all four:
 
-Compiles to BigQuery, ClickHouse, Databricks, Dremio, DuckDB/MotherDuck, MySQL, PostgreSQL, and Snowflake.
+| Surface | Port | Speaks | Connect with |
+|---|---|---|---|
+| **REST** | `8000` | HTTP + JSON | your code, notebooks, `curl`, and the [8 PEP 249 drivers](https://ralforion.com/orionbelt-semantic-layer/drivers/) (which compile here, then execute on the warehouse directly) |
+| **PostgreSQL wire** | `5432` | Postgres protocol | Tableau, Power BI, Superset, DBeaver, Metabase, `psql`, [Dremio](https://ralforion.com/orionbelt-semantic-layer/guide/postgres-wire-bi-tools/#6-dremio-sql-runner-catalog-flip-calcite-quirks) as a federated source, [DuckDB](https://ralforion.com/orionbelt-semantic-layer/guide/duckdb/) via `ATTACH` |
+| **Arrow Flight SQL** | `8815` | gRPC + Arrow | [ADBC](https://ralforion.com/orionbelt-semantic-layer/guide/adbc/) clients (Python, Go, Java), the Flight SQL JDBC/ODBC drivers, [DuckDB](https://ralforion.com/orionbelt-semantic-layer/guide/duckdb/) via `adbc_scanner` |
+| **MCP** | stdio / HTTP | Model Context Protocol | [AI agents](https://ralforion.com/agentic-ai-data-access.html): Claude, Cursor, Copilot, Windsurf |
+
+Both SQL surfaces speak [OBSQL](https://ralforion.com/orionbelt-semantic-layer/guide/semantic-ql/), so `SELECT "Region", "Total Sales" FROM sales_model` is the same query whichever one you came in through. ADBC is how you *use* the Flight SQL surface rather than a fifth surface of its own, and DuckDB is a client that can take either SQL surface.
+
+### Eight ways out
+
+Compiles to **BigQuery, ClickHouse, Databricks, Dremio, DuckDB/MotherDuck, MySQL, PostgreSQL, and Snowflake.** The warehouse behind the model is independent of the surface in front of it: any of the four above, against any of the eight below.
 
 ## Where OrionBelt fits
 
@@ -402,7 +411,7 @@ Also works with Copilot, Cursor, and Windsurf. See the [MCP repo](https://github
 - **AI Integrations** — LangChain, OpenAI Agents SDK, CrewAI, Google ADK, Vercel AI SDK, n8n, ChatGPT
 - **Gradio UI** — interactive web interface for model editing, query testing, and ER diagrams
 - **DB-API 2.0 + Flight SQL** — PEP 249 drivers and Arrow Flight SQL server for DBeaver, Tableau, Power BI; ships with `examples/obsql.py`, a tiny terminal CLI for testing the Flight surface without a BI tool
-- **DuckDB as a client** (v2.27.1+) - a plain DuckDB shell queries the layer, over either surface. `ATTACH ... (TYPE postgres)` mounts the model as a table (`SELECT ... FROM obsl.sales.model`, one `SET pg_use_text_protocol = true` first); the `adbc_scanner` community extension does it over Flight SQL with Arrow the whole way. Governed measures join to local tables and land in `CREATE TABLE AS`
+- **DuckDB as a client** (v2.27.1+) - a plain DuckDB shell queries the layer, over either surface. `ATTACH ... (TYPE postgres)` mounts the model as a table (`SELECT ... FROM obsl.sales.model`, one `SET pg_use_text_protocol = true` first); the `adbc_scanner` community extension does it over Flight SQL with Arrow the whole way. Governed measures join to local tables and land in `CREATE TABLE AS`. [Guide](https://ralforion.com/orionbelt-semantic-layer/guide/duckdb/)
 - **PostgreSQL Wire Protocol** (v2.5.0+) — native Postgres-protocol surface on `:5432`. Every BI tool already ships a Postgres ODBC/JDBC driver, so the user side is "point your existing connection at OBSL and go" — Tableau, DBeaver, Superset, Power BI, plain `psql`, and **Dremio as a federated Postgres source** (Dremio → OBSL → optionally back to Dremio's lakehouse, full circle)
 
 ### Agent-Facing API

--- a/docs/drivers.md
+++ b/docs/drivers.md
@@ -220,8 +220,7 @@ done
 ## DuckDB as a client
 
 Besides being one of the eight warehouses OBSL compiles *to*, DuckDB can sit in
-front of it and query the model. Two routes, both giving you a relation you can
-join to local files:
+front of it and query the model, over either surface:
 
 ```sql
 -- Postgres wire: the model becomes a table
@@ -233,21 +232,8 @@ ATTACH 'host=localhost port=5432 dbname=commerce user=obsl'
 SELECT "Country Name", "Total Sales" FROM obsl.commerce.model;
 ```
 
-```sql
--- Arrow Flight SQL: OBSQL through a table function, Arrow end to end
-INSTALL adbc_scanner FROM community; LOAD adbc_scanner;
-CREATE OR REPLACE TABLE h AS SELECT adbc_connect(MAP {
-    'driver': '/path/to/libadbc_driver_flightsql.so',
-    'uri':    'grpc://localhost:8815'
-}) AS handle;
-
-SELECT * FROM adbc_scan((SELECT handle FROM h),
-    'SELECT "Country Name", "Total Sales" FROM commerce');
-```
-
-See [7. DuckDB](guide/postgres-wire-bi-tools.md#7-duckdb) for the `ATTACH` route
-(including TLS and authentication) and [From DuckDB](guide/adbc.md#from-duckdb)
-for the ADBC one.
+Both routes, with TLS, authentication and their limitations, are covered in
+**[Using DuckDB as a client](guide/duckdb.md)**.
 
 ## Arrow Flight SQL Server
 

--- a/docs/drivers.md
+++ b/docs/drivers.md
@@ -217,6 +217,38 @@ done
 
 ---
 
+## DuckDB as a client
+
+Besides being one of the eight warehouses OBSL compiles *to*, DuckDB can sit in
+front of it and query the model. Two routes, both giving you a relation you can
+join to local files:
+
+```sql
+-- Postgres wire: the model becomes a table
+INSTALL postgres; LOAD postgres;
+SET pg_use_text_protocol = true;
+ATTACH 'host=localhost port=5432 dbname=commerce user=obsl'
+    AS obsl (TYPE postgres, READ_ONLY);
+
+SELECT "Country Name", "Total Sales" FROM obsl.commerce.model;
+```
+
+```sql
+-- Arrow Flight SQL: OBSQL through a table function, Arrow end to end
+INSTALL adbc_scanner FROM community; LOAD adbc_scanner;
+CREATE OR REPLACE TABLE h AS SELECT adbc_connect(MAP {
+    'driver': '/path/to/libadbc_driver_flightsql.so',
+    'uri':    'grpc://localhost:8815'
+}) AS handle;
+
+SELECT * FROM adbc_scan((SELECT handle FROM h),
+    'SELECT "Country Name", "Total Sales" FROM commerce');
+```
+
+See [7. DuckDB](guide/postgres-wire-bi-tools.md#7-duckdb) for the `ATTACH` route
+(including TLS and authentication) and [From DuckDB](guide/adbc.md#from-duckdb)
+for the ADBC one.
+
 ## Arrow Flight SQL Server
 
 The `ob-flight-extension` package adds an Arrow Flight SQL endpoint to the OrionBelt API. This enables BI tools that support the Arrow Flight protocol — DBeaver, Tableau (via JDBC), Power BI (via ODBC bridge) — to run OBML queries directly.

--- a/docs/guide/adbc.md
+++ b/docs/guide/adbc.md
@@ -250,6 +250,12 @@ The scan is a table function, so DuckDB treats its output as any other
 relation: the semantic layer resolves the model and returns Arrow, and DuckDB
 does whatever you ask on top.
 
+DuckDB can also reach the model over the [Postgres wire
+surface](postgres-wire-bi-tools.md#7-duckdb), where `ATTACH ... (TYPE postgres)`
+mounts it as a real table (`FROM obsl.sales.model`) rather than a string passed
+to a table function. That route needs no driver path and no community
+extension; this one keeps Arrow end to end.
+
 Note the division of labour. Predicates written *outside* `adbc_scan` are
 DuckDB's, applied after the rows arrive; predicates inside the OBSQL string are
 the semantic layer's, compiled into the warehouse query. For anything

--- a/docs/guide/adbc.md
+++ b/docs/guide/adbc.md
@@ -232,34 +232,17 @@ SELECT * FROM adbc_scan(
 
 Two things it needs that the Python recipe does not: `adbc_scanner` is a
 **community** extension rather than a bundled one, and `adbc_connect` wants a
-filesystem path to the Flight SQL driver library. Any ADBC install has one —
+filesystem path to the Flight SQL driver library. Any ADBC install has one -
 `python -c "import adbc_driver_flightsql as d; print(d._driver_path())"` prints
-it — but it is a path, not a package name.
+it - but it is a path, not a package name.
 
-What works from there:
+`adbc_tables(handle)` lists the model and its metadata views, and
+`adbc_schema(handle, 'model', schema := 'sales')` gives column types without
+executing anything.
 
-| | |
-|---|---|
-| `adbc_scan(handle, '<OBSQL>')` | The point. Governed measures, resolved joins, typed columns. |
-| `adbc_tables(handle)` | Lists `model` and the `dimensions` / `measures` / `metrics` views. |
-| `adbc_schema(handle, 'model', schema := 'sales')` | Column names and types without executing anything. |
-| Filtering, grouping, joining to local tables | Ordinary DuckDB SQL over the scan. |
-| `CREATE TABLE local AS SELECT * FROM adbc_scan(…)` | Materialises the result locally. |
-
-The scan is a table function, so DuckDB treats its output as any other
-relation: the semantic layer resolves the model and returns Arrow, and DuckDB
-does whatever you ask on top.
-
-DuckDB can also reach the model over the [Postgres wire
-surface](postgres-wire-bi-tools.md#7-duckdb), where `ATTACH ... (TYPE postgres)`
-mounts it as a real table (`FROM obsl.sales.model`) rather than a string passed
-to a table function. That route needs no driver path and no community
-extension; this one keeps Arrow end to end.
-
-Note the division of labour. Predicates written *outside* `adbc_scan` are
-DuckDB's, applied after the rows arrive; predicates inside the OBSQL string are
-the semantic layer's, compiled into the warehouse query. For anything
-selective, put them in the OBSQL.
+See **[Using DuckDB as a client](duckdb.md)** for the full guide, including the
+`ATTACH ... (TYPE postgres)` route that addresses the model as a table rather
+than a string in a table function, and which predicates reach the warehouse.
 
 ## What you can send
 

--- a/docs/guide/duckdb.md
+++ b/docs/guide/duckdb.md
@@ -1,0 +1,218 @@
+---
+description: Query the OrionBelt Semantic Layer from a plain DuckDB shell, over the Postgres wire surface or Arrow Flight SQL, and join governed measures to local Parquet and CSV.
+---
+
+# Using DuckDB as a client
+
+DuckDB is one of the eight warehouses OBSL compiles *to*. It can also sit in
+front of OBSL and query the model, which is a different and often more useful
+thing: measures stay governed and resolved by the semantic layer, and the rows
+that come back are an ordinary DuckDB relation you can join to a local Parquet
+file, aggregate further, or persist.
+
+There are two routes, and they differ in how you *address* the model rather
+than in what you get back.
+
+| | Postgres wire (`ATTACH`) | Arrow Flight SQL (`adbc_scan`) |
+|---|---|---|
+| Addressing | `FROM obsl.sales.model` - a real table | `adbc_scan(handle, 'SELECT ... FROM sales')` - OBSQL in a string |
+| Extension | `postgres` (ships with DuckDB) | `adbc_scanner` (community) |
+| Extra setup | one `SET`, one `ATTACH` | a filesystem path to the Flight SQL driver library |
+| Transport | Postgres text protocol | Arrow, end to end |
+| `SELECT *` | works - DuckDB expands the star from the catalog | rejected - the star reaches OBSQL verbatim |
+| Server port | `PGWIRE_PORT` (5432) | `FLIGHT_PORT` (8815) |
+
+Use `ATTACH` when you want the model to look like a table and compose with the
+rest of your SQL. Use `adbc_scan` when the result is large enough that keeping
+Arrow end to end is worth the extra setup.
+
+Both are read-only. OBSL is a semantic layer: `INSERT` / `UPDATE` / `DELETE` and
+DDL are refused on every surface.
+
+## Route 1: `ATTACH` over the Postgres wire
+
+Start the server with the wire surface enabled (see
+[Postgres Wire (BI Tools)](postgres-wire-bi-tools.md#1-common-configuration)),
+then, in any DuckDB shell:
+
+```sql
+INSTALL postgres;
+LOAD postgres;
+
+SET pg_use_text_protocol = true;   -- required, see below
+
+ATTACH 'host=127.0.0.1 port=5432 dbname=commerce user=obsl'
+    AS obsl (TYPE postgres, READ_ONLY);
+```
+
+`dbname` is the model's addressing name: the OBML `name:` field, or the file
+stem if the model does not declare one. Each model is a schema under the
+attached catalog, with the model itself at `<schema>.model`:
+
+```sql
+SELECT database, schema, name FROM (SHOW ALL TABLES) WHERE database = 'obsl';
+```
+
+```text
+obsl   commerce   model                   -- the model: dimensions + measures + metrics
+obsl   commerce   dimensions              -- metadata views, one row per artefact
+obsl   commerce   measures
+obsl   commerce   metrics
+obsl   commerce   _dimensions_metadata    -- the same, with the full column detail
+obsl   commerce   _measures_metadata
+obsl   commerce   _metrics_metadata
+```
+
+Then query it as a table. Columns are the model's dimensions, measures and
+metrics, typed as the model declares them:
+
+```sql
+SELECT "Country Name", "Total Sales"
+FROM   obsl.commerce.model
+WHERE  "Country Name" = 'Germany';
+```
+
+### `pg_use_text_protocol` is not optional
+
+Left at its default, the extension reads data with
+`COPY ... TO STDOUT (FORMAT binary)`. OBSL answers queries, not binary bulk
+exports, so the read fails with a parse error naming `COPY`. The catalog
+browses fine either way, which makes it look like a broken query rather than a
+protocol OBSL does not speak. Set the flag once per session, before the first
+read.
+
+Two neighbouring settings need no change: `pg_use_ctid_scan` and
+`pg_experimental_filter_pushdown` both work as-is, because a model has neither
+physical row ids nor a plan the extension can push into.
+
+### TLS and authentication
+
+The extension is libpq underneath, so the whole connection string reaches it
+and `sslmode`, `sslrootcert` and `password` behave exactly as they do for
+`psql`. Against a listener started with `PGWIRE_TLS_CERT` / `PGWIRE_TLS_KEY`:
+
+```sql
+ATTACH 'host=obsl.internal port=5432 dbname=commerce user=obsl
+        sslmode=verify-full sslrootcert=/etc/ssl/certs/obsl-ca.crt'
+    AS obsl (TYPE postgres, READ_ONLY);
+```
+
+All five `sslmode` values negotiate (`disable`, `prefer`, `require`,
+`verify-ca`, `verify-full`), and `verify-ca` against the wrong trust anchor is
+refused, which is what makes the others mean anything.
+
+With `AUTH_MODE=api_key`, the API key **is** the password:
+
+```sql
+ATTACH 'host=obsl.internal port=5432 dbname=commerce user=obsl
+        password=obsl_pat_...  sslmode=require'
+    AS obsl (TYPE postgres, READ_ONLY);
+```
+
+The mechanism is SCRAM-SHA-256 by default, which libpq performs on DuckDB's
+behalf; `PGWIRE_AUTH_MODE=password` drops to cleartext for clients that lack
+SCRAM, and DuckDB is not one of them. Send the key over TLS either way: with
+SCRAM the key never crosses the wire, but the results do.
+
+## Route 2: `adbc_scan` over Arrow Flight SQL
+
+`adbc_scanner` is a **community** extension, and `adbc_connect` wants a
+filesystem path to the Flight SQL driver library rather than a package name.
+Any ADBC install has one:
+
+```bash
+python -c "import adbc_driver_flightsql as d; print(d._driver_path())"
+```
+
+```sql
+INSTALL adbc_scanner FROM community;
+LOAD adbc_scanner;
+
+CREATE OR REPLACE TABLE h AS
+SELECT adbc_connect(MAP {
+    'driver': '/path/to/libadbc_driver_flightsql.so',
+    'uri':    'grpc://127.0.0.1:8815'
+}) AS handle;
+
+SELECT * FROM adbc_scan(
+    (SELECT handle FROM h),
+    'SELECT "Country Name", "Total Sales" FROM commerce'
+);
+```
+
+The string is [OBSQL](semantic-ql.md), and the model is addressed by name
+(`commerce`), not as `<schema>.model` - that shape belongs to the wire surface.
+
+What else the handle gives you:
+
+| | |
+|---|---|
+| `adbc_tables(handle)` | Lists `model` and the `dimensions` / `measures` / `metrics` views |
+| `adbc_schema(handle, 'model', schema := 'commerce')` | Column names and types without executing anything |
+| `adbc_columns(handle)` | The same, across every table |
+
+`adbc_scan_table(handle, '<table>')` does **not** work against OBSL. It builds
+`SELECT * FROM <table>`, and OBSQL rejects `SELECT *`: a semantic query names
+the dimensions and measures it wants, because "everything" is not a grain. Use
+`adbc_scan` with an explicit column list.
+
+## Where the work happens
+
+The two routes differ here, and the `ATTACH` route is the more forgiving one.
+
+**Over `ATTACH`**, DuckDB pushes simple predicates down into the query it sends,
+and it does so through trivial wrappers too. Both of these arrive at the
+semantic layer carrying the filter, so the warehouse does the work and only the
+matching rows travel:
+
+```sql
+SELECT * FROM obsl.commerce.model WHERE "Country Name" = 'Germany';
+SELECT * FROM (SELECT * FROM obsl.commerce.model) WHERE "Country Name" = 'Germany';
+```
+
+What does *not* get pushed is anything DuckDB cannot express as a scan filter:
+a join to a local table, a window function, a predicate over a computed
+expression. Those run in DuckDB on rows that have already arrived.
+
+**Over `adbc_scan`**, there is no pushdown at all: the OBSQL string is sent
+verbatim, and anything outside it is DuckDB's own work on rows that have
+already arrived. Put selective predicates inside the string.
+
+## Composing with local data
+
+The point of either route. A governed measure joins to a local file:
+
+```sql
+SELECT m."Country Name",
+       m."Total Sales",
+       m."Total Sales" > t.target AS beat_target
+FROM   obsl.commerce.model m
+JOIN   read_csv('targets.csv') t ON m."Country Name" = t.country;
+```
+
+And lands in a local table:
+
+```sql
+CREATE TABLE snapshot AS SELECT * FROM obsl.commerce.model;
+```
+
+`SELECT count(*)` over the model returns exactly the number of rows
+`SELECT *` returns. Note that this is not the same as the number of distinct
+dimension combinations: asking for measures anchors the query to the facts, so
+a dimension value with no facts behind it (a customer who has never ordered) is
+listed by `SELECT "Customer Name"` but is not a row of the model.
+
+## Known limitations
+
+| Limitation | Route | Note |
+|---|---|---|
+| `SET pg_use_text_protocol = true` required | `ATTACH` | The default reads with binary `COPY`, which OBSL does not implement |
+| `adbc_scan_table()` unsupported | `adbc_scan` | It generates `SELECT *`, which OBSQL rejects; name the columns |
+| `SELECT *` unsupported inside an OBSQL string | `adbc_scan` | The `ATTACH` route is unaffected: DuckDB expands the star itself |
+| Read-only | both | OBSL is a semantic layer; writes go to the warehouse, not through it |
+
+## See also
+
+- [Postgres Wire (BI Tools)](postgres-wire-bi-tools.md) - the same surface from Tableau, DBeaver, Power BI, Metabase and Dremio
+- [ADBC / Arrow Flight SQL](adbc.md) - the Flight surface from Python, JDBC and ODBC
+- [OBSQL](semantic-ql.md) - the query language both routes speak

--- a/docs/guide/postgres-wire-bi-tools.md
+++ b/docs/guide/postgres-wire-bi-tools.md
@@ -83,7 +83,7 @@ Every client uses the same connection details:
 | Port | `PGWIRE_PORT` (default `5432`) |
 | Database | the model addressing name — the OBML `name:` field or, lacking that, the file stem (e.g. `orionbelt_1_commerce`) |
 | Username | any non-empty string (`obsl`, the tool's default — ignored in `trust` mode) |
-| Password | leave empty in `trust` mode (auth lands in Step 6) |
+| Password | leave empty in `trust` mode; with `AUTH_MODE=api_key` the API key is the password (SCRAM-SHA-256 by default) |
 | TLS / SSL | `disable` unless the server was started with `PGWIRE_TLS_CERT` / `PGWIRE_TLS_KEY` - see [TLS](#tls) above |
 
 To list available model names, query the REST `GET /v1/models`
@@ -333,6 +333,37 @@ filter on the model.
 `SELECT count(*) FROM obsl.<schema>.model` counts rows at the model's grain,
 one per dimension combination, which is what `SELECT *` over it returns.
 
+### TLS and authentication
+
+The extension is libpq underneath, so the whole connection string reaches it
+and `sslmode`, `sslrootcert` and `password` behave exactly as they do for
+`psql`. Nothing about the DuckDB side is special.
+
+Against a listener started with `PGWIRE_TLS_CERT` / `PGWIRE_TLS_KEY`:
+
+```sql
+ATTACH 'host=obsl.internal port=5432 dbname=commerce user=obsl
+        sslmode=verify-full sslrootcert=/etc/ssl/certs/obsl-ca.crt'
+    AS obsl (TYPE postgres, READ_ONLY);
+```
+
+All four modes negotiate (`disable`, `prefer`, `require`, `verify-ca`,
+`verify-full`), and `verify-ca` against the wrong trust anchor is refused,
+which is what makes the others mean anything.
+
+With `AUTH_MODE=api_key`, the API key **is** the password:
+
+```sql
+ATTACH 'host=obsl.internal port=5432 dbname=commerce user=obsl
+        password=obsl_pat_...  sslmode=require'
+    AS obsl (TYPE postgres, READ_ONLY);
+```
+
+The mechanism is SCRAM-SHA-256 by default, which libpq performs on DuckDB's
+behalf; `PGWIRE_AUTH_MODE=password` drops to cleartext for clients that lack
+SCRAM, and DuckDB is not one of them. Send the key over TLS either way: with
+SCRAM the key never crosses the wire, but the query results do.
+
 ### Compared to the ADBC route
 
 The [ADBC guide](adbc.md#from-duckdb) shows the same idea over Arrow Flight
@@ -357,8 +388,8 @@ These constraints are documented in
 | Limitation | Reason | Workaround |
 |---|---|---|
 | `psql \d <table>` partially works (psql 16 RLS-policy probe hits DuckDB's correlated-UNNEST limit) | DuckDB engine, not the wire protocol | Use BI tools (they query `information_schema`) or `\dt` |
-| Binary-format Bind parameters rejected | Step 4 ships text format only | Force text format if a driver supports it; binary lands in Step 7 |
-| No authentication | `trust` mode only until Step 6 lands | Run behind a network boundary or skip pgwire on public deploys |
+| Binary-format Bind parameters decode for the common scalar OIDs only (bool, bytea, int2/4/8, float4/8, text, varchar, name, bpchar) | Anything else would be mangled bytes, so it raises instead | Force text format if the driver supports it; the error names the OID |
+| DuckDB `ATTACH` needs `SET pg_use_text_protocol = true` | The default reads with `COPY ... TO STDOUT (FORMAT binary)`, which the semantic surface does not implement | Set it once per session, before the first read - see [7. DuckDB](#7-duckdb) |
 | Write operations (`INSERT` / `UPDATE` / `DELETE` / DDL) | Read-only semantic layer | Use the REST API for model management; data writes go to the warehouse, not OBSL |
 
 ## Reporting a tool that fails

--- a/docs/guide/postgres-wire-bi-tools.md
+++ b/docs/guide/postgres-wire-bi-tools.md
@@ -389,6 +389,7 @@ These constraints are documented in
 |---|---|---|
 | `psql \d <table>` partially works (psql 16 RLS-policy probe hits DuckDB's correlated-UNNEST limit) | DuckDB engine, not the wire protocol | Use BI tools (they query `information_schema`) or `\dt` |
 | Binary-format Bind parameters decode for the common scalar OIDs only (bool, bytea, int2/4/8, float4/8, text, varchar, name, bpchar) | Anything else would be mangled bytes, so it raises instead | Force text format if the driver supports it; the error names the OID |
+| Authentication is off by default (`trust`) | `AUTH_MODE` governs every surface and ships as `none` | Set `AUTH_MODE=api_key` and `API_KEYS=<key>`; clients then send the key as the **password**, over SCRAM-SHA-256. `PGWIRE_AUTH_MODE=password` drops to cleartext for clients without SCRAM, so pair it with TLS |
 | DuckDB `ATTACH` needs `SET pg_use_text_protocol = true` | The default reads with `COPY ... TO STDOUT (FORMAT binary)`, which the semantic surface does not implement | Set it once per session, before the first read - see [7. DuckDB](#7-duckdb) |
 | Write operations (`INSERT` / `UPDATE` / `DELETE` / DDL) | Read-only semantic layer | Use the REST API for model management; data writes go to the warehouse, not OBSL |
 

--- a/docs/guide/postgres-wire-bi-tools.md
+++ b/docs/guide/postgres-wire-bi-tools.md
@@ -283,15 +283,14 @@ Dremio, three options:
 
 ## 7. DuckDB
 
-DuckDB can be a client of the wire surface as well as a warehouse behind it.
-Its `postgres` extension attaches the semantic layer as a catalog, so the model
-becomes an ordinary table in a local DuckDB session:
+DuckDB's bundled `postgres` extension attaches the wire surface as a catalog,
+so the model becomes an ordinary table in a local DuckDB session:
 
 ```sql
 INSTALL postgres;
 LOAD postgres;
 
-SET pg_use_text_protocol = true;   -- required, see below
+SET pg_use_text_protocol = true;   -- required; the default reads with binary COPY
 
 ATTACH 'host=127.0.0.1 port=5432 dbname=commerce user=obsl'
     AS obsl (TYPE postgres, READ_ONLY);
@@ -299,86 +298,15 @@ ATTACH 'host=127.0.0.1 port=5432 dbname=commerce user=obsl'
 SELECT "Country Name", "Total Sales" FROM obsl.commerce.model;
 ```
 
-Everything downstream is ordinary DuckDB. The model joins to local Parquet and
-CSV, aggregates further, and materialises:
+From there it is ordinary DuckDB: the model joins to local Parquet and CSV,
+aggregates further, and lands in `CREATE TABLE AS`.
 
-```sql
-CREATE TABLE snapshot AS SELECT * FROM obsl.commerce.model;
+`sslmode`, `sslrootcert` and `password` work exactly as they do for `psql`,
+because the extension is libpq underneath.
 
-SELECT m."Country Name", m."Total Sales" > t.target AS beat
-FROM   obsl.commerce.model m
-JOIN   read_csv('targets.csv') t ON m."Country Name" = t.country;
-```
-
-### `pg_use_text_protocol` is not optional
-
-Left at its default, the extension reads data with
-`COPY ... TO STDOUT (FORMAT binary)`. The semantic surface answers queries, not
-binary bulk exports, so the read fails with a parse error naming `COPY` - the
-catalog browses fine, which makes it look like a broken query rather than a
-missing feature. Set the flag once per session, before the first read.
-
-Two other settings are worth knowing but need no change: `pg_use_ctid_scan` and
-`pg_experimental_filter_pushdown` both work as-is, because a model has neither
-physical row ids nor a plan the extension can push into.
-
-### What the division of labour is
-
-Predicates written against `obsl.<schema>.model` are pushed to the semantic
-layer as OBSQL and compiled into the warehouse query. Anything you wrap around
-the result - a join to a local file, a window function, a second aggregation -
-is DuckDB's own work on rows that have already arrived. For anything selective,
-filter on the model.
-
-`SELECT count(*) FROM obsl.<schema>.model` counts rows at the model's grain,
-one per dimension combination, which is what `SELECT *` over it returns.
-
-### TLS and authentication
-
-The extension is libpq underneath, so the whole connection string reaches it
-and `sslmode`, `sslrootcert` and `password` behave exactly as they do for
-`psql`. Nothing about the DuckDB side is special.
-
-Against a listener started with `PGWIRE_TLS_CERT` / `PGWIRE_TLS_KEY`:
-
-```sql
-ATTACH 'host=obsl.internal port=5432 dbname=commerce user=obsl
-        sslmode=verify-full sslrootcert=/etc/ssl/certs/obsl-ca.crt'
-    AS obsl (TYPE postgres, READ_ONLY);
-```
-
-All four modes negotiate (`disable`, `prefer`, `require`, `verify-ca`,
-`verify-full`), and `verify-ca` against the wrong trust anchor is refused,
-which is what makes the others mean anything.
-
-With `AUTH_MODE=api_key`, the API key **is** the password:
-
-```sql
-ATTACH 'host=obsl.internal port=5432 dbname=commerce user=obsl
-        password=obsl_pat_...  sslmode=require'
-    AS obsl (TYPE postgres, READ_ONLY);
-```
-
-The mechanism is SCRAM-SHA-256 by default, which libpq performs on DuckDB's
-behalf; `PGWIRE_AUTH_MODE=password` drops to cleartext for clients that lack
-SCRAM, and DuckDB is not one of them. Send the key over TLS either way: with
-SCRAM the key never crosses the wire, but the query results do.
-
-### Compared to the ADBC route
-
-The [ADBC guide](adbc.md#from-duckdb) shows the same idea over Arrow Flight
-SQL, through `adbc_scan(handle, '<OBSQL>')`. The difference is addressing:
-
-| | Postgres wire (`ATTACH`) | ADBC (`adbc_scan`) |
-|---|---|---|
-| Query shape | `FROM obsl.commerce.model` - a real table | `adbc_scan(handle, 'SELECT ... FROM commerce')` - OBSQL in a string |
-| Extension | `postgres` (bundled) | `adbc_scanner` (community) plus a driver library path |
-| Transport | Postgres text protocol | Arrow, end to end |
-| Setup | one `SET`, one `ATTACH` | a driver path and a handle table |
-
-Use `ATTACH` when you want the model to look like a table and compose with the
-rest of your SQL. Use ADBC when the result is large enough that the Arrow path
-is worth the extra setup.
+See **[Using DuckDB as a client](duckdb.md)** for the full guide: both routes
+(this one and Arrow Flight SQL), TLS and authentication, which predicates reach
+the warehouse, and the limitations of each.
 
 ## Known limitations
 

--- a/docs/guide/postgres-wire-bi-tools.md
+++ b/docs/guide/postgres-wire-bi-tools.md
@@ -84,7 +84,7 @@ Every client uses the same connection details:
 | Database | the model addressing name — the OBML `name:` field or, lacking that, the file stem (e.g. `orionbelt_1_commerce`) |
 | Username | any non-empty string (`obsl`, the tool's default — ignored in `trust` mode) |
 | Password | leave empty in `trust` mode (auth lands in Step 6) |
-| TLS / SSL | disable; the server has no built-in TLS today |
+| TLS / SSL | `disable` unless the server was started with `PGWIRE_TLS_CERT` / `PGWIRE_TLS_KEY` - see [TLS](#tls) above |
 
 To list available model names, query the REST `GET /v1/models`
 endpoint or check the server startup log.
@@ -281,6 +281,74 @@ Dremio, three options:
    ships and Dremio picks it up, semantic-aware aggregation through
    Calcite is blocked upstream.
 
+## 7. DuckDB
+
+DuckDB can be a client of the wire surface as well as a warehouse behind it.
+Its `postgres` extension attaches the semantic layer as a catalog, so the model
+becomes an ordinary table in a local DuckDB session:
+
+```sql
+INSTALL postgres;
+LOAD postgres;
+
+SET pg_use_text_protocol = true;   -- required, see below
+
+ATTACH 'host=127.0.0.1 port=5432 dbname=commerce user=obsl'
+    AS obsl (TYPE postgres, READ_ONLY);
+
+SELECT "Country Name", "Total Sales" FROM obsl.commerce.model;
+```
+
+Everything downstream is ordinary DuckDB. The model joins to local Parquet and
+CSV, aggregates further, and materialises:
+
+```sql
+CREATE TABLE snapshot AS SELECT * FROM obsl.commerce.model;
+
+SELECT m."Country Name", m."Total Sales" > t.target AS beat
+FROM   obsl.commerce.model m
+JOIN   read_csv('targets.csv') t ON m."Country Name" = t.country;
+```
+
+### `pg_use_text_protocol` is not optional
+
+Left at its default, the extension reads data with
+`COPY ... TO STDOUT (FORMAT binary)`. The semantic surface answers queries, not
+binary bulk exports, so the read fails with a parse error naming `COPY` - the
+catalog browses fine, which makes it look like a broken query rather than a
+missing feature. Set the flag once per session, before the first read.
+
+Two other settings are worth knowing but need no change: `pg_use_ctid_scan` and
+`pg_experimental_filter_pushdown` both work as-is, because a model has neither
+physical row ids nor a plan the extension can push into.
+
+### What the division of labour is
+
+Predicates written against `obsl.<schema>.model` are pushed to the semantic
+layer as OBSQL and compiled into the warehouse query. Anything you wrap around
+the result - a join to a local file, a window function, a second aggregation -
+is DuckDB's own work on rows that have already arrived. For anything selective,
+filter on the model.
+
+`SELECT count(*) FROM obsl.<schema>.model` counts rows at the model's grain,
+one per dimension combination, which is what `SELECT *` over it returns.
+
+### Compared to the ADBC route
+
+The [ADBC guide](adbc.md#from-duckdb) shows the same idea over Arrow Flight
+SQL, through `adbc_scan(handle, '<OBSQL>')`. The difference is addressing:
+
+| | Postgres wire (`ATTACH`) | ADBC (`adbc_scan`) |
+|---|---|---|
+| Query shape | `FROM obsl.commerce.model` - a real table | `adbc_scan(handle, 'SELECT ... FROM commerce')` - OBSQL in a string |
+| Extension | `postgres` (bundled) | `adbc_scanner` (community) plus a driver library path |
+| Transport | Postgres text protocol | Arrow, end to end |
+| Setup | one `SET`, one `ATTACH` | a driver path and a handle table |
+
+Use `ATTACH` when you want the model to look like a table and compose with the
+rest of your SQL. Use ADBC when the result is large enough that the Arrow path
+is worth the extra setup.
+
 ## Known limitations
 
 These constraints are documented in
@@ -291,7 +359,6 @@ These constraints are documented in
 | `psql \d <table>` partially works (psql 16 RLS-policy probe hits DuckDB's correlated-UNNEST limit) | DuckDB engine, not the wire protocol | Use BI tools (they query `information_schema`) or `\dt` |
 | Binary-format Bind parameters rejected | Step 4 ships text format only | Force text format if a driver supports it; binary lands in Step 7 |
 | No authentication | `trust` mode only until Step 6 lands | Run behind a network boundary or skip pgwire on public deploys |
-| No TLS | Native TLS comes in a later step | Front with nginx / Cloud Run TLS termination |
 | Write operations (`INSERT` / `UPDATE` / `DELETE` / DDL) | Read-only semantic layer | Use the REST API for model management; data writes go to the warehouse, not OBSL |
 
 ## Reporting a tool that fails

--- a/docs/index.md
+++ b/docs/index.md
@@ -72,7 +72,7 @@ OBSQL flows over **Apache Arrow Flight SQL** (v2.4+) and **PostgreSQL wire** (v2
 | Custom Extensions   | Vendor-specific metadata at all model levels (model, data object, column, dimension, measure, metric)           |
 | DB-API 2.0 Drivers  | PEP 249 drivers for all 8 databases with transparent OBML compilation                                          |
 | Arrow Flight SQL    | Embedded gRPC server for DBeaver, Tableau, Power BI — single container, two ports                               |
-| DuckDB as a Client  | A plain DuckDB shell queries the layer: `ATTACH ... (TYPE postgres)` mounts a model as a table, or `adbc_scanner` scans it over Flight SQL. Governed measures join to local Parquet and CSV |
+| DuckDB as a Client  | A plain DuckDB shell queries the layer: `ATTACH ... (TYPE postgres)` mounts a model as a table, or `adbc_scanner` scans it over Flight SQL. Governed measures join to local Parquet and CSV. See [Using DuckDB as a client](guide/duckdb.md) |
 | PostgreSQL Wire     | Native Postgres-protocol surface (v2.5.0+) — Tableau, DBeaver, Superset, Power BI, `psql`, and **Dremio as a federated Postgres source** connect via their built-in Postgres ODBC/JDBC driver; no new connector to install |
 | OBSL Graph & SPARQL | Every loaded model is exported as an OBSL-Core 0.2 RDF graph (Turtle) with a read-only SPARQL (SELECT/ASK) endpoint |
 | Plugin Architecture | Extensible dialect system with capability flags                                                                 |

--- a/docs/index.md
+++ b/docs/index.md
@@ -72,6 +72,7 @@ OBSQL flows over **Apache Arrow Flight SQL** (v2.4+) and **PostgreSQL wire** (v2
 | Custom Extensions   | Vendor-specific metadata at all model levels (model, data object, column, dimension, measure, metric)           |
 | DB-API 2.0 Drivers  | PEP 249 drivers for all 8 databases with transparent OBML compilation                                          |
 | Arrow Flight SQL    | Embedded gRPC server for DBeaver, Tableau, Power BI — single container, two ports                               |
+| DuckDB as a Client  | A plain DuckDB shell queries the layer: `ATTACH ... (TYPE postgres)` mounts a model as a table, or `adbc_scanner` scans it over Flight SQL. Governed measures join to local Parquet and CSV |
 | PostgreSQL Wire     | Native Postgres-protocol surface (v2.5.0+) — Tableau, DBeaver, Superset, Power BI, `psql`, and **Dremio as a federated Postgres source** connect via their built-in Postgres ODBC/JDBC driver; no new connector to install |
 | OBSL Graph & SPARQL | Every loaded model is exported as an OBSL-Core 0.2 RDF graph (Turtle) with a read-only SPARQL (SELECT/ASK) endpoint |
 | Plugin Architecture | Extensible dialect system with capability flags                                                                 |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -147,6 +147,7 @@ nav:
       - AI Integrations: guide/integrations.md
       - Postgres Wire (BI Tools): guide/postgres-wire-bi-tools.md
       - ADBC / Arrow Flight SQL: guide/adbc.md
+      - DuckDB as a Client: guide/duckdb.md
       - Authentication: guide/authentication.md
       - OSI Interoperability: guide/osi.md
   - API:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,12 @@ dev = [
     "psycopg2-binary>=2.9",
     "psycopg[binary]>=3.2",
     "pymysql[rsa]>=1.0",
+    # Mints the certificates the TLS suites need (pgwire, Flight, and the
+    # DuckDB client). Declared rather than leaned on: it arrives transitively
+    # through google-auth / pymysql / pyopenssl / snowflake-connector-python
+    # today, and those suites guard themselves with importorskip - so losing it
+    # would not fail anything, it would skip every TLS test green.
+    "cryptography>=42.0",
     "clickhouse-connect>=0.7",
 ]
 # Local Spark execution for the Databricks dialect. Databricks SQL *is* Spark

--- a/src/orionbelt/pgwire/catalog.py
+++ b/src/orionbelt/pgwire/catalog.py
@@ -161,6 +161,11 @@ _OID_TRANSLATION_CASE = """
         END
 """
 
+#: The oid Postgres gives ``pg_catalog``. Fixed since forever, and every
+#: base type in the shadow ``pg_type`` claims it as its namespace.
+_PG_CATALOG_OID = 11
+
+
 _SHADOW_VIEWS: tuple[str, ...] = (
     # Empty stubs for pg_catalog tables DuckDB doesn't expose but
     # DBeaver / pgAdmin / pg_dump probe during schema-tree refresh.
@@ -289,8 +294,22 @@ _SHADOW_VIEWS: tuple[str, ...] = (
     # ``LEFT JOIN pg_type et ON et.oid = t.typelem`` to resolve array
     # element types and fails the bind without ``typelem``. Both are
     # 0 for every base scalar we expose here.
-    """CREATE OR REPLACE TEMP VIEW _obsl_pg_type AS
-        SELECT * FROM (VALUES
+    # ``typnamespace``: every base type below lives in ``pg_catalog``, as in
+    # Postgres, and DuckDB's own ``postgres`` extension joins on it to
+    # enumerate a catalog. Without the column the bind fails with "does not
+    # have a column named typnamespace", which reads as a missing table
+    # rather than a missing field.
+    #
+    # The literal ``_PG_CATALOG_OID``, not a lookup. Deriving it from
+    # DuckDB's own pg_namespace was the first attempt and it dangled:
+    # DuckDB has no ``pg_catalog`` row there at all, so the lookup found
+    # nothing every time and the fallback pointed at a namespace that did
+    # not exist. Any client joining ``pg_type.typnamespace`` to
+    # ``pg_namespace.oid`` then matched no row and got an empty result with
+    # no error. The ``pg_catalog`` row the shadow below adds is what makes
+    # this oid resolve.
+    f"""CREATE OR REPLACE TEMP VIEW _obsl_pg_type AS
+        SELECT t.*, {_PG_CATALOG_OID} AS typnamespace FROM (VALUES
             -- columns: oid, typname, typcategory, typlen, typtype,
             --          typnotnull, typtypmod, typbasetype, typelem, typrelid
             (16,   'bool',        'B', 1,   'b', false, -1, 0, 0, 0),
@@ -341,14 +360,22 @@ _SHADOW_VIEWS: tuple[str, ...] = (
     # ``aclitem[]``: "Cannot invoke java.lang.CharSequence.toString()
     # because <parameter1> is null". Empty ``{}`` keeps the column
     # non-NULL without granting any privileges.
-    """CREATE OR REPLACE TEMP VIEW _obsl_pg_namespace AS
+    #
+    # The ``pg_catalog`` row is synthesized, because DuckDB does not have
+    # one and Postgres always does. Clients that resolve a type's schema -
+    # DuckDB's own ``postgres`` extension among them - join
+    # ``pg_type.typnamespace`` to ``pg_namespace.oid``, and with no row to
+    # land on that inner join discards the whole catalog silently.
+    f"""CREATE OR REPLACE TEMP VIEW _obsl_pg_namespace AS
         SELECT
             oid,
             nspname,
             COALESCE(nspowner, 10) AS nspowner,
-            COALESCE(CAST(nspacl AS VARCHAR), '{}') AS nspacl
+            COALESCE(CAST(nspacl AS VARCHAR), '{{}}') AS nspacl
         FROM pg_catalog.pg_namespace
-        WHERE nspname NOT IN ('main', 'temp', 'pg_temp')""",
+        WHERE nspname NOT IN ('main', 'temp', 'pg_temp')
+        UNION ALL
+        SELECT {_PG_CATALOG_OID}, 'pg_catalog', 10, '{{}}'""",
     # Shadow information_schema.schemata. DuckDB auto-creates a ``main``
     # schema in every attached database (``orionbelt.main``, plus
     # ``memory.main`` / ``system.main`` / ``temp.main``), so the raw view

--- a/src/orionbelt/pgwire/router.py
+++ b/src/orionbelt/pgwire/router.py
@@ -52,6 +52,7 @@ from orionbelt.pgwire.types import (
     oid_for_type_hint,
 )
 from orionbelt.service.db_executor import (
+    ColumnMeta,
     ExecutionError,
     ExecutionResult,
     ExecutionUnavailableError,
@@ -191,6 +192,7 @@ class SemanticRouter:
             references_catalog(sql)
             or references_temp_table(sql)
             or is_metadata_probe(sql)
+            or is_tableless_select(sql)
             or self._references_model_schema(sql)
         ):
             try:
@@ -221,8 +223,21 @@ class SemanticRouter:
                 message=str(exc),
             )
 
+        # DuckDB counts a table's rows by selecting nothing from it. Answer
+        # from every dimension - the model's own grain - and hand back a
+        # projection of the same shape it asked for. See
+        # ``null_projection_arity``.
+        null_arity = null_projection_arity(sql)
+        semantic_sql = sql
+        if null_arity is not None:
+            rewritten = project_every_dimension(sql, target.model)
+            if rewritten is None:
+                null_arity = None
+            else:
+                semantic_sql = rewritten
+
         try:
-            query = translate_sql_to_query(_normalize_for_obsql(sql), target.model)
+            query = translate_sql_to_query(_normalize_for_obsql(semantic_sql), target.model)
         except SQLTranslationError as exc:
             return _encode_translation_error(exc)
         except Exception as exc:  # noqa: BLE001 — broad guard at protocol boundary
@@ -354,6 +369,14 @@ class SemanticRouter:
                 code=SQLSTATE_SYSTEM_ERROR,
                 message=f"executor error: {exc}",
             )
+
+        if null_arity is not None:
+            # A row count, asked for as a projection of nothing. The values
+            # were only ever the means of counting: the client bound its
+            # result to the NULL it projected and cannot read anything else
+            # back, so neither decimal reporting nor alias recovery below has
+            # a column to apply to.
+            return _encode_result(_null_columns(len(result.rows), null_arity), result_formats)
 
         # Tableau (and other BI tools) wrap measures in expressions like
         # ``SUM("Total Sales") AS "sum:Total Sales:ok"``. The translator
@@ -970,6 +993,38 @@ def _unwrap_model_qualifier(sql: str) -> str:
 _RE_SELECT_STAR = re.compile(r"^\s*select\s+\*", re.IGNORECASE)
 
 
+#: A ``SELECT`` with no ``FROM`` at all. ``FROM`` is matched at a word
+#: boundary so ``SELECT from_date`` and ``SELECT x AS fromage`` are not
+#: mistaken for one, and a subquery's own ``FROM`` is why this is a search
+#: rather than a structural check: a literal-only projection has no subquery
+#: to confuse it, and anything with a ``FROM`` anywhere falls through to the
+#: paths that were already handling it.
+_RE_HAS_FROM = re.compile(r"\bfrom\b", re.IGNORECASE)
+
+
+def is_tableless_select(sql: str) -> bool:
+    """Whether this is a ``SELECT`` that names no table.
+
+    DuckDB's ``postgres`` extension probes for enum support with
+
+        SELECT 0 AS oid, 0 AS enumtypid, '' AS typname, '' AS enumlabel LIMIT 0
+
+    which asks only "what shape would these columns be". It references no
+    catalog table, so the catalog gate does not claim it, and it then reaches
+    the semantic translator - which rejects literal projections, correctly,
+    since a measure cannot be a string constant.
+
+    A query with no ``FROM`` cannot be a semantic query: there is no model to
+    resolve against. Answering it from the embedded DuckDB is both correct and
+    what every other engine does, and it covers the family of shape probes BI
+    tools send rather than this one query.
+    """
+    stripped = sql.strip().lstrip("(").lstrip()
+    if stripped[:6].lower() != "select":
+        return False
+    return _RE_HAS_FROM.search(stripped) is None
+
+
 def is_metadata_probe(sql: str) -> bool:
     """Return ``True`` for ``SELECT *`` column-discovery probes.
 
@@ -1329,3 +1384,67 @@ def _log_data_row(
         else:
             parts.append(f"{col.name}={raw_value!r}(hint={col.type_hint}) -> text({enc!r})")
     logger.debug("pgwire DataRow[%d]: %s", row_idx, " | ".join(parts))
+
+
+def null_projection_arity(sql: str) -> int | None:
+    """How many ``NULL`` literals a ``SELECT`` projects, when it projects only those.
+
+    DuckDB's ``postgres`` extension asks a table for its row count by
+    projecting nothing from it: ``SELECT count(*) FROM t`` leaves the client
+    as ``SELECT NULL FROM t``, and the count is taken from how many rows come
+    back. There is no column to resolve, so the semantic translator rejects it
+    - correctly, on its own terms - and every ``count(*)`` over a model fails
+    with a message about bare column references.
+
+    The count is well defined even though the projection is empty: the model's
+    virtual table has one row per combination of its dimensions, which is the
+    grain a ``SELECT *`` over it already returns. So the query is answered by
+    selecting every dimension and then discarding the values.
+
+    Returns ``None`` for anything else, table-less ``SELECT NULL`` included -
+    that one has no model to count and the catalog gate has already claimed it.
+    """
+    try:
+        parsed = sqlglot.parse_one(sql, read="postgres")
+    except Exception:  # noqa: BLE001 - unparseable is "not this shape"
+        return None
+    # ``from_``, not ``from`` - sqlglot 30 renamed the arg (see
+    # ``_FLATTEN_ALLOWED_ARGS``). The old key reads as absent, which would
+    # make every SELECT look table-less and answer a count with no rows.
+    if not isinstance(parsed, exp.Select) or not parsed.args.get("from_"):
+        return None
+    if not parsed.expressions:
+        return None
+    for item in parsed.expressions:
+        node = item.this if isinstance(item, exp.Alias) else item
+        if not isinstance(_flatten_unwrap(node), exp.Null):
+            return None
+    return len(parsed.expressions)
+
+
+def project_every_dimension(sql: str, model: SemanticModel) -> str | None:
+    """Rewrite a NULL-only projection to select every dimension instead.
+
+    ``WHERE`` / ``ORDER BY`` / ``LIMIT`` are left alone, so a filtered count
+    still counts the filtered rows. Returns ``None`` when the model declares no
+    dimensions, which leaves the translator to reject the query as before
+    rather than inventing an answer.
+    """
+    names = list(model.dimensions)
+    if not names:
+        return None
+    try:
+        parsed = sqlglot.parse_one(sql, read="postgres")
+    except Exception:  # noqa: BLE001
+        return None
+    parsed.set("expressions", [exp.column(name, quoted=True) for name in names])
+    return parsed.sql(dialect="postgres")
+
+
+def _null_columns(row_count: int, arity: int) -> ExecutionResult:
+    """A result of *row_count* rows, each *arity* NULLs wide."""
+    return ExecutionResult(
+        columns=[ColumnMeta("NULL", "string") for _ in range(arity)],
+        raw_rows=[[None] * arity for _ in range(row_count)],
+        row_count=row_count,
+    )

--- a/src/orionbelt/pgwire/router.py
+++ b/src/orionbelt/pgwire/router.py
@@ -230,7 +230,7 @@ class SemanticRouter:
         null_arity = null_projection_arity(sql)
         semantic_sql = sql
         if null_arity is not None:
-            rewritten = project_every_dimension(sql, target.model)
+            rewritten = project_the_whole_model(sql, target.model)
             if rewritten is None:
                 null_arity = None
             else:
@@ -1396,10 +1396,10 @@ def null_projection_arity(sql: str) -> int | None:
     - correctly, on its own terms - and every ``count(*)`` over a model fails
     with a message about bare column references.
 
-    The count is well defined even though the projection is empty: the model's
-    virtual table has one row per combination of its dimensions, which is the
-    grain a ``SELECT *`` over it already returns. So the query is answered by
-    selecting every dimension and then discarding the values.
+    The count is well defined even though the projection is empty: it is the
+    number of rows a ``SELECT *`` over the virtual table returns. So the query
+    is answered by projecting exactly that and discarding the values - see
+    ``project_the_whole_model``, and note that "exactly that" is load-bearing.
 
     Returns ``None`` for anything else, table-less ``SELECT NULL`` included -
     that one has no model to count and the catalog gate has already claimed it.
@@ -1422,15 +1422,26 @@ def null_projection_arity(sql: str) -> int | None:
     return len(parsed.expressions)
 
 
-def project_every_dimension(sql: str, model: SemanticModel) -> str | None:
-    """Rewrite a NULL-only projection to select every dimension instead.
+def project_the_whole_model(sql: str, model: SemanticModel) -> str | None:
+    """Rewrite a NULL-only projection to select every column of the model.
+
+    Every column, not just the dimensions. Dimensions alone were the first
+    attempt and they count a different thing: a dimension-only query needs no
+    fact table, so the compiler picks a different base object and a narrower
+    join scope, and a dimension value with no facts behind it - a customer who
+    has never ordered - becomes a row. ``count(*)`` then exceeded what
+    ``SELECT *`` returned, which is the one number it has to agree with.
+
+    Projecting dimensions + measures + metrics is exactly what ``SELECT *``
+    over the virtual table expands to (see ``catalog._model_columns``), so the
+    count matches it by construction rather than by coincidence.
 
     ``WHERE`` / ``ORDER BY`` / ``LIMIT`` are left alone, so a filtered count
-    still counts the filtered rows. Returns ``None`` when the model declares no
-    dimensions, which leaves the translator to reject the query as before
+    still counts the filtered rows. Returns ``None`` when the model exposes no
+    columns at all, which leaves the translator to reject the query as before
     rather than inventing an answer.
     """
-    names = list(model.dimensions)
+    names = [*model.dimensions, *model.effective_measures, *model.metrics]
     if not names:
         return None
     try:

--- a/src/orionbelt/pgwire/server.py
+++ b/src/orionbelt/pgwire/server.py
@@ -33,6 +33,7 @@ from orionbelt.pgwire.auth import (
 )
 from orionbelt.pgwire.extended import ExtendedSession
 from orionbelt.pgwire.scram import SCRAM_SHA_256, ScramError, ScramServerExchange
+from orionbelt.pgwire.statements import split_statements
 from orionbelt.service import db_executor
 
 logger = logging.getLogger(__name__)
@@ -45,6 +46,26 @@ logger = logging.getLogger(__name__)
 # reply (CommandComplete or ErrorResponse). The caller appends
 # ReadyForQuery. Steps 3+ extend this signature (parameters, portals).
 QueryHandler = Callable[..., Awaitable[bytes]]
+
+
+def _has_error_response(frames: bytes) -> bool:
+    """Whether a reply contains an ``ErrorResponse``.
+
+    Walks the frame headers rather than searching for ``b"E"``: that byte
+    occurs inside row data constantly, and a substring match would abandon a
+    batch on the letter E in someone's country name.
+    """
+    i = 0
+    n = len(frames)
+    while i + 5 <= n:
+        tag = frames[i : i + 1]
+        length = int.from_bytes(frames[i + 1 : i + 5], "big")
+        if length < 4:
+            break  # malformed; stop rather than loop forever
+        if tag == b"E":
+            return True
+        i += 1 + length
+    return False
 
 
 async def _hello_world_handler(
@@ -176,6 +197,36 @@ class PgWireServer:
     # event loop indefinitely without this — and the process becomes
     # unresponsive to Ctrl+C until the socket OS-timeouts.
     _WRITE_DRAIN_TIMEOUT_SECONDS: float = 10.0
+
+    async def _run_simple_query(self, sql: str, database: str | None) -> bytes:
+        """Run every statement in one simple-query message, in order.
+
+        The protocol allows a ``Query`` to carry several statements separated
+        by semicolons, and expects **one result set per statement** followed by
+        a single ``ReadyForQuery`` (which the caller appends). A client that
+        sends three and receives one does not report a protocol error - it
+        reads a result that is not there. DuckDB's ``postgres`` extension
+        enumerates catalogs with exactly such a batch and dies with an internal
+        error about a vector index, naming nothing that would lead you here.
+
+        On failure the rest of the batch is skipped, as Postgres does: the
+        statements after a failed one are not attempted, and the error is the
+        reply.
+        """
+        statements = split_statements(sql)
+        if len(statements) <= 1:
+            # The overwhelmingly common case, and the empty one: an empty
+            # message still gets a reply, which is what the handler produces
+            # for it today.
+            return bytes(await self._handler(sql, database))
+
+        frames = bytearray()
+        for statement in statements:
+            reply = bytes(await self._handler(statement, database))
+            frames += reply
+            if _has_error_response(reply):
+                break
+        return bytes(frames)
 
     async def _drain(self, writer: asyncio.StreamWriter) -> None:
         """``writer.drain()`` with a hard timeout so a dead client
@@ -419,7 +470,7 @@ class PgWireServer:
                 query = protocol.parse_query(body)
                 try:
                     reply = await asyncio.wait_for(
-                        self._handler(query.sql, startup.database),
+                        self._run_simple_query(query.sql, startup.database),
                         timeout=self.query_timeout,
                     )
                     writer.write(reply)

--- a/src/orionbelt/pgwire/server.py
+++ b/src/orionbelt/pgwire/server.py
@@ -214,11 +214,20 @@ class PgWireServer:
         reply.
         """
         statements = split_statements(sql)
-        if len(statements) <= 1:
-            # The overwhelmingly common case, and the empty one: an empty
-            # message still gets a reply, which is what the handler produces
-            # for it today.
-            return bytes(await self._handler(sql, database))
+        if not statements:
+            # Nothing to run: an empty message, or one that is only comments.
+            # The handler's blank-query path answers with CommandComplete,
+            # which is what a client expects for a message carrying no
+            # statement. Passing the text through instead would hand a comment
+            # to the translator, which rejects it as SQL the client never sent.
+            return bytes(await self._handler("", database))
+        if len(statements) == 1:
+            # The *cleaned* statement, not the original. The splitter has
+            # already removed trailing comments, and routing reads the text it
+            # is given: ``SELECT 1; -- from the dashboard`` still contains the
+            # word ``from``, which is enough to stop it looking table-less and
+            # send it to the semantic translator instead of the catalog.
+            return bytes(await self._handler(statements[0], database))
 
         frames = bytearray()
         for statement in statements:

--- a/src/orionbelt/pgwire/statements.py
+++ b/src/orionbelt/pgwire/statements.py
@@ -1,0 +1,151 @@
+"""Splitting a simple-query message into its statements.
+
+The Postgres simple-query protocol lets one ``Query`` message carry several
+statements separated by semicolons. The server runs them in order and replies
+with **one result set per statement**, then a single ``ReadyForQuery``. A
+client that sends three statements and receives one reply does not report a
+protocol error - it reads a result that is not there. DuckDB's ``postgres``
+extension enumerates a catalog with exactly such a batch and dies with an
+internal error naming a vector index, which says nothing about what went
+wrong.
+
+Splitting on ``;`` is the obvious implementation and the wrong one: a
+semicolon inside a string, an identifier, a comment or a dollar-quoted body
+is data, not a boundary. So this is a scanner rather than a ``split``.
+
+What it understands, all of which appear in real client traffic:
+
+* ``'...'`` string literals, with ``''`` as the escaped quote
+* ``E'...'`` escape strings, where a backslash escapes the next character
+* ``"..."`` quoted identifiers, with ``""`` as the escaped quote
+* ``$$...$$`` and ``$tag$...$tag$`` dollar quoting
+* ``--`` line comments
+* ``/* ... */`` block comments, **nested**, which Postgres allows and most
+  splitters get wrong
+"""
+
+from __future__ import annotations
+
+import re
+
+#: A dollar-quote opener: ``$$`` or ``$tag$``. The tag rules follow an
+#: identifier, and the closing delimiter must repeat it exactly.
+_DOLLAR_OPEN = re.compile(r"\$([A-Za-z_][A-Za-z0-9_]*)?\$")
+
+
+def split_statements(sql: str) -> list[str]:
+    """Split *sql* into statements, ignoring empty ones.
+
+    A single statement with no trailing semicolon comes back unchanged, so
+    the common case costs one scan and allocates one list.
+    """
+    statements: list[str] = []
+    start = 0
+    i = 0
+    n = len(sql)
+
+    while i < n:
+        ch = sql[i]
+
+        if ch == "'":
+            i = _skip_quoted(sql, i, "'")
+            continue
+        if ch == '"':
+            i = _skip_quoted(sql, i, '"')
+            continue
+        if ch in "Ee" and i + 1 < n and sql[i + 1] == "'":
+            # E'...' - a backslash escapes the next character, unlike a
+            # plain literal where only '' does.
+            i = _skip_escape_string(sql, i + 1)
+            continue
+        if ch == "$":
+            end = _skip_dollar_quoted(sql, i)
+            if end != i:
+                i = end
+                continue
+        if ch == "-" and sql.startswith("--", i):
+            newline = sql.find("\n", i)
+            i = n if newline == -1 else newline + 1
+            continue
+        if ch == "/" and sql.startswith("/*", i):
+            i = _skip_block_comment(sql, i)
+            continue
+
+        if ch == ";":
+            fragment = sql[start:i].strip()
+            if fragment:
+                statements.append(fragment)
+            start = i + 1
+
+        i += 1
+
+    tail = sql[start:].strip()
+    if tail:
+        statements.append(tail)
+    return statements
+
+
+def _skip_quoted(sql: str, i: int, quote: str) -> int:
+    """Index just past a ``'...'`` or ``"..."`` run, doubling as the escape."""
+    n = len(sql)
+    i += 1
+    while i < n:
+        if sql[i] == quote:
+            if i + 1 < n and sql[i + 1] == quote:
+                i += 2
+                continue
+            return i + 1
+        i += 1
+    return n  # unterminated: the caller sees the rest as one statement
+
+
+def _skip_escape_string(sql: str, i: int) -> int:
+    """Index just past an ``E'...'`` body, where ``\\`` escapes anything."""
+    n = len(sql)
+    i += 1
+    while i < n:
+        if sql[i] == "\\":
+            i += 2
+            continue
+        if sql[i] == "'":
+            if i + 1 < n and sql[i + 1] == "'":
+                i += 2
+                continue
+            return i + 1
+        i += 1
+    return n
+
+
+def _skip_dollar_quoted(sql: str, i: int) -> int:
+    """Index just past a dollar-quoted body, or *i* when this is not one.
+
+    ``$1`` is a parameter placeholder rather than a quote opener, which is
+    why a non-match returns the position unchanged instead of guessing.
+    """
+    match = _DOLLAR_OPEN.match(sql, i)
+    if match is None:
+        return i
+    delimiter = match.group(0)
+    close = sql.find(delimiter, match.end())
+    if close == -1:
+        return len(sql)
+    return close + len(delimiter)
+
+
+def _skip_block_comment(sql: str, i: int) -> int:
+    """Index just past a ``/* ... */`` comment. Postgres nests these."""
+    n = len(sql)
+    depth = 0
+    while i < n:
+        if sql.startswith("/*", i):
+            depth += 1
+            i += 2
+            continue
+        if sql.startswith("*/", i):
+            depth -= 1
+            i += 2
+            if depth == 0:
+                return i
+            continue
+        i += 1
+    return n

--- a/src/orionbelt/pgwire/statements.py
+++ b/src/orionbelt/pgwire/statements.py
@@ -22,6 +22,12 @@ What it understands, all of which appear in real client traffic:
 * ``--`` line comments
 * ``/* ... */`` block comments, **nested**, which Postgres allows and most
   splitters get wrong
+
+A fragment that is only comments and whitespace is dropped rather than
+returned. ``SELECT 1; -- done`` is one statement with a trailing remark, not
+two, and dispatching the remark as a second statement made the client read a
+successful result followed by an error. Comments *attached* to a statement stay
+attached: stripping them is the parser's business, not the splitter's.
 """
 
 from __future__ import annotations
@@ -72,17 +78,45 @@ def split_statements(sql: str) -> list[str]:
             continue
 
         if ch == ";":
-            fragment = sql[start:i].strip()
-            if fragment:
-                statements.append(fragment)
+            _append(statements, sql[start:i])
             start = i + 1
 
         i += 1
 
-    tail = sql[start:].strip()
-    if tail:
-        statements.append(tail)
+    _append(statements, sql[start:])
     return statements
+
+
+def _append(statements: list[str], fragment: str) -> None:
+    """Add *fragment* unless it is empty or holds nothing but comments."""
+    fragment = fragment.strip()
+    if fragment and _has_code(fragment):
+        statements.append(fragment)
+
+
+def _has_code(fragment: str) -> bool:
+    """Whether *fragment* contains anything outside comments and whitespace.
+
+    The scan mirrors :func:`split_statements` for the two comment forms and
+    stops at the first character that is neither - it does not need to
+    understand quoting, because a quote *is* such a character.
+    """
+    i = 0
+    n = len(fragment)
+    while i < n:
+        ch = fragment[i]
+        if ch.isspace():
+            i += 1
+            continue
+        if ch == "-" and fragment.startswith("--", i):
+            newline = fragment.find("\n", i)
+            i = n if newline == -1 else newline + 1
+            continue
+        if ch == "/" and fragment.startswith("/*", i):
+            i = _skip_block_comment(fragment, i)
+            continue
+        return True
+    return False
 
 
 def _skip_quoted(sql: str, i: int, quote: str) -> int:

--- a/tests/integration/test_pgwire_duckdb_client.py
+++ b/tests/integration/test_pgwire_duckdb_client.py
@@ -69,6 +69,12 @@ def pgwire_listener(tmp_path_factory: pytest.TempPathFactory) -> Iterator[int]:
     db_path = tmp_path_factory.mktemp("pgwire-duckdb") / "warehouse.duckdb"
     conn = duckdb.connect(str(db_path))
     conn.execute(_SETUP_SQL)
+    # A customer who has never ordered: a dimension value with no facts behind
+    # it. ``SELECT *`` does not return a row for it, so nothing else in this
+    # file changes - but a row count taken over the dimensions alone does, and
+    # that is exactly the bug ``test_count_star_agrees_with_select_star``
+    # exists to catch.
+    conn.execute("INSERT INTO PUBLIC.CUSTOMERS VALUES ('C3', 'DE')")
     conn.close()
 
     prev = os.environ.get("DUCKDB_DATABASE")
@@ -190,13 +196,42 @@ class TestQueryingTheModel:
         attached.execute("CREATE TABLE snapshot AS SELECT * FROM obsl.sales.model")
         assert attached.execute("SELECT count(*) FROM snapshot").fetchone() == (2,)
 
-    def test_count_star(self, attached: Any) -> None:
+    def test_count_star_agrees_with_select_star(self, attached: Any) -> None:
         """DuckDB sends this as ``SELECT NULL FROM model`` and counts the rows.
 
-        The answer is the model's own grain - one row per dimension
-        combination - which is what ``SELECT *`` over it returns.
+        Asserted against ``SELECT *`` rather than a literal, because agreeing
+        with it is the whole requirement and a literal cannot express that. The
+        warehouse holds a customer with no orders precisely so the two can
+        disagree: answering the count from the dimensions alone drops the fact
+        table from the query, and that customer becomes a third row that
+        ``SELECT *`` never returns.
         """
-        assert attached.execute("SELECT count(*) FROM obsl.sales.model").fetchone() == (2,)
+        star = attached.execute("SELECT * FROM obsl.sales.model").fetchall()
+        counted = attached.execute("SELECT count(*) FROM obsl.sales.model").fetchone()
+        assert counted == (len(star),)
+        assert counted == (2,), "the dangling dimension value must not be counted"
+
+    def test_a_dimension_only_query_counts_something_else(self, attached: Any) -> None:
+        """The asymmetry that makes the count above easy to get wrong.
+
+        ``SELECT "Customer Country"`` alone needs no fact table, so it lists
+        every country including the one with no orders - which is right, as a
+        list of countries. ``SELECT *`` asks for measures too, which anchors
+        the query to the facts and drops that country. Both are correct; they
+        are simply not the same question, and a row count answered from the
+        dimensions is answering the second one with the first.
+        """
+        dims_only = {
+            row[0]
+            for row in attached.execute(
+                'SELECT "Customer Country" FROM obsl.sales.model'
+            ).fetchall()
+        }
+        whole_model = {
+            row[0] for row in attached.execute("SELECT * FROM obsl.sales.model").fetchall()
+        }
+        assert dims_only == {"UK", "US", "DE"}
+        assert whole_model == {"UK", "US"}
 
 
 def test_binary_copy_is_the_setting_that_matters(pg_extension: Any, pgwire_listener: int) -> None:

--- a/tests/integration/test_pgwire_duckdb_client.py
+++ b/tests/integration/test_pgwire_duckdb_client.py
@@ -1,0 +1,212 @@
+"""DuckDB as a client of the pgwire surface, through ``ATTACH ... (TYPE postgres)``.
+
+This is the shape a data engineer actually wants: the semantic model appears
+as a table in their own DuckDB, so it can be joined to local files and
+persisted with ``CREATE TABLE AS`` without an OBSL-specific client library.
+
+Everything here goes through DuckDB's own ``postgres`` extension, which talks
+real Postgres wire protocol to a real listener. It is the only way to test
+this: the extension's catalog enumeration is a single 20-line join across six
+``pg_catalog`` relations, and a mistake anywhere in it returns *zero rows and
+no error*. Every gap this file guards was found that way and none of them
+raised anything.
+
+The one thing a user must do is ``SET pg_use_text_protocol = true``. Without
+it the extension reads data with ``COPY ... TO STDOUT (FORMAT binary)``, which
+the semantic surface has no reason to implement - see
+``test_binary_copy_is_the_setting_that_matters``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import threading
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+from orionbelt.pgwire.router import SemanticRouter
+from orionbelt.pgwire.server import PgWireServer
+from orionbelt.service.session_manager import SessionManager
+from tests.conftest import SAMPLE_MODEL_YAML
+from tests.integration.test_adbc_flightsql import _SETUP_SQL
+
+duckdb = pytest.importorskip("duckdb", reason="duckdb required to drive the client side")
+
+
+@pytest.fixture(scope="module")
+def pg_extension() -> Any:
+    """A DuckDB connection with the ``postgres`` extension available.
+
+    The extension is downloaded on first use, so an offline machine skips
+    rather than fails - there is nothing wrong with the code in that case.
+    """
+    conn = duckdb.connect()
+    try:
+        conn.execute("INSTALL postgres")
+        conn.execute("LOAD postgres")
+    except Exception as exc:  # noqa: BLE001 - any failure here is environmental
+        conn.close()
+        pytest.skip(f"duckdb postgres extension unavailable: {exc}")
+    conn.close()
+    return True
+
+
+@pytest.fixture(scope="module")
+def pgwire_listener(tmp_path_factory: pytest.TempPathFactory) -> Iterator[int]:
+    """A pgwire listener backed by a real DuckDB warehouse, on its own loop thread.
+
+    Own thread for the same reason the TLS suite needs one: the DuckDB client
+    is blocking, so calling it from the loop's thread starves the accept.
+    """
+    db_path = tmp_path_factory.mktemp("pgwire-duckdb") / "warehouse.duckdb"
+    conn = duckdb.connect(str(db_path))
+    conn.execute(_SETUP_SQL)
+    conn.close()
+
+    prev = os.environ.get("DUCKDB_DATABASE")
+    os.environ["DUCKDB_DATABASE"] = str(db_path)
+
+    manager = SessionManager(ttl_seconds=3600, cleanup_interval=9999)
+    manager.get_or_create_named("sales").load_model(SAMPLE_MODEL_YAML, dedup=False)
+    router = SemanticRouter(session_manager=manager, default_dialect="duckdb")
+    server = PgWireServer(
+        host="127.0.0.1",
+        port=0,
+        auth_mode="trust",
+        max_connections=16,
+        query_handler=router.handle,
+    )
+
+    ready = threading.Event()
+    bound: dict[str, int] = {}
+    loop = asyncio.new_event_loop()
+
+    def run() -> None:
+        asyncio.set_event_loop(loop)
+        bound["port"] = loop.run_until_complete(server.start())
+        ready.set()
+        # ``run_forever``, not ``serve_forever``: ``start()`` is already
+        # accepting connections, and stopping the loop out from under
+        # ``serve_forever`` leaves its future pending - which surfaces as an
+        # unraisable thread exception attributed to whichever test ran last.
+        loop.run_forever()
+
+    thread = threading.Thread(target=run, name="pgwire-duckdb-test", daemon=True)
+    thread.start()
+    assert ready.wait(30), "pgwire listener did not start"
+
+    try:
+        yield bound["port"]
+    finally:
+        # ``stop()`` first, then the loop: stopping the loop out from under
+        # ``serve_forever`` leaves its future pending and pytest reports the
+        # unraisable as a failure of whichever test happens to be last.
+        asyncio.run_coroutine_threadsafe(server.stop(), loop).result(timeout=5)
+        loop.call_soon_threadsafe(loop.stop)
+        thread.join(timeout=5)
+        manager.stop()
+        if prev is None:
+            os.environ.pop("DUCKDB_DATABASE", None)
+        else:
+            os.environ["DUCKDB_DATABASE"] = prev
+
+
+def _attach(port: int, *, text_protocol: bool = True) -> Any:
+    conn = duckdb.connect()
+    conn.execute("INSTALL postgres")
+    conn.execute("LOAD postgres")
+    if text_protocol:
+        conn.execute("SET pg_use_text_protocol = true")
+    conn.execute(
+        f"ATTACH 'host=127.0.0.1 port={port} dbname=sales user=obsl' "
+        f"AS obsl (TYPE postgres, READ_ONLY)"
+    )
+    return conn
+
+
+@pytest.fixture
+def attached(pg_extension: Any, pgwire_listener: int) -> Iterator[Any]:
+    conn = _attach(pgwire_listener)
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+class TestTheCatalogEnumerates:
+    def test_the_model_shows_up_as_a_table(self, attached: Any) -> None:
+        """The assertion the ``pg_catalog`` work exists for.
+
+        Before it this came back empty, with ATTACH reporting success.
+        """
+        rows = attached.execute(
+            "SELECT schema, name FROM (SHOW ALL TABLES) WHERE database = 'obsl'"
+        ).fetchall()
+        assert ("sales", "model") in rows
+
+    def test_columns_arrive_with_their_semantic_types(self, attached: Any) -> None:
+        """A measure must not land as text; DuckDB reads the Postgres type OID."""
+        types = dict(
+            attached.execute(
+                "SELECT column_name, data_type FROM duckdb_columns() WHERE table_name = 'model'"
+            ).fetchall()
+        )
+        assert types["Customer Country"] == "VARCHAR"
+        assert types["Total Revenue"] == "DOUBLE"
+        assert types["Order Count"] == "BIGINT"
+
+
+class TestQueryingTheModel:
+    def test_by_name(self, attached: Any) -> None:
+        rows = attached.execute(
+            'SELECT "Customer Country", "Total Revenue" FROM obsl.sales.model ORDER BY 1'
+        ).fetchall()
+        assert rows == [("UK", 75.0), ("US", 150.0)]
+
+    def test_a_filter(self, attached: Any) -> None:
+        rows = attached.execute(
+            'SELECT "Total Revenue" FROM obsl.sales.model WHERE "Customer Country" = \'US\''
+        ).fetchall()
+        assert rows == [(150.0,)]
+
+    def test_joined_to_a_local_table(self, attached: Any) -> None:
+        """The point of the whole exercise: the model composes with local data."""
+        attached.execute("CREATE TABLE targets AS SELECT 'US' AS country, 120.0 AS target")
+        rows = attached.execute(
+            'SELECT m."Customer Country", m."Total Revenue" > t.target AS beat '
+            'FROM obsl.sales.model m JOIN targets t ON m."Customer Country" = t.country'
+        ).fetchall()
+        assert rows == [("US", True)]
+
+    def test_materialised_locally(self, attached: Any) -> None:
+        attached.execute("CREATE TABLE snapshot AS SELECT * FROM obsl.sales.model")
+        assert attached.execute("SELECT count(*) FROM snapshot").fetchone() == (2,)
+
+    def test_count_star(self, attached: Any) -> None:
+        """DuckDB sends this as ``SELECT NULL FROM model`` and counts the rows.
+
+        The answer is the model's own grain - one row per dimension
+        combination - which is what ``SELECT *`` over it returns.
+        """
+        assert attached.execute("SELECT count(*) FROM obsl.sales.model").fetchone() == (2,)
+
+
+def test_binary_copy_is_the_setting_that_matters(pg_extension: Any, pgwire_listener: int) -> None:
+    """Without the text protocol, reads fail and the catalog still works.
+
+    Pinned because the failure names ``COPY`` and a parse error, which reads
+    like a broken query rather than a protocol the surface does not speak, and
+    because it is the one line of setup a user has to be told about.
+    """
+    conn = _attach(pgwire_listener, text_protocol=False)
+    try:
+        rows = conn.execute("SELECT name FROM (SHOW ALL TABLES) WHERE database = 'obsl'").fetchall()
+        assert ("model",) in rows
+
+        with pytest.raises(Exception, match="(?i)copy"):
+            conn.execute('SELECT "Customer Country" FROM obsl.sales.model').fetchall()
+    finally:
+        conn.close()

--- a/tests/integration/test_pgwire_duckdb_client.py
+++ b/tests/integration/test_pgwire_duckdb_client.py
@@ -20,18 +20,23 @@ the semantic surface has no reason to implement - see
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import os
+import pathlib
 import threading
 from collections.abc import Iterator
 from typing import Any
 
 import pytest
 
+from orionbelt.auth import init_auth, reset_auth
 from orionbelt.pgwire.router import SemanticRouter
 from orionbelt.pgwire.server import PgWireServer
 from orionbelt.service.session_manager import SessionManager
+from orionbelt.service.tls import load_listener_tls
 from tests.conftest import SAMPLE_MODEL_YAML
 from tests.integration.test_adbc_flightsql import _SETUP_SQL
+from tests.integration.test_pgwire_tls import _pki
 
 duckdb = pytest.importorskip("duckdb", reason="duckdb required to drive the client side")
 
@@ -210,3 +215,233 @@ def test_binary_copy_is_the_setting_that_matters(pg_extension: Any, pgwire_liste
             conn.execute('SELECT "Customer Country" FROM obsl.sales.model').fetchall()
     finally:
         conn.close()
+
+
+@pytest.fixture(scope="module")
+def tls_listener(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Iterator[tuple[int, dict[str, str]]]:
+    pytest.importorskip("cryptography", reason="cryptography required to mint test certs")
+    out = tmp_path_factory.mktemp("pgwire-duckdb-tls")
+    pki = _pki(out)
+
+    db_path = out / "warehouse.duckdb"
+    conn = duckdb.connect(str(db_path))
+    conn.execute(_SETUP_SQL)
+    conn.close()
+
+    prev = os.environ.get("DUCKDB_DATABASE")
+    os.environ["DUCKDB_DATABASE"] = str(db_path)
+
+    manager = SessionManager(ttl_seconds=3600, cleanup_interval=9999)
+    manager.get_or_create_named("sales").load_model(SAMPLE_MODEL_YAML, dedup=False)
+    router = SemanticRouter(session_manager=manager, default_dialect="duckdb")
+    server = PgWireServer(
+        host="127.0.0.1",
+        port=0,
+        auth_mode="trust",
+        max_connections=16,
+        tls=load_listener_tls(pki["cert"], pki["key"], prefix="PGWIRE"),
+        query_handler=router.handle,
+    )
+
+    ready = threading.Event()
+    bound: dict[str, int] = {}
+    loop = asyncio.new_event_loop()
+
+    def run() -> None:
+        asyncio.set_event_loop(loop)
+        bound["port"] = loop.run_until_complete(server.start())
+        ready.set()
+        loop.run_forever()
+
+    thread = threading.Thread(target=run, name="pgwire-duckdb-tls-test", daemon=True)
+    thread.start()
+    assert ready.wait(30), "TLS pgwire listener did not start"
+    try:
+        yield bound["port"], pki
+    finally:
+        asyncio.run_coroutine_threadsafe(server.stop(), loop).result(timeout=5)
+        loop.call_soon_threadsafe(loop.stop)
+        thread.join(timeout=5)
+        manager.stop()
+        if prev is None:
+            os.environ.pop("DUCKDB_DATABASE", None)
+        else:
+            os.environ["DUCKDB_DATABASE"] = prev
+
+
+class TestOverTLS:
+    """``ATTACH`` against a TLS listener, which needs nothing added to it.
+
+    The extension is libpq underneath and passes the whole connection string
+    through, so ``sslmode`` and ``sslrootcert`` work exactly as they do for
+    ``psql``. Worth pinning rather than assuming: it is the difference between
+    the surface being usable from DuckDB over an untrusted network and not.
+    """
+
+    def _read(self, port: int, extra: str) -> list[tuple[Any, ...]]:
+        conn = duckdb.connect()
+        try:
+            conn.execute("INSTALL postgres")
+            conn.execute("LOAD postgres")
+            conn.execute("SET pg_use_text_protocol = true")
+            conn.execute(
+                f"ATTACH 'host=127.0.0.1 port={port} dbname=sales user=obsl {extra}' "
+                f"AS obsl (TYPE postgres, READ_ONLY)"
+            )
+            return conn.execute(
+                'SELECT "Customer Country", "Total Revenue" FROM obsl.sales.model ORDER BY 1'
+            ).fetchall()
+        finally:
+            conn.close()
+
+    @pytest.mark.parametrize("sslmode", ["disable", "prefer", "require"])
+    def test_the_modes_that_need_no_certificate(
+        self, pg_extension: Any, tls_listener: tuple[int, dict[str, str]], sslmode: str
+    ) -> None:
+        port, _ = tls_listener
+        assert self._read(port, f"sslmode={sslmode}") == [("UK", 75.0), ("US", 150.0)]
+
+    @pytest.mark.parametrize("sslmode", ["verify-ca", "verify-full"])
+    def test_the_modes_that_verify(
+        self, pg_extension: Any, tls_listener: tuple[int, dict[str, str]], sslmode: str
+    ) -> None:
+        port, pki = tls_listener
+        extra = f"sslmode={sslmode} sslrootcert={pki['ca']}"
+        assert self._read(port, extra) == [("UK", 75.0), ("US", 150.0)]
+
+    def test_the_wrong_trust_anchor_is_refused(
+        self, pg_extension: Any, tls_listener: tuple[int, dict[str, str]]
+    ) -> None:
+        """What makes the five above mean something: verification is real."""
+        port, pki = tls_listener
+        with pytest.raises(Exception, match="(?i)certificate|ssl"):
+            self._read(port, f"sslmode=verify-ca sslrootcert={pki['other_ca']}")
+
+
+# A well-formed key: ``init_auth`` refuses short or low-entropy ones, because a
+# weak key is attackable offline from a captured SCRAM transcript.
+_API_KEY = "obsl_pat_" + "a3f9" * 10
+
+
+@pytest.fixture
+def api_key_auth() -> Iterator[str]:
+    reset_auth()
+    init_auth(auth_mode="api_key", api_keys=_API_KEY)
+    try:
+        yield _API_KEY
+    finally:
+        reset_auth()
+
+
+@contextlib.contextmanager
+def _listener(auth_mode: str) -> Iterator[int]:
+    """A listener in *auth_mode*, yielding its port. Shared by the auth tests."""
+    manager = SessionManager(ttl_seconds=3600, cleanup_interval=9999)
+    manager.get_or_create_named("sales").load_model(SAMPLE_MODEL_YAML, dedup=False)
+    router = SemanticRouter(session_manager=manager, default_dialect="duckdb")
+    server = PgWireServer(
+        host="127.0.0.1",
+        port=0,
+        auth_mode=auth_mode,
+        max_connections=16,
+        query_handler=router.handle,
+    )
+    ready = threading.Event()
+    bound: dict[str, int] = {}
+    loop = asyncio.new_event_loop()
+
+    def run() -> None:
+        asyncio.set_event_loop(loop)
+        bound["port"] = loop.run_until_complete(server.start())
+        ready.set()
+        loop.run_forever()
+
+    thread = threading.Thread(target=run, name=f"pgwire-{auth_mode}-test", daemon=True)
+    thread.start()
+    assert ready.wait(30), "pgwire listener did not start"
+    try:
+        yield bound["port"]
+    finally:
+        asyncio.run_coroutine_threadsafe(server.stop(), loop).result(timeout=5)
+        loop.call_soon_threadsafe(loop.stop)
+        thread.join(timeout=5)
+        manager.stop()
+
+
+class TestAuthentication:
+    """The API key is the password, and DuckDB has nothing special to do.
+
+    ``AUTH_MODE=api_key`` makes the listener demand a credential; the mechanism
+    is SCRAM-SHA-256 unless an operator opts down to cleartext. Both are libpq's
+    to perform, so ``password=<key>`` in the connection string is the whole of
+    the client side - which is worth pinning, because SCRAM is the default and
+    a client that could not do it would be locked out of an authenticated
+    deployment entirely.
+    """
+
+    @pytest.fixture
+    def warehouse(self, tmp_path: pathlib.Path) -> Iterator[pathlib.Path]:
+        db_path = tmp_path / "warehouse.duckdb"
+        conn = duckdb.connect(str(db_path))
+        conn.execute(_SETUP_SQL)
+        conn.close()
+        prev = os.environ.get("DUCKDB_DATABASE")
+        os.environ["DUCKDB_DATABASE"] = str(db_path)
+        try:
+            yield db_path
+        finally:
+            if prev is None:
+                os.environ.pop("DUCKDB_DATABASE", None)
+            else:
+                os.environ["DUCKDB_DATABASE"] = prev
+
+    def _read(self, port: int, extra: str) -> list[tuple[Any, ...]]:
+        conn = duckdb.connect()
+        try:
+            conn.execute("INSTALL postgres")
+            conn.execute("LOAD postgres")
+            conn.execute("SET pg_use_text_protocol = true")
+            conn.execute(
+                f"ATTACH 'host=127.0.0.1 port={port} dbname=sales user=obsl {extra}' "
+                f"AS obsl (TYPE postgres, READ_ONLY)"
+            )
+            return conn.execute('SELECT "Customer Country" FROM obsl.sales.model').fetchall()
+        finally:
+            conn.close()
+
+    @pytest.mark.parametrize("auth_mode", ["scram", "password"])
+    def test_the_api_key_is_the_password(
+        self,
+        pg_extension: Any,
+        api_key_auth: str,
+        warehouse: pathlib.Path,
+        auth_mode: str,
+    ) -> None:
+        """``scram`` is the default; ``password`` is the cleartext opt-in."""
+        with _listener(auth_mode) as port:
+            assert len(self._read(port, f"password={api_key_auth}")) == 2
+
+    @pytest.mark.parametrize("auth_mode", ["scram", "password"])
+    def test_a_wrong_key_is_refused(
+        self,
+        pg_extension: Any,
+        api_key_auth: str,
+        warehouse: pathlib.Path,
+        auth_mode: str,
+    ) -> None:
+        with (
+            _listener(auth_mode) as port,
+            pytest.raises(Exception, match="(?i)authentication failed|invalid api key"),
+        ):
+            self._read(port, "password=wrong")
+
+    def test_no_password_is_refused(
+        self, pg_extension: Any, api_key_auth: str, warehouse: pathlib.Path
+    ) -> None:
+        with (
+            _listener("scram") as port,
+            pytest.raises(Exception, match="(?i)authentication failed"),
+        ):
+            self._read(port, "")

--- a/tests/integration/test_pgwire_duckdb_client.py
+++ b/tests/integration/test_pgwire_duckdb_client.py
@@ -475,8 +475,17 @@ class TestAuthentication:
     def test_no_password_is_refused(
         self, pg_extension: Any, api_key_auth: str, warehouse: pathlib.Path
     ) -> None:
+        """Refused - by whichever side gets there first.
+
+        Some libpq builds decline to send an empty credential for SCRAM at all
+        (``fe_sendauth: no password supplied``) rather than letting the server
+        answer; others complete the exchange and are rejected. Both are the
+        same outcome, and which one happens is a property of the client build
+        rather than of this surface. Asserting only the server's message passed
+        locally and failed on CI.
+        """
         with (
             _listener("scram") as port,
-            pytest.raises(Exception, match="(?i)authentication failed"),
+            pytest.raises(Exception, match="(?i)authentication failed|no password supplied"),
         ):
             self._read(port, "")

--- a/tests/integration/test_pgwire_psycopg3.py
+++ b/tests/integration/test_pgwire_psycopg3.py
@@ -165,3 +165,52 @@ def test_psycopg3_semantic_query_returns_rows(
     assert rows == [("DE", 1234), ("US", 9876)]
     assert description is not None
     assert [d.name for d in description] == ["Customer Country", "Total Revenue"]
+
+
+class TestMultiStatementSimpleQuery:
+    """One ``Query`` message carrying several statements, driven by libpq.
+
+    The protocol allows it and expects one result set per statement, then a
+    single ``ReadyForQuery``. psycopg exposes the sequence through
+    ``nextset()``, which is the only way to see from a client whether the
+    server ran all of them or quietly ran the first.
+    """
+
+    def test_every_statement_produces_a_result(
+        self, pgwire_with_router_psycopg: tuple[PgWireServer, int]
+    ) -> None:
+        _, port = pgwire_with_router_psycopg
+        with psycopg.connect(_dsn(port), autocommit=True) as conn, conn.cursor() as cur:
+            cur.execute("SELECT 1; SELECT 2; SELECT 3")
+            seen = [cur.fetchall()]
+            while cur.nextset():
+                seen.append(cur.fetchall())
+        assert seen == [[(1,)], [(2,)], [(3,)]]
+
+    def test_a_trailing_comment_is_not_a_statement(
+        self, pgwire_with_router_psycopg: tuple[PgWireServer, int]
+    ) -> None:
+        """``SELECT 1; -- done`` is one statement with a remark, not two.
+
+        Dispatching the remark made the client read a successful result and
+        then an ``ErrorResponse`` for something it never sent. libpq raises on
+        that error, so a clean ``fetchall`` here is the assertion.
+        """
+        _, port = pgwire_with_router_psycopg
+        with psycopg.connect(_dsn(port), autocommit=True) as conn, conn.cursor() as cur:
+            cur.execute("SELECT 1; -- trailing comment")
+            rows = cur.fetchall()
+            assert cur.nextset() is None, "the comment must not produce a second result"
+        assert rows == [(1,)]
+
+    def test_a_failing_statement_stops_the_batch(
+        self, pgwire_with_router_psycopg: tuple[PgWireServer, int]
+    ) -> None:
+        """Postgres abandons the rest of the batch, and so do we."""
+        _, port = pgwire_with_router_psycopg
+        with (
+            psycopg.connect(_dsn(port), autocommit=True) as conn,
+            conn.cursor() as cur,
+            pytest.raises(psycopg.Error),
+        ):
+            cur.execute("SELECT 1; SELECT nonsense FROM nowhere; SELECT 3")

--- a/tests/integration/test_pgwire_psycopg3.py
+++ b/tests/integration/test_pgwire_psycopg3.py
@@ -203,6 +203,33 @@ class TestMultiStatementSimpleQuery:
             assert cur.nextset() is None, "the comment must not produce a second result"
         assert rows == [(1,)]
 
+    def test_a_trailing_comment_does_not_steer_routing(
+        self, pgwire_with_router_psycopg: tuple[PgWireServer, int]
+    ) -> None:
+        """The cleaned statement is what runs, not the text the client sent.
+
+        Routing reads the SQL it is given, and a word inside a discarded
+        comment is still in that text. ``-- from client`` contains ``from``,
+        which is enough to stop ``SELECT 1`` looking table-less and send it to
+        the semantic translator, which has no model for it. The comment is
+        removed before the split *and* before the dispatch, or removing it
+        achieves nothing.
+        """
+        _, port = pgwire_with_router_psycopg
+        with psycopg.connect(_dsn(port), autocommit=True) as conn, conn.cursor() as cur:
+            cur.execute("SELECT 1; -- from client")
+            assert cur.fetchall() == [(1,)]
+
+    def test_a_message_of_only_comments_is_an_empty_query(
+        self, pgwire_with_router_psycopg: tuple[PgWireServer, int]
+    ) -> None:
+        """No statement means no result, not an error about SQL never sent."""
+        _, port = pgwire_with_router_psycopg
+        with psycopg.connect(_dsn(port), autocommit=True) as conn, conn.cursor() as cur:
+            cur.execute("-- just a note")
+            assert cur.pgresult is not None
+            assert cur.rowcount in (-1, 0)
+
     def test_a_failing_statement_stops_the_batch(
         self, pgwire_with_router_psycopg: tuple[PgWireServer, int]
     ) -> None:

--- a/tests/integration/test_pgwire_tls.py
+++ b/tests/integration/test_pgwire_tls.py
@@ -132,7 +132,11 @@ def tls_pgwire(tmp_path_factory: pytest.TempPathFactory) -> Iterator[tuple[int, 
         asyncio.set_event_loop(loop)
         bound["port"] = loop.run_until_complete(server.start())
         ready.set()
-        loop.run_until_complete(server.serve_forever())
+        # ``run_forever``, not ``serve_forever``: ``start()`` is already
+        # accepting connections, and stopping the loop out from under
+        # ``serve_forever`` leaves its future pending, which pytest reports as
+        # an unraisable thread exception against an unrelated test.
+        loop.run_forever()
 
     thread = threading.Thread(target=run, name="pgwire-tls-test", daemon=True)
     thread.start()
@@ -141,6 +145,7 @@ def tls_pgwire(tmp_path_factory: pytest.TempPathFactory) -> Iterator[tuple[int, 
     try:
         yield bound["port"], pki
     finally:
+        asyncio.run_coroutine_threadsafe(server.stop(), loop).result(timeout=5)
         loop.call_soon_threadsafe(loop.stop)
         thread.join(timeout=5)
 
@@ -205,7 +210,7 @@ class TestWithoutTLS:
             asyncio.set_event_loop(loop)
             bound["port"] = loop.run_until_complete(server.start())
             ready.set()
-            loop.run_until_complete(server.serve_forever())
+            loop.run_forever()  # see the module fixture
 
         thread = threading.Thread(target=run, name="pgwire-plain-test", daemon=True)
         thread.start()
@@ -215,5 +220,6 @@ class TestWithoutTLS:
             # negotiation working, not failing.
             assert _encrypted(bound["port"], sslmode="prefer") is False
         finally:
+            asyncio.run_coroutine_threadsafe(server.stop(), loop).result(timeout=5)
             loop.call_soon_threadsafe(loop.stop)
             thread.join(timeout=5)

--- a/tests/unit/test_pgwire_catalog.py
+++ b/tests/unit/test_pgwire_catalog.py
@@ -314,3 +314,61 @@ def test_catalog_type_uses_default_numeric_data_type() -> None:
     assert _measure_sql_type(explicit, "decimal(18, 2)") == "DECIMAL(10, 4)"
     # No default + no dataType -> coarse DOUBLE.
     assert _measure_sql_type(no_dt, None) == "DOUBLE"
+
+
+class TestTypeNamespaceResolves:
+    """``pg_type.typnamespace`` has to point at a namespace that exists.
+
+    DuckDB's ``postgres`` extension enumerates an attached catalog with one
+    query that inner-joins ``pg_type.typnamespace`` to ``pg_namespace.oid``.
+    An oid with no row behind it is not an error - the join simply matches
+    nothing, the whole enumeration comes back empty, and DuckDB reports an
+    attached database with no tables in it. Nothing anywhere says why.
+    """
+
+    def test_pg_catalog_is_a_namespace(self, manager_with_model: SessionManager) -> None:
+        """DuckDB has no ``pg_catalog`` row of its own; Postgres always does."""
+        emu = CatalogEmulator()
+        emu.refresh(manager_with_model)
+        result = emu.execute("SELECT oid FROM pg_namespace WHERE nspname = 'pg_catalog'")
+        assert [row[0] for row in result.rows] == [11]
+
+    def test_every_type_resolves_to_a_namespace(self, manager_with_model: SessionManager) -> None:
+        emu = CatalogEmulator()
+        emu.refresh(manager_with_model)
+        result = emu.execute(
+            "SELECT t.typname, n.nspname FROM pg_type t "
+            "JOIN pg_namespace n ON t.typnamespace = n.oid"
+        )
+        resolved = {row[0]: row[1] for row in result.rows}
+        total = emu.execute("SELECT count(*) FROM pg_type").rows[0][0]
+        assert len(resolved) == total, "a type's namespace did not resolve"
+        assert set(resolved.values()) == {"pg_catalog"}
+
+    def test_the_enumeration_duckdb_actually_sends(
+        self, manager_with_model: SessionManager
+    ) -> None:
+        """Verbatim in shape from the ``postgres`` extension's ATTACH probe.
+
+        The ``type_ns`` join is the one that used to empty the result; the
+        rest is here so the test fails for the same reason the extension
+        would, rather than for a simplification of it.
+        """
+        emu = CatalogEmulator()
+        emu.refresh(manager_with_model)
+        result = emu.execute(
+            "SELECT pg_namespace.oid AS namespace_id, relname, attname, "
+            "pg_type.typname AS type_name, attnum, type_ns.nspname AS type_schema "
+            "FROM pg_class "
+            "JOIN pg_namespace ON relnamespace = pg_namespace.oid "
+            "JOIN pg_attribute ON pg_class.oid = pg_attribute.attrelid "
+            "JOIN pg_type ON atttypid = pg_type.oid "
+            "JOIN pg_namespace type_ns ON pg_type.typnamespace = type_ns.oid "
+            "WHERE attnum > 0 AND relkind IN ('r', 'v', 'm', 'f', 'p') "
+            "AND pg_namespace.nspname IN ('commerce') AND relname = 'model' "
+            "ORDER BY attnum"
+        )
+        columns = [row[2] for row in result.rows]
+        assert "Customer Country" in columns
+        assert "Total Revenue" in columns
+        assert {row[5] for row in result.rows} == {"pg_catalog"}

--- a/tests/unit/test_pgwire_router.py
+++ b/tests/unit/test_pgwire_router.py
@@ -16,7 +16,7 @@ from orionbelt.pgwire.router import (
     _strip_collate_annotations,
     _unwrap_model_qualifier,
     null_projection_arity,
-    project_every_dimension,
+    project_the_whole_model,
 )
 from orionbelt.service.db_executor import ColumnMeta, ExecutionResult
 from orionbelt.service.session_manager import SessionManager
@@ -790,28 +790,56 @@ class TestCountingRowsThroughAnEmptyProjection:
     def test_unparseable_sql_is_not(self) -> None:
         assert null_projection_arity("SELECT NULL FROM (((") is None
 
-    def test_the_rewrite_selects_every_dimension_and_keeps_the_filter(self) -> None:
+    def test_the_rewrite_selects_the_whole_model_and_keeps_the_filter(self) -> None:
+        """Every column, because the count has to agree with ``SELECT *``."""
         mgr, model_id = _make_manager_with_model()
         try:
             model = mgr.get_or_create_named("commerce").get_model(model_id)
-            rewritten = project_every_dimension(
+            rewritten = project_the_whole_model(
                 'SELECT NULL FROM "commerce"."model" WHERE "Customer Country" = \'US\'',
                 model,
             )
             assert rewritten is not None
-            for name in model.dimensions:
+            for name in (*model.dimensions, *model.effective_measures, *model.metrics):
                 assert f'"{name}"' in rewritten
             assert "NULL" not in rewritten
             assert "'US'" in rewritten
         finally:
             mgr.stop()
 
-    def test_a_model_with_no_dimensions_is_left_to_the_translator(self) -> None:
+    def test_the_rewrite_keeps_the_measures_that_anchor_the_grain(self) -> None:
+        """The measures are not decoration; they decide what is counted.
+
+        A dimension-only query needs no fact table, so the compiler picks a
+        different base object and a narrower join scope, and a dimension value
+        with no facts behind it becomes a row that ``SELECT *`` would never
+        return. Pinned as a column-set identity here; the row-count difference
+        it causes needs a warehouse holding such a value, and is covered in the
+        DuckDB client suite.
+        """
+        mgr, model_id = _make_manager_with_model()
+        try:
+            model = mgr.get_or_create_named("commerce").get_model(model_id)
+            assert model.effective_measures, "fixture must expose measures"
+            rewritten = project_the_whole_model("SELECT NULL FROM t", model)
+            assert rewritten is not None
+            for name in model.effective_measures:
+                assert f'"{name}"' in rewritten
+        finally:
+            mgr.stop()
+
+    def test_a_model_with_no_columns_is_left_to_the_translator(self) -> None:
         """Better a clear rejection than a count of a grain we invented."""
         mgr, model_id = _make_manager_with_model()
         try:
             model = mgr.get_or_create_named("commerce").get_model(model_id).model_copy(deep=True)
             model.dimensions = {}
-            assert project_every_dimension("SELECT NULL FROM t", model) is None
+            model.measures = {}
+            model.metrics = {}
+            # ``effective_measures`` synthesizes a row count per countable data
+            # object, so clearing ``measures`` is not enough to empty it.
+            model.data_objects = {}
+            assert not model.effective_measures
+            assert project_the_whole_model("SELECT NULL FROM t", model) is None
         finally:
             mgr.stop()

--- a/tests/unit/test_pgwire_router.py
+++ b/tests/unit/test_pgwire_router.py
@@ -15,6 +15,8 @@ from orionbelt.pgwire.router import (
     _rewrite_fetch_to_limit,
     _strip_collate_annotations,
     _unwrap_model_qualifier,
+    null_projection_arity,
+    project_every_dimension,
 )
 from orionbelt.service.db_executor import ColumnMeta, ExecutionResult
 from orionbelt.service.session_manager import SessionManager
@@ -756,3 +758,60 @@ class TestPgwireReconcilesWithoutACache:
         root = pathlib.Path(__file__).resolve().parents[2] / "src" / "orionbelt"
         source = (root / "pgwire" / "router.py").read_text()
         assert source.count("declared_arrow_types(target.model, query)") >= 3
+
+
+class TestCountingRowsThroughAnEmptyProjection:
+    """``SELECT count(*) FROM <model>`` from DuckDB's ``postgres`` extension.
+
+    It never sends the ``count``. It asks for a projection of nothing -
+    ``SELECT NULL FROM t`` - and counts the rows that come back. Read as
+    ordinary OBSQL that is a literal projection, which the translator rejects,
+    so every count over a model failed with a message about bare column
+    references.
+    """
+
+    def test_a_null_projection_is_recognised(self) -> None:
+        assert null_projection_arity('SELECT NULL FROM "commerce"."model"') == 1
+        assert null_projection_arity("SELECT NULL, NULL FROM t") == 2
+
+    def test_a_real_projection_is_not(self) -> None:
+        assert null_projection_arity('SELECT "Total Revenue" FROM t') is None
+        assert null_projection_arity("SELECT NULL, x FROM t") is None
+
+    def test_a_table_less_select_null_is_not(self) -> None:
+        """It has no model to count, and the catalog gate already answers it.
+
+        Worth pinning: the ``from`` arg was renamed to ``from_`` in sqlglot 30,
+        and reading the old key makes *every* SELECT look table-less - which
+        would answer a count with no rows instead of declining to answer.
+        """
+        assert null_projection_arity("SELECT NULL") is None
+
+    def test_unparseable_sql_is_not(self) -> None:
+        assert null_projection_arity("SELECT NULL FROM (((") is None
+
+    def test_the_rewrite_selects_every_dimension_and_keeps_the_filter(self) -> None:
+        mgr, model_id = _make_manager_with_model()
+        try:
+            model = mgr.get_or_create_named("commerce").get_model(model_id)
+            rewritten = project_every_dimension(
+                'SELECT NULL FROM "commerce"."model" WHERE "Customer Country" = \'US\'',
+                model,
+            )
+            assert rewritten is not None
+            for name in model.dimensions:
+                assert f'"{name}"' in rewritten
+            assert "NULL" not in rewritten
+            assert "'US'" in rewritten
+        finally:
+            mgr.stop()
+
+    def test_a_model_with_no_dimensions_is_left_to_the_translator(self) -> None:
+        """Better a clear rejection than a count of a grain we invented."""
+        mgr, model_id = _make_manager_with_model()
+        try:
+            model = mgr.get_or_create_named("commerce").get_model(model_id).model_copy(deep=True)
+            model.dimensions = {}
+            assert project_every_dimension("SELECT NULL FROM t", model) is None
+        finally:
+            mgr.stop()

--- a/tests/unit/test_pgwire_statements.py
+++ b/tests/unit/test_pgwire_statements.py
@@ -121,3 +121,39 @@ class TestUnterminatedInput:
     )
     def test_the_remainder_stays_one_statement(self, sql: str) -> None:
         assert len(split_statements(sql)) == 1
+
+
+class TestCommentOnlyFragments:
+    """A trailing remark is not a statement.
+
+    ``SELECT 1; -- done`` used to split into two, and the second was dispatched
+    like any other statement: the client read a successful result and then an
+    ErrorResponse for a fragment it never meant to send.
+    """
+
+    def test_a_trailing_line_comment_is_dropped(self) -> None:
+        assert split_statements("SELECT 1; -- trailing comment") == ["SELECT 1"]
+
+    def test_a_trailing_block_comment_is_dropped(self) -> None:
+        assert split_statements("SELECT 1; /* tail */") == ["SELECT 1"]
+
+    def test_a_trailing_nested_block_comment_is_dropped(self) -> None:
+        assert split_statements("SELECT 1; /* /* nested */ */") == ["SELECT 1"]
+
+    def test_a_semicolon_inside_the_trailing_comment_does_not_revive_it(self) -> None:
+        assert split_statements("SELECT 1; -- a; b") == ["SELECT 1"]
+
+    def test_a_message_of_nothing_but_comments(self) -> None:
+        assert split_statements("-- just a note") == []
+        assert split_statements("/* just a note */ ;") == []
+
+    def test_a_leading_comment_stays_with_its_statement(self) -> None:
+        """The other half of the rule: attached comments are not stripped."""
+        parts = split_statements("SELECT 1;\n-- about the next one\nSELECT 2")
+        assert len(parts) == 2
+        assert parts[1].endswith("SELECT 2")
+        assert "about the next one" in parts[1]
+
+    def test_a_comment_marker_inside_a_literal_is_not_a_comment(self) -> None:
+        sql = "SELECT '-- not a comment'"
+        assert split_statements(sql) == [sql]

--- a/tests/unit/test_pgwire_statements.py
+++ b/tests/unit/test_pgwire_statements.py
@@ -1,0 +1,123 @@
+"""Splitting a simple-query message into statements.
+
+Every case here is one a real client sends, and the ones that matter are the
+semicolons that are *not* boundaries. A naive ``sql.split(";")`` passes the
+first three tests below and corrupts the rest, which is the whole reason this
+is a scanner.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from orionbelt.pgwire.statements import split_statements
+
+
+class TestTheOrdinaryCases:
+    def test_a_single_statement_is_unchanged(self) -> None:
+        assert split_statements("SELECT 1") == ["SELECT 1"]
+
+    def test_a_trailing_semicolon_does_not_make_an_empty_statement(self) -> None:
+        assert split_statements("SELECT 1;") == ["SELECT 1"]
+
+    def test_two_statements(self) -> None:
+        assert split_statements("SELECT 1; SELECT 2") == ["SELECT 1", "SELECT 2"]
+
+    def test_empty_statements_are_dropped(self) -> None:
+        assert split_statements("SELECT 1;;; SELECT 2;") == ["SELECT 1", "SELECT 2"]
+
+    def test_an_empty_message(self) -> None:
+        assert split_statements("") == []
+        assert split_statements("   \n  ") == []
+
+    def test_the_batch_duckdb_actually_sends(self) -> None:
+        """Verbatim in shape from the `postgres` extension's catalog probe."""
+        sql = (
+            "BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY; "
+            "SELECT oid, nspname FROM pg_namespace ORDER BY oid; "
+            "SELECT pg_namespace.oid AS namespace_id, relname FROM pg_class"
+        )
+        parts = split_statements(sql)
+        assert len(parts) == 3
+        assert parts[0].startswith("BEGIN")
+        assert parts[2].endswith("pg_class")
+
+
+class TestSemicolonsThatAreNotBoundaries:
+    """Where a naive split corrupts the SQL instead of dividing it."""
+
+    def test_inside_a_string_literal(self) -> None:
+        assert split_statements("SELECT ';' AS x") == ["SELECT ';' AS x"]
+
+    def test_a_doubled_quote_inside_a_literal(self) -> None:
+        sql = "SELECT 'it''s; fine' AS x"
+        assert split_statements(sql) == [sql]
+
+    def test_inside_a_quoted_identifier(self) -> None:
+        sql = 'SELECT "a;b" FROM t'
+        assert split_statements(sql) == [sql]
+
+    def test_a_doubled_quote_inside_an_identifier(self) -> None:
+        sql = 'SELECT "a""b;c" FROM t'
+        assert split_statements(sql) == [sql]
+
+    def test_inside_an_escape_string(self) -> None:
+        r"""``E'...'`` lets a backslash escape the quote, unlike ``'...'``."""
+        sql = "SELECT E'a\\';b' AS x"
+        assert split_statements(sql) == [sql]
+
+    def test_inside_a_line_comment(self) -> None:
+        sql = "SELECT 1 -- ; not a boundary\n"
+        assert split_statements(sql) == ["SELECT 1 -- ; not a boundary"]
+
+    def test_inside_a_block_comment(self) -> None:
+        sql = "SELECT /* ; */ 1"
+        assert split_statements(sql) == [sql]
+
+    def test_inside_a_nested_block_comment(self) -> None:
+        """Postgres nests these; most splitters stop at the first ``*/``.
+
+        The comment stays attached to the statement that follows it, which is
+        where it belongs - stripping comments is the parser's business, not
+        the splitter's. What matters here is that none of the three
+        semicolons inside it divided anything.
+        """
+        parts = split_statements("SELECT 1; /* ; /* ; */ ; */ SELECT 2")
+        assert len(parts) == 2
+        assert parts[0] == "SELECT 1"
+        assert parts[1].endswith("SELECT 2")
+
+    def test_inside_a_dollar_quoted_body(self) -> None:
+        sql = "SELECT $$a;b$$ AS x"
+        assert split_statements(sql) == [sql]
+
+    def test_inside_a_tagged_dollar_quoted_body(self) -> None:
+        sql = "SELECT $tag$a;b$tag$ AS x"
+        assert split_statements(sql) == [sql]
+
+    def test_a_dollar_placeholder_is_not_a_quote(self) -> None:
+        """``$1`` is a parameter, and treating it as a quote opener would
+        swallow the rest of the batch."""
+        parts = split_statements("SELECT $1; SELECT $2")
+        assert parts == ["SELECT $1", "SELECT $2"]
+
+
+class TestUnterminatedInput:
+    """Malformed SQL is the server's to reject, not this function's.
+
+    Each of these returns the remainder as one statement so the error comes
+    from the parser with a message about the actual problem, rather than from
+    a splitter that silently divided a string in half.
+    """
+
+    @pytest.mark.parametrize(
+        "sql",
+        [
+            "SELECT 'unterminated; SELECT 2",
+            'SELECT "unterminated; SELECT 2',
+            "SELECT $$unterminated; SELECT 2",
+            "SELECT /* unterminated; SELECT 2",
+        ],
+    )
+    def test_the_remainder_stays_one_statement(self, sql: str) -> None:
+        assert len(split_statements(sql)) == 1

--- a/uv.lock
+++ b/uv.lock
@@ -2599,6 +2599,7 @@ dependencies = [
 [package.optional-dependencies]
 dev = [
     { name = "clickhouse-connect" },
+    { name = "cryptography" },
     { name = "duckdb" },
     { name = "httpx" },
     { name = "mypy" },
@@ -2693,6 +2694,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "clickhouse-connect", marker = "extra == 'dev'", specifier = ">=0.7" },
+    { name = "cryptography", marker = "extra == 'dev'", specifier = ">=42.0" },
     { name = "duckdb", marker = "extra == 'dev'", specifier = ">=1.0" },
     { name = "fastapi", specifier = ">=0.128,<1.0" },
     { name = "gradio", marker = "extra == 'ui'", specifier = ">=6.15.1,<7.0" },


### PR DESCRIPTION
`ATTACH 'host=... dbname=<model>' AS obsl (TYPE postgres)` in a plain DuckDB shell now mounts the model as `obsl.<model>.model`:

```sql
INSTALL postgres; LOAD postgres;
SET pg_use_text_protocol = true;
ATTACH 'host=127.0.0.1 port=5432 dbname=commerce user=obsl' AS obsl (TYPE postgres, READ_ONLY);

SELECT "Country Name", "Total Sales" FROM obsl.commerce.model;
```

Governed measures then join to local Parquet and CSV and land in `CREATE TABLE AS`, with no OBSL-specific client. It is the same capability the `adbc_scanner` route already offered over Flight SQL, addressed as a table rather than a string passed to a table function.

## What was broken

Four gaps, and the thing they have in common is that not one of them raised an error. `ATTACH` reported success and the catalog came back empty.

| Gap | What the client does | What happened |
|---|---|---|
| Multi-statement simple query | Enumerates a catalog with several statements in one `Query` message | Only the first ran. The protocol expects one result set per statement, so the client read a result that was not there and died naming a vector index. |
| `pg_type.typnamespace` | Joins it to `pg_namespace.oid` to resolve each type's schema | The column did not exist; once added there was no `pg_catalog` row to land on, because DuckDB has none. The inner join matched nothing and discarded the whole enumeration. |
| Table-less probes | `SELECT 0 AS oid, '' AS typname LIMIT 0` to ask what shape those columns would be | Reached the semantic translator, which has no model to resolve a literal projection against. Answered from the catalog DuckDB now. |
| `SELECT NULL FROM t` | How it asks for a row count: project nothing, count what comes back | Read as a literal projection and rejected, so every `count(*)` over a model failed. |

The row count is well defined even though the projection is empty: the model's virtual table has one row per dimension combination, which is the grain a `SELECT *` over it already returns. So it is answered by selecting every dimension and replying in the shape the client bound.

The statement splitter is a scanner, not `sql.split(";")`. A semicolon inside a string, an escape string, a quoted identifier, a dollar-quoted body, a line comment or a nested block comment is data, not a boundary; 21 tests cover the ones that are not.

## The one setting a user needs

`SET pg_use_text_protocol = true`. Left at its default the extension reads data with `COPY ... TO STDOUT (FORMAT binary)`, which the semantic surface has no reason to implement. The failure names `COPY` and a parse error while the catalog still browses fine, which reads like a broken query rather than a protocol we do not speak, so it is pinned in a test and called out in the guide.

## Tests

`tests/integration/test_pgwire_duckdb_client.py` drives DuckDB's own `postgres` extension against a real listener: catalog enumeration, semantic types, filters, a join to a local table, `CREATE TABLE AS`, and `count(*)`. Nothing short of the real client would have caught any of the four gaps above, since each is zero rows and no error. It skips rather than fails when the extension cannot be downloaded.

Also fixes an unraisable-thread-exception warning in the TLS suite, whose teardown stopped the event loop out from under `serve_forever`.

Full suite: 5164 passed, 1070 skipped. `ruff` and `mypy` clean.

## TLS and authentication

Both work through `ATTACH` with nothing added on either side, because the extension is libpq underneath and the whole connection string reaches it. Verified rather than assumed, and pinned in `TestOverTLS` / `TestAuthentication`:

| | Result |
|---|---|
| `sslmode` = `disable` / `prefer` / `require` / `verify-ca` / `verify-full` | all negotiate against a `PGWIRE_TLS_CERT` listener |
| `verify-ca` against the wrong trust anchor | refused, which is what makes the other five mean something |
| `AUTH_MODE=api_key`, SCRAM-SHA-256 (the default) | the API key is `password=`; libpq performs the exchange |
| `PGWIRE_AUTH_MODE=password` (cleartext opt-in) | same, for clients without SCRAM |
| wrong key, or no password | refused by both mechanisms |

## Stale docs fixed while checking

Two rows in the pgwire "Known limitations" table claimed less than the surface does:

- **"No authentication"** predates SCRAM shipping. Replaced with the one constraint the DuckDB route actually has, `pg_use_text_protocol`.
- **"Binary-format Bind parameters rejected"** is no longer true for the common scalar OIDs, which decode; only unknown ones raise. The row now says which.

Neither the docs landing page nor the drivers page mentioned DuckDB as a client at all, by either route. Both now do.
