### PR TITLE
fix(pgwire): translate the decimal type modifier to Postgres's encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to OrionBelt Semantic Layer are documented here.
 
 ## [Unreleased]
 
+### Fixed
+
+- **A DECIMAL measure could not be read over the DuckDB `ATTACH` route.** The catalog advertised
+  `numeric` correctly and then attached a type modifier in the wrong encoding: `pg_attribute`
+  translated the type *id* from DuckDB's numbering to Postgres's but passed `atttypmod` straight
+  through, and the two engines pack it differently. DuckDB writes `precision * 1000 + scale`
+  (18002 for `DECIMAL(18,2)`); Postgres writes `((precision << 16) | scale) + 4` (1179654).
+
+  Decoded per Postgres, 18002 reads as `DECIMAL(0, 78)` - zero total digits, 78 decimal places -
+  so no real value fits and the extension refused each one with a conversion error naming a string
+  that was perfectly valid: `Could not convert string "1936466.31" to DECIMAL(0,78)`. Browsing the
+  catalog worked throughout, because the modifier only matters once DuckDB allocates a vector to
+  hold values, so the failure looked like bad data rather than a bad type.
+
+  The per-query `RowDescription` had always packed it the Postgres way, which is why `psql` and
+  every BI tool were unaffected; only the catalog path disagreed, and only clients that build
+  typed containers from `atttypmod` could see it. Both paths now agree.
+
+  It shipped because no test model had a decimal measure: every measure in the fixtures was a
+  float, so the suite never produced a NUMERIC column at all. Both pgwire suites now carry a
+  decimal variant.
+
 ## [2.28.0] - 2026-09-10
 
 ### Added

--- a/src/orionbelt/pgwire/catalog.py
+++ b/src/orionbelt/pgwire/catalog.py
@@ -161,6 +161,34 @@ _OID_TRANSLATION_CASE = """
         END
 """
 
+#: DuckDB's internal type id for DECIMAL, which ``_OID_TRANSLATION_CASE``
+#: maps to Postgres NUMERIC (1700). Named because the typmod rewrite below
+#: has to test the *untranslated* id.
+_DUCKDB_DECIMAL_TYPE_ID = 21
+
+#: ``atttypmod`` for a DECIMAL, translated from DuckDB's encoding to
+#: Postgres's.
+#:
+#: The two disagree, and nothing says so: DuckDB packs a decimal as
+#: ``precision * 1000 + scale`` (18002 for DECIMAL(18,2)), Postgres as
+#: ``((precision << 16) | scale) + 4`` (1179654 for the same type). Passing
+#: DuckDB's number through unchanged is not a wrong number, it is a number in
+#: the wrong encoding, so a client that decodes it gets a plausible-looking
+#: type nobody declared - DuckDB's own ``postgres`` extension read 18002 as
+#: DECIMAL(0,78) and then failed to fit any real value into it, reporting a
+#: conversion error against a string that was perfectly valid.
+#:
+#: Every other DuckDB type reports -1 here, which is Postgres's "no modifier"
+#: too, so only the decimal case needs translating.
+_TYPMOD_TRANSLATION_CASE = f"""
+        CASE
+            WHEN atttypid = {_DUCKDB_DECIMAL_TYPE_ID} AND atttypmod > 0
+            THEN ((((atttypmod / 1000)::INTEGER) << 16)
+                  | ((atttypmod % 1000)::INTEGER)) + 4
+            ELSE atttypmod
+        END
+"""
+
 #: The oid Postgres gives ``pg_catalog``. Fixed since forever, and every
 #: base type in the shadow ``pg_type`` claims it as its namespace.
 _PG_CATALOG_OID = 11
