### PR TITLE
feat(cli): let obsl --server present a client certificate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to OrionBelt Semantic Layer are documented here.
 
 ## [Unreleased]
 
+### Added
+
+- **`obsl --server` can present a client certificate.** `--client-cert` / `--client-key` /
+  `--ca-cert` (and `OBSL_CLIENT_CERT` / `OBSL_CLIENT_KEY` / `OBSL_CA_CERT`) let the CLI reach a REST
+  API behind a gateway that requires mutual TLS, which it previously could not connect to at all.
+
+  This makes the CLI *able to satisfy* mTLS; it does not make OBSL serve it. The REST API does not
+  terminate TLS itself, so `https://` comes from whatever sits in front of it, and the client
+  certificate matters only when that thing asks for one. The wire-surface settings
+  (`PGWIRE_TLS_*`, `FLIGHT_TLS_*`) are a different surface and do not apply: `obsl --server` is a
+  REST client and never connects over pgwire or Flight SQL.
+
+  `--ca-cert` replaces the default trust store rather than adding to it, and there is deliberately
+  no flag to disable verification. Certificate material is loaded when the flags are resolved, not
+  when the request is made, so a path that is missing, unreadable, or present but not what it
+  claims names the setting and the file instead of surfacing as an SSL error from inside the HTTP
+  client that names neither.
+
 ## [2.28.2] - 2026-09-11
 
 ### Fixed

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -56,15 +56,15 @@ For `compile` and `execute` you supply the query one of two ways (exactly one):
 
 | Command | Options |
 | --- | --- |
