### PR TITLE
feat(obml): external concept mappings and ontology prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to OrionBelt Semantic Layer are documented here.
 
 ## [Unreleased]
 
+### Added
+
+- **External concept mappings (OBML mapping foundation).** A model, data object, dimension,
+  measure or metric may carry `externalConceptMappings`: qualified links to concepts in an
+  external ontology (`concept` as a compact or full IRI, a required SKOS-style `relation`, and
+  optional `justification`, `source`, `ontologyVersion`, `confidence`, `comment`). A top-level
+  `ontology.prefixes` block declares the prefixes compact IRIs expand with; `rdf`, `rdfs`, `owl`,
+  `skos` and `xsd` are built in. The resolver expands every concept to an absolute IRI and reports
+  `INVALID_ONTOLOGY_PREFIX`, `UNKNOWN_ONTOLOGY_PREFIX`, `INVALID_CONCEPT_IRI`,
+  `INVALID_CONCEPT_MAPPING`, `DUPLICATE_CONCEPT_MAPPING` and `CONFLICTING_CONCEPT_MAPPING` as
+  structured errors with source spans. Mappings are descriptive metadata: compiled SQL and result
+  cache keys are identical with and without them. The JSON schema, contract manifest and OBSL
+  ontology vocabulary (`obsl:ExternalConceptMapping` and its properties) are extended; the RDF
+  exporter, discovery API and OSI round-trip follow in later PRs of the same plan.
+
 ## [2.29.0] - 2026-09-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,12 @@ All notable changes to OrionBelt Semantic Layer are documented here.
   `INVALID_CONCEPT_MAPPING`, `DUPLICATE_CONCEPT_MAPPING` and `CONFLICTING_CONCEPT_MAPPING` as
   structured errors with source spans. Mappings are descriptive metadata: compiled SQL and result
   cache keys are identical with and without them. The JSON schema, contract manifest and OBSL
-  ontology vocabulary (`obsl:ExternalConceptMapping` and its properties) are extended; the RDF
-  exporter, discovery API and OSI round-trip follow in later PRs of the same plan.
+  ontology vocabulary (`obsl:ExternalConceptMapping` and its properties) are extended, and the
+  OSI converter (osi-orionbelt 0.3.1) carries `ontology` and every object's mappings through
+  the OBSL vendor extension so OBML -> OSI -> OBML is lossless. `extends` and `inherits` merge
+  `ontology.prefixes` and model-level mappings; rebinding an already-bound prefix in another
+  fragment is `ONTOLOGY_PREFIX_CONFLICT` rather than a silent rewrite. The RDF exporter and the
+  discovery API follow in later PRs of the same plan.
 
 ## [2.29.0] - 2026-09-11
 

--- a/ontology/obsl.shacl.ttl
+++ b/ontology/obsl.shacl.ttl
@@ -544,3 +544,77 @@ obsl:WithinGroupShape a sh:NodeShape ;
         sh:message "WithinGroup order must be exactly one of 'ASC' or 'DESC'."
     ] .
 
+# -----------------------------------------------------------------------------
+# ExternalConceptMapping --- link to a concept in an external ontology
+# -----------------------------------------------------------------------------
+
+obsl:ExternalConceptMappingShape a sh:NodeShape ;
+    sh:targetClass obsl:ExternalConceptMapping ;
+    rdfs:label "OBSL External Concept Mapping Shape" ;
+    rdfs:comment "Validates that every external concept mapping names exactly one absolute target IRI and one SKOS mapping relation, and that its provenance fields are single-valued." ;
+    sh:property [
+        sh:path obsl:sourceObject ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:IRI ;
+        sh:name "source object" ;
+        sh:message "Every ExternalConceptMapping must point back at exactly one modeled element via obsl:sourceObject."
+    ] ;
+    sh:property [
+        sh:path obsl:targetConcept ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:IRI ;
+        sh:name "target concept" ;
+        sh:message "Every ExternalConceptMapping must have exactly one obsl:targetConcept, an absolute IRI."
+    ] ;
+    sh:property [
+        sh:path obsl:authoredConcept ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
+        sh:name "authored concept"
+    ] ;
+    sh:property [
+        sh:path obsl:mappingRelation ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
+        sh:in ( "exact" "close" "broader" "narrower" "related" ) ;
+        sh:name "mapping relation" ;
+        sh:message "ExternalConceptMapping relation must be exactly one of 'exact', 'close', 'broader', 'narrower' or 'related'."
+    ] ;
+    sh:property [
+        sh:path obsl:mappingJustification ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
+        sh:in ( "curated" "imported" "generated" "inferred" "lexical" ) ;
+        sh:name "mapping justification" ;
+        sh:message "ExternalConceptMapping justification must be one of 'curated', 'imported', 'generated', 'inferred' or 'lexical'."
+    ] ;
+    sh:property [
+        sh:path obsl:mappingSource ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
+        sh:name "mapping source"
+    ] ;
+    sh:property [
+        sh:path obsl:ontologyVersion ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
+        sh:name "ontology version"
+    ] ;
+    sh:property [
+        sh:path obsl:confidence ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:decimal ;
+        sh:minInclusive 0 ;
+        sh:maxInclusive 1 ;
+        sh:name "confidence" ;
+        sh:message "ExternalConceptMapping confidence must be a decimal between 0 and 1."
+    ] ;
+    sh:property [
+        sh:path obsl:mappingComment ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
+        sh:name "mapping comment"
+    ] .

--- a/ontology/obsl.ttl
+++ b/ontology/obsl.ttl
@@ -4,7 +4,6 @@
 @prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix vann:    <http://purl.org/vocab/vann/> .
-@prefix skos:    <http://www.w3.org/2004/02/skos/core#> .
 @prefix obsl:    <https://ralforion.com/ns/obsl#> .
 
 # =============================================================================
@@ -688,9 +687,8 @@ obsl:sourceObject a owl:ObjectProperty ;
 
 obsl:targetConcept a owl:ObjectProperty ;
     rdfs:label "target concept" ;
-    rdfs:comment "The external concept the mapping points at, as an absolute IRI (the authored compact IRI expanded with the model's ontology prefixes)." ;
-    rdfs:domain obsl:ExternalConceptMapping ;
-    rdfs:range skos:Concept .
+    rdfs:comment "The external concept the mapping points at, as an absolute IRI (the authored compact IRI expanded with the model's ontology prefixes).  Deliberately without a range: targets are whatever the external ontology declares them to be (a skos:Concept in a glossary, an owl:Class in FIBO, a schema.org type), and a range would make a reasoner type every one of them." ;
+    rdfs:domain obsl:ExternalConceptMapping .
 
 obsl:authoredConcept a owl:DatatypeProperty ;
     rdfs:label "authored concept" ;

--- a/ontology/obsl.ttl
+++ b/ontology/obsl.ttl
@@ -4,6 +4,7 @@
 @prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix vann:    <http://purl.org/vocab/vann/> .
+@prefix skos:    <http://www.w3.org/2004/02/skos/core#> .
 @prefix obsl:    <https://ralforion.com/ns/obsl#> .
 
 # =============================================================================
@@ -91,6 +92,10 @@ obsl:ModelExample a owl:Class ;
 obsl:WithinGroup a owl:Class ;
     rdfs:label "Within Group" ;
     rdfs:comment "Ordering clause for ordered-set aggregates (LISTAGG).  Names a column and an ASC/DESC direction." .
+
+obsl:ExternalConceptMapping a owl:Class ;
+    rdfs:label "External Concept Mapping" ;
+    rdfs:comment "A qualified link from a modeling element (SemanticModel, DataObject, Dimension, Measure, Metric) to a concept in an external ontology, with the SKOS mapping relation and its provenance (justification, source, ontology version, confidence).  Descriptive metadata: it never affects SQL planning or execution.  The exporter also states the link directly as a skos:*Match triple from the element to the external IRI." .
 
 # =============================================================================
 # 2. OBJECT PROPERTIES --- Model composition
@@ -660,6 +665,76 @@ obsl:intentTag a owl:DatatypeProperty ;
     rdfs:range xsd:string .
 
 # =============================================================================
+# 8.8 EXTERNAL CONCEPT MAPPINGS --- links to governed business concepts
+# =============================================================================
+# An OBML element may map to concepts in external ontologies (a corporate
+# business glossary, FIBO, schema.org).  OBSL states each link twice: as a
+# direct skos:exactMatch / closeMatch / broadMatch / narrowMatch /
+# relatedMatch triple from the element to the external IRI, and, when the
+# mapping carries more than concept + relation, as an ExternalConceptMapping
+# resource that holds the provenance.  External ontologies are linked by
+# IRI, never imported or rewritten.
+
+obsl:hasExternalConceptMapping a owl:ObjectProperty ;
+    rdfs:label "has external concept mapping" ;
+    rdfs:comment "Links a modeled element (SemanticModel, DataObject, Dimension, Measure, Metric) to one of its external concept mappings." ;
+    rdfs:range obsl:ExternalConceptMapping .
+
+obsl:sourceObject a owl:ObjectProperty ;
+    rdfs:label "source object" ;
+    rdfs:comment "The modeled element an ExternalConceptMapping describes (the subject of the skos mapping triple).  Inverse of hasExternalConceptMapping." ;
+    rdfs:domain obsl:ExternalConceptMapping ;
+    owl:inverseOf obsl:hasExternalConceptMapping .
+
+obsl:targetConcept a owl:ObjectProperty ;
+    rdfs:label "target concept" ;
+    rdfs:comment "The external concept the mapping points at, as an absolute IRI (the authored compact IRI expanded with the model's ontology prefixes)." ;
+    rdfs:domain obsl:ExternalConceptMapping ;
+    rdfs:range skos:Concept .
+
+obsl:authoredConcept a owl:DatatypeProperty ;
+    rdfs:label "authored concept" ;
+    rdfs:comment "The concept exactly as written in OBML: a compact IRI such as 'corp:NetRevenue' or a full IRI.  Preserved for round-trip and display; targetConcept holds the expanded form." ;
+    rdfs:domain obsl:ExternalConceptMapping ;
+    rdfs:range xsd:string .
+
+obsl:mappingRelation a owl:DatatypeProperty ;
+    rdfs:label "mapping relation" ;
+    rdfs:comment "How the source object relates to the target concept, read source-first in the SKOS direction: 'exact' (skos:exactMatch), 'close' (skos:closeMatch), 'broader' (skos:broadMatch --- the external concept is the broader one), 'narrower' (skos:narrowMatch --- the external concept is the narrower one), 'related' (skos:relatedMatch)." ;
+    rdfs:domain obsl:ExternalConceptMapping ;
+    rdfs:range xsd:string .
+
+obsl:mappingJustification a owl:DatatypeProperty ;
+    rdfs:label "mapping justification" ;
+    rdfs:comment "How the mapping came to exist: 'curated', 'imported', 'generated', 'inferred' or 'lexical'." ;
+    rdfs:domain obsl:ExternalConceptMapping ;
+    rdfs:range xsd:string .
+
+obsl:mappingSource a owl:DatatypeProperty ;
+    rdfs:label "mapping source" ;
+    rdfs:comment "Where the mapping comes from: a catalog, ontology or process name." ;
+    rdfs:domain obsl:ExternalConceptMapping ;
+    rdfs:range xsd:string .
+
+obsl:ontologyVersion a owl:DatatypeProperty ;
+    rdfs:label "ontology version" ;
+    rdfs:comment "Version of the external ontology the target concept was taken from." ;
+    rdfs:domain obsl:ExternalConceptMapping ;
+    rdfs:range xsd:string .
+
+obsl:confidence a owl:DatatypeProperty ;
+    rdfs:label "confidence" ;
+    rdfs:comment "Confidence in the mapping, a decimal between 0 and 1." ;
+    rdfs:domain obsl:ExternalConceptMapping ;
+    rdfs:range xsd:decimal .
+
+obsl:mappingComment a owl:DatatypeProperty ;
+    rdfs:label "mapping comment" ;
+    rdfs:comment "Free-text note on the mapping (approval, caveat, rationale)." ;
+    rdfs:domain obsl:ExternalConceptMapping ;
+    rdfs:range xsd:string .
+
+# =============================================================================
 # 9. OWL AXIOMS
 # =============================================================================
 
@@ -678,7 +753,8 @@ obsl:intentTag a owl:DatatypeProperty ;
                   obsl:RefreshPolicy
                   obsl:CustomExtension
                   obsl:ModelExample
-                  obsl:WithinGroup ) .
+                  obsl:WithinGroup
+                  obsl:ExternalConceptMapping ) .
 
 # Metric subtypes are disjoint with each other.
 obsl:CumulativeMetric owl:disjointWith obsl:PeriodOverPeriodMetric .
@@ -727,6 +803,16 @@ obsl:extensionData a owl:FunctionalProperty .
 obsl:exampleName a owl:FunctionalProperty .
 obsl:exampleDescription a owl:FunctionalProperty .
 obsl:exampleQuery a owl:FunctionalProperty .
+
+obsl:sourceObject a owl:FunctionalProperty .
+obsl:targetConcept a owl:FunctionalProperty .
+obsl:authoredConcept a owl:FunctionalProperty .
+obsl:mappingRelation a owl:FunctionalProperty .
+obsl:mappingJustification a owl:FunctionalProperty .
+obsl:mappingSource a owl:FunctionalProperty .
+obsl:ontologyVersion a owl:FunctionalProperty .
+obsl:confidence a owl:FunctionalProperty .
+obsl:mappingComment a owl:FunctionalProperty .
 
 # -----------------------------------------------------------------------------
 # 9.3 Inverse properties

--- a/ontology/spec.md
+++ b/ontology/spec.md
@@ -42,6 +42,7 @@ OBSL-Core is not intended to represent:
 - window metric metadata (window function, offset, buckets, order direction, default value, `partitionBy`)
 - canonical example queries (`ModelExample` with name, description, query payload, intent tags)
 - vendor-keyed `CustomExtension` blocks attached to any modeling element (model, data object, column, dimension, measure, metric)
+- `ExternalConceptMapping` links from a model, data object, dimension, measure or metric to a concept in an external ontology (SKOS mapping relation plus provenance)
 - expression strings
 - labels, descriptions, and synonyms
 - SHACL validation shapes
@@ -62,8 +63,11 @@ Final prefixes:
 @prefix owl:  <http://www.w3.org/2002/07/owl#> .
 @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
 @prefix sh:   <http://www.w3.org/ns/shacl#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix obsl: <https://ralforion.com/ns/obsl#> .
 ```
+
+`skos:` is used only for the mapping predicates (`skos:exactMatch`, `skos:closeMatch`, `skos:broadMatch`, `skos:narrowMatch`, `skos:relatedMatch`) that link modeling elements to external concepts, and for `skos:Concept` as the range of `obsl:targetConcept`. External ontologies are referenced by IRI; OBSL never imports or restates them.
 
 The `obsl:` namespace is frozen for `OBSL-Core 0.2` as:
 - `https://ralforion.com/ns/obsl#`
@@ -266,6 +270,38 @@ Additional required:
 - `obsl:offsetGrain`
 - `obsl:comparison`
 