@@ -265,7 +293,7 @@ _SHADOW_VIEWS: tuple[str, ...] = (
             attnum,
             attndims,
             attcacheoff,
-            atttypmod,
+            {_TYPMOD_TRANSLATION_CASE} AS atttypmod,
             attbyval,
             attstorage,
             attalign,

--- a/tests/integration/test_pgwire_duckdb_client.py
+++ b/tests/integration/test_pgwire_duckdb_client.py
@@ -489,3 +489,113 @@ class TestAuthentication:
             pytest.raises(Exception, match="(?i)authentication failed|no password supplied"),
         ):
             self._read(port, "")
+
+
+#: The sample model with its revenue measure declared as a fixed-scale decimal.
+#: Every measure in the default fixture is a float, which is why the typmod
+#: defect below shipped: no test in the suite produced a NUMERIC column, and a
+#: real model almost always has one.
+DECIMAL_MODEL_YAML = SAMPLE_MODEL_YAML.replace(
+    """  Total Revenue:
+    columns:
+      - dataObject: Orders
+        column: Amount
+    resultType: float
+    aggregation: sum""",
+    """  Total Revenue:
+    columns:
+      - dataObject: Orders
+        column: Amount
+    resultType: float
+    dataType: decimal(18,2)
+    aggregation: sum""",
+)
+
+
+@pytest.fixture(scope="module")
+def decimal_listener(tmp_path_factory: pytest.TempPathFactory) -> Iterator[int]:
+    """A listener whose model declares a DECIMAL measure."""
+    db_path = tmp_path_factory.mktemp("pgwire-duckdb-decimal") / "warehouse.duckdb"
+    conn = duckdb.connect(str(db_path))
+    conn.execute(_SETUP_SQL)
+    conn.close()
+
+    prev = os.environ.get("DUCKDB_DATABASE")
+    os.environ["DUCKDB_DATABASE"] = str(db_path)
+
+    manager = SessionManager(ttl_seconds=3600, cleanup_interval=9999)
+    manager.get_or_create_named("sales").load_model(DECIMAL_MODEL_YAML, dedup=False)
+    router = SemanticRouter(session_manager=manager, default_dialect="duckdb")
+    server = PgWireServer(
+        host="127.0.0.1",
+        port=0,
+        auth_mode="trust",
+        max_connections=16,
+        query_handler=router.handle,
+    )
+
+    ready = threading.Event()
+    bound: dict[str, int] = {}
+    loop = asyncio.new_event_loop()
+
+    def run() -> None:
+        asyncio.set_event_loop(loop)
+        bound["port"] = loop.run_until_complete(server.start())
+        ready.set()
+        loop.run_forever()
+
+    thread = threading.Thread(target=run, name="pgwire-decimal-test", daemon=True)
+    thread.start()
+    assert ready.wait(30), "pgwire listener did not start"
+    try:
+        yield bound["port"]
+    finally:
+        asyncio.run_coroutine_threadsafe(server.stop(), loop).result(timeout=5)
+        loop.call_soon_threadsafe(loop.stop)
+        thread.join(timeout=5)
+        manager.stop()
+        if prev is None:
+            os.environ.pop("DUCKDB_DATABASE", None)
+        else:
+            os.environ["DUCKDB_DATABASE"] = prev
+
+
+class TestADecimalMeasure:
+    """A governed DECIMAL has to survive the wire, and it did not.
+
+    ``atttypmod`` reached the client in DuckDB's encoding rather than
+    Postgres's, so the extension decoded ``DECIMAL(18, 2)`` as
+    ``DECIMAL(0, 78)`` and then could not fit a single real value into it. The
+    catalog browsed perfectly; only reading failed, with a conversion error
+    naming a string that was entirely valid::
+
+        Could not convert string "1936466.31" to DECIMAL(0,78)
+
+    Nothing in the suite had a decimal measure before this, which is why it
+    shipped. Most real models have one.
+    """
+
+    @pytest.fixture
+    def attached_decimal(self, pg_extension: Any, decimal_listener: int) -> Iterator[Any]:
+        conn = _attach(decimal_listener)
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+    def test_the_declared_precision_and_scale_arrive(self, attached_decimal: Any) -> None:
+        types = dict(
+            attached_decimal.execute(
+                "SELECT column_name, data_type FROM duckdb_columns() WHERE table_name = 'model'"
+            ).fetchall()
+        )
+        assert types["Total Revenue"] == "DECIMAL(18,2)"
+
+    def test_the_values_can_actually_be_read(self, attached_decimal: Any) -> None:
+        """The assertion the bug report was made of: browsing worked, reading did not."""
+        from decimal import Decimal
+
+        rows = attached_decimal.execute(
+            'SELECT "Customer Country", "Total Revenue" FROM obsl.sales.model ORDER BY 1'
+        ).fetchall()
+        assert rows == [("UK", Decimal("75.00")), ("US", Decimal("150.00"))]

