### PR TITLE
fix(pgwire): map the zoned time types, and sweep the whole type surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to OrionBelt Semantic Layer are documented here.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Zoned timestamps and times advertised an OID that meant something else.** `pg_attribute`
+  translates DuckDB's internal type ids to Postgres OIDs with a `CASE` whose `ELSE` passes the id
+  through unchanged, and two types were missing from it: DuckDB's `TIMESTAMPTZ` is 32, which
+  Postgres uses for `pg_ddl_command`, and its `TIMETZ` is 34, which is not a type OID at all. Both
+  went out dressed as Postgres OIDs. The shadow `pg_type` had declared 1184 and 1266 correctly the
+  whole time; nothing pointed at them.
+
+  Latent rather than live - no shipped model uses either type - but both are legal OBML, and
+  `timestamp_tz` is a first-class time dimension type. Zoned timestamps are the norm on Postgres
+  and Snowflake.
+
+### Added
+
+- **A sweep over the whole type surface, so this class of defect cannot recur.** Three defects of
+  one shape had now shipped: a type whose id or modifier translated for some values and silently
+  fell through for others. None was visible, because the test models only ever used string, int,
+  float and date - the suite tested the types the fixtures happened to use.
+
+  `TestEveryDataTypeMaps` asserts, for every member of `DataType` plus both decimal widths, that
+  the advertised OID is one the shadow `pg_type` declares and that the modifier is either `-1` or a
+  correctly packed decimal. A new `DataType` cannot be added without mapping it.
+
+  It reads back through the emulator rather than re-applying the translation expressions itself.
+  The first version did the latter and was worth less than it looked: it caught a wrong `CASE` but
+  not a correct `CASE` the view forgot to apply, which is exactly one of the defects it exists for.
+  Verified by reverting each fix in turn and watching the right assertion fail.
+
 ## [2.28.1] - 2026-09-10
 
 ### Fixed

--- a/src/orionbelt/pgwire/catalog.py
+++ b/src/orionbelt/pgwire/catalog.py
@@ -151,12 +151,20 @@ _STUB_MACROS: tuple[str, ...] = (
 #   25 → 25   (TEXT — already matches)
 #   26 → 17   (BYTEA)
 #   27 → 1186 (INTERVAL)
+#: DuckDB's internal type id -> the Postgres OID for the same type.
+#:
+#: The ``ELSE`` is the dangerous half: an unmapped id leaves as itself, dressed
+#: as a Postgres OID. DuckDB's TIMESTAMPTZ is 32, which Postgres uses for
+#: ``pg_ddl_command``; TIMETZ is 34, which is not a type OID at all. Both were
+#: advertised that way until a sweep over every ``DataType`` found them - see
+#: ``TestEveryDataTypeMaps``, which is what keeps the ``ELSE`` honest now.
 _OID_TRANSLATION_CASE = """
         CASE atttypid
             WHEN 10 THEN 16    WHEN 12 THEN 21    WHEN 13 THEN 23
             WHEN 14 THEN 20    WHEN 15 THEN 1082  WHEN 16 THEN 1083
             WHEN 19 THEN 1114  WHEN 21 THEN 1700  WHEN 22 THEN 700
             WHEN 23 THEN 701   WHEN 26 THEN 17    WHEN 27 THEN 1186
+            WHEN 32 THEN 1184  WHEN 34 THEN 1266
             ELSE atttypid::INTEGER
         END
 """

--- a/tests/unit/test_pgwire_catalog.py
+++ b/tests/unit/test_pgwire_catalog.py
@@ -457,3 +457,118 @@ class TestDecimalTypeModifier:
         ).rows
         assert len(rows) == 2
         assert all(row[1] == -1 for row in rows), dict(rows)
