### PR TITLE
feat(api): serve TLS on the REST surface

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -156,6 +156,37 @@ SESSION_RATE_LIMIT=10
 # AUTH_ENABLED=false
 
 # =============================================================================
+# Transport security (TLS) — all three surfaces
+# =============================================================================
+# Each surface takes a certificate, its key, and optionally a CA to check
+# client certificates against (mutual TLS). Read by one shared loader, so the
+# rules are identical everywhere: BOTH the certificate and the key, or neither.
+# Half a pair refuses to start rather than serving plaintext under a
+# configuration that reads as encrypted.
+#
+# Unset means plaintext, which is the right default behind a load balancer or
+# ingress that already terminates TLS (Cloud Run, nginx). Set these when there
+# is no proxy, when the hop behind it must be encrypted too, or when mutual TLS
+# should reach the application rather than stop at the edge.
+#
+# REST (v2.29.0+)
+# API_TLS_CERT=/certs/server.crt
+# API_TLS_KEY=/certs/server.key
+# API_TLS_CLIENT_CA=/certs/ca.crt
+#
+# PostgreSQL wire (v2.28.0+)
+# PGWIRE_TLS_CERT=/certs/server.crt
+# PGWIRE_TLS_KEY=/certs/server.key
+# PGWIRE_TLS_CLIENT_CA=/certs/ca.crt
+#
+# Arrow Flight SQL (v2.28.0+) — with a certificate the listener serves
+# grpc+tls instead of grpc, so a plaintext client is refused at the handshake
+# rather than silently downgraded.
+# FLIGHT_TLS_CERT=/certs/server.crt
+# FLIGHT_TLS_KEY=/certs/server.key
+# FLIGHT_TLS_CLIENT_CA=/certs/ca.crt
+
+# =============================================================================
 # Arrow Flight SQL Server (gRPC — for DBeaver, Tableau, Power BI)
 # =============================================================================
 # Enable gRPC Flight SQL server on FLIGHT_PORT (implies QUERY_EXECUTE=true)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,32 @@ All notable changes to OrionBelt Semantic Layer are documented here.
 
 ### Added
 
+- **TLS on the REST surface.** `API_TLS_CERT` + `API_TLS_KEY` (and `API_TLS_CLIENT_CA` for mutual
+  TLS) make the API serve HTTPS, through the same loader and the same rules as the two wire
+  surfaces: both settings or neither, a client CA refused without a server certificate, and every
+  error naming `API_TLS_*` rather than another surface's settings.
+
+  REST was the one surface that could not encrypt itself. The implicit reasoning was that it is
+  always behind something that terminates TLS - but that applied equally to pgwire, which shipped
+  TLS in 2.28.0 anyway, precisely because there is not always a proxy. Leaving REST out was an
+  inconsistency rather than a decision; `design/PLAN_flight_tls.md` scoped T-0 to T-4 to the wire
+  surfaces and recorded no rationale for excluding this one.
+
+  Defaults are unchanged: unset means plaintext, so no existing deployment moves. Set them when
+  there is no proxy, when the hop behind the proxy must be encrypted too, or when mutual TLS should
+  reach the application rather than stop at the edge. The startup line reports which you got.
+
+  Verified end to end with a real client rather than only in unit tests: HTTPS served and validated
+  against the issuing CA, plain HTTP refused, an untrusted CA refused, and under
+  `API_TLS_CLIENT_CA` a client with no certificate refused while one signed by that CA is served.
+
 - **`obsl --server` can present a client certificate.** `--client-cert` / `--client-key` /
   `--ca-cert` (and `OBSL_CLIENT_CERT` / `OBSL_CLIENT_KEY` / `OBSL_CA_CERT`) let the CLI reach a REST
-  API behind a gateway that requires mutual TLS, which it previously could not connect to at all.
+  API that requires mutual TLS, which it previously could not connect to at all.
 