--- a/tests/unit/test_pgwire_catalog.py
+++ b/tests/unit/test_pgwire_catalog.py
@@ -17,6 +17,33 @@ def manager_with_model() -> SessionManager:
     return mgr
 
 
+#: The sample model with its revenue measure declared as a fixed-scale decimal.
+#: The default fixture types every measure as float, which is exactly why the
+#: typmod defect below survived: nothing in the suite produced a NUMERIC column.
+DECIMAL_MODEL_YAML = SAMPLE_MODEL_YAML.replace(
+    """  Total Revenue:
+    columns:
+      - dataObject: Orders
+        column: Amount
+    resultType: float
+    aggregation: sum""",
+    """  Total Revenue:
+    columns:
+      - dataObject: Orders
+        column: Amount
+    resultType: float
+    dataType: decimal(18,2)
+    aggregation: sum""",
+)
+
+
+@pytest.fixture
+def manager_with_decimal_measure() -> SessionManager:
+    mgr = SessionManager()
+    mgr.get_or_create_named("commerce").load_model(DECIMAL_MODEL_YAML)
+    return mgr
+
+
 def test_refresh_creates_one_table_per_model(manager_with_model: SessionManager) -> None:
     """v2.5.0 layout: database=orionbelt, schema=<model>, table='model'."""
 
@@ -372,3 +399,61 @@ class TestTypeNamespaceResolves:
         assert "Customer Country" in columns
         assert "Total Revenue" in columns
         assert {row[5] for row in result.rows} == {"pg_catalog"}
+
+
+class TestDecimalTypeModifier:
+    """``atttypmod`` has to be in Postgres's encoding, not DuckDB's.
+
+    The two disagree and nothing announces it: DuckDB packs a decimal as
+    ``precision * 1000 + scale``, Postgres as ``((precision << 16) | scale) + 4``.
+    Passing DuckDB's number through is not a wrong number, it is a number in the
+    wrong encoding, so a client that decodes it gets a type nobody declared -
+    DuckDB's own ``postgres`` extension read 18002 as ``DECIMAL(0, 78)`` and then
+    refused every real value with a conversion error naming a perfectly valid
+    string.
+    """
+
+    @staticmethod
+    def _decode(typmod: int) -> tuple[int, int]:
+        """Postgres's own numeric typmod decoding."""
+        assert typmod > 0, "a declared decimal must carry a modifier"
+        packed = typmod - 4
+        return (packed >> 16) & 0xFFFF, packed & 0xFFFF
+
+    def test_a_declared_decimal_decodes_to_its_precision_and_scale(
+        self, manager_with_decimal_measure: SessionManager
+    ) -> None:
+        emu = CatalogEmulator()
+        emu.refresh(manager_with_decimal_measure)
+        result = emu.execute(
+            "SELECT a.attname, a.atttypmod FROM pg_attribute a "
+            "JOIN pg_class c ON a.attrelid = c.oid "
+            "WHERE c.relname = 'model' AND a.attname = 'Total Revenue'"
+        )
+        assert result.rows, "the decimal measure must be in the catalog"
+        assert self._decode(result.rows[0][1]) == (18, 2)
+
+    def test_it_is_not_duckdbs_encoding(self, manager_with_decimal_measure: SessionManager) -> None:
+        """The specific wrong value, named so a regression is unmistakable."""
+        emu = CatalogEmulator()
+        emu.refresh(manager_with_decimal_measure)
+        typmod = emu.execute(
+            "SELECT a.atttypmod FROM pg_attribute a JOIN pg_class c ON a.attrelid = c.oid "
+            "WHERE c.relname = 'model' AND a.attname = 'Total Revenue'"
+        ).rows[0][0]
+        assert typmod != 18002, "DuckDB's precision*1000+scale reached the wire"
+        assert typmod == ((18 << 16) | 2) + 4
+
+    def test_a_non_decimal_column_still_reports_no_modifier(
+        self, manager_with_decimal_measure: SessionManager
+    ) -> None:
+        """-1 means the same thing in both encodings, so it must pass through."""
+        emu = CatalogEmulator()
+        emu.refresh(manager_with_decimal_measure)
+        rows = emu.execute(
+            "SELECT a.attname, a.atttypmod FROM pg_attribute a "
+            "JOIN pg_class c ON a.attrelid = c.oid "
+            "WHERE c.relname = 'model' AND a.attname IN ('Customer Country', 'Order Count')"
+        ).rows
+        assert len(rows) == 2
+        assert all(row[1] == -1 for row in rows), dict(rows)