+### 5.10 ExternalConceptMapping
+Represents a qualified link from a modeling element to a concept in an external ontology (a corporate glossary, FIBO, schema.org). Descriptive metadata only: it never affects SQL planning or execution.
+
+The element itself is the subject of a direct SKOS mapping triple:
+
+```ttl
+<model#measure/Revenue> skos:exactMatch <https://ontology.example.com/business/NetRevenue> .
+```
+
+An `obsl:ExternalConceptMapping` resource is emitted alongside it when the mapping carries more than concept and relation.
+
+Required:
+- `obsl:sourceObject` — the modeled element (inverse of `obsl:hasExternalConceptMapping`)
+- `obsl:targetConcept` — the external concept as an absolute IRI (the authored compact IRI expanded with the model's `ontology.prefixes`)
+- `obsl:mappingRelation` — `exact`, `close`, `broader`, `narrower` or `related`
+
+Optional:
+- `obsl:authoredConcept` — the concept as written in OBML (compact or full IRI)
+- `obsl:mappingJustification` — `curated`, `imported`, `generated`, `inferred` or `lexical`
+- `obsl:mappingSource` — catalog, ontology or process the mapping comes from
+- `obsl:ontologyVersion` — version of the external ontology
+- `obsl:confidence` — decimal in [0, 1]
+- `obsl:mappingComment` — free-text note
+
+Direction: the relation reads source-first in the SKOS direction. `broader` (`skos:broadMatch`) means the external concept is the broader one, so the modeling element is a narrower notion of it; `narrower` (`skos:narrowMatch`) means the external concept is the narrower one.
+
+Cardinality:
+- exactly one `obsl:sourceObject`, `obsl:targetConcept` and `obsl:mappingRelation`
+- at most one of each optional property
+
+Domain of `obsl:hasExternalConceptMapping`: `obsl:SemanticModel`, `obsl:DataObject`, `obsl:Dimension`, `obsl:Measure`, `obsl:Metric`. Columns and joins are out of scope until the relation vocabulary can say *identifies* or *references* rather than *is*.
+
 ## 6. Expressions
 In `OBSL-Core 0.2`, the normative expression representation is:
 - `obsl:expressionSource`
@@ -378,6 +414,13 @@ Recommended practice:
 - `metrics` -> `obsl:hasMetric`
 - `description` -> `rdfs:comment`
 
+Any of model, data object, dimension, measure, metric:
+- `externalConceptMappings[]` -> `obsl:hasExternalConceptMapping` (plus a direct `skos:*Match` triple per entry)
+- `externalConceptMappings[].concept` -> `obsl:authoredConcept`; expanded with `ontology.prefixes` -> `obsl:targetConcept`
+- `externalConceptMappings[].relation` -> `obsl:mappingRelation` and the SKOS predicate: `exact` -> `skos:exactMatch`, `close` -> `skos:closeMatch`, `broader` -> `skos:broadMatch`, `narrower` -> `skos:narrowMatch`, `related` -> `skos:relatedMatch`
+- `externalConceptMappings[].justification` / `source` / `ontologyVersion` / `confidence` / `comment` -> `obsl:mappingJustification` / `obsl:mappingSource` / `obsl:ontologyVersion` / `obsl:confidence` / `obsl:mappingComment`
+- `ontology.prefixes` -> namespace bindings of the exported graph (not described as triples)
+
 ### 10.2 Data Objects
 - `code` -> `obsl:code`
 - `database` -> `obsl:database`
@@ -467,6 +510,7 @@ Properties constrained to at most one value are declared `owl:FunctionalProperty
 - Expression: `obsl:expressionSource`, `obsl:filterExpression`
 - Cumulative: `obsl:cumulativeType`, `obsl:window`, `obsl:grainToDate`
 - Period-over-period: `obsl:offset`, `obsl:offsetGrain`, `obsl:comparison`
+- External concept mapping: `obsl:sourceObject`, `obsl:targetConcept`, `obsl:authoredConcept`, `obsl:mappingRelation`, `obsl:mappingJustification`, `obsl:mappingSource`, `obsl:ontologyVersion`, `obsl:confidence`, `obsl:mappingComment`
 
 This mirrors the `sh:maxCount 1` constraints in SHACL but at the ontology level, enabling OWL-aware tools to enforce cardinality without loading the SHACL shapes.
 
@@ -531,6 +575,7 @@ Core object properties:
 - `obsl:referencesMeasure`
 - `obsl:timeDimension`
 - `obsl:belongsToModel` (inverse of `obsl:hasDataObject`)
+- `obsl:hasExternalConceptMapping`, `obsl:sourceObject` (functional, inverse of `obsl:hasExternalConceptMapping`), `obsl:targetConcept` (functional)
 
 Core datatype properties:
 - `obsl:code` (functional)

--- a/ontology/spec.md
+++ b/ontology/spec.md
@@ -67,7 +67,7 @@ Final prefixes:
 @prefix obsl: <https://ralforion.com/ns/obsl#> .
 ```
 
-`skos:` is used only for the mapping predicates (`skos:exactMatch`, `skos:closeMatch`, `skos:broadMatch`, `skos:narrowMatch`, `skos:relatedMatch`) that link modeling elements to external concepts, and for `skos:Concept` as the range of `obsl:targetConcept`. External ontologies are referenced by IRI; OBSL never imports or restates them.
+`skos:` is used only for the mapping predicates (`skos:exactMatch`, `skos:closeMatch`, `skos:broadMatch`, `skos:narrowMatch`, `skos:relatedMatch`) that link modeling elements to external concepts. `obsl:targetConcept` declares no range: a target is whatever the external ontology says it is (a `skos:Concept`, an `owl:Class`, a schema.org type), and OBSL never imports or restates it.
 
 The `obsl:` namespace is frozen for `OBSL-Core 0.2` as:
 - `https://ralforion.com/ns/obsl#`

--- a/packages/osi-orionbelt/pyproject.toml
+++ b/packages/osi-orionbelt/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "osi-orionbelt"
-version = "0.3.0"
+version = "0.3.1"
 description = "Bidirectional OBML <-> OSI (Open Semantic Interchange) converter for OrionBelt semantic models"
 license = "Apache-2.0"
 license-files = ["LICENSE"]

--- a/packages/osi-orionbelt/src/osi_orionbelt/__init__.py
+++ b/packages/osi-orionbelt/src/osi_orionbelt/__init__.py
@@ -22,7 +22,7 @@ from osi_orionbelt.converter import (
     validate_osi,
 )
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 __all__ = [
     "OBMLtoOSI",

--- a/packages/osi-orionbelt/src/osi_orionbelt/obml_to_osi.py
+++ b/packages/osi-orionbelt/src/osi_orionbelt/obml_to_osi.py
@@ -21,6 +21,19 @@ from osi_orionbelt._common import (
 )
 
 
+def _stash_concept_links(
+    obml_obj: dict, extras: dict, key: str = "obml_external_concept_mappings"
+) -> None:
+    """Copy an OBML object's ``externalConceptMappings`` into an extras payload.
+
+    The links have no OSI slot; they ride in the OBSL-vendor extension of
+    the entity the object became and are restored verbatim on the way back.
+    """
+    links = obml_obj.get("externalConceptMappings")
+    if links:
+        extras[key] = links
+
+
 class OBMLtoOSI:
     """Convert an OBML semantic model YAML to OSI format."""
 
@@ -114,6 +127,12 @@ class OBMLtoOSI:
         count_label_pattern = self.obml.get("countLabelPattern")
         if count_label_pattern is not None:
             roundtrip_data["obml_count_label_pattern"] = count_label_pattern
+        # Ontology prefixes and model-level external concept links. OSI has
+        # no slot for either, and the links are only meaningful together with
+        # the prefixes their compact IRIs expand with.
+        if self.obml.get("ontology"):
+            roundtrip_data["obml_ontology"] = self.obml["ontology"]
+        _stash_concept_links(self.obml, roundtrip_data)
         sem_model["custom_extensions"] = [
             {
                 "vendor_name": _VENDOR_OBML,
@@ -266,6 +285,7 @@ class OBMLtoOSI:
         # object into a table with an empty name.
         if do_obj.get("nestedIn"):
             do_extras["obml_nested_in"] = do_obj["nestedIn"]
+        _stash_concept_links(do_obj, do_extras)
         if do_extras:
             ds_exts = dataset.setdefault("custom_extensions", [])
             ds_exts.append(
@@ -440,6 +460,7 @@ class OBMLtoOSI:
                     ext_data["obml_dimension_synonyms"] = dim_obj["synonyms"]
                 if dim_obj.get("customExtensions"):
                     ext_data["obml_dimension_custom_extensions"] = dim_obj["customExtensions"]
+                _stash_concept_links(dim_obj, ext_data, "obml_dimension_external_concept_mappings")
             else:
                 descriptor: dict[str, Any] = {"name": _dim_name}
                 for prop in ("resultType", "timeGrain", "format", "description", "owner", "via"):
@@ -451,6 +472,7 @@ class OBMLtoOSI:
                     descriptor["synonyms"] = dim_obj["synonyms"]
                 if dim_obj.get("customExtensions"):
                     descriptor["customExtensions"] = dim_obj["customExtensions"]
+                _stash_concept_links(dim_obj, descriptor, "externalConceptMappings")
                 extra_dims.append(descriptor)
         if extra_dims:
             ext_data["obml_extra_dimensions"] = extra_dims
@@ -587,6 +609,7 @@ class OBMLtoOSI:
         for measure_name, measure_obj in obml_measures.items():
             osi_metric = self._convert_measure(measure_name, measure_obj, data_objects)
             if osi_metric:
+                self._carry_concept_links_to_osi_metric(measure_obj, osi_metric)
                 self._carry_foreign_to_osi_metric(measure_obj, osi_metric)
                 self._emit_osi_metric_datatype(measure_obj, osi_metric)
                 osi_metrics.append(osi_metric)
@@ -610,11 +633,38 @@ class OBMLtoOSI:
                     metric_name, metric_obj, obml_measures, data_objects
                 )
             if osi_metric:
+                self._carry_concept_links_to_osi_metric(metric_obj, osi_metric)
                 self._carry_foreign_to_osi_metric(metric_obj, osi_metric)
                 self._emit_osi_metric_datatype(metric_obj, osi_metric)
                 osi_metrics.append(osi_metric)
 
         return osi_metrics
+
+    @staticmethod
+    def _carry_concept_links_to_osi_metric(obml_obj: dict, osi_metric: dict) -> None:
+        """Stash an OBML measure/metric's ``externalConceptMappings`` on the OSI metric.
+
+        Every conversion path emits at most one OBSL-vendor extension per
+        metric, and the reverse direction reads only the first one it finds,
+        so the links are merged into that payload rather than appended as a
+        second extension.
+        """
+        links = obml_obj.get("externalConceptMappings")
+        if not links:
+            return
+        exts = osi_metric.setdefault("custom_extensions", [])
+        for ext in exts:
+            if ext.get("vendor_name") == _VENDOR_OBML:
+                data = json.loads(ext.get("data") or "{}")
+                data["obml_external_concept_mappings"] = links
+                ext["data"] = json.dumps(data)
+                return
+        exts.append(
+            {
+                "vendor_name": _VENDOR_OBML,
+                "data": json.dumps({"obml_external_concept_mappings": links}),
+            }
+        )
 
     def _carry_foreign_to_osi_metric(self, obml_obj: dict, osi_metric: dict) -> None:
         """Re-emit third-party vendor extensions on an OBML measure/metric to

--- a/packages/osi-orionbelt/src/osi_orionbelt/osi_to_obml.py
+++ b/packages/osi-orionbelt/src/osi_orionbelt/osi_to_obml.py
@@ -73,6 +73,22 @@ _FLOAT_RESULT_AGGS = frozenset(
 )
 
 
+def _restore_concept_links(
+    extras: dict, target: dict, key: str = "obml_external_concept_mappings"
+) -> None:
+    """Put stashed ``externalConceptMappings`` back on an OBML object.
+
+    Extension data is opaque to ``validate_osi``, so a foreign payload may
+    put anything under the key: only a list of mappings is accepted, and
+    only its mapping-shaped entries. The OBML parser validates the rest.
+    """
+    links = extras.get(key)
+    if isinstance(links, list):
+        clean = [entry for entry in links if isinstance(entry, dict)]
+        if clean:
+            target["externalConceptMappings"] = clean
+
+
 class OSItoOBML:
     """Convert an OSI semantic model YAML to OBML format."""
 
@@ -233,6 +249,9 @@ class OSItoOBML:
                         obml["exposeCounts"] = ext_data["obml_expose_counts"]
                     if ext_data.get("obml_count_label_pattern") is not None:
                         obml["countLabelPattern"] = ext_data["obml_count_label_pattern"]
+                    if isinstance(ext_data.get("obml_ontology"), dict):
+                        obml["ontology"] = ext_data["obml_ontology"]
+                    _restore_concept_links(ext_data, obml)
                 except (json.JSONDecodeError, TypeError):
                     pass
                 break
@@ -365,6 +384,7 @@ class OSItoOBML:
                         do["countLabel"] = ext_data["obml_count_label"]
                     if ext_data.get("obml_nested_in"):
                         do["nestedIn"] = ext_data["obml_nested_in"]
+                    _restore_concept_links(ext_data, do)
                 except (json.JSONDecodeError, TypeError):
                     pass
                 break
@@ -726,6 +746,9 @@ class OSItoOBML:
                                 clean_exts = [e for e in _exts if isinstance(e, dict)]
                                 if clean_exts:
                                     dim_def["customExtensions"] = clean_exts
+                            _restore_concept_links(
+                                ext_data, dim_def, "obml_dimension_external_concept_mappings"
+                            )
                             # Additional dimensions over the same column, preserved
                             # by the export because OSI has no slot for them.
                             _extras = ext_data.get("obml_extra_dimensions")
@@ -776,6 +799,7 @@ class OSItoOBML:
                         clean_exts = [e for e in exts if isinstance(e, dict)]
                         if clean_exts:
                             extra_def["customExtensions"] = clean_exts
+                    _restore_concept_links(desc, extra_def, "externalConceptMappings")
                     self._insert_dimension(dimensions, ds_name, dname, extra_def)
         return dimensions
 
@@ -1003,6 +1027,8 @@ class OSItoOBML:
             target = metrics.get(m["name"]) or measures.get(m["name"])
             if target is not None:
                 self._carry_foreign_extensions(m.get("custom_extensions"), target)
+                # External concept links, whichever OBML entity the metric became.
+                _restore_concept_links(self._extract_obml_extras(m), target)
                 # Apache Ossie v0.2+ metric `datatype` -> OBML exact `dataType`
                 # (its natural home; `Decimal` -> decimal(p, s)). Don't override a
                 # dataType already restored from an OBML-origin extension, and

--- a/packages/osi-orionbelt/src/osi_orionbelt/schemas/obml-schema.json
+++ b/packages/osi-orionbelt/src/osi_orionbelt/schemas/obml-schema.json
@@ -92,6 +92,13 @@
             "$ref": "#/definitions/customExtension"
           }
         },
+        "externalConceptMappings": {
+          "type": "array",
+          "description": "Links to concepts in external ontologies (SKOS-style, descriptive only)",
+          "items": {
+            "$ref": "#/definitions/externalConceptMapping"
+          }
+        },
         "refresh": {
           "type": "object",
           "description": "Freshness contract for the physical table this dataObject maps to. Drives result-cache TTL composition and heartbeat invalidation. See PLAN_freshness_driven_cache.md \u00a75.",
@@ -542,6 +549,13 @@
           "items": {
             "$ref": "#/definitions/customExtension"
           }
+        },
+        "externalConceptMappings": {
+          "type": "array",
+          "description": "Links to concepts in external ontologies (SKOS-style, descriptive only)",
+          "items": {
+            "$ref": "#/definitions/externalConceptMapping"
+          }
         }
       },
       "required": [
@@ -796,6 +810,13 @@
           "items": {
             "$ref": "#/definitions/customExtension"
           }
+        },
+        "externalConceptMappings": {
+          "type": "array",
+          "description": "Links to concepts in external ontologies (SKOS-style, descriptive only)",
+          "items": {
+            "$ref": "#/definitions/externalConceptMapping"
+          }
         }
       },
       "required": [
@@ -985,6 +1006,13 @@
           "items": {
             "$ref": "#/definitions/customExtension"
           }
+        },
+        "externalConceptMappings": {
+          "type": "array",
+          "description": "Links to concepts in external ontologies (SKOS-style, descriptive only)",
+          "items": {
+            "$ref": "#/definitions/externalConceptMapping"
+          }
         }
       },
       "allOf": [
@@ -1090,6 +1118,87 @@
         "dataObject",
         "column"
       ],
+      "additionalProperties": false
+    },
+    "externalConceptRelation": {
+      "type": "string",
+      "description": "SKOS mapping relation, read artifact-first: exact (skos:exactMatch), close (skos:closeMatch), broader (skos:broadMatch: the external concept is the broader one), narrower (skos:narrowMatch: the external concept is the narrower one), related (skos:relatedMatch).",
+      "enum": [
+        "exact",
+        "close",
+        "broader",
+        "narrower",
+        "related"
+      ]
+    },
+    "mappingJustification": {
+      "type": "string",
+      "description": "How the mapping came to exist: curated (human decision), imported (from another catalog or format), generated or inferred (by tooling), lexical (name match only).",
+      "enum": [
+        "curated",
+        "imported",
+        "generated",
+        "inferred",
+        "lexical"
+      ]
+    },
+    "externalConceptMapping": {
+      "type": "object",
+      "description": "A qualified link from an OBML artifact to a concept in an external ontology. Descriptive metadata only: it never changes SQL, execution, cache keys or join selection.",
+      "properties": {
+        "concept": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The external concept: a compact IRI (prefix:LocalName, expanded with ontology.prefixes or a built-in prefix) or a full IRI (https://... or urn:...). Blank nodes and relative references are rejected at load."
+        },
+        "relation": {
+          "$ref": "#/definitions/externalConceptRelation",
+          "description": "Required. How the artifact relates to the concept; there is no implicit exact."
+        },
+        "justification": {
+          "$ref": "#/definitions/mappingJustification"
+        },
+        "source": {
+          "type": "string",
+          "description": "Where the mapping comes from (a catalog, ontology or process name)"
+        },
+        "ontologyVersion": {
+          "type": "string",
+          "description": "Version of the external ontology the concept was taken from"
+        },
+        "confidence": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Confidence in the mapping, 0 to 1"
+        },
+        "comment": {
+          "type": "string",
+          "description": "Free-text note (approval, caveat, rationale)"
+        }
+      },
+      "required": [
+        "concept",
+        "relation"
+      ],
+      "additionalProperties": false
+    },
+    "ontologyConfig": {
+      "type": "object",
+      "description": "Ontology settings for the model: the prefixes that compact concept IRIs expand with. rdf, rdfs, owl, skos and xsd are built in and cannot be bound to another namespace.",
+      "properties": {
+        "prefixes": {
+          "type": "object",
+          "description": "Prefix name to absolute namespace IRI (e.g. corp: https://ontology.example.com/business/)",
+          "propertyNames": {
+            "pattern": "^[A-Za-z_][A-Za-z0-9_.-]*$"
+          },
+          "additionalProperties": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      },
       "additionalProperties": false
     }
   },
@@ -1328,11 +1437,22 @@
       },
       "additionalProperties": false
     },
+    "ontology": {
+      "$ref": "#/definitions/ontologyConfig",
+      "description": "Ontology settings (prefixes for compact concept IRIs)"
+    },
     "customExtensions": {
       "type": "array",
       "description": "Vendor-keyed extension data at model level",
       "items": {
         "$ref": "#/definitions/customExtension"
+      }
+    },
+    "externalConceptMappings": {
+      "type": "array",
+      "description": "Links from the model as a whole to concepts in external ontologies",
+      "items": {
+        "$ref": "#/definitions/externalConceptMapping"
       }
     }
   },

--- a/packages/osi-orionbelt/tests/test_osi_converter_concept_links.py
+++ b/packages/osi-orionbelt/tests/test_osi_converter_concept_links.py
@@ -1,0 +1,198 @@
+"""OBML external concept mappings survive the OBML -> OSI -> OBML round trip.
+
+OSI has no slot for ``ontology.prefixes`` or ``externalConceptMappings``, so
+both ride in the OBSL-vendor ``custom_extensions`` of the entity each OBML
+object becomes (semantic model, dataset, field, metric) and are restored
+verbatim. A mapping that only makes sense with its prefix must come back
+with that prefix, or the OBML parser would reject it as
+``UNKNOWN_ONTOLOGY_PREFIX``.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from typing import Any
+
+import osi_orionbelt.converter as conv
+
+CORP = "https://ontology.example.com/business/"
+
+_LINK = {"concept": "corp:Thing", "relation": "exact"}
+_RICH_LINK = {
+    "concept": "https://schema.org/MonetaryAmount",
+    "relation": "broader",
+    "justification": "curated",
+    "source": "enterprise-finance-ontology",
+    "ontologyVersion": "2026.1",
+    "confidence": 0.9,
+    "comment": "Approved by Finance",
+}
+
+_OBML: dict[str, Any] = {
+    "version": 1.0,
+    "ontology": {"prefixes": {"corp": CORP}},
+    "externalConceptMappings": [{"concept": "corp:SalesModel", "relation": "exact"}],
+    "dataObjects": {
+        "Orders": {
+            "code": "ORDERS",
+            "database": "W",
+            "schema": "P",
+            "externalConceptMappings": [{"concept": "corp:Order", "relation": "exact"}],
+            "columns": {
+                "Order ID": {"code": "ORDER_ID", "abstractType": "string"},
+                "Amount": {"code": "AMOUNT", "abstractType": "float"},
+                "Order Date": {"code": "ORDER_DATE", "abstractType": "date"},
+            },
+        },
+    },
+    "dimensions": {
+        "Order ID": {
+            "dataObject": "Orders",
+            "column": "Order ID",
+            "externalConceptMappings": [{"concept": "corp:OrderIdentifier", "relation": "exact"}],
+        },
+        "Order Month": {
+            "dataObject": "Orders",
+            "column": "Order Date",
+            "resultType": "date",
+            "timeGrain": "month",
+            "externalConceptMappings": [{"concept": "corp:Month", "relation": "close"}],
+        },
+        "Order Year": {
+            "dataObject": "Orders",
+            "column": "Order Date",
+            "resultType": "date",
+            "timeGrain": "year",
+            "externalConceptMappings": [{"concept": "corp:Year", "relation": "close"}],
+        },
+    },
+    "measures": {
+        "Revenue": {
+            "aggregation": "sum",
+            "columns": [{"dataObject": "Orders", "column": "Amount"}],
+            "owner": "finance",
+            "externalConceptMappings": [
+                _RICH_LINK,
+                {"concept": "corp:NetRevenue", "relation": "exact"},
+            ],
+        },
+        "Delegated": {
+            "aggregation": "measure",
+            "externalConceptMappings": [_LINK],
+        },
+    },
+    "metrics": {
+        "Revenue Doubled": {
+            "expression": "{[Revenue]} * 2",
+            "externalConceptMappings": [{"concept": "corp:DoubleRevenue", "relation": "narrower"}],
+        },
+        "Running Revenue": {
+            "type": "cumulative",
+            "measure": "Revenue",
+            "timeDimension": "Order Month",
+            "externalConceptMappings": [{"concept": "corp:RunningRevenue", "relation": "related"}],
+        },
+        "Revenue YoY": {
+            "type": "period_over_period",
+            "expression": "{[Revenue]}",
+            "periodOverPeriod": {
+                "timeDimension": "Order Month",
+                "offset": 1,
+                "offsetGrain": "year",
+            },
+            "externalConceptMappings": [{"concept": "corp:YoY", "relation": "related"}],
+        },
+        "Revenue Rank": {
+            "type": "window",
+            "measure": "Revenue",
+            "windowFunction": "rank",
+            "externalConceptMappings": [{"concept": "corp:Rank", "relation": "related"}],
+        },
+    },
+}
+
+
+def _roundtrip(obml: dict) -> dict:
+    osi = conv.OBMLtoOSI(copy.deepcopy(obml)).convert()
+    return conv.OSItoOBML(osi).convert()
+
+
+def _links(obj: dict) -> list:
+    return obj.get("externalConceptMappings", [])
+
+
+class TestRoundTrip:
+    def test_model_level_ontology_and_mappings(self) -> None:
+        back = _roundtrip(_OBML)
+        assert back["ontology"] == {"prefixes": {"corp": CORP}}
+        assert _links(back) == _OBML["externalConceptMappings"]
+
+    def test_data_object(self) -> None:
+        back = _roundtrip(_OBML)
+        assert _links(back["dataObjects"]["Orders"]) == [
+            {"concept": "corp:Order", "relation": "exact"}
+        ]
+
+    def test_primary_and_extra_dimensions(self) -> None:
+        back = _roundtrip(_OBML)
+        dims = back["dimensions"]
+        assert _links(dims["Order ID"]) == [
+            {"concept": "corp:OrderIdentifier", "relation": "exact"}
+        ]
+        # Two dimensions over one column: the first is carried on the field,
+        # the second as an extra descriptor. Both keep their links.
+        assert _links(dims["Order Month"]) == [{"concept": "corp:Month", "relation": "close"}]
+        assert _links(dims["Order Year"]) == [{"concept": "corp:Year", "relation": "close"}]
+
+    def test_measures_keep_rich_metadata(self) -> None:
+        back = _roundtrip(_OBML)
+        assert (
+            _links(back["measures"]["Revenue"])
+            == _OBML["measures"]["Revenue"]["externalConceptMappings"]
+        )
+        assert back["measures"]["Revenue"]["owner"] == "finance"
+        assert _links(back["measures"]["Delegated"]) == [_LINK]
+
+    def test_every_metric_type(self) -> None:
+        back = _roundtrip(_OBML)
+        for name in ("Revenue Doubled", "Running Revenue", "Revenue YoY", "Revenue Rank"):
+            assert (
+                _links(back["metrics"][name]) == _OBML["metrics"][name]["externalConceptMappings"]
+            ), name
+
+    def test_no_mappings_means_no_key(self) -> None:
+        plain = copy.deepcopy(_OBML)
+        plain.pop("ontology")
+        plain.pop("externalConceptMappings")
+        for section in ("dataObjects", "dimensions", "measures", "metrics"):
+            for obj in plain[section].values():
+                obj.pop("externalConceptMappings", None)
+        back = _roundtrip(plain)
+        assert "ontology" not in back
+        assert "externalConceptMappings" not in back
+        for section in ("dataObjects", "dimensions", "measures", "metrics"):
+            for obj in back[section].values():
+                assert "externalConceptMappings" not in obj
+
+    def test_links_ride_in_the_obsl_vendor_extension(self) -> None:
+        osi = conv.OBMLtoOSI(copy.deepcopy(_OBML)).convert()
+        metric = next(m for m in osi["semantic_model"][0]["metrics"] if m["name"] == "Revenue")
+        obsl_exts = [e for e in metric["custom_extensions"] if e["vendor_name"] == "ORIONBELT"]
+        assert len(obsl_exts) == 1, "links merge into the single ORIONBELT payload"
+        assert (
+            json.loads(obsl_exts[0]["data"])["obml_external_concept_mappings"]
+            == _OBML["measures"]["Revenue"]["externalConceptMappings"]
+        )
+
+    def test_foreign_garbage_under_the_key_is_ignored(self) -> None:
+        osi = conv.OBMLtoOSI(copy.deepcopy(_OBML)).convert()
+        model = osi["semantic_model"][0]
+        ext = next(e for e in model["custom_extensions"] if e["vendor_name"] == "ORIONBELT")
+        data = json.loads(ext["data"])
+        data["obml_external_concept_mappings"] = "not a list"
+        data["obml_ontology"] = ["not a mapping"]
+        ext["data"] = json.dumps(data)
+        back = conv.OSItoOBML(osi).convert()
+        assert "externalConceptMappings" not in back
+        assert "ontology" not in back

--- a/schema/obml-contract.yml
+++ b/schema/obml-contract.yml
@@ -190,7 +190,7 @@ classes:
         type: "list[ExternalConceptMapping]"
         json_schema: true
         ontology_property: hasExternalConceptMapping
-        osi_roundtrip: false
+        osi_roundtrip: true
       refresh:
         alias: refresh
         type: "RefreshPolicy | None"
@@ -437,7 +437,7 @@ classes:
         type: "list[ExternalConceptMapping]"
         json_schema: true
         ontology_property: hasExternalConceptMapping
-        osi_roundtrip: false
+        osi_roundtrip: true
   ExternalConceptMapping:
     python: orionbelt.models.semantic.ExternalConceptMapping
     json_schema_def: externalConceptMapping
@@ -448,49 +448,49 @@ classes:
         type: "str"
         json_schema: true
         ontology_property: authoredConcept
-        osi_roundtrip: false
+        osi_roundtrip: true
       expanded_iri:
         alias: expandedIri
         type: "str | None"
         json_schema: false
         ontology_property: targetConcept
-        osi_roundtrip: false
+        osi_roundtrip: true
       relation:
         alias: relation
         type: "ExternalConceptRelation"
         json_schema: true
         ontology_property: mappingRelation
-        osi_roundtrip: false
+        osi_roundtrip: true
       justification:
         alias: justification
         type: "MappingJustification | None"
         json_schema: true
         ontology_property: mappingJustification
-        osi_roundtrip: false
+        osi_roundtrip: true
       source:
         alias: source
         type: "str | None"
         json_schema: true
         ontology_property: mappingSource
-        osi_roundtrip: false
+        osi_roundtrip: true
       ontology_version:
         alias: ontologyVersion
         type: "str | None"
         json_schema: true
         ontology_property: ontologyVersion
-        osi_roundtrip: false
+        osi_roundtrip: true
       confidence:
         alias: confidence
         type: "float | None"
         json_schema: true
         ontology_property: confidence
-        osi_roundtrip: false
+        osi_roundtrip: true
       comment:
         alias: comment
         type: "str | None"
         json_schema: true
         ontology_property: mappingComment
-        osi_roundtrip: false
+        osi_roundtrip: true
   FilterContext:
     python: orionbelt.models.semantic.FilterContext
     json_schema_def: filterContext
@@ -760,7 +760,7 @@ classes:
         type: "list[ExternalConceptMapping]"
         json_schema: true
         ontology_property: hasExternalConceptMapping
-        osi_roundtrip: false
+        osi_roundtrip: true
   MeasureFilter:
     python: orionbelt.models.semantic.MeasureFilter
     json_schema_def: filter
@@ -945,7 +945,7 @@ classes:
         type: "list[ExternalConceptMapping]"
         json_schema: true
         ontology_property: hasExternalConceptMapping
-        osi_roundtrip: false
+        osi_roundtrip: true
   ModelExample:
     python: orionbelt.models.semantic.ModelExample
     json_schema_pointer: properties/examples/items
@@ -1073,7 +1073,7 @@ classes:
         type: "dict[str, str]"
         json_schema: true
         ontology_property: null
-        osi_roundtrip: false
+        osi_roundtrip: true
   PeriodOverPeriod:
     python: orionbelt.models.semantic.PeriodOverPeriod
     json_schema_def: periodOverPeriod
@@ -1250,13 +1250,13 @@ classes:
         type: "OntologyConfig | None"
         json_schema: true
         ontology_property: null
-        osi_roundtrip: false
+        osi_roundtrip: true
       external_concept_mappings:
         alias: externalConceptMappings
         type: "list[ExternalConceptMapping]"
         json_schema: true
         ontology_property: hasExternalConceptMapping
-        osi_roundtrip: false
+        osi_roundtrip: true
   WithinGroup:
     python: orionbelt.models.semantic.WithinGroup
     json_schema_pointer: definitions/measure/properties/withinGroup

--- a/schema/obml-contract.yml
+++ b/schema/obml-contract.yml
@@ -60,6 +60,12 @@ enums:
   WindowFunctionKind:
     python: orionbelt.models.semantic.WindowFunctionKind
     values: ['rank', 'dense_rank', 'row_number', 'ntile', 'lag', 'lead', 'first_value', 'last_value']
+  ExternalConceptRelation:
+    python: orionbelt.models.semantic.ExternalConceptRelation
+    values: ['exact', 'close', 'broader', 'narrower', 'related']
+  MappingJustification:
+    python: orionbelt.models.semantic.MappingJustification
+    values: ['curated', 'imported', 'generated', 'inferred', 'lexical']
 
 classes:
   CustomExtension:
@@ -179,6 +185,12 @@ classes:
         json_schema: true
         ontology_property: null
         osi_roundtrip: true
+      external_concept_mappings:
+        alias: externalConceptMappings
+        type: "list[ExternalConceptMapping]"
+        json_schema: true
+        ontology_property: hasExternalConceptMapping
+        osi_roundtrip: false
       refresh:
         alias: refresh
         type: "RefreshPolicy | None"
@@ -420,6 +432,65 @@ classes:
         json_schema: true
         ontology_property: null
         osi_roundtrip: true
+      external_concept_mappings:
+        alias: externalConceptMappings
+        type: "list[ExternalConceptMapping]"
+        json_schema: true
+        ontology_property: hasExternalConceptMapping
+        osi_roundtrip: false
+  ExternalConceptMapping:
+    python: orionbelt.models.semantic.ExternalConceptMapping
+    json_schema_def: externalConceptMapping
+    ontology_class: ExternalConceptMapping
+    fields:
+      concept:
+        alias: concept
+        type: "str"
+        json_schema: true
+        ontology_property: authoredConcept
+        osi_roundtrip: false
+      expanded_iri:
+        alias: expandedIri
+        type: "str | None"
+        json_schema: false
+        ontology_property: targetConcept
+        osi_roundtrip: false
+      relation:
+        alias: relation
+        type: "ExternalConceptRelation"
+        json_schema: true
+        ontology_property: mappingRelation
+        osi_roundtrip: false
+      justification:
+        alias: justification
+        type: "MappingJustification | None"
+        json_schema: true
+        ontology_property: mappingJustification
+        osi_roundtrip: false
+      source:
+        alias: source
+        type: "str | None"
+        json_schema: true
+        ontology_property: mappingSource
+        osi_roundtrip: false
+      ontology_version:
+        alias: ontologyVersion
+        type: "str | None"
+        json_schema: true
+        ontology_property: ontologyVersion
+        osi_roundtrip: false
+      confidence:
+        alias: confidence
+        type: "float | None"
+        json_schema: true
+        ontology_property: confidence
+        osi_roundtrip: false
+      comment:
+        alias: comment
+        type: "str | None"
+        json_schema: true
+        ontology_property: mappingComment
+        osi_roundtrip: false
   FilterContext:
     python: orionbelt.models.semantic.FilterContext
     json_schema_def: filterContext
@@ -684,6 +755,12 @@ classes:
         json_schema: true
         ontology_property: null
         osi_roundtrip: true
+      external_concept_mappings:
+        alias: externalConceptMappings
+        type: "list[ExternalConceptMapping]"
+        json_schema: true
+        ontology_property: hasExternalConceptMapping
+        osi_roundtrip: false
   MeasureFilter:
     python: orionbelt.models.semantic.MeasureFilter
     json_schema_def: filter
@@ -863,6 +940,12 @@ classes:
         json_schema: true
         ontology_property: null
         osi_roundtrip: true
+      external_concept_mappings:
+        alias: externalConceptMappings
+        type: "list[ExternalConceptMapping]"
+        json_schema: true
+        ontology_property: hasExternalConceptMapping
+        osi_roundtrip: false
   ModelExample:
     python: orionbelt.models.semantic.ModelExample
     json_schema_pointer: properties/examples/items
@@ -980,6 +1063,17 @@ classes:
         json_schema: true
         ontology_property: null
         osi_roundtrip: true
+  OntologyConfig:
+    python: orionbelt.models.semantic.OntologyConfig
+    json_schema_def: ontologyConfig
+    ontology_class: null
+    fields:
+      prefixes:
+        alias: prefixes
+        type: "dict[str, str]"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: false
   PeriodOverPeriod:
     python: orionbelt.models.semantic.PeriodOverPeriod
     json_schema_def: periodOverPeriod
@@ -1151,6 +1245,18 @@ classes:
         json_schema: true
         ontology_property: null
         osi_roundtrip: true
+      ontology:
+        alias: ontology
+        type: "OntologyConfig | None"
+        json_schema: true
+        ontology_property: null
+        osi_roundtrip: false
+      external_concept_mappings:
+        alias: externalConceptMappings
+        type: "list[ExternalConceptMapping]"
+        json_schema: true
+        ontology_property: hasExternalConceptMapping
+        osi_roundtrip: false
   WithinGroup:
     python: orionbelt.models.semantic.WithinGroup
     json_schema_pointer: definitions/measure/properties/withinGroup

--- a/schema/obml-schema.json
+++ b/schema/obml-schema.json
@@ -92,6 +92,13 @@
             "$ref": "#/definitions/customExtension"
           }
         },
+        "externalConceptMappings": {
+          "type": "array",
+          "description": "Links to concepts in external ontologies (SKOS-style, descriptive only)",
+          "items": {
+            "$ref": "#/definitions/externalConceptMapping"
+          }
+        },
         "refresh": {
           "type": "object",
           "description": "Freshness contract for the physical table this dataObject maps to. Drives result-cache TTL composition and heartbeat invalidation. See PLAN_freshness_driven_cache.md \u00a75.",
@@ -542,6 +549,13 @@
           "items": {
             "$ref": "#/definitions/customExtension"
           }
+        },
+        "externalConceptMappings": {
+          "type": "array",
+          "description": "Links to concepts in external ontologies (SKOS-style, descriptive only)",
+          "items": {
+            "$ref": "#/definitions/externalConceptMapping"
+          }
         }
       },
       "required": [
@@ -796,6 +810,13 @@
           "items": {
             "$ref": "#/definitions/customExtension"
           }
+        },
+        "externalConceptMappings": {
+          "type": "array",
+          "description": "Links to concepts in external ontologies (SKOS-style, descriptive only)",
+          "items": {
+            "$ref": "#/definitions/externalConceptMapping"
+          }
         }
       },
       "required": [
@@ -985,6 +1006,13 @@
           "items": {
             "$ref": "#/definitions/customExtension"
           }
+        },
+        "externalConceptMappings": {
+          "type": "array",
+          "description": "Links to concepts in external ontologies (SKOS-style, descriptive only)",
+          "items": {
+            "$ref": "#/definitions/externalConceptMapping"
+          }
         }
       },
       "allOf": [
@@ -1090,6 +1118,87 @@
         "dataObject",
         "column"
       ],