+
+
+class TestEveryDataTypeMaps:
+    """A sweep over the whole type surface, not the types a fixture happens to use.
+
+    Two defects of the same shape shipped before this existed, and both were
+    silent. ``atttypid`` is translated from DuckDB's numbering to Postgres's by
+    a CASE whose ``ELSE`` passes the id through unchanged, and ``atttypmod`` by
+    another; a type missing from either leaves as a plausible-looking number
+    that means something else. DuckDB's TIMESTAMPTZ is 32, which is Postgres's
+    ``pg_ddl_command``; its TIMETZ is 34, which is not a type OID at all; and
+    DECIMAL's modifier used a different packing entirely.
+
+    None of that was visible because the test models only ever used string,
+    int, float and date. So this asserts the property for *every* member of
+    ``DataType`` plus decimal, and a new one cannot be added without mapping
+    it.
+    """
+
+    #: The OIDs the shadow ``pg_type`` declares. An advertised OID outside this
+    #: set is one no client can resolve.
+    DECLARED_OIDS = frozenset(
+        {
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            23,
+            25,
+            26,
+            700,
+            701,
+            1042,
+            1043,
+            1082,
+            1083,
+            1114,
+            1184,
+            1186,
+            1266,
+            1700,
+            2950,
+        }
+    )
+
+    @staticmethod
+    def _probe(sql_types: dict[str, str]) -> list[tuple[str, int, int]]:
+        """(label, advertised oid, advertised typmod) for each SQL type.
+
+        Read back through the emulator, so this exercises the ``pg_attribute``
+        a client is actually served. Applying the translation expressions
+        directly here was the first attempt and it was worth less than it
+        looked: it would have caught a wrong CASE, but not a correct CASE that
+        the view forgot to apply - which is one of the two defects this class
+        exists for.
+        """
+        emu = CatalogEmulator()
+        cols = ", ".join(f'"c{i}" {sql}' for i, sql in enumerate(sql_types.values()))
+        emu.execute(f"CREATE TABLE probe ({cols})")
+        result = emu.execute(
+            "SELECT a.atttypid, a.atttypmod FROM pg_attribute a "
+            "JOIN pg_class c ON a.attrelid = c.oid "
+            "WHERE c.relname = 'probe' ORDER BY a.attnum"
+        )
+        return [(label, row[0], row[1]) for label, row in zip(sql_types, result.rows, strict=True)]
+
+    @staticmethod
+    def _all_types() -> dict[str, str]:
+        from orionbelt.pgwire.catalog import _DATATYPE_TO_DUCKDB
+
+        types = {dt.value: sql for dt, sql in _DATATYPE_TO_DUCKDB.items()}
+        types["decimal(18,2)"] = "DECIMAL(18, 2)"
+        types["decimal(38,6)"] = "DECIMAL(38, 6)"
+        return types
+
+    def test_every_type_advertises_an_oid_the_catalog_declares(self) -> None:
+        unknown = {
+            label: oid
+            for label, oid, _ in self._probe(self._all_types())
+            if oid not in self.DECLARED_OIDS
+        }
+        assert not unknown, (
+            f"these types advertise an OID no client can resolve: {unknown}. "
+            "Add the mapping to _OID_TRANSLATION_CASE, and the type to the "
+            "shadow pg_type if it is not there."
+        )
+
+    def test_the_zoned_time_types_specifically(self) -> None:
+        """Named, because they were wrong and the wrong values were plausible."""
+        by_label = {label: oid for label, oid, _ in self._probe(self._all_types())}
+        assert by_label["timestamp_tz"] == 1184, "32 is pg_ddl_command, not timestamptz"
+        assert by_label["time_tz"] == 1266, "34 is not a type OID at all"
+
+    def test_no_type_carries_a_modifier_it_should_not(self) -> None:
+        """Only decimals declare one; everything else must say -1.
+
+        A non -1 modifier on a type that has none is the decimal defect in its
+        general form: a number in an encoding the reader does not share.
+        """
+        stray = {
+            label: mod
+            for label, oid, mod in self._probe(self._all_types())
+            if mod != -1 and oid != 1700
+        }
+        assert not stray, f"non-decimal types carrying a type modifier: {stray}"
+
+    def test_a_decimal_modifier_round_trips(self) -> None:
+        probed = {label: mod for label, oid, mod in self._probe(self._all_types()) if oid == 1700}
+        assert len(probed) == 2, "both decimal widths must be probed"
+        for label, mod in probed.items():
+            precision, scale = ((mod - 4) >> 16) & 0xFFFF, (mod - 4) & 0xFFFF
+            expected = label[len("decimal(") : -1].split(",")
+            assert (precision, scale) == (int(expected[0]), int(expected[1])), label


### PR DESCRIPTION
Two more instances of the defect 2.28.1 fixed, found by auditing the type surface rather than by tripping over them.

## The defect

`pg_attribute` translates DuckDB's internal type ids to Postgres OIDs with a `CASE` whose `ELSE` passes the id through unchanged. Two types were missing:

| OBML type | Advertised OID | What that OID actually means | Correct |
|---|---|---|---|
| `timestamp_tz` | **32** | `pg_ddl_command`, a Postgres internal type | 1184 `timestamptz` |
| `time_tz` | **34** | nothing, no such type OID exists | 1266 `timetz` |

The shadow `pg_type` declared 1184 and 1266 correctly the whole time. Nothing ever pointed at them.

**Latent rather than live:** no shipped example or fixture uses either type. But both are legal OBML, `DataType.TIMESTAMP_TZ` is in `DATE_BEARING_TYPES` so it is a first-class time dimension type, and zoned timestamps are the norm on Postgres and Snowflake. This breaks for whoever declares one first.

## The part worth having

Three defects of one shape have now shipped: a type whose id or modifier translated for some values and silently fell through for others. None was visible, and the reason is the same each time - the test models only ever used string, int, float and date, so the suite tested the types the fixtures happened to use.

`TestEveryDataTypeMaps` asserts, for every member of `DataType` plus both decimal widths:

- the advertised OID is one the shadow `pg_type` declares, so a client can resolve it
- the modifier is `-1`, or a decimal modifier that decodes back to its declared precision and scale

A new `DataType` cannot be added without mapping it.

## One thing I got wrong first, worth knowing

The initial version of the sweep re-applied the translation expressions itself rather than reading back through the emulator. It passed, and it was worth less than it looked: it would have caught a wrong `CASE`, but not a correct `CASE` that the view forgot to apply - which is exactly one of the two defects it exists for. Reverting the decimal fix left it green.

It now queries the `pg_attribute` a client is actually served. Verified by reverting each fix in turn:

| Reverted | Fails |
|---|---|
| the zoned-time mappings | `test_every_type_advertises_an_oid_the_catalog_declares`, `test_the_zoned_time_types_specifically` |
| the decimal typmod translation | `test_a_decimal_modifier_round_trips` |

Full suite: 5198 passed, 1070 skipped. `ruff` and `mypy` clean.