### PR DESCRIPTION
A model with a DECIMAL measure cannot be read over the DuckDB `ATTACH` route in 2.28.0. Found while setting up a live demo against the commerce model, which has 28 decimal measures.

```
Conversion Error: Could not convert string "1936466.31" to DECIMAL(0,78)
```

## What went wrong

The catalog advertised the type correctly as `numeric`, then attached a type modifier in the wrong encoding. `_obsl_pg_attribute` translated the type *id* from DuckDB's numbering to Postgres's, and passed `atttypmod` straight through:

```sql
{_OID_TRANSLATION_CASE} AS atttypid,   -- translated
atttypmod,                             -- not translated
```

The two engines pack it differently, and nothing announces it:

| | Encoding of `DECIMAL(18,2)` | Value |
|---|---|---|
| DuckDB | `precision * 1000 + scale` | `18002` |
| Postgres | `((precision << 16) \| scale) + 4` | `1179654` |

Decoded per Postgres, `18002 - 4 = 17998` gives precision `17998 >> 16` = **0** and scale `0x4E` = **78**. `DECIMAL(0, 78)`: zero total digits, seventy-eight decimal places. Nothing fits in it.

Browsing the catalog worked throughout, because the modifier only matters once DuckDB allocates a vector to hold values. So the failure arrived at read time, blaming a string that was entirely valid.

## Scope

Confined to clients that build typed containers from `pg_attribute.atttypmod`, which is exactly what `ATTACH ... (TYPE postgres)` does. The per-query `RowDescription` had always packed the Postgres encoding (`router.py`), so `psql`, Tableau, DBeaver and the rest were unaffected, as were Flight/ADBC and REST. The right encoding was already in the codebase; only the catalog path disagreed with it.

## Why nothing caught it

No fixture had a decimal measure. Every measure in the test models was a float, so the suite never produced a NUMERIC column at all, and most real models have one.

Both pgwire suites now carry a decimal variant of the sample model:

- `test_pgwire_catalog.py` asserts the modifier decodes back to the declared precision and scale, and names `18002` explicitly so a regression is unmistakable. A third test pins that non-decimal columns still report `-1`, which means the same thing in both encodings and must pass through.
- `test_pgwire_duckdb_client.py` reproduces the original failure end to end against the real extension: the column must arrive as `DECIMAL(18,2)`, and the values must actually read back.

Verified non-vacuous: reverting the one-line view change fails both catalog assertions.

Full suite: 5194 passed, 1070 skipped. `ruff` and `mypy` clean.