+      "additionalProperties": false
+    },
+    "externalConceptRelation": {
+      "type": "string",
+      "description": "SKOS mapping relation, read artifact-first: exact (skos:exactMatch), close (skos:closeMatch), broader (skos:broadMatch: the external concept is the broader one), narrower (skos:narrowMatch: the external concept is the narrower one), related (skos:relatedMatch).",
+      "enum": [
+        "exact",
+        "close",
+        "broader",
+        "narrower",
+        "related"
+      ]
+    },
+    "mappingJustification": {
+      "type": "string",
+      "description": "How the mapping came to exist: curated (human decision), imported (from another catalog or format), generated or inferred (by tooling), lexical (name match only).",
+      "enum": [
+        "curated",
+        "imported",
+        "generated",
+        "inferred",
+        "lexical"
+      ]
+    },
+    "externalConceptMapping": {
+      "type": "object",
+      "description": "A qualified link from an OBML artifact to a concept in an external ontology. Descriptive metadata only: it never changes SQL, execution, cache keys or join selection.",
+      "properties": {
+        "concept": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The external concept: a compact IRI (prefix:LocalName, expanded with ontology.prefixes or a built-in prefix) or a full IRI (https://... or urn:...). Blank nodes and relative references are rejected at load."
+        },
+        "relation": {
+          "$ref": "#/definitions/externalConceptRelation",
+          "description": "Required. How the artifact relates to the concept; there is no implicit exact."
+        },
+        "justification": {
+          "$ref": "#/definitions/mappingJustification"
+        },
+        "source": {
+          "type": "string",
+          "description": "Where the mapping comes from (a catalog, ontology or process name)"
+        },
+        "ontologyVersion": {
+          "type": "string",
+          "description": "Version of the external ontology the concept was taken from"
+        },
+        "confidence": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "Confidence in the mapping, 0 to 1"
+        },
+        "comment": {
+          "type": "string",
+          "description": "Free-text note (approval, caveat, rationale)"
+        }
+      },
+      "required": [
+        "concept",
+        "relation"
+      ],
+      "additionalProperties": false
+    },
+    "ontologyConfig": {
+      "type": "object",
+      "description": "Ontology settings for the model: the prefixes that compact concept IRIs expand with. rdf, rdfs, owl, skos and xsd are built in and cannot be bound to another namespace.",
+      "properties": {
+        "prefixes": {
+          "type": "object",
+          "description": "Prefix name to absolute namespace IRI (e.g. corp: https://ontology.example.com/business/)",
+          "propertyNames": {
+            "pattern": "^[A-Za-z_][A-Za-z0-9_.-]*$"
+          },
+          "additionalProperties": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      },
       "additionalProperties": false
     }
   },