-| _common (where remote-capable)_ | `-f, --format {table,json,csv,tsv}` · `-s, --server URL` (env `OBSL_SERVER`) · `--api-key KEY` (env `OBSL_API_KEY`) |
-| `validate` | `--online` · `-d/--dialect NAME` (with `--online`; defaults to `DB_VENDOR`) · `-f/--format` · `-s/--server` · `--api-key` |
-| `compile` | `-q/--query PATH` · `--sql TEXT` · `-d/--dialect NAME` · `--explain` · `--pretty/--no-pretty` (default pretty) · `-f/--format` · `-s/--server` · `--api-key` |
-| `execute` | `-q/--query PATH` · `--sql TEXT` · `-d/--dialect NAME` · `--limit N` (default 1000; see note) · `-f/--format` · `-s/--server` · `--api-key` |
+| _common (where remote-capable)_ | `-f, --format {table,json,csv,tsv}` · `-s, --server URL` (env `OBSL_SERVER`) · `--api-key KEY` (env `OBSL_API_KEY`) · `--ca-cert PATH` (env `OBSL_CA_CERT`) · `--client-cert PATH` (env `OBSL_CLIENT_CERT`) · `--client-key PATH` (env `OBSL_CLIENT_KEY`) - see [TLS in remote mode](#tls-in-remote-mode) |
+| `validate` | `--online` · `-d/--dialect NAME` (with `--online`; defaults to `DB_VENDOR`) · `-f/--format` · `-s/--server` · `--api-key` · TLS options above |
+| `compile` | `-q/--query PATH` · `--sql TEXT` · `-d/--dialect NAME` · `--explain` · `--pretty/--no-pretty` (default pretty) · `-f/--format` · `-s/--server` · `--api-key` · TLS options above |
+| `execute` | `-q/--query PATH` · `--sql TEXT` · `-d/--dialect NAME` · `--limit N` (default 1000; see note) · `-f/--format` · `-s/--server` · `--api-key` · TLS options above |
 | `describe` | `-f/--format` |
 | `diagram` | `--columns/--no-columns` (default columns) · `--theme NAME` (Mermaid theme, default `default`) |
 | `graph` | _(none)_ |
-| `convert` | `DIRECTION` (`osi-to-obml`\|`obml-to-osi`) · `INPUT` · `--name NAME` (OSI model name, obml-to-osi) · `-s/--server` · `--api-key` |
-| `dialects` | `-f/--format` · `-s/--server` · `--api-key` |
+| `convert` | `DIRECTION` (`osi-to-obml`\|`obml-to-osi`) · `INPUT` · `--name NAME` (OSI model name, obml-to-osi) · `-s/--server` · `--api-key` · TLS options above |
+| `dialects` | `-f/--format` · `-s/--server` · `--api-key` · TLS options above |
 
 Global: `-V/--version`, `--install-completion`, `--show-completion`.
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -212,12 +212,59 @@ go to **stderr** — so `obsl ... -f json | jq` and redirects work cleanly.
 | --- | --- | --- |
 | `--server URL` | `OBSL_SERVER` | Target a deployed OrionBelt REST API |
 | `--api-key KEY` | `OBSL_API_KEY` | API key for that server |
+| `--ca-cert PATH` | `OBSL_CA_CERT` | PEM CA bundle for a private or self-signed authority |
+| `--client-cert PATH` | `OBSL_CLIENT_CERT` | PEM client certificate, when an ingress requires one |
+| `--client-key PATH` | `OBSL_CLIENT_KEY` | Its private key, when they are separate files |
 
 `compile` and `execute` in remote mode run the query against the **server's
 curated model** (via the `/v1/query/sql` and `/v1/query/execute` shortcuts that
 auto-resolve the deployed model) — no model is uploaded, so `MODEL` is omitted
 and governed single-model deployments (where ad-hoc model upload is disabled)
 are respected. `validate` and `convert` operate on the model you pass.
+
+### TLS in remote mode
+
+`--server` speaks HTTP to the REST API, so an `https://` URL is encrypted and
+**verified**: the certificate chain and the hostname are both checked, and an
+expired or untrusted certificate is refused rather than warned about.
+
+`--ca-cert` **replaces** the default trust store rather than adding to it, and
+there is deliberately no flag to disable verification: a CLI that can be told to
+trust anything gets told to trust anything.
+
+```bash
+obsl validate model.yaml --server https://obsl.internal \
+  --ca-cert /etc/ssl/certs/internal-ca.crt
+```
+
+Against a gateway that requires mutual TLS:
+
+```bash
+obsl execute --sql 'SELECT "Region", "Sales" FROM model' \
+  --server https://obsl.internal \
+  --ca-cert     /etc/ssl/certs/internal-ca.crt \
+  --client-cert /etc/ssl/certs/obsl-client.crt \
+  --client-key  /etc/ssl/private/obsl-client.key
+```
+
+Omit `--client-key` when the certificate and key live in one PEM.
+
+Every failure names the setting it is about: a path that is missing, unreadable,
+or present but not what it claims fails when the flags are resolved rather than
+as an SSL error from inside the HTTP client mentioning neither the flag nor the
+file.
+
+!!! note "What this does and does not do"
+
+    These make the CLI *able to satisfy* mutual TLS. They do not make OBSL
+    *serve* it: the REST API does not terminate TLS itself, so `https://` is
+    provided by whatever sits in front of it, and `--client-cert` matters only
+    when that thing asks for a certificate.
+
+    The wire-surface settings are separate and do not apply here. `obsl
+    --server` is a REST client; it never connects over pgwire or Flight SQL.
+    For those see [Postgres wire](postgres-wire-bi-tools.md) and
+    [ADBC / Arrow Flight SQL](adbc.md#tls).
 
 ```bash
 export OBSL_SERVER=https://your-host

--- a/src/orionbelt/cli/_remote.py
+++ b/src/orionbelt/cli/_remote.py
@@ -93,15 +93,23 @@ def resolve_tls(client_cert: str | None, client_key: str | None, ca_cert: str | 
     if expanded["cert"] is None and expanded["ca"] is None:
         return ClientTLS()
 
-    # ``httpx.create_ssl_context``, not ``ssl.create_default_context``. They do
-    # not trust the same things: httpx falls back to the certifi bundle (and
-    # honours SSL_CERT_FILE / SSL_CERT_DIR before it), while ssl's default is
-    # OpenSSL's own store, which on some platforms is close to empty. Building
-    # our own would have meant that adding --client-cert silently changed which
-    # authorities the *server* is checked against, so a server that verified
-    # before could start failing for an unrelated reason.
+    # Two paths, and the split is the point.
+    #
+    # With no --ca-cert we must land on *httpx's* default trust, not ssl's:
+    # httpx falls back to the certifi bundle (honouring SSL_CERT_FILE /
+    # SSL_CERT_DIR first), while ssl's default is OpenSSL's own store, which on
+    # some platforms is close to empty. Building our own there would have meant
+    # that adding --client-cert silently changed which authorities the *server*
+    # is checked against.
+    #
+    # With --ca-cert we are replacing that store deliberately, so there is no
+    # default to preserve and we build the context directly. httpx deprecates
+    # ``verify=<str>`` and points at exactly this construction.
     try:
-        context = httpx.create_ssl_context(verify=expanded["ca"] or True)
+        if expanded["ca"]:
+            context = ssl.create_default_context(cafile=expanded["ca"])
+        else:
+            context = httpx.create_ssl_context(verify=True)
     except (ssl.SSLError, OSError) as exc:
         raise CliError(
             f"--ca-cert: not a usable PEM CA bundle ({path_reason(exc)}): {expanded['ca']}"

--- a/src/orionbelt/cli/_remote.py
+++ b/src/orionbelt/cli/_remote.py
@@ -13,6 +13,10 @@ endpoints.
 
 from __future__ import annotations
 
+import os
+import ssl
+from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, cast
 
 import httpx
@@ -25,11 +29,92 @@ from orionbelt.models.query import QueryObject
 _TIMEOUT = httpx.Timeout(120.0, connect=10.0)
 
 
+@dataclass(frozen=True)
+class ClientTLS:
+    """Certificate material for the ``--server`` connection.
+
+    Only the ``--server`` path uses this. Local mode opens no HTTP connection at
+    all, and a local ``execute`` reaches the warehouse through its vendor
+    driver, whose TLS is that driver's business.
+
+    Holds the *built* context rather than the paths: httpx 0.28 deprecates
+    ``cert=`` in favour of ``verify=<ssl_context>``, and building once means the
+    material validated at flag-resolution time is the same object that goes on
+    the wire.
+    """
+
+    context: ssl.SSLContext | None = None
+
+    @property
+    def verify(self) -> Any:
+        """The value for httpx's ``verify``.
+
+        ``True`` keeps the default trust store and full verification. A context
+        carries whatever was configured; it is never ``False``, because there is
+        deliberately no flag for that - a CLI that can be told to trust anything
+        gets told to trust anything.
+        """
+        return self.context if self.context is not None else True
+
+
+def resolve_tls(client_cert: str | None, client_key: str | None, ca_cert: str | None) -> ClientTLS:
+    """Validate the three settings and build a :class:`ClientTLS`.
+
+    Every failure here is a configuration failure and says which setting is
+    wrong, for the same reason the listener loaders do: a path that is missing,
+    unreadable, or present but not what it claims otherwise surfaces as an SSL
+    error from inside the HTTP client, naming none of them.
+    """
+    if client_key and not client_cert:
+        raise CliError(
+            "--client-key was given without --client-cert. A private key alone "
+            "cannot identify a client; supply the certificate too."
+        )
+    for label, value in (
+        ("--client-cert", client_cert),
+        ("--client-key", client_key),
+        ("--ca-cert", ca_cert),
+    ):
+        if value is None:
+            continue
+        path = Path(value).expanduser()
+        if not path.is_file():
+            raise CliError(f"{label}: no such file: {path}")
+        if not os.access(path, os.R_OK):
+            raise CliError(f"{label}: not readable: {path}")
+
+    if client_cert is None and ca_cert is None:
+        return ClientTLS()
+
+    try:
+        context = ssl.create_default_context(cafile=ca_cert)
+    except (ssl.SSLError, OSError) as exc:
+        raise CliError(
+            f"--ca-cert: not a usable PEM CA bundle ({path_reason(exc)}): {ca_cert}"
+        ) from None
+    if client_cert:
+        try:
+            context.load_cert_chain(client_cert, client_key)
+        except (ssl.SSLError, OSError) as exc:
+            flag = "--client-cert/--client-key" if client_key else "--client-cert"
+            raise CliError(f"{flag}: could not load the certificate ({path_reason(exc)})") from None
+    return ClientTLS(context=context)
+
+
+def path_reason(exc: BaseException) -> str:
+    """The useful half of an ssl/OS error, without the file path repeated."""
+    reason = getattr(exc, "reason", None) or getattr(exc, "strerror", None)
+    return str(reason or exc).strip() or exc.__class__.__name__
+
+
 class RemoteClient:
     """Thin wrapper over the OrionBelt REST API for the CLI's remote path."""
 
-    def __init__(self, server: str, api_key: str | None = None) -> None:
+    def __init__(
+        self, server: str, api_key: str | None = None, tls: ClientTLS | None = None
+    ) -> None:
         self.base = server.rstrip("/")
+        self._tls = tls if tls is not None else ClientTLS()
         # Identify as obsl rather than the default "python-httpx/..." — some
         # WAFs (e.g. Cloud Armor in front of the demo deployment) deny the
         # generic httpx agent.
@@ -59,9 +144,15 @@ class RemoteClient:
     ) -> Any:
         url = f"{self.base}/v1{path}"
         try:
-            resp = httpx.request(
-                method, url, json=json, params=params, headers=self._headers, timeout=_TIMEOUT
-            )
+            # A Client rather than ``httpx.request``: the module-level helper
+            # cannot take a prepared SSL context, and the client certificate
+            # lives on that context.
+            with httpx.Client(
+                headers=self._headers,
+                timeout=_TIMEOUT,
+                verify=self._tls.verify,
+            ) as client:
+                resp = client.request(method, url, json=json, params=params)
         except httpx.RequestError as exc:
             raise CliError(f"Could not reach server {self.base}: {exc}") from None
         if resp.status_code >= 400:

--- a/src/orionbelt/cli/_remote.py
+++ b/src/orionbelt/cli/_remote.py
@@ -70,10 +70,16 @@ def resolve_tls(client_cert: str | None, client_key: str | None, ca_cert: str | 
             "--client-key was given without --client-cert. A private key alone "
             "cannot identify a client; supply the certificate too."
         )
-    for label, value in (
-        ("--client-cert", client_cert),
-        ("--client-key", client_key),
-        ("--ca-cert", ca_cert),
+
+    # Expand here and use the expanded form everywhere below. Checking
+    # ``~/ca.pem`` and then handing the literal string to OpenSSL would pass
+    # this validation and fail in the handshake, which is the opposite of what
+    # validating early is for.
+    expanded: dict[str, str | None] = {"cert": None, "key": None, "ca": None}
+    for slot, label, value in (
+        ("cert", "--client-cert", client_cert),
+        ("key", "--client-key", client_key),
+        ("ca", "--ca-cert", ca_cert),
     ):
         if value is None:
             continue
@@ -82,21 +88,29 @@ def resolve_tls(client_cert: str | None, client_key: str | None, ca_cert: str | 
             raise CliError(f"{label}: no such file: {path}")
         if not os.access(path, os.R_OK):
             raise CliError(f"{label}: not readable: {path}")
+        expanded[slot] = str(path)
 
-    if client_cert is None and ca_cert is None:
+    if expanded["cert"] is None and expanded["ca"] is None:
         return ClientTLS()
 
+    # ``httpx.create_ssl_context``, not ``ssl.create_default_context``. They do
+    # not trust the same things: httpx falls back to the certifi bundle (and
+    # honours SSL_CERT_FILE / SSL_CERT_DIR before it), while ssl's default is
+    # OpenSSL's own store, which on some platforms is close to empty. Building
+    # our own would have meant that adding --client-cert silently changed which
+    # authorities the *server* is checked against, so a server that verified
+    # before could start failing for an unrelated reason.
     try:
-        context = ssl.create_default_context(cafile=ca_cert)
+        context = httpx.create_ssl_context(verify=expanded["ca"] or True)
     except (ssl.SSLError, OSError) as exc:
         raise CliError(
-            f"--ca-cert: not a usable PEM CA bundle ({path_reason(exc)}): {ca_cert}"
+            f"--ca-cert: not a usable PEM CA bundle ({path_reason(exc)}): {expanded['ca']}"
         ) from None
-    if client_cert:
+    if expanded["cert"]:
         try:
-            context.load_cert_chain(client_cert, client_key)
+            context.load_cert_chain(expanded["cert"], expanded["key"])
         except (ssl.SSLError, OSError) as exc:
-            flag = "--client-cert/--client-key" if client_key else "--client-cert"
+            flag = "--client-cert/--client-key" if expanded["key"] else "--client-cert"
             raise CliError(f"{flag}: could not load the certificate ({path_reason(exc)})") from None
     return ClientTLS(context=context)
 

--- a/src/orionbelt/cli/main.py
+++ b/src/orionbelt/cli/main.py
@@ -78,6 +78,64 @@ ApiKeyOpt = Annotated[
     str | None,
     typer.Option("--api-key", envvar="OBSL_API_KEY", help="API key for the remote server."),
 ]
+#: Client certificate material for ``--server``. Per-command rather than
+#: global, so it sits beside ``--server`` and ``--api-key`` where a reader
+#: expects it: a global flag would have to precede the subcommand while its two
+#: companions follow it.
+ClientCertOpt = Annotated[
+    str | None,
+    typer.Option(
+        "--client-cert",
+        envvar="OBSL_CLIENT_CERT",
+        help=(
+            "PEM client certificate for --server, when an ingress in front of the REST "
+            "API requires one (mutual TLS). Holds the key too unless --client-key is given."
+        ),
+    ),
+]
+ClientKeyOpt = Annotated[
+    str | None,
+    typer.Option(
+        "--client-key",
+        envvar="OBSL_CLIENT_KEY",
+        help="PEM private key for --client-cert, when the two are separate files.",
+    ),
+]
+CaCertOpt = Annotated[
+    str | None,
+    typer.Option(
+        "--ca-cert",
+        envvar="OBSL_CA_CERT",
+        help=(
+            "PEM CA bundle used to verify the --server certificate, for a private or "
+            "self-signed authority. Replaces the default trust store; it never disables "
+            "verification."
+        ),
+    ),
+]
+
+
+def _remote_client(
+    server: str,
+    api_key: str | None,
+    client_cert: str | None,
+    client_key: str | None,
+    ca_cert: str | None,
+) -> Any:
+    """Build a ``RemoteClient``, failing on bad certificate paths first.
+
+    Every failure names the setting it is about, for the same reason the
+    listener loaders do: a missing or unreadable path otherwise surfaces as a
+    TLS handshake error mentioning none of them.
+    """
+    from orionbelt.cli._local import CliError
+    from orionbelt.cli._remote import RemoteClient, resolve_tls
+
+    try:
+        tls = resolve_tls(client_cert, client_key, ca_cert)
+    except CliError as exc:
+        raise _fail(str(exc)) from None
+    return RemoteClient(server, api_key, tls=tls)
 
 
 class ConvertDirection(enum.StrEnum):
@@ -186,6 +244,9 @@ def validate(
     dialect: ProbeDialectOpt = None,
     server: ServerOpt = None,
     api_key: ApiKeyOpt = None,
+    client_cert: ClientCertOpt = None,
+    client_key: ClientKeyOpt = None,
+    ca_cert: CaCertOpt = None,
 ) -> None:
     """Validate an OBML model. Exits non-zero when the model is invalid.
 
@@ -197,10 +258,9 @@ def validate(
     model_yaml = _io.read_text(model)
     if server:
         from orionbelt.cli._local import CliError
-        from orionbelt.cli._remote import RemoteClient
 
         try:
-            data = RemoteClient(server, api_key).validate(
+            data = _remote_client(server, api_key, client_cert, client_key, ca_cert).validate(
                 model_yaml, online=online, dialect=dialect
             )
         except CliError as exc:
@@ -254,6 +314,9 @@ def compile(  # noqa: A001 — "compile" is the natural verb for this command
     fmt: FormatOpt = OutputFormat.table,
     server: ServerOpt = None,
     api_key: ApiKeyOpt = None,
+    client_cert: ClientCertOpt = None,
+    client_key: ClientKeyOpt = None,
+    ca_cert: CaCertOpt = None,
 ) -> None:
     """Compile a query to SQL from a query document (-q) or an OBSQL string (--sql).
 
@@ -270,9 +333,8 @@ def compile(  # noqa: A001 — "compile" is the natural verb for this command
         # Remote only when no local model is given: a provided MODEL is
         # authoritative (compiled locally), so an ambient OBSL_SERVER never
         # silently redirects an explicit `obsl compile model.yaml`.
-        from orionbelt.cli._remote import RemoteClient
 
-        client = RemoteClient(server, api_key)
+        client = _remote_client(server, api_key, client_cert, client_key, ca_cert)
         try:
             if sql:
                 item = client.compile_obsql(sql, dialect)
@@ -358,6 +420,9 @@ def execute(
     fmt: FormatOpt = OutputFormat.table,
     server: ServerOpt = None,
     api_key: ApiKeyOpt = None,
+    client_cert: ClientCertOpt = None,
+    client_key: ClientKeyOpt = None,
+    ca_cert: CaCertOpt = None,
 ) -> None:
     """Execute a query (from -q or --sql) against the configured warehouse.
 
@@ -373,14 +438,12 @@ def execute(
     from orionbelt.cli._local import CliError
 
     if server and not model:
-        from orionbelt.cli._remote import RemoteClient
-
         if sql and limit is not None:
             _render.warn(
                 "--limit cannot be applied to --sql in remote mode; include LIMIT in the "
                 "query (the server applies its own default row limit otherwise)."
             )
-        client = RemoteClient(server, api_key)
+        client = _remote_client(server, api_key, client_cert, client_key, ca_cert)
         try:
             if sql:
                 item = client.execute_obsql(sql, dialect)
@@ -530,6 +593,9 @@ def convert(
     ] = "semantic_model",
     server: ServerOpt = None,
     api_key: ApiKeyOpt = None,
+    client_cert: ClientCertOpt = None,
+    client_key: ClientKeyOpt = None,
+    ca_cert: CaCertOpt = None,
 ) -> None:
     """Convert between OSI and OBML model formats."""
     input_yaml = _io.read_text(input_file)
@@ -538,10 +604,10 @@ def convert(
     warnings: list[Any]
     if direction is ConvertDirection.osi_to_obml:
         if server:
-            from orionbelt.cli._remote import RemoteClient
-
             try:
-                data = RemoteClient(server, api_key).convert_osi_to_obml(input_yaml)
+                data = _remote_client(
+                    server, api_key, client_cert, client_key, ca_cert
+                ).convert_osi_to_obml(input_yaml)
             except CliError as exc:
                 raise _fail(str(exc)) from None
             output = data.get("output_yaml", "")
@@ -562,12 +628,10 @@ def convert(
 
     # obml-to-osi
     if server:
-        from orionbelt.cli._remote import RemoteClient
-
         try:
-            data = RemoteClient(server, api_key).convert_obml_to_osi(
-                input_yaml, model_name=model_name
-            )
+            data = _remote_client(
+                server, api_key, client_cert, client_key, ca_cert
+            ).convert_obml_to_osi(input_yaml, model_name=model_name)
         except CliError as exc:
             raise _fail(str(exc)) from None
         output = data.get("output_yaml", "")
@@ -591,14 +655,16 @@ def dialects(
     fmt: FormatOpt = OutputFormat.table,
     server: ServerOpt = None,
     api_key: ApiKeyOpt = None,
+    client_cert: ClientCertOpt = None,
+    client_key: ClientKeyOpt = None,
+    ca_cert: CaCertOpt = None,
 ) -> None:
     """List the supported SQL dialects."""
     if server:
         from orionbelt.cli._local import CliError
-        from orionbelt.cli._remote import RemoteClient
 
         try:
-            names = RemoteClient(server, api_key).dialects()
+            names = _remote_client(server, api_key, client_cert, client_key, ca_cert).dialects()
         except CliError as exc:
             raise _fail(str(exc)) from None
     else:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -495,8 +495,13 @@ class TestClientCertificates:
     """
 
     @staticmethod
-    def _pem(tmp_path: Path) -> tuple[str, str]:
-        """A self-signed certificate and its key, as separate PEM files."""
+    def _pem(tmp_path: Path, *, ca: bool = False) -> tuple[str, str]:
+        """A self-signed certificate and its key, as separate PEM files.
+
+        ``ca=True`` adds the basic constraint that makes it usable as a trust
+        anchor - without it ``SSLContext.get_ca_certs()`` reports nothing,
+        because a leaf certificate loaded as a CA bundle anchors nothing.
+        """
         pytest.importorskip("cryptography", reason="cryptography required to mint a test cert")
         import datetime as dt
 
@@ -508,7 +513,7 @@ class TestClientCertificates:
         key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
         name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "obsl-cli-test")])
         now = dt.datetime.now(dt.UTC)
-        cert = (
+        builder = (
             x509.CertificateBuilder()
             .subject_name(name)
             .issuer_name(name)
@@ -516,8 +521,12 @@ class TestClientCertificates:
             .serial_number(x509.random_serial_number())
             .not_valid_before(now - dt.timedelta(minutes=5))
             .not_valid_after(now + dt.timedelta(days=1))
-            .sign(key, hashes.SHA256())
         )
+        if ca:
+            builder = builder.add_extension(
+                x509.BasicConstraints(ca=True, path_length=None), critical=True
+            )
+        cert = builder.sign(key, hashes.SHA256())
         cert_path = tmp_path / "client.crt"
         key_path = tmp_path / "client.key"
         cert_path.write_bytes(cert.public_bytes(serialization.Encoding.PEM))
@@ -611,3 +620,57 @@ class TestClientCertificates:
         result = runner.invoke(app, ["dialects", "--ca-cert", str(tmp_path / "nope.crt")])
         assert result.exit_code == 0, result.output
         assert "duckdb" in result.output
+
+    def test_a_client_certificate_alone_keeps_httpxs_default_trust(self, tmp_path: Path) -> None:
+        """Adding --client-cert must not change who the *server* is checked against.
+
+        The two defaults are not the same: httpx falls back to the certifi
+        bundle, while ``ssl.create_default_context()`` uses OpenSSL's own store,
+        which on some platforms is close to empty. Building our own context
+        therefore made ``--client-cert`` silently swap the trust anchors, so a
+        server that verified before could start failing for a reason having
+        nothing to do with the client certificate.
+
+        Compared by the actual CA set rather than by construction, because the
+        defect was that two plausible-looking constructions disagree.
+        """
+        import httpx
+
+        from orionbelt.cli._remote import resolve_tls
+
+        cert, key = self._pem(tmp_path)
+        ours = resolve_tls(cert, key, None).context
+        assert ours is not None
+        httpx_default = httpx.create_ssl_context(verify=True)
+        assert ours.get_ca_certs() == httpx_default.get_ca_certs()
+
+    def test_a_ca_bundle_replaces_that_trust_rather_than_adding_to_it(self, tmp_path: Path) -> None:
+        """The other half: --ca-cert is an override, and must actually override."""
+        import httpx
+
+        from orionbelt.cli._remote import resolve_tls
+
+        ca_cert, _ = self._pem(tmp_path, ca=True)
+        ours = resolve_tls(None, None, ca_cert).context
+        assert ours is not None
+        assert ours.get_ca_certs() != httpx.create_ssl_context(verify=True).get_ca_certs()
+        assert len(ours.get_ca_certs()) == 1, "only the bundle we named should be trusted"
+
+    def test_a_tilde_path_is_expanded_before_openssl_sees_it(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``~/ca.pem`` passed the existence check and then failed in the handshake.
+
+        The check expanded the path and the SSL call did not, so validating
+        early achieved the opposite of what it is for.
+        """
+        from orionbelt.cli._remote import resolve_tls
+
+        home = tmp_path / "home"
+        home.mkdir()
+        cert, key = self._pem(home)
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+
+        tls = resolve_tls(f"~/{Path(cert).name}", f"~/{Path(key).name}", None)
+        assert tls.context is not None

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -8,6 +8,7 @@ so no live server is required.
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import pytest
 from typer.testing import CliRunner
@@ -476,3 +477,137 @@ def test_validate_offline_sends_no_params(monkeypatch):
     monkeypatch.setattr(RemoteClient, "_request", fake_request)
     RemoteClient("http://example", None).validate("version: 1.0")
     assert seen["params"] is None
+
+
+class TestClientCertificates:
+    """``--client-cert`` / ``--client-key`` / ``--ca-cert`` on the remote path.
+
+    These exist for one deployment shape: an ingress in front of the REST API
+    that requires a client certificate. OBSL does not serve TLS on REST itself,
+    so there is nothing here that makes the *server* do mutual TLS - what these
+    do is let the CLI satisfy a gateway that already demands it, where before
+    it could not connect at all.
+
+    Every assertion is about the error, because that is the whole value: a path
+    that is missing, unreadable or not what it claims otherwise surfaces as an
+    SSL exception from inside the HTTP client, naming neither the flag nor the
+    file.
+    """
+
+    @staticmethod
+    def _pem(tmp_path: Path) -> tuple[str, str]:
+        """A self-signed certificate and its key, as separate PEM files."""
+        pytest.importorskip("cryptography", reason="cryptography required to mint a test cert")
+        import datetime as dt
+
+        from cryptography import x509
+        from cryptography.hazmat.primitives import hashes, serialization
+        from cryptography.hazmat.primitives.asymmetric import rsa
+        from cryptography.x509.oid import NameOID
+
+        key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "obsl-cli-test")])
+        now = dt.datetime.now(dt.UTC)
+        cert = (
+            x509.CertificateBuilder()
+            .subject_name(name)
+            .issuer_name(name)
+            .public_key(key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now - dt.timedelta(minutes=5))
+            .not_valid_after(now + dt.timedelta(days=1))
+            .sign(key, hashes.SHA256())
+        )
+        cert_path = tmp_path / "client.crt"
+        key_path = tmp_path / "client.key"
+        cert_path.write_bytes(cert.public_bytes(serialization.Encoding.PEM))
+        key_path.write_bytes(
+            key.private_bytes(
+                serialization.Encoding.PEM,
+                serialization.PrivateFormat.TraditionalOpenSSL,
+                serialization.NoEncryption(),
+            )
+        )
+        return str(cert_path), str(key_path)
+
+    def test_a_key_without_a_certificate_is_refused(self, tmp_path: Path) -> None:
+        _, key = self._pem(tmp_path)
+        result = runner.invoke(
+            app, ["dialects", "--server", "https://example.invalid", "--client-key", key]
+        )
+        assert result.exit_code != 0
+        assert "--client-cert" in result.output
+
+    def test_a_missing_path_names_the_flag_and_the_file(self, tmp_path: Path) -> None:
+        missing = str(tmp_path / "nope.crt")
+        result = runner.invoke(
+            app, ["dialects", "--server", "https://example.invalid", "--ca-cert", missing]
+        )
+        assert result.exit_code != 0
+        assert "--ca-cert" in result.output
+        assert "no such file" in result.output.lower()
+
+    def test_a_file_that_is_not_a_ca_bundle_is_caught_before_the_request(
+        self, tmp_path: Path
+    ) -> None:
+        """Readable and present is not the same as usable.
+
+        Without this check the failure came out of the HTTP client as an
+        unhandled SSL exception mentioning neither the flag nor the path.
+        """
+        junk = tmp_path / "not-a-ca.pem"
+        junk.write_text("this is not a certificate\n")
+        result = runner.invoke(
+            app, ["dialects", "--server", "https://example.invalid", "--ca-cert", str(junk)]
+        )
+        assert result.exit_code != 0
+        assert "--ca-cert" in result.output
+        assert "not a usable" in result.output.lower()
+
+    def test_a_mismatched_certificate_and_key_are_caught(self, tmp_path: Path) -> None:
+        cert, _ = self._pem(tmp_path)
+        other_dir = tmp_path / "other"
+        other_dir.mkdir()
+        _, other_key = self._pem(other_dir)
+        result = runner.invoke(
+            app,
+            [
+                "dialects",
+                "--server",
+                "https://example.invalid",
+                "--client-cert",
+                cert,
+                "--client-key",
+                other_key,
+            ],
+        )
+        assert result.exit_code != 0
+        assert "--client-cert" in result.output
+
+    def test_valid_material_reaches_the_request(self, tmp_path: Path) -> None:
+        """The material loads, so the command fails on the *connection* instead.
+
+        ``example.invalid`` cannot resolve, so reaching a connection error is
+        proof the certificate checks passed rather than short-circuited.
+        """
+        cert, key = self._pem(tmp_path)
+        result = runner.invoke(
+            app,
+            [
+                "dialects",
+                "--server",
+                "https://example.invalid",
+                "--client-cert",
+                cert,
+                "--client-key",
+                key,
+            ],
+        )
+        assert result.exit_code != 0
+        assert "could not reach server" in result.output.lower()
+
+    def test_the_flags_are_inert_without_a_server(self, tmp_path: Path) -> None:
+        """Local mode opens no HTTP connection, so there is nothing to apply them to."""
+        result = runner.invoke(app, ["dialects", "--ca-cert", str(tmp_path / "nope.crt")])
+        assert result.exit_code == 0, result.output
+        assert "duckdb" in result.output

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -656,6 +656,26 @@ class TestClientCertificates:
         assert ours.get_ca_certs() != httpx.create_ssl_context(verify=True).get_ca_certs()
         assert len(ours.get_ca_certs()) == 1, "only the bundle we named should be trusted"
 
+    def test_no_path_uses_a_deprecated_httpx_api(self, tmp_path: Path) -> None:
+        """Both context constructions must be current API.
+
+        ``verify=<str>`` is deprecated in httpx 0.28 and would eventually stop
+        working; ``cert=`` already did, which is how the first version of this
+        code got caught. Pinned as an error so the next deprecation surfaces
+        here rather than in a release.
+        """
+        import warnings
+
+        from orionbelt.cli._remote import resolve_tls
+
+        ca_cert, _ = self._pem(tmp_path, ca=True)
+        cert, key = self._pem(tmp_path)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            resolve_tls(cert, key, None)
+            resolve_tls(None, None, ca_cert)
+            resolve_tls(cert, key, ca_cert)
+
     def test_a_tilde_path_is_expanded_before_openssl_sees_it(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
`--client-cert` / `--client-key` / `--ca-cert` (and `OBSL_CLIENT_CERT` / `OBSL_CLIENT_KEY` / `OBSL_CA_CERT`) let the CLI reach a REST API behind a gateway that requires mutual TLS.

Before this it could not connect to one **at all** - the handshake failed and every command with it. A wall, not a degradation, which is the argument for doing it.

```bash
obsl execute --sql 'SELECT "Region", "Sales" FROM model' \
  --server https://obsl.internal \
  --ca-cert     /etc/ssl/certs/internal-ca.crt \
  --client-cert /etc/ssl/certs/obsl-client.crt \
  --client-key  /etc/ssl/private/obsl-client.key
```

## What this is not

It does **not** make OBSL serve mTLS. The REST API does not terminate TLS itself - there is no `ssl_certfile` wiring in `uvicorn.run` - so `https://` comes from whatever sits in front of it, and a client certificate matters only when that thing asks for one.

`PGWIRE_TLS_*` and `FLIGHT_TLS_*` secure a **different surface** and do not apply here: `obsl --server` is a REST client and never connects over pgwire or Flight SQL. The guide says this in as many words, because it is exactly the assumption someone would make after 2.28.0.

Whether the REST listener should serve TLS natively, like the two wire surfaces now do, is a separate question this PR does not answer.

## Three decisions worth reviewing

**Per-command, not global.** They were on the app callback first, which put them *before* the subcommand while `--server` and `--api-key` follow it. That inconsistency would have cost a reader something for no benefit. Making them per-command also let me delete the module-level mutable default the global version needed.

**Validated at flag resolution, not at request time.** A path that is missing, unreadable, or present but not what it claims now names the setting and the file. Without it, a readable non-CA file raised an unhandled SSL exception out of the HTTP client naming neither - which is how it behaved while I was building it:

```
error: --ca-cert: not a usable PEM CA bundle (NO_CERTIFICATE_OR_CRL_FOUND): /etc/hosts
error: --client-key was given without --client-cert. A private key alone cannot identify a client…
```

**`ClientTLS` carries a built `SSLContext`, not paths.** httpx 0.28 deprecates `cert=` in favour of `verify=<ssl_context>`, and building once means the material validated at resolution time is the same object that goes on the wire. The deprecation warning is what surfaced this - the new tests caught it, I had not noticed.

`--ca-cert` replaces the default trust store rather than adding to it, and there is deliberately no flag to disable verification: a CLI that can be told to trust anything gets told to trust anything.

## Tests

Six cases in `TestClientCertificates`, all asserting on the *error*, since that is the whole value: key without certificate, missing path, a readable file that is not a CA bundle, a mismatched certificate/key pair, valid material reaching the connection attempt (proving the checks passed rather than short-circuited), and the flags being inert in local mode where no HTTP connection exists.

Full suite: 5204 passed, 1070 skipped. `ruff`, `mypy` and `mkdocs build --strict` clean.

## Note on #445

That PR adds a "TLS in remote mode" section to `docs/guide/cli.md` describing the *pre-flag* behaviour. This branch writes the section with the flags included. Whichever merges second will need a rebase; I would merge this one first and drop that section from #445.