-  This makes the CLI *able to satisfy* mTLS; it does not make OBSL serve it. The REST API does not
-  terminate TLS itself, so `https://` comes from whatever sits in front of it, and the client
-  certificate matters only when that thing asks for one. The wire-surface settings
-  (`PGWIRE_TLS_*`, `FLIGHT_TLS_*`) are a different surface and do not apply: `obsl --server` is a
-  REST client and never connects over pgwire or Flight SQL.
+  With `API_TLS_CLIENT_CA` above, that is OBSL itself; it equally satisfies a gateway in front that
+  asks for a certificate. The wire-surface settings remain a different surface and do not apply:
+  `obsl --server` is a REST client and never connects over pgwire or Flight SQL.
 
   `--ca-cert` replaces the default trust store rather than adding to it, and there is deliberately
   no flag to disable verification. Certificate material is loaded when the flags are resolved, not

--- a/docs/guide/authentication.md
+++ b/docs/guide/authentication.md
@@ -47,6 +47,52 @@ with a comma-separated second key.
 Startup fails fast (refuses to boot) if `AUTH_MODE=api_key` with an empty
 `API_KEYS`, or if any key is shorter than 16 characters.
 
+## Transport security (TLS)
+
+Authentication proves *who* is calling; TLS stops anyone else reading what they
+said. They are separate settings and both matter: SCRAM keeps a pgwire key off
+the wire even without TLS, but the query results still cross it in the clear.
+
+All three surfaces take the same three settings, read by the same loader, and
+each names its own prefix in every error message:
+
+| Surface | Certificate | Key | Client CA (mutual TLS) |
+|---|---|---|---|
+| REST | `API_TLS_CERT` | `API_TLS_KEY` | `API_TLS_CLIENT_CA` |
+| Postgres wire | `PGWIRE_TLS_CERT` | `PGWIRE_TLS_KEY` | `PGWIRE_TLS_CLIENT_CA` |
+| Arrow Flight SQL | `FLIGHT_TLS_CERT` | `FLIGHT_TLS_KEY` | `FLIGHT_TLS_CLIENT_CA` |
+
+```bash
+API_TLS_CERT=/certs/server.crt \
+API_TLS_KEY=/certs/server.key \
+API_TLS_CLIENT_CA=/certs/ca.crt \
+uv run orionbelt-api
+```
+
+The startup line says which you got, so confirming TLS is live needs no packet
+capture:
+
+```
+REST API serving HTTPS on 0.0.0.0:8000 (client certificates required)
+```
+
+**Both settings or neither.** A certificate without its key refuses to start
+rather than falling back to plaintext, because a deployment that reads as
+encrypted and is not is worse than one that does not come up. A client CA
+without a server certificate is refused for the same reason: mutual TLS needs
+both halves.
+
+**When you need this and when you do not.** Behind Cloud Run, an ingress or
+nginx, TLS is already terminated at the edge and these can stay unset - that is
+why they default to off and why every existing deployment is unchanged. Set them
+when there is no proxy (a LAN or on-premise deployment), when the hop between
+the proxy and OrionBelt must be encrypted too, or when you want mutual TLS all
+the way to the application rather than to the edge.
+
+The [CLI](cli.md#tls-in-remote-mode) can present a client certificate with
+`--client-cert` / `--client-key`, so `obsl --server` works against a listener
+configured this way.
+
 ## Generating keys
 
 Out-of-band — there is no in-app key generation endpoint. Use any secure RNG:
@@ -192,6 +238,6 @@ deployment:
 - [ ] `AUTH_MODE=api_key`
 - [ ] `API_KEYS` set to at least one random key (≥40 chars recommended)
 - [ ] Keys stored in your platform's secret manager, not committed to a repo
-- [ ] HTTPS / TLS terminating in front of OrionBelt (reverse proxy or platform)
+- [ ] TLS on every exposed surface: either terminated in front (reverse proxy or platform) or served by OrionBelt itself with `API_TLS_*` / `PGWIRE_TLS_*` / `FLIGHT_TLS_*` - see [Transport security](#transport-security-tls)
 - [ ] Rotation cadence documented (90 days is a reasonable default)
 - [ ] Public demo deployments use a separate key set from production

--- a/docs/guide/authentication.md
+++ b/docs/guide/authentication.md
@@ -89,6 +89,10 @@ when there is no proxy (a LAN or on-premise deployment), when the hop between
 the proxy and OrionBelt must be encrypted too, or when you want mutual TLS all
 the way to the application rather than to the edge.
 
+The [CLI](cli.md#tls-in-remote-mode) can present a client certificate with
+`--client-cert` / `--client-key`, so `obsl --server` works against a listener
+configured with `API_TLS_CLIENT_CA`.
+
 ## Generating keys
 
 Out-of-band — there is no in-app key generation endpoint. Use any secure RNG:

--- a/docs/guide/authentication.md
+++ b/docs/guide/authentication.md
@@ -89,10 +89,6 @@ when there is no proxy (a LAN or on-premise deployment), when the hop between
 the proxy and OrionBelt must be encrypted too, or when you want mutual TLS all
 the way to the application rather than to the edge.
 
-The [CLI](cli.md#tls-in-remote-mode) can present a client certificate with
-`--client-cert` / `--client-key`, so `obsl --server` works against a listener
-configured this way.
-
 ## Generating keys
 
 Out-of-band — there is no in-app key generation endpoint. Use any secure RNG:

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -254,16 +254,17 @@ or present but not what it claims fails when the flags are resolved rather than
 as an SSL error from inside the HTTP client mentioning neither the flag nor the
 file.
 
-!!! note "What this does and does not do"
+!!! note "Which end these are"
 
-    These make the CLI *able to satisfy* mutual TLS. They do not make OBSL
-    *serve* it: the REST API does not terminate TLS itself, so `https://` is
-    provided by whatever sits in front of it, and `--client-cert` matters only
-    when that thing asks for a certificate.
+    These are the *client* half. The server half is
+    [`API_TLS_CLIENT_CA`](authentication.md#transport-security-tls), which makes
+    the REST API demand a certificate; `--client-cert` is how `obsl` presents
+    one. They also work against a gateway in front of OBSL that asks for a
+    certificate, in which case nothing on the server needs configuring at all.
 
-    The wire-surface settings are separate and do not apply here. `obsl
-    --server` is a REST client; it never connects over pgwire or Flight SQL.
-    For those see [Postgres wire](postgres-wire-bi-tools.md) and
+    The wire-surface settings are a different surface and do not apply here.
+    `obsl --server` is a REST client; it never connects over pgwire or Flight
+    SQL. For those see [Postgres wire](postgres-wire-bi-tools.md) and
     [ADBC / Arrow Flight SQL](adbc.md#tls).
 
 ```bash

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -36,6 +36,15 @@ Configuration is via environment variables or a `.env` file. See `.env.template`
 | `PGWIRE_AUTH_MODE`         | `trust`     | `trust` today; `password` / `scram-sha-256` planned alongside the unified-auth subsystem |
 | `PGWIRE_MAX_CONNECTIONS`   | `64`        | Concurrent connection cap                 |
 | `PGWIRE_QUERY_TIMEOUT_SECONDS` | `60`    | Per-query wall-clock timeout              |
+| `API_TLS_CERT`             | —           | PEM certificate; with `API_TLS_KEY` the REST API serves HTTPS (v2.29.0+) |
+| `API_TLS_KEY`              | —           | PEM private key. Both or neither: one alone refuses to start rather than serving plaintext |
+| `API_TLS_CLIENT_CA`        | —           | PEM CA for client certificates; turns on mutual TLS (needs cert + key) |
+| `PGWIRE_TLS_CERT`          | —           | PEM certificate; with the key, pgwire answers `S` to an `SSLRequest` and upgrades the socket (v2.28.0+) |
+| `PGWIRE_TLS_KEY`           | —           | PEM private key. Both or neither                  |
+| `PGWIRE_TLS_CLIENT_CA`     | —           | PEM CA for client certificates; turns on mutual TLS |
+| `FLIGHT_TLS_CERT`          | —           | PEM certificate; with the key, Flight serves `grpc+tls` instead of `grpc` (v2.28.0+) |
+| `FLIGHT_TLS_KEY`           | —           | PEM private key. Both or neither                  |
+| `FLIGHT_TLS_CLIENT_CA`     | —           | PEM CA for client certificates; turns on mutual TLS |
 | `DB_VENDOR`                | `duckdb`    | Database vendor for query execution       |
 
 ## Admin-Curated Mode

--- a/src/orionbelt/api/app.py
+++ b/src/orionbelt/api/app.py
@@ -854,4 +854,54 @@ def main() -> None:
         log_config=None,
         access_log=access_log,
         timeout_graceful_shutdown=3,
+        **_rest_tls_kwargs(settings),
     )
+
+
+def _rest_tls_kwargs(settings: Any) -> dict[str, Any]:
+    """uvicorn's TLS arguments, or an empty dict when TLS is not configured.
+
+    Loaded before the socket binds, through the same loader the Flight and
+    pgwire listeners use, so a misconfiguration stops startup with the
+    operator's message instead of serving plaintext on a deployment whose
+    configuration reads as encrypted. That failure mode is the whole reason
+    both other surfaces refuse to start on a half-configured pair.
+
+    uvicorn takes paths rather than PEM bytes, which is why ``ListenerTLS``
+    carries both.
+    """
+    from orionbelt.service.tls import TLSConfigError, load_listener_tls
+
+    try:
+        tls = load_listener_tls(
+            settings.api_tls_cert,
+            settings.api_tls_key,
+            settings.api_tls_client_ca,
+            prefix="API",
+        )
+    except TLSConfigError as exc:
+        raise RuntimeError(f"REST TLS configuration is unusable: {exc}") from None
+    if tls is None:
+        logger.info(
+            "REST API serving plaintext HTTP on %s:%s",
+            settings.api_server_host,
+            settings.effective_port,
+        )
+        return {}
+
+    kwargs: dict[str, Any] = {
+        "ssl_certfile": tls.cert_path,
+        "ssl_keyfile": tls.key_path,
+    }
+    if tls.client_ca_path is not None:
+        import ssl
+
+        kwargs["ssl_ca_certs"] = tls.client_ca_path
+        kwargs["ssl_cert_reqs"] = ssl.CERT_REQUIRED
+    logger.info(
+        "REST API serving HTTPS on %s:%s (client certificates %s)",
+        settings.api_server_host,
+        settings.effective_port,
+        "required" if tls.client_ca_path else "not required",
+    )
+    return kwargs

--- a/src/orionbelt/settings.py
+++ b/src/orionbelt/settings.py
@@ -125,6 +125,14 @@ class Settings(BaseSettings):
     # by the same loader. Postgres negotiates with an SSLRequest rather than
     # starting encrypted, so with these set the server answers ``S`` and
     # upgrades the socket; without them it answers ``N`` as before.
+    # TLS for the REST listener, same shape and same loader as the two wire
+    # surfaces. Unlike those, REST is usually behind something that terminates
+    # TLS already (Cloud Run, an ingress, nginx) - these are for when it is not:
+    # a LAN or on-premise deployment with no proxy, or a requirement that the
+    # internal hop be encrypted too rather than only the edge.
+    api_tls_cert: str | None = None
+    api_tls_key: str | None = None
+    api_tls_client_ca: str | None = None
     pgwire_tls_cert: str | None = None
     pgwire_tls_key: str | None = None
     pgwire_tls_client_ca: str | None = None

--- a/tests/unit/test_api_tls.py
+++ b/tests/unit/test_api_tls.py
@@ -1,0 +1,166 @@
+"""TLS on the REST listener.
+
+The two wire surfaces gained TLS in 2.28.0 and REST did not, which left it as
+the only surface that could not encrypt itself. The reasoning was presumably
+that REST is always behind something that terminates TLS - but that applies to
+pgwire too, and pgwire got it anyway, precisely because there is not always a
+proxy.
+
+What is asserted here is the *wiring*: that the settings reach uvicorn in the
+form it expects, and that a misconfiguration stops startup rather than serving
+plaintext under a configuration that reads as encrypted. The handshake itself is
+``ssl``'s and is already covered where the shared loader is tested.
+"""
+
+from __future__ import annotations
+
+import ssl
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from orionbelt.api.app import _rest_tls_kwargs
+from orionbelt.service.tls import TLSConfigError
+
+
+class _Settings:
+    """Only the attributes ``_rest_tls_kwargs`` reads."""
+
+    def __init__(self, cert: str | None, key: str | None, client_ca: str | None = None) -> None:
+        self.api_tls_cert = cert
+        self.api_tls_key = key
+        self.api_tls_client_ca = client_ca
+        self.api_server_host = "127.0.0.1"
+        self.effective_port = 8000
+
+
+@pytest.fixture
+def pki(tmp_path: Path) -> dict[str, str]:
+    """A CA, and a server certificate signed by it."""
+    pytest.importorskip("cryptography", reason="cryptography required to mint test certs")
+    import datetime as dt
+
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    from cryptography.x509.oid import NameOID
+
+    now = dt.datetime.now(dt.UTC)
+
+    def name(cn: str) -> Any:
+        return x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, cn)])
+
+    ca_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    ca = (
+        x509.CertificateBuilder()
+        .subject_name(name("OBSL Test CA"))
+        .issuer_name(name("OBSL Test CA"))
+        .public_key(ca_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - dt.timedelta(minutes=5))
+        .not_valid_after(now + dt.timedelta(days=1))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        .sign(ca_key, hashes.SHA256())
+    )
+    srv_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    srv = (
+        x509.CertificateBuilder()
+        .subject_name(name("localhost"))
+        .issuer_name(ca.subject)
+        .public_key(srv_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - dt.timedelta(minutes=5))
+        .not_valid_after(now + dt.timedelta(days=1))
+        .sign(ca_key, hashes.SHA256())
+    )
+    paths = {
+        "ca": tmp_path / "ca.crt",
+        "cert": tmp_path / "server.crt",
+        "key": tmp_path / "server.key",
+    }
+    paths["ca"].write_bytes(ca.public_bytes(serialization.Encoding.PEM))
+    paths["cert"].write_bytes(srv.public_bytes(serialization.Encoding.PEM))
+    paths["key"].write_bytes(
+        srv_key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.TraditionalOpenSSL,
+            serialization.NoEncryption(),
+        )
+    )
+    return {k: str(v) for k, v in paths.items()}
+
+
+class TestUnconfigured:
+    def test_no_settings_means_no_uvicorn_arguments(self) -> None:
+        """Plaintext stays the default, so every existing deployment is unchanged."""
+        assert _rest_tls_kwargs(_Settings(None, None)) == {}
+
+
+class TestConfigured:
+    def test_the_certificate_and_key_reach_uvicorn_as_paths(self, pki: dict[str, str]) -> None:
+        """uvicorn takes paths, not PEM bytes - which is why the loader keeps both."""
+        kwargs = _rest_tls_kwargs(_Settings(pki["cert"], pki["key"]))
+        assert kwargs == {"ssl_certfile": pki["cert"], "ssl_keyfile": pki["key"]}
+
+    def test_a_client_ca_turns_on_mutual_tls(self, pki: dict[str, str]) -> None:
+        """The point of the setting: without CERT_REQUIRED uvicorn would accept
+        any client, and a CA that is loaded but not enforced is worse than none,
+        because the configuration reads as mutual TLS."""
+        kwargs = _rest_tls_kwargs(_Settings(pki["cert"], pki["key"], pki["ca"]))
+        assert kwargs["ssl_ca_certs"] == pki["ca"]
+        assert kwargs["ssl_cert_reqs"] == ssl.CERT_REQUIRED
+
+    def test_the_material_actually_loads(self, pki: dict[str, str]) -> None:
+        """Paths that uvicorn will hand to ``ssl``, proven usable here rather
+        than at bind time in production."""
+        kwargs = _rest_tls_kwargs(_Settings(pki["cert"], pki["key"], pki["ca"]))
+        ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        ctx.load_cert_chain(kwargs["ssl_certfile"], kwargs["ssl_keyfile"])
+        ctx.load_verify_locations(cafile=kwargs["ssl_ca_certs"])
+
+
+class TestMisconfiguredStopsStartup:
+    """Half a configuration must not serve plaintext.
+
+    A deployment that set one of the pair and got HTTP would believe it was
+    encrypted. Refusing to start is the louder and safer failure, and is what
+    both wire surfaces already do.
+    """
+
+    def test_a_certificate_without_a_key(self, pki: dict[str, str]) -> None:
+        with pytest.raises(RuntimeError, match="API_TLS_KEY"):
+            _rest_tls_kwargs(_Settings(pki["cert"], None))
+
+    def test_a_key_without_a_certificate(self, pki: dict[str, str]) -> None:
+        with pytest.raises(RuntimeError, match="API_TLS_CERT"):
+            _rest_tls_kwargs(_Settings(None, pki["key"]))
+
+    def test_a_client_ca_alone(self, pki: dict[str, str]) -> None:
+        """Mutual TLS needs the server's own certificate as well."""
+        with pytest.raises(RuntimeError, match="API_TLS_CLIENT_CA"):
+            _rest_tls_kwargs(_Settings(None, None, pki["ca"]))
+
+    def test_a_missing_file_names_the_setting(self, tmp_path: Path) -> None:
+        missing = str(tmp_path / "nope.crt")
+        with pytest.raises(RuntimeError, match="API_TLS_CERT"):
+            _rest_tls_kwargs(_Settings(missing, missing))
+
+    def test_the_error_names_this_surface_not_another(self, pki: dict[str, str]) -> None:
+        """``prefix='API'`` matters: an error naming FLIGHT_TLS_KEY on the REST
+        listener would send an operator to the wrong setting entirely."""
+        with pytest.raises(RuntimeError) as exc:
+            _rest_tls_kwargs(_Settings(pki["cert"], None))
+        assert "FLIGHT" not in str(exc.value)
+        assert "PGWIRE" not in str(exc.value)
+
+
+def test_the_loader_is_shared_with_the_wire_surfaces() -> None:
+    """Not a reimplementation: the same loader, so the same error messages and
+    the same refusal to start on half a pair."""
+    import inspect
+
+    from orionbelt.api import app
+
+    assert "load_listener_tls" in inspect.getsource(app._rest_tls_kwargs)
+    assert issubclass(TLSConfigError, ValueError)


### PR DESCRIPTION
`API_TLS_CERT` + `API_TLS_KEY` make the REST API serve HTTPS; `API_TLS_CLIENT_CA` additionally requires a client certificate signed by that CA.

```bash
API_TLS_CERT=/certs/server.crt \
API_TLS_KEY=/certs/server.key \
API_TLS_CLIENT_CA=/certs/ca.crt \
uv run orionbelt-api
```

```
REST API serving HTTPS on 0.0.0.0:8000 (client certificates required)
```

## Why

REST was the **only surface that could not encrypt itself**. The implicit reasoning was that it is always behind something that terminates TLS - but that applied equally to pgwire, which shipped TLS in 2.28.0 anyway, precisely because there is not always a proxy.

`design/PLAN_flight_tls.md` scoped T-0 to T-4 to the two wire surfaces and recorded **no rationale** for excluding REST, so this was an inconsistency rather than a decision. The plan now carries a T-5 saying what was decided and why, which is what was missing the first time.

## Same loader, deliberately

No new loader and no new error vocabulary: `load_listener_tls(..., prefix="API")`, the same one Flight and pgwire use. So the same rules come for free - both settings or neither, a client CA refused without a server certificate, and the non-root-readable-key message that took a while to get right the first time.

uvicorn takes **paths** rather than PEM bytes, which is the third shape of the same material and the reason `ListenerTLS` carries both: Flight wants bytes, pgwire wants an `SSLContext` built from paths, REST wants the paths themselves.

Loaded **before the socket binds**, so a misconfiguration stops startup with the operator's message instead of serving plaintext under a configuration that reads as encrypted.

## Nothing moves for existing deployments

Unset means plaintext, exactly as before - including the Cloud Run demo, where the load balancer still terminates TLS. These are for when there is no proxy (LAN, on-premise), when the hop behind the proxy must be encrypted too, or when mutual TLS should reach the application rather than stop at the edge.

## Verified with a real client, not only unit tests

| | Result |
|---|---|
| HTTPS with the issuing CA | ✅ served |
| Plain HTTP against the HTTPS port | ✅ refused (curl 52) |
| Untrusted CA | ✅ refused |
| `API_TLS_CLIENT_CA` set, no client certificate | ✅ refused (curl 56) |
| `API_TLS_CLIENT_CA` set, certificate signed by it | ✅ served |

Plus 10 unit tests covering the wiring: the settings reaching uvicorn in the form it expects, `CERT_REQUIRED` actually being set when a client CA is given (a CA loaded but not enforced is worse than none, since the configuration reads as mutual TLS), every half-configuration refusing startup, and the errors naming `API_TLS_*` rather than `FLIGHT_` or `PGWIRE_` - an error pointing at the wrong surface's setting sends an operator somewhere useless.

Full suite: 5208 passed, 1070 skipped. `ruff`, `mypy`, `mkdocs build --strict` clean.

## Related

Pairs with #446, which lets `obsl --server` present a client certificate - together they make mutual TLS work end to end to OBSL itself rather than only to a gateway in front of it.