@@ -1328,11 +1437,22 @@
       },
       "additionalProperties": false
     },
+    "ontology": {
+      "$ref": "#/definitions/ontologyConfig",
+      "description": "Ontology settings (prefixes for compact concept IRIs)"
+    },
     "customExtensions": {
       "type": "array",
       "description": "Vendor-keyed extension data at model level",
       "items": {
         "$ref": "#/definitions/customExtension"
+      }
+    },
+    "externalConceptMappings": {
+      "type": "array",
+      "description": "Links from the model as a whole to concepts in external ontologies",
+      "items": {
+        "$ref": "#/definitions/externalConceptMapping"
       }
     }
   },

--- a/src/orionbelt/models/concept_links.py
+++ b/src/orionbelt/models/concept_links.py
@@ -1,0 +1,130 @@
+"""External concept links: prefix handling and IRI expansion.
+
+``externalConceptMappings`` name a concept either as a compact IRI
+(``corp:NetRevenue``) that the model's ``ontology.prefixes`` expand, or as a
+full IRI. This module owns the rules both forms follow, so the resolver, the
+RDF exporter and the discovery index agree on what a concept expands to.
+
+Nothing here dereferences a remote IRI: the checks are syntactic.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from types import MappingProxyType
+
+# Prefixes every model may use without declaring them. An authored
+# ``ontology.prefixes`` entry may repeat one of these verbatim but may not
+# bind the name to a different namespace.
+BUILTIN_PREFIXES: Mapping[str, str] = MappingProxyType(
+    {
+        "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+        "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+        "owl": "http://www.w3.org/2002/07/owl#",
+        "skos": "http://www.w3.org/2004/02/skos/core#",
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+    }
+)
+
+# Conservative prefix names: an XML NCName-like identifier. Deliberately
+# narrower than Turtle's PN_PREFIX so a prefix never needs escaping in any
+# serialization the graph may be written to.
+PREFIX_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_.-]*$")
+
+_SCHEME_RE = re.compile(r"^([A-Za-z][A-Za-z0-9+.-]*):(.*)$", re.DOTALL)
+# Characters RFC 3987 excludes from an IRI (and whitespace).
+_FORBIDDEN_IRI_CHARS = frozenset(' \t\r\n<>"{}|\\^`')
+
+
+class ConceptIriError(ValueError):
+    """An authored concept or namespace value that cannot become an absolute IRI.
+
+    ``code`` is the OBML error code the resolver reports
+    (``INVALID_CONCEPT_IRI`` or ``UNKNOWN_ONTOLOGY_PREFIX``).
+    """
+
+    def __init__(self, code: str, message: str, suggestions: list[str] | None = None) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.suggestions = suggestions or []
+
+
+def is_absolute_iri(value: object) -> bool:
+    """Whether *value* is a full IRI rather than a compact one or a fragment.
+
+    A full IRI has a scheme followed by an authority (``https://…``) or is a
+    URN (``urn:…``), and contains none of the characters RFC 3987 excludes.
+    ``corp:NetRevenue`` has a scheme-shaped prefix too, so a bare
+    ``scheme:`` is not enough to count as absolute: that is exactly the
+    shape of a compact IRI, and treating it as absolute would let an
+    undeclared prefix through silently.
+    """
+    if not isinstance(value, str) or not value:
+        return False
+    if _FORBIDDEN_IRI_CHARS.intersection(value):
+        return False
+    m = _SCHEME_RE.match(value)
+    if m is None:
+        return False
+    scheme, rest = m.group(1).lower(), m.group(2)
+    if scheme == "urn":
+        return bool(rest)
+    return rest.startswith("//") and len(rest) > 2
+
+
+def effective_prefixes(declared: Mapping[str, str] | None) -> dict[str, str]:
+    """The built-in prefixes plus the model's declared ones."""
+    merged = dict(BUILTIN_PREFIXES)
+    merged.update(declared or {})
+    return merged
+
+
+def expand_concept(concept: object, prefixes: Mapping[str, str]) -> str:
+    """Return the absolute IRI an authored ``concept`` value denotes.
+
+    A full IRI is returned as written. A compact IRI ``prefix:local`` is
+    expanded with *prefixes* (use :func:`effective_prefixes` to include the
+    built-ins). Blank nodes, relative references, angle-bracketed IRIs and
+    values with illegal characters raise :class:`ConceptIriError`.
+    """
+    if not isinstance(concept, str) or not concept:
+        raise ConceptIriError("INVALID_CONCEPT_IRI", "'concept' must be a non-empty string")
+    if concept.startswith("_:"):
+        raise ConceptIriError(
+            "INVALID_CONCEPT_IRI",
+            f"'{concept}' is a blank node identifier; a concept must be an IRI",
+        )
+    if concept.startswith("<") and concept.endswith(">"):
+        raise ConceptIriError(
+            "INVALID_CONCEPT_IRI",
+            f"'{concept}' is wrapped in angle brackets; write the IRI without them",
+        )
+    if is_absolute_iri(concept):
+        return concept
+    bad = sorted(_FORBIDDEN_IRI_CHARS.intersection(concept))
+    if bad:
+        shown = ", ".join(repr(c) for c in bad)
+        raise ConceptIriError(
+            "INVALID_CONCEPT_IRI", f"'{concept}' contains characters not allowed in an IRI: {shown}"
+        )
+    prefix, sep, local = concept.partition(":")
+    if not sep:
+        raise ConceptIriError(
+            "INVALID_CONCEPT_IRI",
+            f"'{concept}' is a relative reference; use a full IRI or a declared prefix "
+            "(e.g. 'corp:NetRevenue')",
+        )
+    if not local:
+        raise ConceptIriError(
+            "INVALID_CONCEPT_IRI", f"'{concept}' has no local name after the prefix"
+        )
+    namespace = prefixes.get(prefix)
+    if namespace is None:
+        raise ConceptIriError(
+            "UNKNOWN_ONTOLOGY_PREFIX",
+            f"Unknown prefix '{prefix}' in '{concept}'; declare it under ontology.prefixes",
+            suggestions=sorted(prefixes),
+        )
+    return namespace + local

--- a/src/orionbelt/models/semantic.py
+++ b/src/orionbelt/models/semantic.py
@@ -251,6 +251,42 @@ class FilterLogic(StrEnum):
     OR = "or"
 
 
+class ExternalConceptRelation(StrEnum):
+    """How an OBML artifact relates to an external ontology concept.
+
+    The values follow the SKOS mapping vocabulary and read in the SKOS
+    direction, artifact first: ``exact`` is ``skos:exactMatch``, ``close`` is
+    ``skos:closeMatch``, ``broader`` is ``skos:broadMatch`` (the external
+    concept is the *broader* one, so the artifact is a narrower notion of it),
+    ``narrower`` is ``skos:narrowMatch`` (the external concept is the
+    *narrower* one) and ``related`` is ``skos:relatedMatch``. A measure
+    ``Net Revenue`` mapped ``broader`` to ``corp:Revenue`` says corp:Revenue
+    is broader than Net Revenue.
+    """
+
+    EXACT = "exact"
+    CLOSE = "close"
+    BROADER = "broader"
+    NARROWER = "narrower"
+    RELATED = "related"
+
+
+class MappingJustification(StrEnum):
+    """How an external concept mapping came to exist.
+
+    ``curated`` is a human decision; ``imported`` came from another catalog
+    or format (an OSI / Ossie ``maps_to_concept``); ``generated`` and
+    ``inferred`` were produced by tooling, from structure or from reasoning;
+    ``lexical`` rests on a name match only.
+    """
+
+    CURATED = "curated"
+    IMPORTED = "imported"
+    GENERATED = "generated"
+    INFERRED = "inferred"
+    LEXICAL = "lexical"
+
+
 class CustomExtension(BaseModel):
     """Vendor-keyed extension data — opaque to OrionBelt.
 
@@ -260,6 +296,49 @@ class CustomExtension(BaseModel):
 
     vendor: str
     data: str
+
+    model_config = {"populate_by_name": True, "extra": "forbid"}
+
+
+class OntologyConfig(BaseModel):
+    """Model-level ontology settings: the prefixes compact concept IRIs expand with.
+
+    ``prefixes`` maps a prefix name to an absolute namespace IRI. A mapping's
+    ``concept: "corp:NetRevenue"`` expands to the namespace followed by the
+    local name. The RDF, RDFS, OWL, SKOS and XSD prefixes are built in
+    (:data:`orionbelt.models.concept_links.BUILTIN_PREFIXES`) and cannot be
+    rebound to another namespace.
+    """
+
+    prefixes: dict[str, str] = Field(default_factory=dict)
+
+    model_config = {"populate_by_name": True, "extra": "forbid"}
+
+
+class ExternalConceptMapping(BaseModel):
+    """A qualified link from an OBML artifact to a concept in an external ontology.
+
+    Descriptive metadata only: it says what governed business concept a
+    model, data object, dimension, measure or metric stands for. It never
+    changes SQL planning, execution, cache keys, join selection or metric
+    expansion.
+
+    ``concept`` is the authored value, a compact IRI (``corp:NetRevenue``,
+    expanded with the model's ``ontology.prefixes``) or a full IRI. The
+    resolver stores the absolute form in ``expanded_iri``; it is derived, so
+    authoring ``expandedIri`` in YAML is an ``UNKNOWN_PROPERTY`` error.
+    ``relation`` is required (there is no implicit ``exact``) and reads in the
+    SKOS direction, see :class:`ExternalConceptRelation`.
+    """
+
+    concept: str
+    expanded_iri: str | None = Field(None, alias="expandedIri")
+    relation: ExternalConceptRelation
+    justification: MappingJustification | None = None
+    source: str | None = None
+    ontology_version: str | None = Field(None, alias="ontologyVersion")
+    confidence: float | None = Field(None, ge=0.0, le=1.0)
+    comment: str | None = None
 
     model_config = {"populate_by_name": True, "extra": "forbid"}
 
@@ -501,6 +580,9 @@ class DataObject(BaseModel):
     )
     synonyms: list[str] = Field(default_factory=list)
     custom_extensions: list[CustomExtension] = Field(default_factory=list, alias="customExtensions")
+    external_concept_mappings: list[ExternalConceptMapping] = Field(
+        default_factory=list, alias="externalConceptMappings"
+    )
     refresh: RefreshPolicy | None = Field(
         default=None,
         description=(
@@ -606,6 +688,9 @@ class Dimension(BaseModel):
     owner: str | None = None
     synonyms: list[str] = Field(default_factory=list)
     custom_extensions: list[CustomExtension] = Field(default_factory=list, alias="customExtensions")
+    external_concept_mappings: list[ExternalConceptMapping] = Field(
+        default_factory=list, alias="externalConceptMappings"
+    )
 
     model_config = {"populate_by_name": True, "extra": "forbid"}
 
@@ -734,6 +819,9 @@ class Measure(BaseModel):
     owner: str | None = None
     synonyms: list[str] = Field(default_factory=list)
     custom_extensions: list[CustomExtension] = Field(default_factory=list, alias="customExtensions")
+    external_concept_mappings: list[ExternalConceptMapping] = Field(
+        default_factory=list, alias="externalConceptMappings"
+    )
 
     model_config = {"populate_by_name": True, "extra": "forbid"}
 
@@ -925,6 +1013,9 @@ class Metric(BaseModel):
     owner: str | None = None
     synonyms: list[str] = Field(default_factory=list)
     custom_extensions: list[CustomExtension] = Field(default_factory=list, alias="customExtensions")
+    external_concept_mappings: list[ExternalConceptMapping] = Field(
+        default_factory=list, alias="externalConceptMappings"
+    )
 
     model_config = {"populate_by_name": True, "extra": "forbid"}
 
@@ -1201,6 +1292,16 @@ class SemanticModel(BaseModel):
         ),
     )
     custom_extensions: list[CustomExtension] = Field(default_factory=list, alias="customExtensions")
+    ontology: OntologyConfig | None = Field(
+        default=None,
+        description=(
+            "Ontology settings: the prefixes that compact concept IRIs in "
+            "externalConceptMappings expand with."
+        ),
+    )
+    external_concept_mappings: list[ExternalConceptMapping] = Field(
+        default_factory=list, alias="externalConceptMappings"
+    )
 
     model_config = {"populate_by_name": True, "extra": "forbid"}
 

--- a/src/orionbelt/obml_reference.py
+++ b/src/orionbelt/obml_reference.py
@@ -349,6 +349,43 @@ customExtensions:
 Each entry has `vendor` (identifier string) and `data` (opaque JSON string).
 OrionBelt preserves these during parsing but does not interpret them.
 
+## 7. externalConceptMappings — links to governed business concepts (optional)
+
+The model, a dataObject, a dimension, a measure or a metric may link to
+concepts in an external ontology (a corporate glossary, FIBO, schema.org).
+Descriptive metadata only: mappings never change SQL, execution or caching.
+
+```yaml
+ontology:
+  prefixes:
+    corp: "https://ontology.example.com/business/"
+
+measures:
+  Revenue:
+    aggregation: sum
+    expression: "{[Orders].[Amount]}"
+    externalConceptMappings:
+      - concept: "corp:NetRevenue"          # compact IRI, or a full https://... IRI
+        relation: exact                     # required: exact | close | broader | narrower | related
+        justification: curated              # optional: curated | imported | generated | inferred | lexical
+        source: "enterprise-finance-ontology"
+        ontologyVersion: "2026.1"
+        confidence: 1.0
+        comment: "Approved by Finance Data Governance"
+```
+
+- `concept` is a compact IRI (`prefix:LocalName`, expanded with `ontology.prefixes`; \
+`rdf`, `rdfs`, `owl`, `skos`, `xsd` are built in) or a full IRI (`https://...`, `urn:...`). \
+An undeclared prefix is `UNKNOWN_ONTOLOGY_PREFIX`; a blank node, relative reference or \
+malformed value is `INVALID_CONCEPT_IRI`.
+- `relation` reads artifact-first in the SKOS direction: `broader` means the external \
+concept is the *broader* one (the artifact is a narrower notion of it); `narrower` \
+means the external concept is the narrower one. There is no implicit `exact`.
+- One IRI carries one relation per object: the same expanded IRI twice is \
+`DUPLICATE_CONCEPT_MAPPING`; twice with different relations is `CONFLICTING_CONCEPT_MAPPING`.
+- Not on columns or joins: `customer_id` *identifies* a Customer rather than *being* one, \
+which needs a more precise relation than this vocabulary offers.
+
 {FUNCTION_CATALOG_SECTION}
 
 ## Key Rules

--- a/src/orionbelt/parser/merger.py
+++ b/src/orionbelt/parser/merger.py
@@ -279,11 +279,15 @@ class ExtendsMerger:
         if parent_filters or child_filters:
             merged["filters"] = parent_filters + child_filters
 
-        # customExtensions: concatenate
-        parent_exts = list(merged.get("customExtensions") or [])
-        child_exts = list(child.get("customExtensions") or [])
-        if parent_exts or child_exts:
-            merged["customExtensions"] = parent_exts + child_exts
+        # customExtensions / externalConceptMappings: concatenate
+        for list_key in ("customExtensions", "externalConceptMappings"):
+            parent_items = list(merged.get(list_key) or [])
+            child_items = list(child.get(list_key) or [])
+            if parent_items or child_items:
+                merged[list_key] = parent_items + child_items
+
+        # ontology.prefixes: union; a rebinding is an error, see _merge_prefixes
+        self._merge_prefixes(merged, child, origin)
 
         # Owner: child wins if present
         if child.get("owner"):
@@ -319,22 +323,39 @@ class ExtendsMerger:
             if src_items:
                 target.setdefault(list_key, []).extend(src_items)
 
-        # ontology.prefixes: union, source wins on conflict like the
-        # analytical keys. An extension's measures expand their compact
-        # concept IRIs with the prefixes the extension declares, so dropping
-        # them would fail every such mapping with UNKNOWN_ONTOLOGY_PREFIX.
-        src_ontology = source.get("ontology")
-        src_prefixes = src_ontology.get("prefixes") if isinstance(src_ontology, dict) else None
-        if isinstance(src_prefixes, dict) and src_prefixes:
-            tgt_ontology = target.setdefault("ontology", {})
-            tgt_prefixes = tgt_ontology.setdefault("prefixes", {})
-            for name, namespace in src_prefixes.items():
-                if name in tgt_prefixes and tgt_prefixes[name] != namespace:
-                    warnings.append(f"Ontology prefix '{name}' overridden by '{origin}'")
-                tgt_prefixes[name] = namespace
+        ExtendsMerger._merge_prefixes(target, source, origin)
 
         # description: last non-None wins
         if source.get("description"):
             target["description"] = source["description"]
 
         return warnings
+
+    @staticmethod
+    def _merge_prefixes(target: dict[str, Any], source: dict[str, Any], origin: str) -> None:
+        """Union ``source``'s ``ontology.prefixes`` into ``target``.
+
+        A fragment's compact concept IRIs expand with the prefixes the
+        fragment declares, so they have to survive the merge. But every
+        mapping in the merged document expands against one prefix map, so
+        rebinding a name that is already bound would silently rewrite the
+        other fragment's mappings to a different namespace. That is an
+        error, not a warning: ``corp:Base`` must not become
+        ``https://child.example/Base`` because a later file reused ``corp``.
+        """
+        src_ontology = source.get("ontology")
+        src_prefixes = src_ontology.get("prefixes") if isinstance(src_ontology, dict) else None
+        if not isinstance(src_prefixes, dict) or not src_prefixes:
+            return
+        tgt_ontology = target.setdefault("ontology", {})
+        tgt_prefixes = tgt_ontology.setdefault("prefixes", {})
+        for name, namespace in src_prefixes.items():
+            bound = tgt_prefixes.get(name)
+            if bound is not None and bound != namespace:
+                raise MergeError(
+                    "ONTOLOGY_PREFIX_CONFLICT",
+                    f"Ontology prefix '{name}' is bound to <{bound}> and '{origin}' binds it "
+                    f"to <{namespace}>; a prefix must expand to one namespace across all "
+                    "merged fragments",
+                )
+            tgt_prefixes[name] = namespace

--- a/src/orionbelt/parser/merger.py
+++ b/src/orionbelt/parser/merger.py
@@ -344,12 +344,26 @@ class ExtendsMerger:
         ``https://child.example/Base`` because a later file reused ``corp``.
         """
         src_ontology = source.get("ontology")
-        src_prefixes = src_ontology.get("prefixes") if isinstance(src_ontology, dict) else None
-        if not isinstance(src_prefixes, dict) or not src_prefixes:
+        if src_ontology is None:
             return
-        # A malformed block on either side (``ontology: []``, ``prefixes: [..]``)
-        # is left exactly as authored: the resolver reports it as
-        # ONTOLOGY_PARSE_ERROR with a source span, which is better than
+        src_prefixes = src_ontology.get("prefixes") if isinstance(src_ontology, dict) else None
+        if not isinstance(src_ontology, dict) or (
+            src_prefixes is not None and not isinstance(src_prefixes, dict)
+        ):
+            # The fragment's block is not copied into the merged document (only
+            # its prefixes are), so a malformed one would vanish without a
+            # trace if it were skipped here. Refuse the merge instead; the
+            # resolver never sees fragment sources, so this is the only place
+            # that can name the file.
+            raise MergeError(
+                "ONTOLOGY_PARSE_ERROR",
+                f"'ontology' in '{origin}' must be a mapping with a 'prefixes' mapping",
+            )
+        if not src_prefixes:
+            return
+        # A malformed block on the target side (``ontology: []``,
+        # ``prefixes: [..]``) is left exactly as authored: the resolver reports
+        # it as ONTOLOGY_PARSE_ERROR with a source span, which is better than
         # anything the merger could say about it. Nothing is merged into it.
         tgt_ontology = target.get("ontology")
         if tgt_ontology is None:

--- a/src/orionbelt/parser/merger.py
+++ b/src/orionbelt/parser/merger.py
@@ -347,8 +347,20 @@ class ExtendsMerger:
         src_prefixes = src_ontology.get("prefixes") if isinstance(src_ontology, dict) else None
         if not isinstance(src_prefixes, dict) or not src_prefixes:
             return
-        tgt_ontology = target.setdefault("ontology", {})
-        tgt_prefixes = tgt_ontology.setdefault("prefixes", {})
+        # A malformed block on either side (``ontology: []``, ``prefixes: [..]``)
+        # is left exactly as authored: the resolver reports it as
+        # ONTOLOGY_PARSE_ERROR with a source span, which is better than
+        # anything the merger could say about it. Nothing is merged into it.
+        tgt_ontology = target.get("ontology")
+        if tgt_ontology is None:
+            tgt_ontology = target["ontology"] = {}
+        if not isinstance(tgt_ontology, dict):
+            return
+        tgt_prefixes = tgt_ontology.get("prefixes")
+        if tgt_prefixes is None:
+            tgt_prefixes = tgt_ontology["prefixes"] = {}
+        if not isinstance(tgt_prefixes, dict):
+            return
         for name, namespace in src_prefixes.items():
             bound = tgt_prefixes.get(name)
             if bound is not None and bound != namespace:

--- a/src/orionbelt/parser/merger.py
+++ b/src/orionbelt/parser/merger.py
@@ -9,9 +9,17 @@ from typing import Any
 
 import yaml
 
+from orionbelt.models.semantic import OntologyConfig
+
 logger = logging.getLogger("orionbelt.parser.merger")
 
 MAX_EXTENDS_DEPTH = 5
+
+
+# Keys a fragment's ``ontology`` block may carry, from the model it becomes.
+_ONTOLOGY_KEYS = frozenset(OntologyConfig.model_fields)
+# Origin label for the child side of an ``inherits`` merge in error messages.
+_INHERITING_MODEL = "inheriting model"
 
 
 class MergeError(Exception):
@@ -279,15 +287,21 @@ class ExtendsMerger:
         if parent_filters or child_filters:
             merged["filters"] = parent_filters + child_filters
 
-        # customExtensions / externalConceptMappings: concatenate
-        for list_key in ("customExtensions", "externalConceptMappings"):
-            parent_items = list(merged.get(list_key) or [])
-            child_items = list(child.get(list_key) or [])
-            if parent_items or child_items:
-                merged[list_key] = parent_items + child_items
+        # customExtensions: concatenate
+        parent_exts = list(merged.get("customExtensions") or [])
+        child_exts = list(child.get("customExtensions") or [])
+        if parent_exts or child_exts:
+            merged["customExtensions"] = parent_exts + child_exts
+
+        # externalConceptMappings: concatenate (the child's are type-checked,
+        # see _fragment_mappings)
+        parent_links = list(merged.get("externalConceptMappings") or [])
+        child_links = self._fragment_mappings(child, _INHERITING_MODEL)
+        if parent_links or child_links:
+            merged["externalConceptMappings"] = parent_links + child_links
 
         # ontology.prefixes: union; a rebinding is an error, see _merge_prefixes
-        self._merge_prefixes(merged, child, origin)
+        self._merge_prefixes(merged, child, _INHERITING_MODEL)
 
         # Owner: child wins if present
         if child.get("owner"):
@@ -317,11 +331,15 @@ class ExtendsMerger:
                     warnings.append(f"{key[:-1].title()} '{name}' overridden by '{origin}'")
                 tgt_section[name] = defn
 
-        # customExtensions / externalConceptMappings: concatenate lists
-        for list_key in ("customExtensions", "externalConceptMappings"):
-            src_items = source.get(list_key)
-            if src_items:
-                target.setdefault(list_key, []).extend(src_items)
+        # customExtensions: concatenate lists
+        src_exts = source.get("customExtensions")
+        if src_exts:
+            target.setdefault("customExtensions", []).extend(src_exts)
+
+        # externalConceptMappings: concatenate lists (type-checked first)
+        src_links = ExtendsMerger._fragment_mappings(source, origin)
+        if src_links:
+            target.setdefault("externalConceptMappings", []).extend(src_links)
 
         ExtendsMerger._merge_prefixes(target, source, origin)
 
@@ -330,6 +348,24 @@ class ExtendsMerger:
             target["description"] = source["description"]
 
         return warnings
+
+    @staticmethod
+    def _fragment_mappings(source: dict[str, Any], origin: str) -> list[Any]:
+        """A fragment's model-level ``externalConceptMappings``, or a MergeError.
+
+        Only a list can be concatenated into the target; anything else
+        (``externalConceptMappings: {}``) would otherwise be dropped here
+        without the resolver ever seeing it.
+        """
+        items = source.get("externalConceptMappings")
+        if items is None:
+            return []
+        if not isinstance(items, list):
+            raise MergeError(
+                "INVALID_CONCEPT_MAPPING",
+                f"'externalConceptMappings' in '{origin}' must be a list of mapping entries",
+            )
+        return items
 
     @staticmethod
     def _merge_prefixes(target: dict[str, Any], source: dict[str, Any], origin: str) -> None:
@@ -359,6 +395,14 @@ class ExtendsMerger:
                 "ONTOLOGY_PARSE_ERROR",
                 f"'ontology' in '{origin}' must be a mapping with a 'prefixes' mapping",
             )
+        # Same strictness as the resolver's UNKNOWN_PROPERTY check on a
+        # top-level block: a typo in a fragment must not pass because only
+        # ``prefixes`` is ever read from it.
+        for key in src_ontology:
+            if key not in _ONTOLOGY_KEYS:
+                raise MergeError(
+                    "UNKNOWN_PROPERTY", f"Unknown property '{key}' at ontology in '{origin}'"
+                )
         if not src_prefixes:
             return
         # A malformed block on the target side (``ontology: []``,

--- a/src/orionbelt/parser/merger.py
+++ b/src/orionbelt/parser/merger.py
@@ -313,10 +313,25 @@ class ExtendsMerger:
                     warnings.append(f"{key[:-1].title()} '{name}' overridden by '{origin}'")
                 tgt_section[name] = defn
 
-        # customExtensions: concatenate lists
-        src_exts = source.get("customExtensions")
-        if src_exts:
-            target.setdefault("customExtensions", []).extend(src_exts)
+        # customExtensions / externalConceptMappings: concatenate lists
+        for list_key in ("customExtensions", "externalConceptMappings"):
+            src_items = source.get(list_key)
+            if src_items:
+                target.setdefault(list_key, []).extend(src_items)
+
+        # ontology.prefixes: union, source wins on conflict like the
+        # analytical keys. An extension's measures expand their compact
+        # concept IRIs with the prefixes the extension declares, so dropping
+        # them would fail every such mapping with UNKNOWN_ONTOLOGY_PREFIX.
+        src_ontology = source.get("ontology")
+        src_prefixes = src_ontology.get("prefixes") if isinstance(src_ontology, dict) else None
+        if isinstance(src_prefixes, dict) and src_prefixes:
+            tgt_ontology = target.setdefault("ontology", {})
+            tgt_prefixes = tgt_ontology.setdefault("prefixes", {})
+            for name, namespace in src_prefixes.items():
+                if name in tgt_prefixes and tgt_prefixes[name] != namespace:
+                    warnings.append(f"Ontology prefix '{name}' overridden by '{origin}'")
+                tgt_prefixes[name] = namespace
 
         # description: last non-None wins
         if source.get("description"):

--- a/src/orionbelt/parser/resolver.py
+++ b/src/orionbelt/parser/resolver.py
@@ -9,6 +9,14 @@ from typing import Any
 from pydantic import BaseModel
 from pydantic import ValidationError as PydanticValidationError
 
+from orionbelt.models.concept_links import (
+    BUILTIN_PREFIXES,
+    PREFIX_NAME_RE,
+    ConceptIriError,
+    effective_prefixes,
+    expand_concept,
+    is_absolute_iri,
+)
 from orionbelt.models.errors import SemanticError, ValidationResult
 from orionbelt.models.expressions import find_malformed_measure_refs, find_qualified_refs
 from orionbelt.models.semantic import (
@@ -18,6 +26,7 @@ from orionbelt.models.semantic import (
     DataObjectColumn,
     DataObjectJoin,
     Dimension,
+    ExternalConceptMapping,
     FilterContext,
     FilterContextFilter,
     FilterValue,
@@ -32,6 +41,7 @@ from orionbelt.models.semantic import (
     ModelFilter,
     ModelSettings,
     NestedSource,
+    OntologyConfig,
     PeriodOverPeriod,
     RefreshPolicy,
     SemanticModel,
@@ -130,6 +140,11 @@ _MODEL_FILTER_KEYS = _allowed_keys(ModelFilter)
 _MODEL_SETTINGS_KEYS = _allowed_keys(ModelSettings)
 _MODEL_EXAMPLE_KEYS = _allowed_keys(ModelExample)
 _CUSTOM_EXTENSION_KEYS = _allowed_keys(CustomExtension)
+_ONTOLOGY_KEYS = _allowed_keys(OntologyConfig)
+# ``expandedIri`` is derived by the resolver, never authored.
+_EXTERNAL_CONCEPT_MAPPING_KEYS = _allowed_keys(
+    ExternalConceptMapping, exclude=("expanded_iri", "expandedIri")
+)
 # Period-over-period / Window / Cumulative metric blocks share the Metric
 # field set, but the inner periodOverPeriod block has its own shape.
 _PERIOD_OVER_PERIOD_KEYS = _allowed_keys(PeriodOverPeriod)
@@ -169,6 +184,171 @@ def _parse_extensions(
                     source_map,
                 )
     return [CustomExtension(vendor=e.get("vendor", ""), data=e.get("data", "")) for e in exts]
+
+
+def _parse_ontology(
+    raw: object,
+    errors: list[SemanticError],
+    source_map: SourceMap | None = None,
+) -> OntologyConfig | None:
+    """Parse the top-level ``ontology`` block.
+
+    Every prefix is checked on its own (a conservative identifier as the
+    name, an absolute IRI as the namespace, no rebinding of a built-in) and
+    a bad one is reported and dropped, so the rest of the model still
+    resolves and every problem is listed at once.
+    """
+    if raw is None:
+        return None
+    span = source_map.get("ontology") if source_map else None
+    if not isinstance(raw, dict):
+        errors.append(
+            SemanticError(
+                code="ONTOLOGY_PARSE_ERROR",
+                message="'ontology' must be a mapping with a 'prefixes' block",
+                path="ontology",
+                span=span,
+            )
+        )
+        return None
+    _check_unknown_keys(raw, _ONTOLOGY_KEYS, "ontology", errors, source_map)
+    raw_prefixes = raw.get("prefixes", {})
+    if raw_prefixes is None:
+        raw_prefixes = {}
+    if not isinstance(raw_prefixes, dict):
+        errors.append(
+            SemanticError(
+                code="ONTOLOGY_PARSE_ERROR",
+                message="'ontology.prefixes' must be a mapping of prefix name to namespace IRI",
+                path="ontology.prefixes",
+                span=source_map.get("ontology.prefixes") if source_map else span,
+            )
+        )
+        return OntologyConfig()
+    prefixes: dict[str, str] = {}
+    for name, namespace in raw_prefixes.items():
+        path = f"ontology.prefixes.{name}"
+        pspan = source_map.get(path) if source_map else None
+        problem: str | None = None
+        if not isinstance(name, str) or not PREFIX_NAME_RE.match(name):
+            problem = (
+                f"Prefix name {name!r} is not a valid identifier "
+                "(letters, digits, '_', '-' and '.', starting with a letter or '_')"
+            )
+        elif not is_absolute_iri(namespace):
+            problem = f"Prefix '{name}' must map to an absolute IRI, got {namespace!r}"
+        elif name in BUILTIN_PREFIXES and namespace != BUILTIN_PREFIXES[name]:
+            problem = (
+                f"Prefix '{name}' is built in as <{BUILTIN_PREFIXES[name]}> "
+                "and cannot be bound to another namespace"
+            )
+        if problem is not None:
+            errors.append(
+                SemanticError(
+                    code="INVALID_ONTOLOGY_PREFIX", message=problem, path=path, span=pspan
+                )
+            )
+            continue
+        prefixes[name] = namespace
+    return OntologyConfig(prefixes=prefixes)
+
+
+def _parse_concept_mappings(
+    raw: dict[str, Any],
+    path: str,
+    prefixes: dict[str, str],
+    errors: list[SemanticError],
+    source_map: SourceMap | None = None,
+) -> list[ExternalConceptMapping]:
+    """Parse ``externalConceptMappings`` on one object and expand each concept.
+
+    Returns only the mappings that survive validation, each with its
+    ``expanded_iri`` set. A malformed entry, an unexpandable concept, or a
+    repeat of an already-mapped IRI is reported as a structured error and
+    dropped; the owning object is still built, so one bad mapping does not
+    hide every other error on it.
+    """
+    entries = raw.get("externalConceptMappings")
+    if entries is None:
+        return []
+    list_path = f"{path}.externalConceptMappings" if path else "externalConceptMappings"
+    if not isinstance(entries, list):
+        errors.append(
+            SemanticError(
+                code="INVALID_CONCEPT_MAPPING",
+                message=f"'{list_path}' must be a list of mapping entries",
+                path=list_path,
+                span=source_map.get(list_path) if source_map else None,
+            )
+        )
+        return []
+    out: list[ExternalConceptMapping] = []
+    seen: dict[str, tuple[str, int]] = {}
+    for i, entry in enumerate(entries):
+        epath = f"{list_path}[{i}]"
+        span = source_map.get(epath) if source_map else None
+        if not isinstance(entry, dict):
+            errors.append(
+                SemanticError(
+                    code="INVALID_CONCEPT_MAPPING",
+                    message=f"{epath} must be a mapping with 'concept' and 'relation'",
+                    path=epath,
+                    span=span,
+                )
+            )
+            continue
+        _check_unknown_keys(entry, _EXTERNAL_CONCEPT_MAPPING_KEYS, epath, errors, source_map)
+        known = {k: v for k, v in entry.items() if k in _EXTERNAL_CONCEPT_MAPPING_KEYS}
+        try:
+            mapping = ExternalConceptMapping(**known)
+        except PydanticValidationError as exc:
+            for detail in exc.errors():
+                field = ".".join(str(part) for part in detail["loc"]) or "entry"
+                errors.append(
+                    SemanticError(
+                        code="INVALID_CONCEPT_MAPPING",
+                        message=f"{epath}.{field}: {detail['msg']}",
+                        path=epath,
+                        span=span,
+                    )
+                )
+            continue
+        try:
+            expanded = expand_concept(mapping.concept, prefixes)
+        except ConceptIriError as exc:
+            errors.append(
+                SemanticError(
+                    code=exc.code,
+                    message=f"{epath}: {exc.message}",
+                    path=epath,
+                    span=span,
+                    suggestions=exc.suggestions,
+                )
+            )
+            continue
+        previous = seen.get(expanded)
+        if previous is not None:
+            prior_relation, prior_index = previous
+            same = prior_relation == mapping.relation.value
+            errors.append(
+                SemanticError(
+                    code="DUPLICATE_CONCEPT_MAPPING" if same else "CONFLICTING_CONCEPT_MAPPING",
+                    message=(
+                        f"{epath} maps <{expanded}> again with the same relation "
+                        f"'{mapping.relation.value}' as entry [{prior_index}]"
+                        if same
+                        else f"{epath} maps <{expanded}> as '{mapping.relation.value}' but "
+                        f"entry [{prior_index}] maps it as '{prior_relation}'; one IRI "
+                        "carries one relation"
+                    ),
+                    path=epath,
+                    span=span,
+                )
+            )
+            continue
+        seen[expanded] = (mapping.relation.value, i)
+        out.append(mapping.model_copy(update={"expanded_iri": expanded}))
+    return out
 
 
 def _parse_settings(
@@ -409,6 +589,11 @@ class ReferenceResolver:
         # ``dataObjekt:`` that would silently be dropped by ``raw.get(...)``).
         _check_unknown_keys(raw, _TOP_LEVEL_KEYS, "", errors, source_map)
 
+        # Ontology prefixes come first: every object's externalConceptMappings
+        # expand against them.
+        ontology = _parse_ontology(raw.get("ontology"), errors, source_map)
+        prefixes = effective_prefixes(ontology.prefixes if ontology else None)
+
         # Parse data objects
         data_objects: dict[str, DataObject] = {}
         raw_objects = raw.get("dataObjects", {})
@@ -487,6 +672,9 @@ class ReferenceResolver:
                     count_label=raw_obj.get("countLabel"),
                     synonyms=raw_obj.get("synonyms", []),
                     custom_extensions=_parse_extensions(raw_obj),
+                    external_concept_mappings=_parse_concept_mappings(
+                        raw_obj, f"dataObjects.{name}", prefixes, errors, source_map
+                    ),
                     refresh=_parse_refresh(raw_obj.get("refresh"), name, errors),
                     nested_in=_parse_nested_in(raw_obj.get("nestedIn")),
                 )
@@ -586,6 +774,9 @@ class ReferenceResolver:
                     owner=raw_dim.get("owner"),
                     synonyms=raw_dim.get("synonyms", []),
                     custom_extensions=_parse_extensions(raw_dim),
+                    external_concept_mappings=_parse_concept_mappings(
+                        raw_dim, f"dimensions.{name}", prefixes, errors, source_map
+                    ),
                 )
             except Exception as e:
                 span = source_map.get(f"dimensions.{name}") if source_map else None
@@ -796,6 +987,9 @@ class ReferenceResolver:
                     owner=raw_meas.get("owner"),
                     synonyms=raw_meas.get("synonyms", []),
                     custom_extensions=_parse_extensions(raw_meas),
+                    external_concept_mappings=_parse_concept_mappings(
+                        raw_meas, f"measures.{name}", prefixes, errors, source_map
+                    ),
                 )
             except Exception as e:
                 span = source_map.get(f"measures.{name}") if source_map else None
@@ -880,6 +1074,9 @@ class ReferenceResolver:
                         source_map,
                     )
                 metric_type = raw_metric.get("type", "derived")
+                concept_links = _parse_concept_mappings(
+                    raw_metric, f"metrics.{name}", prefixes, errors, source_map
+                )
 
                 if metric_type == MetricType.CUMULATIVE:
                     # Cumulative metric: validate measure reference exists
@@ -936,6 +1133,7 @@ class ReferenceResolver:
                         owner=raw_metric.get("owner"),
                         synonyms=raw_metric.get("synonyms", []),
                         custom_extensions=_parse_extensions(raw_metric),
+                        external_concept_mappings=concept_links,
                     )
                 elif metric_type == MetricType.PERIOD_OVER_PERIOD:
                     # Period-over-period metric: validate expression + PoP config.
@@ -1008,6 +1206,7 @@ class ReferenceResolver:
                         owner=raw_metric.get("owner"),
                         synonyms=raw_metric.get("synonyms", []),
                         custom_extensions=_parse_extensions(raw_metric),
+                        external_concept_mappings=concept_links,
                     )
                 elif metric_type == MetricType.WINDOW:
                     # Window metric (rank/lag/lead/ntile/first_value/last_value)
@@ -1065,6 +1264,7 @@ class ReferenceResolver:
                         owner=raw_metric.get("owner"),
                         synonyms=raw_metric.get("synonyms", []),
                         custom_extensions=_parse_extensions(raw_metric),
+                        external_concept_mappings=concept_links,
                     )
                 else:
                     # Derived metric (default). It may reference another derived
@@ -1093,6 +1293,7 @@ class ReferenceResolver:
                         owner=raw_metric.get("owner"),
                         synonyms=raw_metric.get("synonyms", []),
                         custom_extensions=_parse_extensions(raw_metric),
+                        external_concept_mappings=concept_links,
                     )
             except Exception as e:
                 span = source_map.get(f"metrics.{name}") if source_map else None
@@ -1192,6 +1393,10 @@ class ReferenceResolver:
             expose_counts=_expose_counts,
             count_label_pattern=_count_pattern,
             custom_extensions=_parse_extensions(raw, "", errors, source_map),
+            ontology=ontology,
+            external_concept_mappings=_parse_concept_mappings(
+                raw, "", prefixes, errors, source_map
+            ),
             settings=settings,
         )
 

--- a/tests/unit/test_external_concept_mappings.py
+++ b/tests/unit/test_external_concept_mappings.py
@@ -640,6 +640,36 @@ class TestInheritsMerge:
         [m] = model.measures["Order Count"].external_concept_mappings
         assert m.expanded_iri == "http://purl.org/goodrelations/v1#Offering"
 
+    @pytest.mark.parametrize("bad_block", ["ontology: []\n", "ontology:\n  prefixes: [corp]\n"])
+    def test_malformed_parent_ontology_reaches_the_resolver(self, bad_block: str) -> None:
+        """The merger leaves a malformed block alone; the resolver reports it."""
+        parent_raw, _ = TrackedLoader().load_string(
+            _BASE.replace(
+                'ontology:\n  prefixes:\n    corp: "https://ontology.example.com/business/"\n'
+                '    fibo: "https://spec.edmcouncil.org/fibo/ontology/"\n',
+                bad_block,
+            )
+        )
+        child_raw, _ = TrackedLoader().load_string(
+            f"version: 1.0\nontology:\n  prefixes:\n    corp: '{CORP}'\n"
+        )
+        merged, _ = ExtendsMerger().merge_from_strings(child_raw, inherits_raw=parent_raw)
+        _, result = ReferenceResolver().resolve(merged)
+        assert _codes(result.errors) == ["ONTOLOGY_PARSE_ERROR"]
+
+    def test_malformed_base_ontology_with_extension_reaches_the_resolver(self) -> None:
+        base_raw, _ = TrackedLoader().load_string(
+            _BASE.replace(
+                'ontology:\n  prefixes:\n    corp: "https://ontology.example.com/business/"\n'
+                '    fibo: "https://spec.edmcouncil.org/fibo/ontology/"\n',
+                "ontology: []\n",
+            )
+        )
+        extension = f"version: 1.0\nontology:\n  prefixes:\n    corp: '{CORP}'\n"
+        merged, _ = ExtendsMerger().merge_from_strings(base_raw, [extension])
+        _, result = ReferenceResolver().resolve(merged)
+        assert _codes(result.errors) == ["ONTOLOGY_PARSE_ERROR"]
+
     def test_child_rebinding_a_parent_prefix_is_an_error(self) -> None:
         parent_raw, _ = TrackedLoader().load_string(_BASE)
         child_raw, _ = TrackedLoader().load_string(

--- a/tests/unit/test_external_concept_mappings.py
+++ b/tests/unit/test_external_concept_mappings.py
@@ -1,0 +1,758 @@
+"""External concept mappings: the OBML mapping foundation.
+
+``externalConceptMappings`` link a model, data object, dimension, measure or
+metric to a concept in an external ontology. These tests pin the contract of
+the first PR of ``PLAN_OBSL_CONTEXT_ONTOLOGY_SYNC``: prefixes and IRIs
+normalize to absolute IRIs, every invalid shape is a structured error with a
+source span, existing models load unchanged, and compiled SQL and cache keys
+are byte-identical with and without mappings.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+from pydantic import ValidationError
+
+from orionbelt.cache.key import build_cache_key
+from orionbelt.compiler.pipeline import CompilationPipeline
+from orionbelt.models.concept_links import (
+    BUILTIN_PREFIXES,
+    ConceptIriError,
+    effective_prefixes,
+    expand_concept,
+    is_absolute_iri,
+)
+from orionbelt.models.errors import SemanticError
+from orionbelt.models.query import QueryObject, QuerySelect
+from orionbelt.models.semantic import (
+    ExternalConceptMapping,
+    ExternalConceptRelation,
+    MappingJustification,
+    SemanticModel,
+)
+from orionbelt.parser.loader import TrackedLoader
+from orionbelt.parser.merger import ExtendsMerger
+from orionbelt.parser.resolver import ReferenceResolver
+
+_SCHEMA = json.loads(
+    (Path(__file__).resolve().parents[2] / "schema" / "obml-schema.json").read_text()
+)
+_VALIDATOR = jsonschema.Draft7Validator(_SCHEMA)
+
+CORP = "https://ontology.example.com/business/"
+
+_BASE = """\
+version: 1.0
+ontology:
+  prefixes:
+    corp: "https://ontology.example.com/business/"
+    fibo: "https://spec.edmcouncil.org/fibo/ontology/"
+dataObjects:
+  Orders:
+    code: ORDERS
+    database: EDW
+    schema: SALES
+    columns:
+      ID:
+        code: ID
+        abstractType: string
+      Amount:
+        code: AMOUNT
+        abstractType: float
+        numClass: additive
+      Order Date:
+        code: ORDER_DATE
+        abstractType: date
+dimensions:
+  Order ID:
+    dataObject: Orders
+    column: ID
+  Order Month:
+    dataObject: Orders
+    column: Order Date
+    resultType: date
+    timeGrain: month
+measures:
+  Revenue:
+    columns:
+      - dataObject: Orders
+        column: Amount
+    aggregation: sum
+metrics:
+  Revenue Doubled:
+    expression: "{[Revenue]} * 2"
+"""
+
+
+def _resolve(yaml_text: str) -> tuple[SemanticModel, list[SemanticError]]:
+    raw, source_map = TrackedLoader().load_string(yaml_text)
+    model, result = ReferenceResolver().resolve(raw, source_map)
+    return model, result.errors
+
+
+def _codes(errors: list[SemanticError]) -> list[str]:
+    return [e.code for e in errors]
+
+
+def _with_measure_mappings(block: str) -> str:
+    """The base model with an indented mapping block under the Revenue measure."""
+    indented = "\n".join(f"    {line}" if line else line for line in block.splitlines())
+    return _BASE.replace(
+        "    aggregation: sum\n",
+        f"    aggregation: sum\n{indented}\n",
+    )
+
+
+# ───────────────────────────── valid shapes ─────────────────────────────
+
+
+class TestValidMappings:
+    def test_compact_iri_expands(self) -> None:
+        model, errors = _resolve(
+            _with_measure_mappings(
+                "externalConceptMappings:\n  - concept: corp:NetRevenue\n    relation: exact\n"
+            )
+        )
+        assert errors == []
+        [mapping] = model.measures["Revenue"].external_concept_mappings
+        assert mapping.concept == "corp:NetRevenue"
+        assert mapping.expanded_iri == CORP + "NetRevenue"
+        assert mapping.relation is ExternalConceptRelation.EXACT
+        assert mapping.justification is None
+
+    def test_full_iri_is_kept_verbatim(self) -> None:
+        model, errors = _resolve(
+            _with_measure_mappings(
+                "externalConceptMappings:\n"
+                "  - concept: https://schema.org/MonetaryAmount\n"
+                "    relation: close\n"
+            )
+        )
+        assert errors == []
+        [mapping] = model.measures["Revenue"].external_concept_mappings
+        assert mapping.expanded_iri == "https://schema.org/MonetaryAmount"
+
+    def test_builtin_prefix_needs_no_declaration(self) -> None:
+        model, errors = _resolve(
+            _with_measure_mappings(
+                "externalConceptMappings:\n  - concept: skos:Concept\n    relation: related\n"
+            )
+        )
+        assert errors == []
+        [mapping] = model.measures["Revenue"].external_concept_mappings
+        assert mapping.expanded_iri == BUILTIN_PREFIXES["skos"] + "Concept"
+
+    def test_redeclaring_a_builtin_verbatim_is_allowed(self) -> None:
+        yaml_text = _BASE.replace("    fibo:", f'    skos: "{BUILTIN_PREFIXES["skos"]}"\n    fibo:')
+        _, errors = _resolve(yaml_text)
+        assert errors == []
+
+    def test_all_metadata_round_trips(self) -> None:
+        model, errors = _resolve(
+            _with_measure_mappings(
+                "externalConceptMappings:\n"
+                "  - concept: corp:NetRevenue\n"
+                "    relation: broader\n"
+                "    justification: curated\n"
+                "    source: enterprise-finance-ontology\n"
+                '    ontologyVersion: "2026.1"\n'
+                "    confidence: 0.9\n"
+                "    comment: Approved by Finance Data Governance\n"
+            )
+        )
+        assert errors == []
+        [mapping] = model.measures["Revenue"].external_concept_mappings
+        assert mapping.relation is ExternalConceptRelation.BROADER
+        assert mapping.justification is MappingJustification.CURATED
+        assert mapping.source == "enterprise-finance-ontology"
+        assert mapping.ontology_version == "2026.1"
+        assert mapping.confidence == pytest.approx(0.9)
+        assert mapping.comment == "Approved by Finance Data Governance"
+
+    def test_same_iri_on_different_objects_is_fine(self) -> None:
+        yaml_text = _with_measure_mappings(
+            "externalConceptMappings:\n  - concept: corp:NetRevenue\n    relation: exact\n"
+        ).replace(
+            '    expression: "{[Revenue]} * 2"\n',
+            '    expression: "{[Revenue]} * 2"\n'
+            "    externalConceptMappings:\n"
+            "      - concept: corp:NetRevenue\n"
+            "        relation: narrower\n",
+        )
+        _, errors = _resolve(yaml_text)
+        assert errors == []
+
+    @pytest.mark.parametrize("relation", [r.value for r in ExternalConceptRelation])
+    def test_every_relation_loads(self, relation: str) -> None:
+        _, errors = _resolve(
+            _with_measure_mappings(
+                f"externalConceptMappings:\n  - concept: corp:X\n    relation: {relation}\n"
+            )
+        )
+        assert errors == []
+
+    @pytest.mark.parametrize("justification", [j.value for j in MappingJustification])
+    def test_every_justification_loads(self, justification: str) -> None:
+        _, errors = _resolve(
+            _with_measure_mappings(
+                "externalConceptMappings:\n  - concept: corp:X\n    relation: exact\n"
+                f"    justification: {justification}\n"
+            )
+        )
+        assert errors == []
+
+
+class TestSupportedObjects:
+    """Mappings load on every object in the initial scope and nowhere else."""
+
+    _ENTRY = "externalConceptMappings:\n  - concept: corp:Thing\n    relation: exact\n"
+
+    def test_model_level(self) -> None:
+        model, errors = _resolve(_BASE + self._ENTRY)
+        assert errors == []
+        assert model.external_concept_mappings[0].expanded_iri == CORP + "Thing"
+        assert model.ontology is not None
+        assert model.ontology.prefixes["corp"] == CORP
+
+    def test_data_object(self) -> None:
+        yaml_text = _BASE.replace(
+            "    schema: SALES\n",
+            "    schema: SALES\n    externalConceptMappings:\n"
+            "      - concept: corp:Order\n        relation: exact\n",
+        )
+        model, errors = _resolve(yaml_text)
+        assert errors == []
+        [m] = model.data_objects["Orders"].external_concept_mappings
+        assert m.expanded_iri == CORP + "Order"
+
+    def test_dimension(self) -> None:
+        yaml_text = _BASE.replace(
+            "    column: ID\n",
+            "    column: ID\n    externalConceptMappings:\n"
+            "      - concept: corp:OrderIdentifier\n        relation: exact\n",
+        )
+        model, errors = _resolve(yaml_text)
+        assert errors == []
+        [m] = model.dimensions["Order ID"].external_concept_mappings
+        assert m.expanded_iri == CORP + "OrderIdentifier"
+
+    def test_measure(self) -> None:
+        model, errors = _resolve(_with_measure_mappings(self._ENTRY))
+        assert errors == []
+        assert model.measures["Revenue"].external_concept_mappings[0].expanded_iri == CORP + "Thing"
+
+    def test_derived_metric(self) -> None:
+        yaml_text = _BASE.replace(
+            '    expression: "{[Revenue]} * 2"\n',
+            '    expression: "{[Revenue]} * 2"\n    externalConceptMappings:\n'
+            "      - concept: corp:DoubleRevenue\n        relation: exact\n",
+        )
+        model, errors = _resolve(yaml_text)
+        assert errors == []
+        [m] = model.metrics["Revenue Doubled"].external_concept_mappings
+        assert m.expanded_iri == CORP + "DoubleRevenue"
+
+    @pytest.mark.parametrize(
+        "block",
+        [
+            "type: cumulative\nmeasure: Revenue\ntimeDimension: Order Month\n",
+            "type: window\nmeasure: Revenue\nwindowFunction: rank\n",
+            'type: period_over_period\nexpression: "{[Revenue]}"\n'
+            "periodOverPeriod:\n  timeDimension: Order Month\n  offset: 1\n  offsetGrain: month\n",
+        ],
+        ids=["cumulative", "window", "period_over_period"],
+    )
+    def test_other_metric_types(self, block: str) -> None:
+        indented = "\n".join(f"    {line}" for line in block.splitlines())
+        yaml_text = _BASE + (
+            f"  Running:\n{indented}\n    externalConceptMappings:\n"
+            "      - concept: corp:Running\n        relation: exact\n"
+        )
+        model, errors = _resolve(yaml_text)
+        assert errors == [], errors
+        [m] = model.metrics["Running"].external_concept_mappings
+        assert m.expanded_iri == CORP + "Running"
+
+    def test_column_is_rejected(self) -> None:
+        yaml_text = _BASE.replace(
+            "        code: AMOUNT\n",
+            "        code: AMOUNT\n        externalConceptMappings:\n"
+            "          - concept: corp:Amount\n            relation: exact\n",
+        )
+        _, errors = _resolve(yaml_text)
+        assert [(e.code, e.path) for e in errors] == [
+            ("UNKNOWN_PROPERTY", "dataObjects.Orders.columns.Amount")
+        ]
+
+    def test_join_is_rejected(self) -> None:
+        yaml_text = _BASE.replace(
+            "dimensions:\n",
+            "  Customers:\n    code: CUSTOMERS\n    columns:\n      ID: {code: ID}\n",
+            1,
+        ).replace(
+            "    schema: SALES\n",
+            "    schema: SALES\n    joins:\n      - joinTo: Customers\n        columnsFrom: [ID]\n"
+            "        columnsTo: [ID]\n        externalConceptMappings: []\n",
+        )
+        yaml_text = yaml_text.replace(
+            "      ID: {code: ID}\n", "      ID: {code: ID}\ndimensions:\n", 1
+        )
+        _, errors = _resolve(yaml_text)
+        assert "UNKNOWN_PROPERTY" in _codes(errors)
+
+
+# ──────────────────────────── invalid shapes ────────────────────────────
+
+
+class TestPrefixErrors:
+    def test_unknown_prefix(self) -> None:
+        model, errors = _resolve(
+            _with_measure_mappings(
+                "externalConceptMappings:\n  - concept: acme:Revenue\n    relation: exact\n"
+            )
+        )
+        [err] = errors
+        assert err.code == "UNKNOWN_ONTOLOGY_PREFIX"
+        assert err.path == "measures.Revenue.externalConceptMappings[0]"
+        assert err.span is not None
+        assert {"corp", "fibo", "skos"} <= set(err.suggestions)
+        # The measure itself still loads; only the mapping is dropped.
+        assert model.measures["Revenue"].external_concept_mappings == []
+
+    def test_invalid_prefix_name(self) -> None:
+        yaml_text = _BASE.replace("    fibo:", '    "1bad": "https://x.example/"\n    fibo:')
+        _, errors = _resolve(yaml_text)
+        [err] = errors
+        assert err.code == "INVALID_ONTOLOGY_PREFIX"
+        assert err.path == "ontology.prefixes.1bad"
+
+    @pytest.mark.parametrize("namespace", ["relative/path", "corp:X", "'has space'", "42"])
+    def test_invalid_namespace(self, namespace: str) -> None:
+        yaml_text = _BASE.replace("    fibo:", f"    bad: {namespace}\n    fibo:")
+        _, errors = _resolve(yaml_text)
+        assert _codes(errors) == ["INVALID_ONTOLOGY_PREFIX"]
+        assert errors[0].path == "ontology.prefixes.bad"
+
+    def test_rebinding_a_builtin_is_rejected(self) -> None:
+        yaml_text = _BASE.replace(
+            "    fibo:", '    skos: "https://example.com/not-skos#"\n    fibo:'
+        )
+        _, errors = _resolve(yaml_text)
+        assert _codes(errors) == ["INVALID_ONTOLOGY_PREFIX"]
+        assert "built in" in errors[0].message
+
+    def test_bad_prefix_does_not_hide_the_good_ones(self) -> None:
+        yaml_text = _BASE.replace("    fibo:", "    bad: nope\n    fibo:")
+        model, errors = _resolve(yaml_text)
+        assert _codes(errors) == ["INVALID_ONTOLOGY_PREFIX"]
+        assert model.ontology is not None
+        assert set(model.ontology.prefixes) == {"corp", "fibo"}
+
+    def test_ontology_block_must_be_a_mapping(self) -> None:
+        yaml_text = _BASE.replace(
+            'ontology:\n  prefixes:\n    corp: "https://ontology.example.com/business/"\n'
+            '    fibo: "https://spec.edmcouncil.org/fibo/ontology/"\n',
+            "ontology: [corp]\n",
+        )
+        _, errors = _resolve(yaml_text)
+        assert _codes(errors) == ["ONTOLOGY_PARSE_ERROR"]
+
+    def test_prefixes_must_be_a_mapping(self) -> None:
+        yaml_text = _BASE.replace(
+            '  prefixes:\n    corp: "https://ontology.example.com/business/"\n'
+            '    fibo: "https://spec.edmcouncil.org/fibo/ontology/"\n',
+            "  prefixes: [corp]\n",
+        )
+        _, errors = _resolve(yaml_text)
+        assert _codes(errors) == ["ONTOLOGY_PARSE_ERROR"]
+        assert errors[0].path == "ontology.prefixes"
+
+    def test_unknown_key_in_ontology_block(self) -> None:
+        yaml_text = _BASE.replace("ontology:\n", "ontology:\n  imports: []\n")
+        _, errors = _resolve(yaml_text)
+        assert [(e.code, e.path) for e in errors] == [("UNKNOWN_PROPERTY", "ontology")]
+
+
+class TestConceptIriErrors:
+    @pytest.mark.parametrize(
+        "concept",
+        [
+            "_:b0",
+            "NetRevenue",
+            "<https://ontology.example.com/business/NetRevenue>",
+            "'corp:Net Revenue'",
+            "'corp:'",
+            "''",
+        ],
+        ids=["blank-node", "relative", "angle-brackets", "whitespace", "no-local-name", "empty"],
+    )
+    def test_invalid_concept(self, concept: str) -> None:
+        _, errors = _resolve(
+            _with_measure_mappings(
+                f"externalConceptMappings:\n  - concept: {concept}\n    relation: exact\n"
+            )
+        )
+        assert _codes(errors) == ["INVALID_CONCEPT_IRI"], errors
+        assert errors[0].path == "measures.Revenue.externalConceptMappings[0]"
+        assert errors[0].span is not None
+
+
+class TestMappingShapeErrors:
+    def test_missing_relation(self) -> None:
+        _, errors = _resolve(
+            _with_measure_mappings("externalConceptMappings:\n  - concept: corp:NetRevenue\n")
+        )
+        [err] = errors
+        assert err.code == "INVALID_CONCEPT_MAPPING"
+        assert "relation" in err.message
+        assert err.path == "measures.Revenue.externalConceptMappings[0]"
+
+    def test_invalid_relation(self) -> None:
+        _, errors = _resolve(
+            _with_measure_mappings(
+                "externalConceptMappings:\n  - concept: corp:NetRevenue\n    relation: same\n"
+            )
+        )
+        assert _codes(errors) == ["INVALID_CONCEPT_MAPPING"]
+        assert "relation" in errors[0].message
+
+    def test_invalid_justification(self) -> None:
+        _, errors = _resolve(
+            _with_measure_mappings(
+                "externalConceptMappings:\n  - concept: corp:NetRevenue\n    relation: exact\n"
+                "    justification: guessed\n"
+            )
+        )
+        assert _codes(errors) == ["INVALID_CONCEPT_MAPPING"]
+        assert "justification" in errors[0].message
+
+    @pytest.mark.parametrize("confidence", ["-0.1", "1.5"])
+    def test_confidence_out_of_range(self, confidence: str) -> None:
+        _, errors = _resolve(
+            _with_measure_mappings(
+                "externalConceptMappings:\n  - concept: corp:NetRevenue\n    relation: exact\n"
+                f"    confidence: {confidence}\n"
+            )
+        )
+        assert _codes(errors) == ["INVALID_CONCEPT_MAPPING"]
+        assert "confidence" in errors[0].message
+
+    def test_unknown_key_in_entry(self) -> None:
+        _, errors = _resolve(
+            _with_measure_mappings(
+                "externalConceptMappings:\n  - concept: corp:NetRevenue\n    relation: exact\n"
+                "    relatoin: exact\n"
+            )
+        )
+        assert [(e.code, e.path) for e in errors] == [
+            ("UNKNOWN_PROPERTY", "measures.Revenue.externalConceptMappings[0]")
+        ]
+
+    def test_expanded_iri_is_not_authorable(self) -> None:
+        _, errors = _resolve(
+            _with_measure_mappings(
+                "externalConceptMappings:\n  - concept: corp:NetRevenue\n    relation: exact\n"
+                "    expandedIri: https://x.example/\n"
+            )
+        )
+        assert _codes(errors) == ["UNKNOWN_PROPERTY"]
+
+    def test_entries_must_be_a_list(self) -> None:
+        _, errors = _resolve(
+            _with_measure_mappings("externalConceptMappings:\n  concept: corp:NetRevenue\n")
+        )
+        assert _codes(errors) == ["INVALID_CONCEPT_MAPPING"]
+        assert errors[0].path == "measures.Revenue.externalConceptMappings"
+
+    def test_entry_must_be_a_mapping(self) -> None:
+        _, errors = _resolve(
+            _with_measure_mappings("externalConceptMappings:\n  - corp:NetRevenue\n")
+        )
+        assert _codes(errors) == ["INVALID_CONCEPT_MAPPING"]
+        assert errors[0].path == "measures.Revenue.externalConceptMappings[0]"
+
+
+class TestDuplicatesAndConflicts:
+    def test_duplicate_same_relation(self) -> None:
+        model, errors = _resolve(
+            _with_measure_mappings(
+                "externalConceptMappings:\n"
+                "  - concept: corp:NetRevenue\n    relation: exact\n"
+                "  - concept: https://ontology.example.com/business/NetRevenue\n"
+                "    relation: exact\n"
+            )
+        )
+        [err] = errors
+        assert err.code == "DUPLICATE_CONCEPT_MAPPING"
+        assert err.path == "measures.Revenue.externalConceptMappings[1]"
+        # The first occurrence is kept, the repeat dropped.
+        assert len(model.measures["Revenue"].external_concept_mappings) == 1
+
+    def test_conflicting_relations(self) -> None:
+        _, errors = _resolve(
+            _with_measure_mappings(
+                "externalConceptMappings:\n"
+                "  - concept: corp:NetRevenue\n    relation: exact\n"
+                "  - concept: corp:NetRevenue\n    relation: broader\n"
+            )
+        )
+        [err] = errors
+        assert err.code == "CONFLICTING_CONCEPT_MAPPING"
+        assert "'exact'" in err.message and "'broader'" in err.message
+
+    def test_each_problem_is_reported_once(self) -> None:
+        """Three broken entries give three errors, one per entry, and none masks another."""
+        _, errors = _resolve(
+            _with_measure_mappings(
+                "externalConceptMappings:\n"
+                "  - concept: acme:Revenue\n    relation: exact\n"
+                "  - concept: corp:Revenue\n    relation: nope\n"
+                "  - concept: corp:Revenue\n    relation: exact\n"
+                "  - concept: corp:Revenue\n    relation: exact\n"
+            )
+        )
+        assert _codes(errors) == [
+            "UNKNOWN_ONTOLOGY_PREFIX",
+            "INVALID_CONCEPT_MAPPING",
+            "DUPLICATE_CONCEPT_MAPPING",
+        ]
+
+
+# ───────────────────── existing models and execution ────────────────────
+
+
+class TestNoBehaviourChange:
+    def test_model_without_mappings_loads_unchanged(self) -> None:
+        yaml_text = _BASE.replace(
+            'ontology:\n  prefixes:\n    corp: "https://ontology.example.com/business/"\n'
+            '    fibo: "https://spec.edmcouncil.org/fibo/ontology/"\n',
+            "",
+        )
+        model, errors = _resolve(yaml_text)
+        assert errors == []
+        assert model.ontology is None
+        assert model.external_concept_mappings == []
+        assert all(o.external_concept_mappings == [] for o in model.data_objects.values())
+        assert all(d.external_concept_mappings == [] for d in model.dimensions.values())
+        assert all(m.external_concept_mappings == [] for m in model.measures.values())
+        assert all(m.external_concept_mappings == [] for m in model.metrics.values())
+
+    @pytest.mark.parametrize("dialect", ["postgres", "duckdb", "snowflake"])
+    def test_sql_and_cache_key_are_identical_with_mappings(self, dialect: str) -> None:
+        plain, plain_errors = _resolve(_BASE)
+        mapped, mapped_errors = _resolve(
+            _with_measure_mappings(
+                "externalConceptMappings:\n"
+                "  - concept: corp:NetRevenue\n    relation: exact\n"
+                "  - concept: fibo:Revenue\n    relation: broader\n    confidence: 0.7\n"
+            )
+            + "externalConceptMappings:\n  - concept: corp:SalesModel\n    relation: exact\n"
+        )
+        assert plain_errors == [] and mapped_errors == []
+        query = QueryObject(
+            select=QuerySelect(dimensions=["Order Month"], measures=["Revenue"]),
+        )
+        pipeline = CompilationPipeline()
+        a = pipeline.compile(query, plain, dialect)
+        b = pipeline.compile(query, mapped, dialect)
+        assert a.sql == b.sql
+        assert [w.code for w in a.warnings] == [w.code for w in b.warnings]
+        key = build_cache_key(datasource="ds", model_id="m", dialect=dialect, sql=a.sql)
+        assert key == build_cache_key(datasource="ds", model_id="m", dialect=dialect, sql=b.sql)
+
+
+class TestExtendsMerge:
+    def test_extension_prefixes_and_model_mappings_survive_merge(self) -> None:
+        base_raw, _ = TrackedLoader().load_string(
+            _BASE + "externalConceptMappings:\n  - concept: corp:Base\n    relation: exact\n"
+        )
+        extension = (
+            "version: 1.0\n"
+            "ontology:\n  prefixes:\n    gr: 'http://purl.org/goodrelations/v1#'\n"
+            "measures:\n  Order Count:\n    aggregation: count\n"
+            "    columns: [{dataObject: Orders, column: ID}]\n"
+            "    externalConceptMappings:\n"
+            "      - concept: gr:Offering\n        relation: related\n"
+            "externalConceptMappings:\n"
+            "  - concept: gr:BusinessEntity\n    relation: related\n"
+        )
+        merged, warnings = ExtendsMerger().merge_from_strings(base_raw, [extension])
+        assert warnings == []
+        model, result = ReferenceResolver().resolve(merged)
+        assert result.errors == []
+        assert model.ontology is not None
+        assert set(model.ontology.prefixes) == {"corp", "fibo", "gr"}
+        assert [m.concept for m in model.external_concept_mappings] == [
+            "corp:Base",
+            "gr:BusinessEntity",
+        ]
+        [m] = model.measures["Order Count"].external_concept_mappings
+        assert m.expanded_iri == "http://purl.org/goodrelations/v1#Offering"
+
+    def test_conflicting_prefix_is_warned_and_overridden(self) -> None:
+        base_raw, _ = TrackedLoader().load_string(_BASE)
+        extension = "version: 1.0\nontology:\n  prefixes:\n    corp: 'https://other.example/'\n"
+        merged, warnings = ExtendsMerger().merge_from_strings(base_raw, [extension])
+        assert any("corp" in w for w in warnings)
+        assert merged["ontology"]["prefixes"]["corp"] == "https://other.example/"
+
+
+# ────────────────────────────── JSON schema ─────────────────────────────
+
+
+class TestJsonSchema:
+    _DOC = {
+        "version": 1.0,
+        "ontology": {"prefixes": {"corp": CORP}},
+        "dataObjects": {
+            "O": {
+                "code": "O",
+                "database": "d",
+                "schema": "s",
+                "columns": {"C": {"code": "C", "abstractType": "string"}},
+                "externalConceptMappings": [{"concept": "corp:Order", "relation": "exact"}],
+            }
+        },
+        "dimensions": {
+            "D": {
+                "dataObject": "O",
+                "column": "C",
+                "externalConceptMappings": [{"concept": "corp:D", "relation": "close"}],
+            }
+        },
+        "measures": {
+            "M": {
+                "aggregation": "count",
+                "columns": [{"dataObject": "O", "column": "C"}],
+                "externalConceptMappings": [
+                    {
+                        "concept": "corp:M",
+                        "relation": "broader",
+                        "justification": "curated",
+                        "source": "s",
+                        "ontologyVersion": "1",
+                        "confidence": 0.5,
+                        "comment": "c",
+                    }
+                ],
+            }
+        },
+        "metrics": {
+            "X": {
+                "expression": "{[M]}",
+                "externalConceptMappings": [{"concept": "corp:X", "relation": "narrower"}],
+            }
+        },
+        "externalConceptMappings": [{"concept": "https://x.example/Model", "relation": "related"}],
+    }
+
+    def _errors(self, doc: dict) -> list[str]:
+        return [e.message for e in _VALIDATOR.iter_errors(doc)]
+
+    def test_full_document_validates(self) -> None:
+        assert self._errors(self._DOC) == []
+
+    def _mutated(self, path: list, value) -> dict:
+        doc = json.loads(json.dumps(self._DOC))
+        node = doc
+        for key in path[:-1]:
+            node = node[key]
+        if value is _DELETE:
+            del node[path[-1]]
+        else:
+            node[path[-1]] = value
+        return doc
+
+    def test_relation_is_required(self) -> None:
+        doc = self._mutated(["metrics", "X", "externalConceptMappings", 0, "relation"], _DELETE)
+        assert any("relation" in m for m in self._errors(doc))
+
+    def test_unknown_relation_rejected(self) -> None:
+        doc = self._mutated(["metrics", "X", "externalConceptMappings", 0, "relation"], "same")
+        assert self._errors(doc)
+
+    def test_confidence_bounds(self) -> None:
+        doc = self._mutated(["measures", "M", "externalConceptMappings", 0, "confidence"], 1.5)
+        assert self._errors(doc)
+
+    def test_expanded_iri_rejected(self) -> None:
+        doc = self._mutated(
+            ["metrics", "X", "externalConceptMappings", 0, "expandedIri"], "https://x.example/"
+        )
+        assert self._errors(doc)
+
+    def test_invalid_prefix_name_rejected(self) -> None:
+        doc = self._mutated(["ontology", "prefixes"], {"1bad": CORP})
+        assert self._errors(doc)
+
+    def test_mappings_on_column_rejected(self) -> None:
+        doc = self._mutated(
+            ["dataObjects", "O", "columns", "C", "externalConceptMappings"],
+            [{"concept": "corp:C", "relation": "exact"}],
+        )
+        assert self._errors(doc)
+
+
+_DELETE = object()
+
+
+# ──────────────────────────── model + helpers ───────────────────────────
+
+
+class TestPydanticModel:
+    def test_python_names_and_aliases(self) -> None:
+        m = ExternalConceptMapping(concept="corp:X", relation="exact", ontology_version="1")
+        assert m.relation is ExternalConceptRelation.EXACT
+        assert ExternalConceptMapping.model_validate({"concept": "corp:X", "relation": "close"})
+        dumped = m.model_dump(by_alias=True, exclude_none=True)
+        assert dumped == {"concept": "corp:X", "relation": "exact", "ontologyVersion": "1"}
+
+    def test_relation_required(self) -> None:
+        with pytest.raises(ValidationError):
+            ExternalConceptMapping(concept="corp:X")  # type: ignore[call-arg]
+
+    @pytest.mark.parametrize("confidence", [-0.01, 1.01])
+    def test_confidence_bounds(self, confidence: float) -> None:
+        with pytest.raises(ValidationError):
+            ExternalConceptMapping(concept="corp:X", relation="exact", confidence=confidence)
+
+
+class TestConceptLinkHelpers:
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            ("https://example.com/a", True),
+            ("http://example.com", True),
+            ("urn:isbn:0451450523", True),
+            ("corp:NetRevenue", False),
+            ("https://", False),
+            ("https://exa mple.com/a", False),
+            ("/relative", False),
+            ("", False),
+            (None, False),
+        ],
+    )
+    def test_is_absolute_iri(self, value: object, expected: bool) -> None:
+        assert is_absolute_iri(value) is expected
+
+    def test_effective_prefixes_layers_declared_over_builtins(self) -> None:
+        merged = effective_prefixes({"corp": CORP})
+        assert merged["corp"] == CORP
+        assert merged["skos"] == BUILTIN_PREFIXES["skos"]
+        assert effective_prefixes(None) == dict(BUILTIN_PREFIXES)
+
+    def test_expand_compact(self) -> None:
+        assert expand_concept("corp:Net", {"corp": CORP}) == CORP + "Net"
+
+    def test_expand_full_iri_verbatim(self) -> None:
+        assert expand_concept("urn:x:y", {}) == "urn:x:y"
+
+    def test_unknown_prefix_error_carries_suggestions(self) -> None:
+        with pytest.raises(ConceptIriError) as exc:
+            expand_concept("acme:X", {"corp": CORP})
+        assert exc.value.code == "UNKNOWN_ONTOLOGY_PREFIX"
+        assert exc.value.suggestions == ["corp"]

--- a/tests/unit/test_external_concept_mappings.py
+++ b/tests/unit/test_external_concept_mappings.py
@@ -670,6 +670,27 @@ class TestInheritsMerge:
         _, result = ReferenceResolver().resolve(merged)
         assert _codes(result.errors) == ["ONTOLOGY_PARSE_ERROR"]
 
+    @pytest.mark.parametrize("bad_block", ["ontology: []\n", "ontology:\n  prefixes: [corp]\n"])
+    def test_malformed_fragment_ontology_is_a_merge_error(self, bad_block: str) -> None:
+        """A fragment's block is never copied whole, so it cannot be left to the resolver."""
+        base_raw, _ = TrackedLoader().load_string(_BASE)
+        fragment = "version: 1.0\n" + bad_block
+        with pytest.raises(MergeError) as exc:
+            ExtendsMerger().merge_from_strings(base_raw, [fragment])
+        assert exc.value.code == "ONTOLOGY_PARSE_ERROR"
+        child_raw, _ = TrackedLoader().load_string(fragment)
+        with pytest.raises(MergeError) as exc:
+            ExtendsMerger().merge_from_strings(child_raw, inherits_raw=base_raw)
+        assert exc.value.code == "ONTOLOGY_PARSE_ERROR"
+
+    def test_empty_fragment_ontology_is_fine(self) -> None:
+        base_raw, _ = TrackedLoader().load_string(_BASE)
+        merged, warnings = ExtendsMerger().merge_from_strings(
+            base_raw, ["version: 1.0\nontology: {}\n", "version: 1.0\nontology:\n  prefixes: {}\n"]
+        )
+        assert warnings == []
+        assert merged["ontology"]["prefixes"]["corp"] == CORP
+
     def test_child_rebinding_a_parent_prefix_is_an_error(self) -> None:
         parent_raw, _ = TrackedLoader().load_string(_BASE)
         child_raw, _ = TrackedLoader().load_string(

--- a/tests/unit/test_external_concept_mappings.py
+++ b/tests/unit/test_external_concept_mappings.py
@@ -35,7 +35,7 @@ from orionbelt.models.semantic import (
     SemanticModel,
 )
 from orionbelt.parser.loader import TrackedLoader
-from orionbelt.parser.merger import ExtendsMerger
+from orionbelt.parser.merger import ExtendsMerger, MergeError
 from orionbelt.parser.resolver import ReferenceResolver
 
 _SCHEMA = json.loads(
@@ -593,12 +593,61 @@ class TestExtendsMerge:
         [m] = model.measures["Order Count"].external_concept_mappings
         assert m.expanded_iri == "http://purl.org/goodrelations/v1#Offering"
 
-    def test_conflicting_prefix_is_warned_and_overridden(self) -> None:
-        base_raw, _ = TrackedLoader().load_string(_BASE)
+    def test_rebinding_a_prefix_in_an_extension_is_an_error(self) -> None:
+        """A rebinding would silently expand the base file's mappings elsewhere."""
+        base_raw, _ = TrackedLoader().load_string(
+            _BASE + "externalConceptMappings:\n  - concept: corp:Base\n    relation: exact\n"
+        )
         extension = "version: 1.0\nontology:\n  prefixes:\n    corp: 'https://other.example/'\n"
+        with pytest.raises(MergeError) as exc:
+            ExtendsMerger().merge_from_strings(base_raw, [extension])
+        assert exc.value.code == "ONTOLOGY_PREFIX_CONFLICT"
+        assert "corp" in exc.value.message
+
+    def test_redeclaring_a_prefix_verbatim_in_an_extension_is_fine(self) -> None:
+        base_raw, _ = TrackedLoader().load_string(_BASE)
+        extension = f"version: 1.0\nontology:\n  prefixes:\n    corp: '{CORP}'\n"
         merged, warnings = ExtendsMerger().merge_from_strings(base_raw, [extension])
-        assert any("corp" in w for w in warnings)
-        assert merged["ontology"]["prefixes"]["corp"] == "https://other.example/"
+        assert warnings == []
+        assert merged["ontology"]["prefixes"]["corp"] == CORP
+
+
+class TestInheritsMerge:
+    def test_child_prefixes_and_mappings_survive_inherits(self) -> None:
+        parent_raw, _ = TrackedLoader().load_string(
+            _BASE + "externalConceptMappings:\n  - concept: corp:Parent\n    relation: exact\n"
+        )
+        child_raw, _ = TrackedLoader().load_string(
+            "version: 1.0\n"
+            "ontology:\n  prefixes:\n    gr: 'http://purl.org/goodrelations/v1#'\n"
+            "measures:\n  Order Count:\n    aggregation: count\n"
+            "    columns: [{dataObject: Orders, column: ID}]\n"
+            "    externalConceptMappings:\n"
+            "      - concept: gr:Offering\n        relation: related\n"
+            "externalConceptMappings:\n"
+            "  - concept: gr:BusinessEntity\n    relation: related\n"
+        )
+        merged, warnings = ExtendsMerger().merge_from_strings(child_raw, inherits_raw=parent_raw)
+        assert warnings == []
+        model, result = ReferenceResolver().resolve(merged)
+        assert result.errors == []
+        assert model.ontology is not None
+        assert set(model.ontology.prefixes) == {"corp", "fibo", "gr"}
+        assert [m.concept for m in model.external_concept_mappings] == [
+            "corp:Parent",
+            "gr:BusinessEntity",
+        ]
+        [m] = model.measures["Order Count"].external_concept_mappings
+        assert m.expanded_iri == "http://purl.org/goodrelations/v1#Offering"
+
+    def test_child_rebinding_a_parent_prefix_is_an_error(self) -> None:
+        parent_raw, _ = TrackedLoader().load_string(_BASE)
+        child_raw, _ = TrackedLoader().load_string(
+            "version: 1.0\nontology:\n  prefixes:\n    corp: 'https://other.example/'\n"
+        )
+        with pytest.raises(MergeError) as exc:
+            ExtendsMerger().merge_from_strings(child_raw, inherits_raw=parent_raw)
+        assert exc.value.code == "ONTOLOGY_PREFIX_CONFLICT"
 
 
 # ────────────────────────────── JSON schema ─────────────────────────────

--- a/tests/unit/test_external_concept_mappings.py
+++ b/tests/unit/test_external_concept_mappings.py
@@ -683,6 +683,39 @@ class TestInheritsMerge:
             ExtendsMerger().merge_from_strings(child_raw, inherits_raw=base_raw)
         assert exc.value.code == "ONTOLOGY_PARSE_ERROR"
 
+    @pytest.mark.parametrize(
+        "bad_block",
+        [
+            "ontology:\n  prefix: {}\n",
+            f"ontology:\n  prefixes:\n    corp: '{CORP}'\n  imports: []\n",
+        ],
+        ids=["typo", "extra-key"],
+    )
+    def test_unknown_key_in_fragment_ontology_is_a_merge_error(self, bad_block: str) -> None:
+        """Fragments are as strict as a top-level block: only ``prefixes`` is read from them."""
+        base_raw, _ = TrackedLoader().load_string(_BASE)
+        fragment = "version: 1.0\n" + bad_block
+        with pytest.raises(MergeError) as exc:
+            ExtendsMerger().merge_from_strings(base_raw, [fragment])
+        assert exc.value.code == "UNKNOWN_PROPERTY"
+        child_raw, _ = TrackedLoader().load_string(fragment)
+        with pytest.raises(MergeError) as exc:
+            ExtendsMerger().merge_from_strings(child_raw, inherits_raw=base_raw)
+        assert exc.value.code == "UNKNOWN_PROPERTY"
+
+    @pytest.mark.parametrize("bad_value", ["{}", "corp:Thing", "{concept: corp:Thing}"])
+    def test_non_list_fragment_mappings_are_a_merge_error(self, bad_value: str) -> None:
+        """``externalConceptMappings: {}`` on a fragment used to be dropped as falsy."""
+        base_raw, _ = TrackedLoader().load_string(_BASE)
+        fragment = f"version: 1.0\nexternalConceptMappings: {bad_value}\n"
+        with pytest.raises(MergeError) as exc:
+            ExtendsMerger().merge_from_strings(base_raw, [fragment])
+        assert exc.value.code == "INVALID_CONCEPT_MAPPING"
+        child_raw, _ = TrackedLoader().load_string(fragment)
+        with pytest.raises(MergeError) as exc:
+            ExtendsMerger().merge_from_strings(child_raw, inherits_raw=base_raw)
+        assert exc.value.code == "INVALID_CONCEPT_MAPPING"
+
     def test_empty_fragment_ontology_is_fine(self) -> None:
         base_raw, _ = TrackedLoader().load_string(_BASE)
         merged, warnings = ExtendsMerger().merge_from_strings(

--- a/tests/unit/test_ontology_drift.py
+++ b/tests/unit/test_ontology_drift.py
@@ -48,6 +48,8 @@ _MODELED_CLASSES = (
     semantic_models.FilterValue,
     semantic_models.ModelFilter,
     semantic_models.ModelSettings,
+    semantic_models.ExternalConceptMapping,
+    semantic_models.OntologyConfig,
 )
 
 # Fields that intentionally have no ontology property:
@@ -152,6 +154,11 @@ _EXCLUDED_FIELDS = frozenset(
         "filterContext",
         "grain",
         "columns",
+        # ontology.prefixes is authoring sugar: compact concept IRIs are
+        # expanded at load time and the exporter binds the namespaces on the
+        # graph rather than describing them as triples.
+        "ontology",
+        "prefixes",
     }
 )
 
@@ -240,6 +247,22 @@ _NAME_REMAP = {
     "order": "withinGroupOrder",
     # query (on ModelExample) → exampleQuery
     "query": "exampleQuery",
+    # ExternalConceptMapping
+    "external_concept_mappings": "hasExternalConceptMapping",
+    "externalConceptMappings": "hasExternalConceptMapping",
+    "concept": "authoredConcept",
+    "expanded_iri": "targetConcept",
+    "expandedIri": "targetConcept",
+    "relation": "mappingRelation",
+    "justification": "mappingJustification",
+    "source": "mappingSource",
+    "ontology_version": "ontologyVersion",
+    "ontologyVersion": "ontologyVersion",
+    "confidence": "confidence",
+    # ``comment`` on a mapping is obsl:mappingComment; the generic
+    # ``comment`` (DataObject) stays excluded above, so this remap only
+    # ever resolves for ExternalConceptMapping.
+    "comment": "mappingComment",
 }
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -2845,7 +2845,7 @@ wheels = [
 
 [[package]]
 name = "osi-orionbelt"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "packages/osi-orionbelt" }
 dependencies = [
     { name = "jsonschema" },


### PR DESCRIPTION
## Summary

PR 1 of `design/PLAN_OBSL_CONTEXT_ONTOLOGY_SYNC.md` (mapping foundation). No SQL planning is touched.

- `ontology.prefixes` at the top level; `rdf`, `rdfs`, `owl`, `skos`, `xsd` are built in and cannot be rebound.
- `externalConceptMappings` on `SemanticModel`, `DataObject`, `Dimension`, `Measure`, `Metric` (not on columns or joins, per the plan). Each entry: `concept` (compact or full IRI), required `relation` (`exact | close | broader | narrower | related`), optional `justification` (`curated | imported | generated | inferred | lexical`), `source`, `ontologyVersion`, `confidence` (0..1), `comment`.
- Resolver expands every concept to an absolute IRI (`expandedIri` is derived; authoring it is `UNKNOWN_PROPERTY`) and reports `INVALID_ONTOLOGY_PREFIX`, `UNKNOWN_ONTOLOGY_PREFIX`, `INVALID_CONCEPT_IRI`, `INVALID_CONCEPT_MAPPING`, `DUPLICATE_CONCEPT_MAPPING`, `CONFLICTING_CONCEPT_MAPPING` with source spans. A bad mapping is dropped; the owning object still loads, so every problem is listed at once.
- `extends` merges carry `ontology.prefixes` (source wins, warning on conflict) and concatenate model-level mappings.
- New helper `models/concept_links.py` owns the prefix and IRI rules so the exporter and discovery index (PR 2, PR 3) reuse them.

## Decisions to confirm

- **Relation direction is SKOS-native, artifact first.** `broader` is `skos:broadMatch`: the *external concept is the broader one*, the OBML object is a narrower notion of it. `narrower` is `skos:narrowMatch`. The plan's Workstream A bullet said the opposite ("the OBML object is broader than the external concept") while its RDF table mapped `broader -> skos:broadMatch`; the two contradict each other under SKOS semantics, so the predicate mapping was kept and the direction bullet corrected in the plan. Stated in docstrings, JSON schema, `obml_reference.py` and `spec.md`.
- **Full IRI vs compact IRI.** A value with `://` after its scheme, or a `urn:` value, is a full IRI; any other `prefix:local` is a compact IRI whose prefix must be declared. Treating every `scheme:` as absolute would let an undeclared prefix through silently.
- **Ontology vocabulary landed here, not in PR 2.** `test_ontology_drift.py` requires an `obsl:` property for every new Pydantic field, so `obsl:ExternalConceptMapping` and its properties (`hasExternalConceptMapping`, `sourceObject`, `targetConcept`, `authoredConcept`, `mappingRelation`, `mappingJustification`, `mappingSource`, `ontologyVersion`, `confidence`, `mappingComment`), the SHACL shape and spec section 5.10 are in this PR. PR 2 only needs the exporter.
- Duplicate/conflicting mappings are resolver errors (per owning object) so they carry spans; the semantic validator was not needed.
- The result cache key is built from compiled SQL, so no fingerprint exclusion was needed; the regression test proves identical SQL and identical key with and without mappings on postgres, duckdb and snowflake.

## Dependents updated together

JSON schema + vendored copy in `packages/osi-orionbelt`, `schema/obml-contract.yml`, `ontology/obsl.ttl` + `obsl.shacl.ttl` + `spec.md`, `test_ontology_drift.py` remaps, `obml_reference.py` section 7, CHANGELOG. After review: the OSI converter carries `ontology` and every object's mappings through the ORIONBELT vendor extension (osi-orionbelt 0.3.1, lossless round-trip, `osi_roundtrip: true`), `extends`/`inherits` merge prefixes and model-level mappings with `ONTOLOGY_PREFIX_CONFLICT` on a rebinding, and `obsl:targetConcept` has no range. MkDocs pages come with PR 5.

## Test plan

- [x] `tests/unit/test_external_concept_mappings.py`: 85 tests covering the plan's section 9 matrix (valid full/compact IRI, unknown/invalid prefix, invalid namespace, built-in rebinding, invalid relation/justification, confidence bounds, duplicate, conflict, every supported object type incl. cumulative/window/PoP metrics, column/join rejection, source spans, SQL + cache-key regression, extends merge, JSON schema accept/reject, helper unit tests)
- [x] Full suite: 5305 passed, 1070 skipped
- [x] `ruff check`, `ruff format`, `mypy src/` clean
- [x] Both Turtle files parse with rdflib

